### PR TITLE
Extended rescue_from to take blocks for custom exception handling

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -93,6 +93,22 @@ The error format can be specified using `error_format`. Available formats are `:
       error_format :json
     end
 
+You can rescue all exceptions with a code block. The `rack_response` wrapper automatically sets the default error code and content-type.
+
+    class Twitter::API < Grape::API
+      rescue_from :all do |e|
+        rack_response({ :message => "rescued from #{e.class.name}" })
+      end
+    end
+
+You can also rescue specific exceptions with a code block and handle the Rack response at the lowest level.
+
+    class Twitter::API < Grape::API
+      rescue_from :all do |e|
+        Rack::Response.new([ e.message ], 500, { "Content-type" => "text/error" ).finish
+      end
+    end
+
 ## Note on Patches/Pull Requests
  
 * Fork the project.

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -617,4 +617,54 @@ describe Grape::API do
       last_response.status.should eql 403
     end
   end
+  
+  describe ".rescue_from klass, block" do
+    it 'should rescue Exception' do
+      subject.rescue_from RuntimeError do |e|
+        rack_response({ :message => "rescued from #{e.message}" }, 202)
+      end
+      subject.get '/exception' do
+        raise "rain!"
+      end
+      get '/exception'
+      last_response.status.should eql 202
+      last_response.body.should == '{:message=>"rescued from rain!"}'
+    end
+    it 'should rescue an error via rescue_from :all' do
+      class ConnectionError < RuntimeError; end
+      subject.rescue_from :all do |e|
+        rack_response({ :message => "rescued from #{e.class.name}" }, 500)
+      end
+      subject.get '/exception' do
+        raise ConnectionError
+      end
+      get '/exception'
+      last_response.status.should eql 500
+      last_response.body.should == '{:message=>"rescued from ConnectionError"}'
+    end
+    it 'should rescue a specific error' do
+      class ConnectionError < RuntimeError; end
+      subject.rescue_from ConnectionError do |e|
+        rack_response({ :message => "rescued from #{e.class.name}" }, 500)
+      end
+      subject.get '/exception' do
+        raise ConnectionError
+      end
+      get '/exception'
+      last_response.status.should eql 500
+      last_response.body.should == '{:message=>"rescued from ConnectionError"}'
+    end
+    it 'should not rescue a different error' do
+      class CommunicationError < RuntimeError; end
+      subject.rescue_from RuntimeError do |e|
+        rack_response({ :message => "rescued from #{e.class.name}" }, 500)
+      end
+      subject.get '/uncaught' do
+        raise CommunicationError
+      end
+      lambda { get '/uncaught' }.should raise_error(CommunicationError)
+    end
+  end
+  
+  
 end

--- a/spec/grape/middleware/exception_spec.rb
+++ b/spec/grape/middleware/exception_spec.rb
@@ -116,5 +116,6 @@ describe Grape::Middleware::Error do
       get '/'
       last_response.status.should == 401    
     end 
+    
   end 
 end


### PR DESCRIPTION
You can rescue all exceptions with a code block. The `rack_response` wrapper automatically sets the default error code and content-type.

```
  class Twitter::API < Grape::API
    rescue_from :all do |e|
      rack_response({ :message => "rescued from #{e.class.name}" })
    end
  end
```

You can also rescue specific exceptions with a code block and handle the Rack response at the lowest level.

```
  class Twitter::API < Grape::API
    rescue_from :all do |e|
      Rack::Response.new([ e.message ], 500, { "Content-type" => "text/error" ).finish
    end
 end
```

This is completely compatible with the previous rescue_from syntax! We use this to handle Mongoid::Error::Validation and augment the JSON with a "detail" field that contains all the validation errors from e.document.errors.
