### PR TITLE
Fix Grape::Middleware::Formatter#headers

### DIFF
--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -15,7 +15,7 @@ module Grape
       end
       
       def headers
-        env.dup.inject({}){|h,(k,v)| h[k.downcase] = v; h}
+        env.dup.inject({}){|h,(k,v)| h[k.downcase[5..-1]] = v if k.downcase.start_with?('http_'); h}
       end
       
       def before


### PR DESCRIPTION
The current `#headers` implementation is wrong, rack sets headers as `http_*` so the check in `#mime_array` will always fail, because it should look for `'http_accept'` instead.

Dunno if older versions of rack set http headers without the `http_` prefix though.
