### PR TITLE
Accept header strict

### DIFF
--- a/lib/grape/middleware/versioner/header.rb
+++ b/lib/grape/middleware/versioner/header.rb
@@ -18,7 +18,7 @@ module Grape
       #    env['api.version]  => 'v1'
       #    env['api.format]   => 'format'
       #
-      # If version does not match this route, then a 404 is throw with
+      # If version does not match this route, then a 406 is throw with
       # X-Cascade header to alert Rack::Mount to attempt the next matched
       # route.
       class Header < Base
@@ -26,8 +26,8 @@ module Grape
           accept = env['HTTP_ACCEPT'] || ""
 
           if options[:version_options] && options[:version_options].keys.include?(:strict) && options[:version_options][:strict]
-            if (incorrect_header?(accept))  && options[:version_options][:using] == :header
-              throw :error, :status => 404, :headers => {'X-Cascade' => 'pass'}, :message => "404 API Version Not Found"
+            if (is_accept_header_valid?(accept))  && options[:version_options][:using] == :header
+              throw :error, :status => 406, :headers => {'X-Cascade' => 'pass'}, :message => "406 API Version Not Found"
             end
           end
           accept.strip.scan(/^(.+?)\/(.+?)$/) do |type, subtype|
@@ -39,7 +39,7 @@ module Grape
               is_vendored_match = is_vendored ? options[:version_options][:vendor] == vendor : true
 
               if (options[:versions] && !options[:versions].include?(version)) || !is_vendored_match
-                throw :error, :status => 404, :headers => {'X-Cascade' => 'pass'}, :message => "404 API Version Not Found"
+                throw :error, :status => 406, :headers => {'X-Cascade' => 'pass'}, :message => "406 API Version Not Found"
               end
 
               env['api.version'] = version
@@ -50,7 +50,7 @@ module Grape
         end
 
         protected
-        def incorrect_header?(header)
+        def is_accept_header_valid?(header)
           (header.strip =~ /application\/vnd\.(.+?)-(.+?)\+(.+?)/).nil?
         end
       end

--- a/spec/grape/middleware/versioner/header_spec.rb
+++ b/spec/grape/middleware/versioner/header_spec.rb
@@ -70,7 +70,7 @@ describe Grape::Middleware::Versioner::Header do
     end
 
     context 'when strict header versioning is used' do
-      it 'should return a 404 when no header' do
+      it 'should return a 406 when no header' do
         @options = {
           :versions => ['v1'],
           :version_options => {:using => :header, :strict => true}
@@ -79,13 +79,13 @@ describe Grape::Middleware::Versioner::Header do
           env = subject.call('HTTP_ACCEPT' => '').last
         }.to throw_symbol(
           :error,
-          :status => 404,
+          :status => 406,
           :headers => {'X-Cascade' => 'pass'},
-          :message => "404 API Version Not Found"
+          :message => "406 API Version Not Found"
         )
       end
 
-      it 'should return a 404 when incorrect header format is used' do
+      it 'should return a 406 when incorrect header format is used' do
         @options = {
           :versions => ['v1'],
           :version_options => {:using => :header, :strict => true}
@@ -94,9 +94,9 @@ describe Grape::Middleware::Versioner::Header do
           env = subject.call('HTTP_ACCEPT' => '*/*').last
         }.to throw_symbol(
           :error,
-          :status => 404,
+          :status => 406,
           :headers => {'X-Cascade' => 'pass'},
-          :message => "404 API Version Not Found"
+          :message => "406 API Version Not Found"
         )
       end
 
@@ -127,7 +127,7 @@ describe Grape::Middleware::Versioner::Header do
     it 'should not match with an incorrect vendor' do
       expect {
         env = subject.call('HTTP_ACCEPT' => 'application/vnd.othervendor-v1+json').last
-      }.to throw_symbol(:error, :status => 404, :headers => {'X-Cascade' => 'pass'}, :message => "404 API Version Not Found")
+      }.to throw_symbol(:error, :status => 406, :headers => {'X-Cascade' => 'pass'}, :message => "406 API Version Not Found")
     end
   end
 
@@ -139,10 +139,10 @@ describe Grape::Middleware::Versioner::Header do
       }
     end
 
-    it 'should throw 404 error with X-Cascade header set to pass' do
+    it 'should throw 406 error with X-Cascade header set to pass' do
       expect {
         env = subject.call('HTTP_ACCEPT' => accept).last
-      }.to throw_symbol(:error, :status => 404, :headers => {'X-Cascade' => 'pass'}, :message => "404 API Version Not Found")
+      }.to throw_symbol(:error, :status => 406, :headers => {'X-Cascade' => 'pass'}, :message => "406 API Version Not Found")
     end
   end
 end


### PR DESCRIPTION
Hey,

I was a bit confused about header versioning (for example #133) and I thought maybe it should be more strict.
When no Accept is passed like

```
curl http://localhost:9292/hello
```

I had default value `*/*` of accept header, so condition:

```
(accept.nil? || accept.empty?)
```

was never true.

BTW.
Test case covered only this scenario:

```
curl -H "Accept: " http://localhost:9292/hello
```

I've added few more tests.
