### PR TITLE
Added custom exceptions to Grape. Updated validation errors to use ValidationError.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,7 @@
 Next Release
 ============
 
+* [#201](https://github.com/intridea/grape/pull/201): Added custom exceptions to Grape. Updated validations to use ValidationError that can be rescued. - [@adamgotterer](https://github.com/adamgotterer).
 * [#211](https://github.com/intridea/grape/pull/211): Updates to validation and coercion: Fix #211 and force order of operations for presence and coercion - [@adamgotterer](https://github.com/adamgotterer).
 * [#210](https://github.com/intridea/grape/pull/210): Fix: `Endpoint#body_params` causing undefined method 'size' - [@adamgotterer](https://github.com/adamgotterer).
 * [#201](https://github.com/intridea/grape/pull/201): Rewritten `params` DSL, including support for coercion and validations - [@schmurfy](https://github.com/schmurfy).

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -11,6 +11,11 @@ module Grape
   autoload :Cookies,         'grape/cookies'
   autoload :Validations,     'grape/validations'
 
+  module Exceptions
+    autoload :Base, 'grape/exceptions/base'
+  end
+  autoload :ValidationError, 'grape/exceptions/validation_error'
+
   module Middleware
     autoload :Base,      'grape/middleware/base'
     autoload :Prefixer,  'grape/middleware/prefixer'

--- a/lib/grape/exceptions/base.rb
+++ b/lib/grape/exceptions/base.rb
@@ -1,0 +1,17 @@
+module Grape
+  module Exceptions
+    class Base < StandardError
+      attr_reader :status, :message, :headers
+
+      def initialize(args = {})
+        @status = args[:status] || nil
+        @message = args[:message] || nil
+        @headers = args[:headers] || nil
+      end
+
+      def [](index)
+        self.send(index)
+      end 
+    end
+  end
+end

--- a/lib/grape/exceptions/validation_error.rb
+++ b/lib/grape/exceptions/validation_error.rb
@@ -1,0 +1,4 @@
+require 'grape/exceptions/base'
+
+class ValidationError < Grape::Exceptions::Base
+end

--- a/lib/grape/validations/coerce.rb
+++ b/lib/grape/validations/coerce.rb
@@ -12,7 +12,7 @@ module Grape
         if valid_type?(new_value)
           params[attr_name] = new_value
         else
-          throw :error, :status => 400, :message => "invalid parameter: #{attr_name}"
+          raise ValidationError, :status => 400, :message => "invalid parameter: #{attr_name}"
         end
       end
   

--- a/lib/grape/validations/presence.rb
+++ b/lib/grape/validations/presence.rb
@@ -1,13 +1,11 @@
 module Grape
   module Validations
-    
     class PresenceValidator < Validator
       def validate_param!(attr_name, params)
         unless params.has_key?(attr_name)
-          throw :error, :status => 400, :message => "missing parameter: #{attr_name}"
+          raise ValidationError, :status => 400, :message => "missing parameter: #{attr_name}"
         end
       end
     end
-    
   end
 end

--- a/lib/grape/validations/regexp.rb
+++ b/lib/grape/validations/regexp.rb
@@ -4,7 +4,7 @@ module Grape
     class RegexpValidator < SingleOptionValidator
       def validate_param!(attr_name, params)
         if params[attr_name] && !( params[attr_name].to_s =~ @option )
-          throw :error, :status => 400, :message => "invalid parameter: #{attr_name}"
+          raise ValidationError, :status => 400, :message => "invalid parameter: #{attr_name}"
         end
       end
     end

--- a/spec/grape/middleware/exception_spec.rb
+++ b/spec/grape/middleware/exception_spec.rb
@@ -34,6 +34,16 @@ describe Grape::Middleware::Error do
       end
     end
   end
+
+  # raises a custom error
+  class CustomError < Grape::Exceptions::Base; end
+  class CustomErrorApp
+    class << self
+      def call(env)
+        raise CustomError, :status => 400, :message => 'failed validation'
+      end
+    end
+  end
   
   def app
     @app
@@ -116,6 +126,17 @@ describe Grape::Middleware::Error do
       get '/'
       last_response.status.should == 401    
     end 
+
+    it 'should respond to custom Grape exceptions appropriately' do
+      @app ||= Rack::Builder.app do
+        use Grape::Middleware::Error, :rescue_all => false
+        run CustomErrorApp
+      end
+
+      get '/'
+      last_response.status.should == 400
+      last_response.body.should == 'failed validation'
+    end
     
   end 
 end


### PR DESCRIPTION
Custom exceptions should extend Grape:: Exceptions::Base. The current error/exception handler will treat the base class the same way that it treats :error. Anything extending Base can be rescued and acts like a more traditional exception. Converted Validation errors to use ValidationError, which is now an exception available anywhere in Grape.

Would love to hear thoughts and suggestions if there is room for improvement.

Original comment thread and concept from #201.
