### PR TITLE
Goliath sends symbols in the header hash

### DIFF
--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -15,7 +15,7 @@ module Grape
       end
 
       def headers
-        env.dup.inject({}){|h,(k,v)| h[k.downcase[5..-1]] = v if k.downcase.to_s.start_with?('http_'); h}
+        env.dup.inject({}){|h,(k,v)| h[k.to_s.downcase[5..-1]] = v if k.downcase.to_s.start_with?('http_'); h}
       end
 
       def before

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -116,6 +116,11 @@ describe Grape::Middleware::Formatter do
       subject.call({'PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/vnd.test-v1+xml'})
       subject.env['api.format'].should == :xml
     end
+
+    it 'should properly parse headers with symbols as hash keys' do
+      subject.call({'PATH_INFO' => '/info', 'http_accept' => 'application/xml', :system_time => '091293'})
+      subject.env[:system_time].should == '091293'
+    end
   end
 
   context 'Content-type' do


### PR DESCRIPTION
Fix  error: undefined method `start_with?' for :start_time:Symbol when using grape with goliath
