### PR TITLE
Updating "Describing and Inspecting an API" to reflect actual behavior

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -679,7 +679,7 @@ class MyAPI < Grape::API
   helpers do
     def validate_request!
       # skip validation if no parameter is declared
-      if route.route_params.nil?; return end
+      return unless route.route_params
       route.route_params.each do |k, v|
         if !params.has_key? k
           error!("Missing field: #{k}", 400)


### PR DESCRIPTION
In the current example, parameters are listed with an array instead of hash:

``` ruby
get "split/:string", { :params => [ "token" ], :optional_params => [ "limit" ] } do
```

However, it throws the following error: TypeError: can't convert Array into Hash

I have updated the example to use hashes and added a sample helper that performs parameter checking based on the provided information.
