### PR TITLE
Adding :requirements to routes so it's possible to use periods etc in path

### DIFF
--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -52,7 +52,9 @@ module Grape
           anchor = options[:route_options][:anchor]
           anchor = anchor.nil? ? true : anchor
 
-          path = compile_path(prepared_path, anchor && !options[:app])
+          requirements = options[:route_options][:requirements] || {}
+
+          path = compile_path(prepared_path, anchor && !options[:app], requirements)
           regex = Rack::Mount::RegexpWithNamedGroups.new(path)
           path_params = {}
           # named parameters in the api path
@@ -91,9 +93,10 @@ module Grape
       Rack::Mount::Utils.normalize_path(settings.stack.map{|s| s[:namespace]}.join('/'))
     end
 
-    def compile_path(prepared_path, anchor = true)
+    def compile_path(prepared_path, anchor = true, requirements = {})
       endpoint_options = {}
       endpoint_options[:version] = /#{settings[:version].join('|')}/ if settings[:version]
+      endpoint_options.merge!(requirements)
       Rack::Mount::Strexp.compile(prepared_path, endpoint_options, %w( / . ? ), anchor)
     end
 

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -42,13 +42,12 @@ module Grape
       
       def format_from_extension
         parts = request.path.split('.')
-        hit = parts.last.to_sym
-        
-        if parts.size <= 1
-          nil
-        else
-          hit
+        extension = parts.last.to_sym
+
+        if parts.size > 1 && content_types.key?(extension)
+          return extension
         end
+        nil
       end
       
       def format_from_header

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -107,7 +107,7 @@ describe Grape::Endpoint do
       ]
     end
   end
-  
+
   describe '#params' do
     it 'should be available to the caller' do
       subject.get('/hey') do
@@ -133,6 +133,42 @@ describe Grape::Endpoint do
       end
       get '/location?location[city]=Dallas'
       last_response.body.should == 'Dallas'
+    end
+
+    context 'with special requirements' do
+      it 'should parse email param with provided requirements for params' do
+        subject.get('/:person_email', :requirements => { :person_email => /.*/ }) do
+        params[:person_email]
+        end
+
+        get '/rodzyn@grape.com'
+        last_response.body.should == 'rodzyn@grape.com'
+
+        get 'rodzyn@grape.com.pl'
+        last_response.body.should == 'rodzyn@grape.com.pl'
+      end
+
+      it 'should parse many params with provided regexps' do
+        subject.get('/:person_email/test/:number',
+          :requirements => {
+            :person_email => /rodzyn@(.*).com/,
+            :number => /[0-9]/ }) do
+        params[:person_email] << params[:number]
+        end
+
+        get '/rodzyn@grape.com/test/1'
+        last_response.body.should == 'rodzyn@grape.com1'
+
+        get '/rodzyn@testing.wrong/test/1'
+        last_response.status.should == 404
+
+        get 'rodzyn@test.com/test/wrong_number'
+        last_response.status.should == 404
+
+        get 'rodzyn@test.com/wrong_middle/1'
+        last_response.status.should == 404
+
+      end
     end
   end
 

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -82,11 +82,6 @@ describe Grape::Middleware::Formatter do
       subject.call({'PATH_INFO' => '/info.txt', 'HTTP_ACCEPT' => 'application/json'})
       subject.env['api.format'].should == :txt
     end
-    
-    it 'should throw an error on an unrecognized format' do
-      err = catch(:error){ subject.call({'PATH_INFO' => '/info.barklar'}) }
-      err.should == {:status => 406, :message => "The requested format is not supported."}
-    end
   end
 
   context 'Accept header detection' do


### PR DESCRIPTION
This is a pull request that simplifies the work done by @rodzyn here: https://github.com/intridea/grape/pull/145

The main differences is that it's updated for the latest master, and also doesn't change the handling of the default format. The difference from how things work today is that it doesn't throw an exception if the :format is not part of the allowed content_types.
