### PR TITLE
Call #to_xml if the content type is xml

### DIFF
--- a/lib/grape/middleware/base.rb
+++ b/lib/grape/middleware/base.rb
@@ -54,6 +54,7 @@ module Grape
         FORMATTERS = {
           :json => :encode_json,
           :txt => :encode_txt,
+          :xml => :encode_xml
         }
         PARSERS = {
           :json => :decode_json
@@ -119,6 +120,10 @@ module Grape
 
         def encode_txt(object)
           object.respond_to?(:to_txt) ? object.to_txt : object.to_s
+        end
+        
+        def encode_xml(object)
+          object.respond_to?(:to_xml) ? object.to_xml : object.to_s
         end
       end
 

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -35,6 +35,17 @@ describe Grape::Middleware::Formatter do
       
       subject.call({'PATH_INFO' => '/somewhere'}).last.each{|b| b.should == '{"abc":"def"}'}
     end
+    
+    it 'should call #to_xml if the content type is xml' do
+      @body = "string"
+      @body.instance_eval do
+        def to_xml
+          "<bar/>"
+        end
+      end
+      
+      subject.call({'PATH_INFO' => '/somewhere.xml'}).last.each{|b| b.should == '<bar/>'}
+    end
   end
   
   context 'detection' do


### PR DESCRIPTION
Objects now get serialized to xml if the content type is xml and the object responds to #to_xml.
