### PR TITLE
HEAD requests can return a body

### DIFF
--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -296,6 +296,7 @@ module Grape
     def build_middleware
       b = Rack::Builder.new
 
+      b.use Rack::Head
       b.use Grape::Middleware::Error,
         :default_status => settings[:default_error_status] || 403,
         :rescue_all => settings[:rescue_all],

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -284,7 +284,7 @@ describe Grape::API do
           verb
         end
         send(verb, '/example')
-        last_response.body.should eql verb
+        last_response.body.should eql verb == 'head' ? '' : verb
         # Call it with a method other than the properly constrained one.
         send(verbs[(verbs.index(verb) + 1) % verbs.size], '/example')
         last_response.status.should eql 404

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -410,7 +410,7 @@ describe Grape::Endpoint do
         end
         send(verb, '/example/and/some/more')
         last_response.status.should eql (verb == "post" ? 201 : 200)
-        last_response.body.should eql verb
+        last_response.body.should eql verb == 'head' ? '' : verb
       end
     end
   end


### PR DESCRIPTION
Right now, Grape doesn't adhere to HTTP/1.1:

> The HEAD method is identical to GET except that the server MUST NOT return a message-body in the response.

—http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.4

(A simple `curl -X HEAD` will show the body for a HEAD endpoint.)
