### PR TITLE
frontier: bug: .format is broken, can't serve .txt or respond with params[:format]

### DIFF
--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -33,7 +33,7 @@ module Grape
         options[:method].each do |method|
           options[:path].each do |path|
             prepared_path = prepare_path(path)
-            path = compile_path(path, !options[:app])
+            path = compile_path(prepared_path, !options[:app])
             regex = Rack::Mount::RegexpWithNamedGroups.new(path)
             path_params = regex.named_captures.map { |nc| nc[0] } - [ 'version', 'format' ]
             path_params |= (options[:route_options][:params] || [])
@@ -71,11 +71,10 @@ module Grape
       Rack::Mount::Utils.normalize_path(settings.stack.map{|s| s[:namespace]}.join('/'))
     end
 
-    def compile_path(path, anchor = true)
+    def compile_path(prepared_path, anchor = true)
       endpoint_options = {}
       endpoint_options[:version] = /#{settings[:version].join('|')}/ if settings[:version]
-
-      Rack::Mount::Strexp.compile(prepare_path(path), endpoint_options, %w( / . ? ), anchor)
+      Rack::Mount::Strexp.compile(prepared_path, endpoint_options, %w( / . ? ), anchor)
     end
 
     def call(env)

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -175,13 +175,24 @@ describe Grape::API do
       last_response.body.should eql 'foo'
     end
 
-    it 'should allow for format' do
-      subject.get("/abc") do
-        "json"
+    context "format" do
+      before(:each) do
+        subject.get("/abc") do
+          params[:format]
+        end
+      end
+    
+      it "should allow .json" do
+        get '/abc.json'
+        last_response.status.should == 200
+        last_response.body.should eql '"json"' # json-encoded symbol
       end
 
-      get '/abc.json'
-      last_response.body.should eql '"json"'
+      it "should allow .txt" do
+        get '/abc.txt'
+        last_response.status.should == 200
+        last_response.body.should eql "txt" # raw text
+      end
     end
 
     it 'should allow for format without corrupting a param' do


### PR DESCRIPTION
This closes #84 on frontier.
