### PR TITLE
Added support for API descriptions  (frontier)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ tmtags
 \#*
 .\#*
 
+## REDCAR
+.redcar
+
 ## VIM
 *.swp
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,6 @@
-# Grape
-[![Build Status](http://travis-ci.org/intridea/grape.png)](http://travis-ci.org/intridea/grape)
+# Grape [![Build Status](http://travis-ci.org/intridea/grape.png)](http://travis-ci.org/intridea/grape)
+
+**Note:** This is the `master` branch of Grape where we're trying to maintain things to be relatively stable. If you want to live on the edge, check out the [frontier](https://github.com/intridea/grape/tree/frontier).
 
 Grape is a REST-like API micro-framework for Ruby. It is built to complement existing web application frameworks such as Rails and Sinatra by providing a simple DSL to easily provide APIs. It has built-in support for common conventions such as multiple formats, subdomain/prefix restriction, and versioning.
 
@@ -86,37 +87,35 @@ To circumvent this default behaviour, one could use the `:strict` option. When t
 
 Serialization takes place automatically. For more detailed usage information, please visit the [Grape Wiki](http://github.com/intridea/grape/wiki).
 
-## Working with Entities
+## Helpers
 
-A common problem in designing Ruby APIs is that you probably don't want
-the exact structure of your data models exposed. ActiveRecord, for
-instance, will dump all of its attributes. While you can override
-`#as_json` to alter this behavior somewhat, what is really needed is an
-intermediary layer between the model and the API. This is where the
-`Grape::Entity` class comes in.
+You can define helper methods that your endpoints can use with the `helpers`
+macro by either giving a block or a module:
 
-```ruby
-module Entities
-  class User < Grape::Entity
-    expose :first_name, :last_name
-    expose :email, :if => {:authenticated => true}
-    expose :name, :id => {:version => 'v1'} # deprecated
+````ruby
+module MyHelpers
+  def say_hello(user)
+    "hey there #{user.name}"
   end
 end
 
 class API < Grape::API
-  version 'v1', 'v2'
+  # define helpers with a block
+  helpers do
+    def current_user
+      User.find(params[:user_id])
+    end
+  end
 
-  get '/users/:id' do
-    present User.find(params[:id]),
-      :with => Entities::User,
-      :authenticated => env.key?('api.token')
+  # or mix in a module
+  helpers MyHelpers
+
+  get '/hello' do
+    # helpers available in your endpoint and filters
+    say_hello(current_user)
   end
 end
-```
-
-For more information about Entities, view the project's YARD
-documentation.
+````
 
 ## Raising Errors
 

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -49,7 +49,7 @@ module Grape
       def imbue(key, value)
         settings.imbue(key, value)
       end
-      
+
       # Define a root URL prefix for your entire
       # API.
       def prefix(prefix = nil)
@@ -61,11 +61,11 @@ module Grape
       # @example API with legacy support.
       #   class MyAPI < Grape::API
       #     version 'v2'
-      #     
+      #
       #     get '/main' do
       #       {:some => 'data'}
       #     end
-      #         
+      #
       #     version 'v1' do
       #       get '/main' do
       #         {:legacy => 'data'}
@@ -77,7 +77,7 @@ module Grape
         if args.any?
           options = args.pop if args.last.is_a? Hash
           options ||= {}
-          options = {:using => :header}.merge!(options)
+          options = {:using => :path}.merge!(options)
           @versions = versions | args
           nest(block) do
             set(:version, args)
@@ -90,8 +90,8 @@ module Grape
       def desc(description, options = {})
         @last_description = options.merge({description: description})
       end
-      
-      # Specify the default format for the API's 
+
+      # Specify the default format for the API's
       # serializers. Currently only `:json` is
       # supported.
       def default_format(new_format = nil)
@@ -167,7 +167,10 @@ module Grape
       #
       # When called without a block, all known helpers within this scope
       # are included.
-      # 
+      #
+      # @param mod [Module] optional module of methods to include
+      # @param &block [Block] optional block of methods to include
+      #
       # @example Define some helpers.
       #     class ExampleAPI < Grape::API
       #       helpers do
@@ -176,17 +179,17 @@ module Grape
       #         end
       #       end
       #     end
-      def helpers(&block)
-        if block_given?
-          m = settings.peek[:helpers] || Module.new
-          m.class_eval &block
-          set(:helpers, m)
+      def helpers(mod = nil, &block)
+        if block_given? || mod
+          mod ||= settings.peek[:helpers] || Module.new
+          mod.class_eval &block if block_given?
+          set(:helpers, mod)
         else
-          m = Module.new
+          mod = Module.new
           settings.stack.each do |s|
-            m.send :include, s[:helpers] if s[:helpers]
+            mod.send :include, s[:helpers] if s[:helpers]
           end
-          m
+          mod
         end
       end
 
@@ -220,7 +223,7 @@ module Grape
 
         mounts.each_pair do |app, path|
           next unless app.respond_to?(:call)
-          route_set.add_route(app, 
+          route_set.add_route(app,
             :path_info => compile_path(path, false)
           )
         end
@@ -280,8 +283,8 @@ module Grape
       def before(&block)
         settings.imbue(:befores, [block])
       end
-      
-      def after(&block) 
+
+      def after(&block)
         settings.imbue(:afters, [block])
       end
 
@@ -300,14 +303,14 @@ module Grape
           Rack::Mount::Utils.normalize_path(settings.stack.map{|s| s[:namespace]}.join('/'))
         end
       end
-      
+
       alias_method :group, :namespace
       alias_method :resource, :namespace
       alias_method :resources, :namespace
       alias_method :segment, :namespace
-      
+
       # Create a scope without affecting the URL.
-      # 
+      #
       # @param name [Symbol] Purely placebo, just allows to to name the scope to make the code more readable.
       def scope(name = nil, &block)
         nest(block)
@@ -340,7 +343,7 @@ module Grape
       end
       
       protected
-      
+
       # Execute first the provided block, then each of the
       # block passed in. Allows for simple 'before' setups
       # of settings stack pushes.
@@ -364,11 +367,11 @@ module Grape
 
       def build_endpoint(&block)
         b = Rack::Builder.new
-        b.use Grape::Middleware::Error, 
-          :default_status => settings[:default_error_status] || 403, 
-          :rescue_all => settings[:rescue_all], 
-          :rescued_errors => settings[:rescued_errors], 
-          :format => settings[:error_format] || :txt, 
+        b.use Grape::Middleware::Error,
+          :default_status => settings[:default_error_status] || 403,
+          :rescue_all => settings[:rescue_all],
+          :rescued_errors => settings[:rescued_errors],
+          :format => settings[:error_format] || :txt,
           :rescue_options => settings[:rescue_options],
           :rescue_handlers => settings[:rescue_handlers] || {}
 
@@ -399,7 +402,7 @@ module Grape
         b.run endpoint
         b.to_app
       end
-      
+
       def inherited(subclass)
         subclass.reset!
         subclass.logger = logger.clone


### PR DESCRIPTION
You can now use `desc` to add a description (inspectable with `route_description`) along with any other parameters in the format of your liking. The parameters merge with whatever is tagged after the method, `desc` is merely a DSL extension ala rake.

Note that desc is not a block. It applies to the next method declaration and is then cleared.
