### PR TITLE
Change time creation to adhere to ruby 1.8.

### DIFF
--- a/spec/grape/entity_spec.rb
+++ b/spec/grape/entity_spec.rb
@@ -99,7 +99,7 @@ describe Grape::Entity do
 
           subject.expose :birthday, :format_with => :timestamp
 
-          model  = { :birthday => Time.new(2012, 2, 27) }
+          model  = { :birthday => Time.gm(2012, 2, 27) }
           subject.new(mock(model)).as_json[:birthday].should == '02/27/2012'
         end
       end
@@ -239,11 +239,11 @@ describe Grape::Entity do
     let(:attributes){ {
       :name => 'Bob Bobson', 
       :email => 'bob@example.com',
-      :birthday => Time.new(2012, 2, 27),
+      :birthday => Time.gm(2012, 2, 27),
       :fantasies => ['Unicorns', 'Double Rainbows', 'Nessy'],
       :friends => [
-        mock(:name => "Friend 1", :email => 'friend1@example.com', :fantasies => [], :birthday => Time.new(2012, 2, 27), :friends => []), 
-        mock(:name => "Friend 2", :email => 'friend2@example.com', :fantasies => [], :birthday => Time.new(2012, 2, 27), :friends => [])
+        mock(:name => "Friend 1", :email => 'friend1@example.com', :fantasies => [], :birthday => Time.gm(2012, 2, 27), :friends => []), 
+        mock(:name => "Friend 2", :email => 'friend2@example.com', :fantasies => [], :birthday => Time.gm(2012, 2, 27), :friends => [])
       ]
     } }
     subject{ fresh_class.new(model) }


### PR DESCRIPTION
Changes the spec file to use Ruby's 1.8 way of creating a specific time.
