### PR TITLE
Content type for error response

### DIFF
--- a/lib/grape/middleware/base.rb
+++ b/lib/grape/middleware/base.rb
@@ -2,7 +2,7 @@ module Grape
   module Middleware
     class Base
       attr_reader :app, :env, :options
-      
+
       # @param [Rack Application] app The standard argument for a Rack middleware.
       # @param [Hash] options A hash of options, simply stored for use by subclasses.
       def initialize(app, options = {})
@@ -38,6 +38,52 @@ module Grape
       def response
         Rack::Response.new(@app_response)
       end
+
+
+      module Formats
+
+        CONTENT_TYPES = {
+          :xml => 'application/xml',
+          :json => 'application/json',
+          :atom => 'application/atom+xml',
+          :rss => 'application/rss+xml',
+          :txt => 'text/plain'
+        }
+        FORMATTERS = {
+          :json => :encode_json,
+          :txt => :encode_txt,
+        }
+
+        def formatters
+          FORMATTERS.merge(options[:formatters] || {})
+        end
+
+        def content_types
+          CONTENT_TYPES.merge(options[:content_types] || {})
+        end
+
+        def content_type
+          content_types[options[:format]] || 'text/html'
+        end
+
+        def mime_types
+          content_types.invert
+        end
+
+        def formatter_for(api_format)
+          spec = formatters[api_format]
+          case spec
+          when nil
+            lambda { |obj| obj }
+          when Symbol
+            method(spec)
+          else
+            spec
+          end
+        end
+
+      end
+
     end
   end
 end

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -4,36 +4,14 @@ require 'multi_json'
 module Grape
   module Middleware
     class Formatter < Base
-      CONTENT_TYPES = {
-        :xml => 'application/xml',
-        :json => 'application/json',
-        :atom => 'application/atom+xml',
-        :rss => 'application/rss+xml',
-        :txt => 'text/plain'
-      }
-      FORMATTERS = {
-        :json => :encode_json,
-        :txt => :encode_txt,
-      }
-      
+      include Formats
+
       def default_options
         { 
           :default_format => :txt,
           :formatters => {},
           :content_types => {}
         }
-      end
-      
-      def content_types
-        CONTENT_TYPES.merge(options[:content_types])
-      end
-
-      def formatters
-        FORMATTERS.merge(options[:formatters])
-      end
-      
-      def mime_types
-        content_types.invert
       end
       
       def headers
@@ -92,18 +70,6 @@ module Grape
         Rack::Response.new(bodymap, status, headers).to_a
       end
 
-      def formatter_for(api_format)
-        spec = formatters[api_format]
-        case spec
-        when nil
-          lambda { |obj| obj }
-        when Symbol
-          method(spec)
-        else
-          spec
-        end
-      end
-      
       def encode_json(object)
         if object.respond_to? :serializable_hash
           MultiJson.encode(object.serializable_hash)

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -276,6 +276,35 @@ describe Grape::API do
       last_response.body.should eql 'Created'
     end
   end
+
+  context 'format' do
+    before do
+      subject.get("/foo") { "bar" }
+    end
+
+    it 'should set content type for txt format' do
+      get '/foo'
+      last_response.headers['Content-Type'].should eql 'text/plain'
+    end
+
+    it 'should set content type for json' do
+      get '/foo.json'
+      last_response.headers['Content-Type'].should eql 'application/json'
+    end
+
+    it 'should set content type for error' do
+      subject.get('/error') { error!('error in plain text', 500) }
+      get '/error'
+      last_response.headers['Content-Type'].should eql 'text/plain'
+    end
+
+    it 'should set content type for error' do
+      subject.error_format :json
+      subject.get('/error') { error!('error in json', 500) }
+      get '/error.json'
+      last_response.headers['Content-Type'].should eql 'application/json'
+    end
+  end
   
   context 'custom middleware' do
     class PhonyMiddleware


### PR DESCRIPTION
I just found the 'Content-Type' header for error response is always 'text/html', no matter you set error_format to :txt or :json, as demostrate by line 295-306 in spec/grape/api_spec.rb.

The commit also includes a little refactoring of format handling - duplicated codes are moved into Grape::Middleware::Base::Formats module.
