### PR TITLE
Please consider pulling my version-related patch

### DIFF
--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -62,11 +62,12 @@ module Grape
       #     end
       #         
       #     version 'v1' do
-      #       get '/legacy' do
+      #       get '/main' do
       #         {:legacy => 'data'}
       #       end
       #     end
       #   end
+      #
       def version(*new_versions, &block)
         new_versions.any? ? nest(block){ set(:version, new_versions) } : settings[:version]
       end
@@ -139,10 +140,12 @@ module Grape
         paths = ['/'] if paths == []
         paths = Array(paths)
         endpoint = build_endpoint(&block)
+        options = {}
+        options[:version] = /#{version.join('|')}/ if version
         
         methods.each do |method|
           paths.each do |path|
-            path = Rack::Mount::Strexp.compile(compile_path(path))
+            path = Rack::Mount::Strexp.compile(compile_path(path), options)
             route_set.add_route(endpoint, 
               :path_info => path, 
               :request_method => (method.to_s.upcase unless method == :any)

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -78,6 +78,27 @@ describe Grape::API do
       get '/v3/awesome'
       last_response.status.should == 404
     end
+    
+    it 'should allow the same endpoint to be implemented for different versions' do
+      subject.version 'v2'
+      subject.get 'version' do
+        request.env['api.version']
+      end
+      
+      subject.version 'v1' do
+        get 'version' do
+          "version " + request.env['api.version']
+        end
+      end
+      
+      get '/v2/version'
+      last_response.status.should == 200
+      last_response.body.should == 'v2'
+      get '/v1/version'
+      last_response.status.should == 200
+      last_response.body.should == 'version v1'
+    end
+      
   end
   
   describe '.namespace' do


### PR DESCRIPTION
This patch allows the definition of different behaviors with the same name across versions. This was not possible before. With this patch, the following is possible:

```
...
version 'v1' do
  get '/test' do
      "Some version 1 behavior"
  end
end

version 'v2' do
  get '/test' do
    "Some version 2 behavior"
  end
end
```

This allows a clear separation of behavior for different versions of an api, and the ability to store different versions of the api in different files.

I am not sure if this omission was deliberate, but I think that the patch introduces expected behavior.
