### PR TITLE
This is a minor fix for the issue where nested attributes of hashes are still strings (c.f., sporkd's comment on https://github.com/intridea/grape/issues/27).

### DIFF
--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -1,5 +1,6 @@
 require 'rack'
 require 'grape'
+require File.dirname(__FILE__) + '/helpers/extensions/hash'
 
 module Grape
   # An Endpoint is the proxy scope in which all routing
@@ -30,7 +31,11 @@ module Grape
     def params
       @params ||= request.params.merge(env['rack.routing_args'] || {}).inject({}) do |h,(k,v)|
         h[k.to_s] = v
-        h[k.to_sym] = v
+
+        # Also return a version of the parameters with symbols as hash keys
+        v_sym = (v.kind_of?(Hash) && v.respond_to?(:key_strings_to_symbols)) ? v.key_strings_to_symbols : v
+        h[k.to_sym] = v_sym
+        
         h
       end
     end

--- a/lib/grape/helpers/extensions/hash.rb
+++ b/lib/grape/helpers/extensions/hash.rb
@@ -1,0 +1,12 @@
+class Hash
+  # Recursively replace key names that should be symbols with symbols.
+  def key_strings_to_symbols
+    new_hash = Hash.new
+    self.each_pair do |k,v|
+      new_value = (v.kind_of?(Hash) && v.respond_to?(:key_strings_to_symbols)) ? v.key_strings_to_symbols : v
+      new_key = k.kind_of?(String) ? k.to_sym : k
+      new_hash[new_key] = new_value
+    end
+    new_hash
+  end
+end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -48,6 +48,42 @@ describe Grape::Endpoint do
       get '/hey/12'
       last_response.body.should == '12'
     end
+
+    it 'returns a hashed version of parameters which are hashes with symbol keys' do
+      subject.get('/hey') do
+        "#{params[:location][:city]}, #{params[:location][:state]}"
+      end
+
+      get '/hey?location[city]=New%20York&location[state]=NY'
+      last_response.body.should == "New York, NY"
+    end
+
+    it 'returns a hashed version of parameters which are hashes with string keys' do
+      subject.get('/hey') do
+        "#{params['location']['city']}, #{params['location']['state']}"
+      end
+
+      get '/hey?location[city]=New%20York&location[state]=NY'
+      last_response.body.should == "New York, NY"
+    end
+
+    it 'returns a hashed version of parameters which are hashes with symbol keys multiple levels deep' do
+      subject.get('/hey') do
+        params[:location][:city][:neighborhood]
+      end
+
+      get '/hey?location[city][neighborhood]=Chelsea'
+      last_response.body.should == "Chelsea"
+    end
+
+    it 'returns a hashed version of parameters which are hashes with string keys multiple levels deep' do
+      subject.get('/hey') do
+        params['location']['city']['neighborhood']
+      end
+
+      get '/hey?location[city][neighborhood]=Chelsea'
+      last_response.body.should == "Chelsea"
+    end
   end
   
   describe '#error!' do


### PR DESCRIPTION
Updating params such that the symbol version returned recursively uses symbols as hash keys.

That is, passing:
/url?location[city]=Dallas&location[state]=TX

will be available in the params hash as both
- params[:location][:city] and params[:location][:state]
- params['location']['city'] and params['location']['state']
