### PR TITLE
Initial idea to add permission based whitelisting to params

### DIFF
--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -123,6 +123,12 @@ module Grape
         deep_merge(self.body_params)
     end
 
+    def request_params
+      @request_params ||= Hashie::Mash.new.
+        deep_merge(request.params).
+        deep_merge(self.body_params)
+    end
+
     # Pull out request body params if the content type matches and we're on a POST or PUT
     def body_params
       if ['POST', 'PUT'].include?(request.request_method.to_s.upcase) && request.content_length.to_i > 0
@@ -292,7 +298,13 @@ module Grape
       cookies.read(@request)
             
       Array(settings[:validations]).each do |validator|
-        validator.validate!(params)
+        #the permissions validation needs to only take the params for the object
+        #excluding anything to do with the rack env or routing
+        if validator.respond_to?(:permissions)
+          validator.validate!(request_params)
+        else
+          validator.validate!(params)
+        end
       end
       
       run_filters befores

--- a/lib/grape/validations.rb
+++ b/lib/grape/validations.rb
@@ -80,6 +80,15 @@ module Grape
         
         validates(attrs, validations)
       end
+
+      def permits(*attrs)
+        validations = {:permission => true}
+        if attrs.last.is_a?(Hash)
+          validations.merge!(attrs.pop)
+        end
+        
+        validates(attrs, validations)
+      end
       
       def optional(*attrs)
         validations = {}
@@ -112,6 +121,11 @@ module Grape
         # Validate for presence before any other validators
         if validations.has_key?(:presence) && validations[:presence]
           validate('presence', validations[:presence], attrs, doc_attrs)
+        end
+
+        # Next validate for mission before any other validators
+        if validations.has_key?(:permission) && validations[:permission]
+          validate('permission', validations[:permission], attrs, doc_attrs)
         end
 
         # Before we run the rest of the validators, lets handle

--- a/lib/grape/validations/permission.rb
+++ b/lib/grape/validations/permission.rb
@@ -1,0 +1,50 @@
+require 'pry'
+
+module Grape
+  module Validations
+
+    class PermissionValidator < Validator
+
+      def permissions
+        true
+      end
+
+      def validate!(request_params)
+        forbidden = false
+        forbidden_keys = []
+
+        request_params.keys.each do |param|
+          unless @attrs.include? param.to_sym
+            forbidden = true
+            forbidden_keys << param
+          end
+        end
+
+        if forbidden
+          throw :error, :status => 400, :message => "forbidden parameter: #{forbidden_keys.join(',')}"
+          # throw :error, :status => 400, :message => "#{@attrs} |||| #{forbidden_keys.join(',')}"
+        end
+      end
+        # @attrs.each do |attr_name|
+        #   if @required || params.has_key?(attr_name)
+        #     validate_param!(attr_name, params)
+        #   end
+        # end
+
+
+
+      # def validate_param!(attr_name, params)
+      #   @params = params
+      #   params.keys.each do |key|
+      #     puts "Key=" + key.to_s
+      #   end
+
+      #   unless params.has_key?(attr_name)
+      #     throw :error, :status => 400, :message => "forbidden parameter: #{attr_name}"
+      #   end
+
+      # end
+    end
+
+  end
+end

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -48,6 +48,25 @@ describe Grape::Validations do
       end
     end
 
+    context 'permitted' do
+      before do
+        subject.params { permits :key }
+        subject.get '/permitted' do 'permitted works'; end
+      end
+
+      it "allows specified key" do
+        get '/permitted', { :key => 'cool' }
+        # last_response.status.should == 200
+        last_response.body.should == 'permitted works'
+      end
+
+      it "disallows any other key" do
+        get '/permitted', { :foo => 'cool' }
+        last_response.status.should == 400
+        last_response.body.should == 'forbidden parameter: foo'
+      end
+    end
+
     context 'custom validation' do
       module CustomValidations  
         class Customvalidator < Grape::Validations::Validator


### PR DESCRIPTION
This pull isn't really intended to be merged as-is, but more as a convenient way to start a dialogue around the concept.  It does work and included tests.

This is conceptually similar to the new StrongParameters built for Rails, in this case for each endpoint you can add a list of parameters to the Endpoint via permit(:foo, :bar, :baz) that will deny anyone calling that endpoint with params not on the whitelist.

This initial example only handles the most simple path.  The deep merging of params causes a problem, it would likely be necessary for a full solution to automatically filter permit params coming from rack.  Currently I used a simple hack of passing an alternative params hash to this particular validator.

I personally agree with the emerging trend that parameter whitelisting is a concern for the controller/api layer, and you should have the flexibility to permit based on the particular action that is occuring, rather than just declaring accessible in the models.  In complex applications that isn't always sufficient, especially if different endpoints in the API serve different levels of authorisation.

What do other people think? 
