### PR TITLE
Return 404 if no header is sent, but header based version is used

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -81,6 +81,9 @@ request:
 
     curl -H Accept=application/vnd.twitter-v1+json http://localhost:9292/statuses/public_timeline
 
+By default, the first matching version is used when no Accept header is supplied. This behavior is similar to routing in Rails.
+To circumvent this default behaviour, one could use the `:strict` option. When this option is set to `true`, a `404 Not found` error is returned when no correct Accept header is supplied.
+
 Serialization takes place automatically. For more detailed usage information, please visit the [Grape Wiki](http://github.com/intridea/grape/wiki).
 
 ## Working with Entities
@@ -105,7 +108,7 @@ class API < Grape::API
   version 'v1', 'v2'
 
   get '/users/:id' do
-    present User.find(params[:id]), 
+    present User.find(params[:id]),
       :with => Entities::User,
       :authenticated => env.key?('api.token')
   end
@@ -191,9 +194,9 @@ You can test a Grape API with RSpec. Tests make HTTP requests, therefore they mu
 
 ```ruby
 RSpec.configure do |config|
-  config.include RSpec::Rails::RequestExampleGroup, :type => :request, :example_group => { 
+  config.include RSpec::Rails::RequestExampleGroup, :type => :request, :example_group => {
     :file_path => /spec\/api/
-  } 
+  }
 end
 ```
 
@@ -218,10 +221,10 @@ end
 Grape exposes arrays of API versions and compiled routes. Each route contains a `route_prefix`, `route_version`, `route_namespace`, `route_method`, `route_path` and `route_params`.
 
 ```ruby
-class TwitterAPI < Grape::API      
+class TwitterAPI < Grape::API
 
   version 'v1'
-  get "version" do 
+  get "version" do
     api.version
   end
 
@@ -242,7 +245,7 @@ Grape also supports storing additional parameters with the route information. Th
 
 ```ruby
 class StringAPI < Grape::API
-  get "split/:string", { :params => [ "token" ], :optional_params => [ "limit" ] } do 
+  get "split/:string", { :params => [ "token" ], :optional_params => [ "limit" ] } do
     params[:string].split(params[:token], (params[:limit] || 0))
   end
 end

--- a/lib/grape/middleware/versioner/header.rb
+++ b/lib/grape/middleware/versioner/header.rb
@@ -23,7 +23,13 @@ module Grape
       # route.
       class Header < Base
         def before
-          accept = env['HTTP_ACCEPT'] || ""
+          accept = env['HTTP_ACCEPT']
+
+          if options[:version_options] && options[:version_options].keys.include?(:strict) && options[:version_options][:strict]
+            if (accept.nil? || accept.empty?) && options[:versions] && options[:version_options][:using] == :header
+              throw :error, :status => 404, :headers => {'X-Cascade' => 'pass'}, :message => "404 API Version Not Found"
+            end
+          end
           accept.strip.scan(/^(.+?)\/(.+?)$/) do |type, subtype|
             env['api.type']    = type
             env['api.subtype'] = subtype

--- a/spec/grape/middleware/versioner/header_spec.rb
+++ b/spec/grape/middleware/versioner/header_spec.rb
@@ -50,6 +50,34 @@ describe Grape::Middleware::Versioner::Header do
     end
   end
 
+  context 'no header' do
+    it 'should return a 200 when no header is set and no strict setting is done' do
+      @options = {
+        :versions => ['v1'],
+        :version_options => {:using => :header}
+      }
+      subject.call('HTTP_ACCEPT' => '').first.should == 200
+    end
+
+    it 'should return a 200 when no header is set but strict header based versioning is disabled' do
+      @options = {
+        :versions => ['v1'],
+        :version_options => {:using => :header, :strict => false}
+      }
+      subject.call('HTTP_ACCEPT' => '').first.should == 200
+    end
+
+    it 'should return a 404 when no header is set but strict header based versioning is used' do
+      @options = {
+        :versions => ['v1'],
+        :version_options => {:using => :header, :strict => true}
+      }
+      expect {
+        env = subject.call('HTTP_ACCEPT' => '').last
+      }.to throw_symbol(:error, :status => 404, :headers => {'X-Cascade' => 'pass'}, :message => "404 API Version Not Found")
+    end
+  end
+
   context 'no matched version' do
     before do
       @options = {


### PR DESCRIPTION
When no header is sent, but :using => :header is used, a 404 should be
returned, because this would mean no version is being selected
