### PR TITLE
Root keys for entity representations

### DIFF
--- a/lib/grape/entity.rb
+++ b/lib/grape/entity.rb
@@ -195,7 +195,7 @@ module Grape
       if exposure_options[:proc]
         exposure_options[:proc].call(object, options)
       elsif exposure_options[:using]
-        exposure_options[:using].represent(object.send(attribute))
+        exposure_options[:using].represent(object.send(attribute), :root => nil)
       else
         object.send(attribute)
       end

--- a/spec/grape/entity_spec.rb
+++ b/spec/grape/entity_spec.rb
@@ -211,6 +211,21 @@ describe Grape::Entity do
         rep.last.serializable_hash[:name].should == 'Friend 2'
       end
 
+      it 'should disable root key name for child representations' do
+        class FriendEntity < Grape::Entity
+          root 'friends', 'friend'
+          expose :name, :email
+        end
+        fresh_class.class_eval do
+          expose :friends, :using => FriendEntity
+        end
+        rep = subject.send(:value_for, :friends)
+        rep.should be_kind_of(Array)
+        rep.reject{|r| r.is_a?(FriendEntity)}.should be_empty
+        rep.first.serializable_hash[:name].should == 'Friend 1'
+        rep.last.serializable_hash[:name].should == 'Friend 2'
+      end
+
       it 'should call through to the proc if there is one' do
         subject.send(:value_for, :computed, :awesome => 123).should == 123
       end


### PR DESCRIPTION
Here is initial support for specifying root keys for entity representations.

You can do this:

``` ruby
module API::Entities
  class User < Grape::Entity
    root 'users', 'user'
  end
end

module API
  class Users < Grape::API

    # this will render { "users": [ {"id":"1"}, {"id":"2"} ] }
    get '/users' do
      @users = User.all
      present @users, :with => API::Entities::User
    end

    # this will render { "user": {"id":"1"} }
    get '/users/:id' do
      @user = User.find(params[:id])
      present @user, :with => API::Entities::User
    end
  end
end
```

I could write an auto mode that would allow you to just specify 'root' with no arguments in the Entity class, but I'd have to add a dependency on something like [linguistics](http://deveiate.org/projects/Linguistics/wiki/English) or [activesupport](http://as.rubyonrails.org/classes/ActiveSupport/Inflector.html) so I could pluralize the class name properly. What do you think?
