### PR TITLE
Root keys for entity representations - another version

### DIFF
--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -42,7 +42,7 @@ module Grape
         end
       end
     end
-    
+
     def prepare_routes
       routes = []
       options[:method].each do |method|
@@ -82,7 +82,7 @@ module Grape
       parts.last << '(.:format)'
       Rack::Mount::Utils.normalize_path(parts.join('/'))
     end
-    
+
     def namespace
       Rack::Mount::Utils.normalize_path(settings.stack.map{|s| s[:namespace]}.join('/'))
     end
@@ -193,13 +193,18 @@ module Grape
         entity_class ||= (settings[:representations] || {})[potential]
       end
 
-      if entity_class
+      root = options.delete(:root)
+
+      representation = if entity_class
         embeds = {:env => env}
         embeds[:version] = env['api.version'] if env['api.version']
-        body entity_class.represent(object, embeds.merge(options))
+        entity_class.represent(object, embeds.merge(options))
       else
-        body object
+        object
       end
+
+      representation = { root => representation } if root
+      body representation
     end
 
     protected
@@ -220,11 +225,11 @@ module Grape
     def build_middleware
       b = Rack::Builder.new
 
-      b.use Grape::Middleware::Error, 
-        :default_status => settings[:default_error_status] || 403, 
-        :rescue_all => settings[:rescue_all], 
-        :rescued_errors => settings[:rescued_errors], 
-        :format => settings[:error_format] || :txt, 
+      b.use Grape::Middleware::Error,
+        :default_status => settings[:default_error_status] || 403,
+        :rescue_all => settings[:rescue_all],
+        :rescued_errors => settings[:rescued_errors],
+        :format => settings[:error_format] || :txt,
         :rescue_options => settings[:rescue_options],
         :rescue_handlers => settings[:rescue_handlers] || {}
 

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -178,6 +178,14 @@ describe Grape::Endpoint do
       get '/example'
       last_response.body.should == 'Hiya'
     end
+
+    it 'should add a root key to the output if one is given' do
+      subject.get '/example' do
+        present({:abc => 'def'}, :root => :root)
+        body.should == {:root => {:abc => 'def'}}
+      end
+      get '/example'
+    end
   end
 
   context 'filters' do


### PR DESCRIPTION
This is a much simpler patch than last time.

It lets you do this:

``` ruby
   present object, :root => 'thing'
```

which will render out `{ 'thing' => object }`

I would like to be able to support `:root => true`, and have it introspect the object to find out its name, and pluralize it if presenting an array. The problem is, what root key should the code use if it is asked to present an empty array, or an array containing different objects?
