### PR TITLE
Frontier: Entity array representation

### DIFF
--- a/lib/grape/middleware/base.rb
+++ b/lib/grape/middleware/base.rb
@@ -12,20 +12,20 @@ module Grape
         @app = app
         @options = default_options.merge(options)
       end
-      
+
       def default_options; {} end
-      
+
       def call(env)
         dup.call!(env)
       end
-      
+
       def call!(env)
         @env = env
         before
         @app_response = @app.call(@env)
         after || @app_response
       end
-      
+
       # @abstract
       # Called before the application is called in the middleware lifecycle.
       def before; end
@@ -33,11 +33,11 @@ module Grape
       # Called after the application is called in the middleware lifecycle.
       # @return [Response, nil] a Rack SPEC response or nil to call the application afterwards.
       def after; end
-      
+
       def request
         Rack::Request.new(self.env)
       end
-      
+
       def response
         Rack::Response.new(@app_response)
       end
@@ -115,6 +115,8 @@ module Grape
 
           if object.respond_to? :serializable_hash
             MultiJson.encode(object.serializable_hash)
+          elsif object.kind_of?(Array) && !object.map {|o| o.respond_to? :serializable_hash }.include?(false)
+            MultiJson.encode(object.map {|o| o.serializable_hash })
           elsif object.respond_to? :to_json
             object.to_json
           else
@@ -125,11 +127,11 @@ module Grape
         def encode_txt(object)
           object.respond_to?(:to_txt) ? object.to_txt : object.to_s
         end
-        
+
         def decode_xml(object)
           MultiXml.parse(object)
         end
-        
+
         def encode_xml(object)
           object.respond_to?(:to_xml) ? object.to_xml : object.to_s
         end

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -3,16 +3,16 @@ require 'spec_helper'
 describe Grape::Middleware::Formatter do
   subject{ Grape::Middleware::Formatter.new(app, :default_format => :json)}
   before{ subject.stub!(:dup).and_return(subject) }
-  
+
   let(:app){ lambda{|env| [200, {}, [@body]]} }
-  
+
   context 'serialization' do
     it 'should look at the bodies for possibly serializable data' do
       @body = {"abc" => "def"}
       status, headers, bodies = *subject.call({'PATH_INFO' => '/somewhere'})
       bodies.each{|b| b.should == MultiJson.encode(@body) }
     end
-    
+
     it 'should call #to_json first if it is available' do
       @body = ['foo']
       @body.instance_eval do
@@ -20,22 +20,34 @@ describe Grape::Middleware::Formatter do
           "\"bar\""
         end
       end
-      
+
       subject.call({'PATH_INFO' => '/somewhere'}).last.each{|b| b.should == '"bar"'}
     end
-    
+
     it 'should serialize the #serializable_hash if that is available' do
       class SimpleExample
         def serializable_hash
           {:abc => 'def'}
         end
       end
-      
+
+      @body = [SimpleExample.new, SimpleExample.new]
+
+      subject.call({'PATH_INFO' => '/somewhere'}).last.each{|b| b.should == '[{"abc":"def"},{"abc":"def"}]'}
+    end
+
+    it 'should serialize multiple objects that respond to #serializable_hash' do
+      class SimpleExample
+        def serializable_hash
+          {:abc => 'def'}
+        end
+      end
+
       @body = SimpleExample.new
-      
+
       subject.call({'PATH_INFO' => '/somewhere'}).last.each{|b| b.should == '{"abc":"def"}'}
     end
-    
+
     it 'should call #to_xml if the content type is xml' do
       @body = "string"
       @body.instance_eval do
@@ -43,11 +55,11 @@ describe Grape::Middleware::Formatter do
           "<bar/>"
         end
       end
-      
+
       subject.call({'PATH_INFO' => '/somewhere.xml'}).last.each{|b| b.should == '<bar/>'}
     end
   end
-  
+
   context 'detection' do
     it 'should use the extension if one is provided' do
       subject.call({'PATH_INFO' => '/info.xml'})
@@ -55,41 +67,41 @@ describe Grape::Middleware::Formatter do
       subject.call({'PATH_INFO' => '/info.json'})
       subject.env['api.format'].should == :json
     end
-    
+
     it 'should use the default format if none is provided' do
       subject.call({'PATH_INFO' => '/info'})
       subject.env['api.format'].should == :json
     end
-    
+
     it 'should throw an error on an unrecognized format' do
       err = catch(:error){ subject.call({'PATH_INFO' => '/info.barklar'}) }
       err.should == {:status => 406, :message => "The requested format is not supported."}
     end
   end
-  
+
   context 'Accept header detection' do
     it 'should detect from the Accept header' do
       subject.call({'PATH_INFO' => '/info', 'Accept' => 'application/xml'})
       subject.env['api.format'].should == :xml
     end
-    
+
     it 'should look for case-indifferent headers' do
       subject.call({'PATH_INFO' => '/info', 'accept' => 'application/xml'})
       subject.env['api.format'].should == :xml
     end
-    
+
     it 'should use quality rankings to determine formats' do
       subject.call({'PATH_INFO' => '/info', 'Accept' => 'application/json; q=0.3,application/xml; q=1.0'})
       subject.env['api.format'].should == :xml
       subject.call({'PATH_INFO' => '/info', 'Accept' => 'application/json; q=1.0,application/xml; q=0.3'})
       subject.env['api.format'].should == :json
     end
-    
+
     it 'should handle quality rankings mixed with nothing' do
       subject.call({'PATH_INFO' => '/info', 'Accept' => 'application/json,application/xml; q=1.0'})
       subject.env['api.format'].should == :xml
     end
-    
+
     it 'should properly parse headers with other attributes' do
       subject.call({'PATH_INFO' => '/info', 'Accept' => 'application/json; abc=2.3; q=1.0,application/xml; q=0.7'})
       subject.env['api.format'].should == :json


### PR DESCRIPTION
Hello,

thank you for the library, especially the frontier branch which has a lot of useful stuff :). Here is small patch that allows to represent an entity array when it is a root element of the body. To my mind, this is a temporary solution and there is still a need for more advanced refactoring. I think that there could be an entity related class that is able to represent single entities as well as their arrays.

Sorry about auto whitespace removal.
