### PR TITLE
Added HTTP verb: OPTIONS. 

### DIFF
--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -284,6 +284,7 @@ module Grape
       def put(paths = ['/'], options = {}, &block); route('PUT', paths, options, &block) end
       def head(paths = ['/'], options = {}, &block); route('HEAD', paths, options, &block) end
       def delete(paths = ['/'], options = {}, &block); route('DELETE', paths, options, &block) end
+      def options(paths = ['/'], options = {}, &block); route('OPTIONS', paths, options, &block) end
 
       def namespace(space = nil, &block)
         if space || block_given?

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -238,13 +238,13 @@ describe Grape::API do
         "lol"
       end
 
-      %w(get post put delete).each do |m|
+      %w(get post put delete options).each do |m|
         send(m, '/abc')
         last_response.body.should eql 'lol'
       end
     end
 
-    verbs = %w(post get head delete put)
+    verbs = %w(post get head delete put options)
     verbs.each do |verb|
       it "should allow and properly constrain a #{verb.upcase} method" do
         subject.send(verb, '/example') do


### PR DESCRIPTION
Required for cross-domain calls in Firefox. We should also add PATCH as it's a standard now - already added to Sinatra.
