### PR TITLE
Enable OAuth2

### DIFF
--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -266,6 +266,7 @@ module Grape
         :rescue_options => settings[:rescue_options],
         :rescue_handlers => settings[:rescue_handlers] || {}
 
+      b.use Grape::Middleware::Auth::OAuth2, settings[:auth] if settings[:auth] and settings[:auth][:type] == :oauth2
       b.use Rack::Auth::Basic, settings[:auth][:realm], &settings[:auth][:proc] if settings[:auth] && settings[:auth][:type] == :http_basic
       b.use Rack::Auth::Digest::MD5, settings[:auth][:realm], settings[:auth][:opaque], &settings[:auth][:proc] if settings[:auth] && settings[:auth][:type] == :http_digest
       b.use Grape::Middleware::Prefixer, :prefix => settings[:root_prefix] if settings[:root_prefix]


### PR DESCRIPTION
I know this commit has a terrible name, I edited it directly in GitHub and I'm not sure how to do "amend"s here. Nevertheless, since we have enabled OAuth2 on our site we decided to suggest that you enable it upstream - it's working well for us. 

Thanks,
Dan
