### PR TITLE
Add a check to Entity#serializable_hash to verify an entity exists on a model

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+0.2.2
+=================
+* [#203](https://github.com/intridea/grape/pull/203): Added a check to Entity#serializable_hash that verifies an entity exists on an object - [@adamgotterer](https://github.com/adamgotterer).
+
 0.2.1 (7/11/2012)
 =================
 

--- a/lib/grape/entity.rb
+++ b/lib/grape/entity.rb
@@ -259,7 +259,10 @@ module Grape
       return nil if object.nil?
       opts = options.merge(runtime_options || {})
       exposures.inject({}) do |output, (attribute, exposure_options)|
-        output[key_for(attribute)] = value_for(attribute, opts) if conditions_met?(exposure_options, opts)
+        if object.respond_to?(attribute) && conditions_met?(exposure_options, opts)
+          output[key_for(attribute)] = value_for(attribute, opts) 
+        end
+
         output
       end
     end

--- a/spec/grape/entity_spec.rb
+++ b/spec/grape/entity_spec.rb
@@ -257,6 +257,31 @@ describe Grape::Entity do
         fresh_class.expose :name
         expect{ fresh_class.new(nil).serializable_hash }.not_to raise_error
       end
+
+      it 'should not throw an exception when an attribute is not found on the object' do
+        fresh_class.expose :name, :non_existant_attribute
+        expect{ fresh_class.new(model).serializable_hash }.not_to raise_error
+      end
+
+      it "should not expose attributes that don't exist on the object" do
+        fresh_class.expose :email, :non_existant_attribute, :name
+
+        res = fresh_class.new(model).serializable_hash
+        res.should have_key :email
+        res.should_not have_key :non_existant_attribute
+        res.should have_key :name
+      end
+
+      it "should not expose attributes that don't exist on the object, even with criteria" do
+        fresh_class.expose :email
+        fresh_class.expose :non_existant_attribute, :if => lambda { false }
+        fresh_class.expose :non_existant_attribute2, :if => lambda { true }
+
+        res = fresh_class.new(model).serializable_hash
+        res.should have_key :email
+        res.should_not have_key :non_existant_attribute
+        res.should_not have_key :non_existant_attribute2
+      end
     end
 
     describe '#value_for' do


### PR DESCRIPTION
Ran into an issue where I was exposing keys on a Mongo object that has a dynamic schema. When processing the entity it would try and access a field that didn't exist and threw and exception. This will verify that the entity can be accessed before trying.
