### PR TITLE
Added HTTP Accept-header based version selection

### DIFF
--- a/lib/grape/middleware/versioner.rb
+++ b/lib/grape/middleware/versioner.rb
@@ -10,16 +10,29 @@ module Grape
       end
       
       def before
-        pieces = env['PATH_INFO'].split('/')
-        potential_version = pieces[1]
-        if potential_version =~ options[:pattern]
-          if options[:versions] && !options[:versions].include?(potential_version)
-            throw :error, :status => 404, :message => "404 API Version Not Found"
+        if options[:vendors] && env['HTTP_ACCEPT'] =~ /application\/vnd\.(.+)-(.+)\+(.+)/
+          potential_vendor       = $1
+          potential_version      = $2
+          potential_content_type = $3
+
+          if options[:vendors] && options[:vendors].include?(potential_vendor)
+            if options[:versions] && options[:versions].include?(potential_version)
+              env['api.version'] = potential_version
+            end
           end
-          
-          truncated_path = "/#{pieces[2..-1].join('/')}"
-          env['api.version'] = potential_version
-          env['PATH_INFO'] = truncated_path
+          throw :error, :status => 404, :message => "404 API Version Not Found" unless env['api.version']
+        else
+          pieces = env['PATH_INFO'].split('/')
+          potential_version = pieces[1]
+          if potential_version =~ options[:pattern]
+            if options[:versions] && !options[:versions].include?(potential_version)
+              throw :error, :status => 404, :message => "404 API Version Not Found"
+            end
+            
+            truncated_path = "/#{pieces[2..-1].join('/')}"
+            env['api.version'] = potential_version
+            env['PATH_INFO'] = truncated_path
+          end
         end
       end
     end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -21,6 +21,35 @@ describe Grape::API do
     end
   end
 
+  describe '.vendor' do
+    it 'should set the vendor' do
+      subject.vendor 'grape'
+      subject.vendor.should eql ['grape']
+    end
+
+    it 'should not use HTTP_ACCEPT headers when no vendor is set' do
+      subject.get :hello do
+        "Hello"
+      end
+
+      subject.version 'v1'
+      subject.get :hello do
+        "World"
+      end
+
+      header 'Accept', 'application/vnd.grape-v1+json'
+      get '/hello'
+      last_response.status.should eql 200
+      last_response.body.should eql 'Hello'
+
+      
+      header 'Accept', 'application/vnd.grape-v1+json'
+      get '/v1/hello'
+      last_response.status.should eql 200
+      last_response.body.should eql 'World'
+    end
+  end
+
   describe '.version' do
     it 'should set the API version' do
       subject.version 'v1'

--- a/spec/grape/middleware/versioner_spec.rb
+++ b/spec/grape/middleware/versioner_spec.rb
@@ -37,4 +37,21 @@ describe Grape::Middleware::Versioner do
       subject.call('PATH_INFO' => '/v1/asoasd').last.should == 'v1'
     end
   end
+
+  context 'with the accept header' do
+    before{ @options = {:versions => ['v1'], :vendors => ['grape']}}
+
+    
+    it 'should select the correct version based on the HTTP_ACCEPT headers' do
+      subject.call('HTTP_ACCEPT' => 'application/vnd.grape-v1+json', 'PATH_INFO' => '/awesome').last.should == 'v1'
+    end
+
+    it 'should not select a version if a wrong vendor is set' do
+      catch(:error){subject.call('HTTP_ACCEPT' => 'application/vnd.fruit-v1+json', 'PATH_INFO' => '/awesome')}[:status].should == 404
+    end
+
+    it 'should select the correct version based on the url if the HTTP_ACCEPT header is not set' do
+      subject.call('PATH_INFO' => '/v1/awesome').last.should == 'v1'
+    end
+  end
 end


### PR DESCRIPTION
Added a #vendor method to be able to use an accept header with application/vnd.<vendor>-<version>+<contenttype> to be able to create more RESTful API's.
