### PR TITLE
added nested attributes validation support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -253,9 +253,10 @@ end
 ### Custom Validators
 ```ruby
 class doit < Grape::Validations::Validator
-  def validate_param!(attr_name, params)
-    unless params[attr_name] == 'im custom'
-      throw :error, :status => 400, :message => "#{attr_name}: is not custom!"
+  def validate_param!(path, params)
+    value = params.read(path)
+    unless value == 'im custom'
+      throw :error, :status => 400, :message => "#{value}: is not custom!"
     end    
   end
 end  
@@ -270,9 +271,10 @@ end
 You can also create custom classes that take additional parameters
 ```ruby
 class Length < Grape::Validations::SingleOptionValidator
-  def validate_param!(attr_name, params)
-    unless params[attr_name].length == @option
-      throw :error, :status => 400, :message => "#{attr_name}: must be #{@option} characters long"
+  def validate_param!(path, params)
+    value = params.read(path)
+    unless value.length == @option
+      throw :error, :status => 400, :message => "#{value}: must be #{@option} characters long"
     end    
   end
 end  

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -10,6 +10,7 @@ module Grape
   autoload :Entity,          'grape/entity'
   autoload :Cookies,         'grape/cookies'
   autoload :Validations,     'grape/validations'
+  autoload :ParamsWrapper,   'grape/params_wrapper'
 
   module Middleware
     autoload :Base,      'grape/middleware/base'

--- a/lib/grape/params_wrapper.rb
+++ b/lib/grape/params_wrapper.rb
@@ -1,0 +1,90 @@
+module Grape
+  
+  class ParamsWrapper
+    attr_reader :params
+    
+    def initialize(params)
+      @params = params
+    end
+    
+    # define methods as needed
+    def method_missing(name, *args)
+      if @params.respond_to?(name)
+        self.class.class_eval %{
+          def #{name}(*params)
+            @params.send(:#{name}, *params)
+          end
+        }
+        
+        send(name, *args)
+      end
+    end
+    
+    def has_key?(path)
+      parts = split_path(path)
+      _recursive_hash_key?(parts)
+    end
+    
+    def read(path, curr = @params)
+      parts = split_path(path)
+      _recursive_read(parts)
+    end
+    
+    def write(path, value)
+      parts = split_path(path)
+      _recursive_write(parts, value)
+    end
+  
+  private
+    def split_path(path)
+      path.to_s.split('.')
+    end
+    
+    def _recursive_hash_key?(path_parts, curr = @params)
+      if curr.is_a?(Hash)
+        if path_parts.size > 1
+          key, *rest = path_parts
+          _recursive_hash_key?(rest, curr[key])
+          
+        else
+          curr.has_key?(path_parts[0])
+        end
+        
+      else
+        false
+      end
+    end
+    
+    def _recursive_read(path_parts, curr = @params)
+      if curr.is_a?(Hash)
+        if path_parts.size > 1
+          key, *rest = path_parts
+          _recursive_read(rest, curr[key])
+          
+        elsif curr.has_key?(path_parts[0])
+          curr[path_parts[0]]
+        end
+        
+      else
+        nil
+      end
+    end
+    
+    def _recursive_write(path_parts, value, curr = @params)
+      if curr.is_a?(Hash)
+        if path_parts.size > 1
+          key, *rest = path_parts
+          _recursive_write(rest, value, curr[key])
+          
+        else
+          curr[path_parts[0]] = value
+        end
+      end
+      
+      # always return nil
+      nil
+    end
+    
+  end
+    
+end

--- a/lib/grape/validations.rb
+++ b/lib/grape/validations.rb
@@ -18,6 +18,7 @@ module Grape
       end
 
       def validate!(params)
+        params = ParamsWrapper.new(params)
         @attrs.each do |attr_name|
           if @required || params.has_key?(attr_name)
             validate_param!(attr_name, params)

--- a/lib/grape/validations/coerce.rb
+++ b/lib/grape/validations/coerce.rb
@@ -7,12 +7,13 @@ module Grape
   module Validations
     
     class CoerceValidator < SingleOptionValidator
-      def validate_param!(attr_name, params)
-        new_value = coerce_value(@option, params[attr_name])
+      def validate_param!(path, params)
+        value = params.read(path)
+        new_value = coerce_value(@option, value)
         if valid_type?(new_value)
-          params[attr_name] = new_value
+          params.write(path, new_value)
         else
-          throw :error, :status => 400, :message => "invalid parameter: #{attr_name}"
+          throw :error, :status => 400, :message => "invalid parameter: #{path}"
         end
       end
   

--- a/lib/grape/validations/presence.rb
+++ b/lib/grape/validations/presence.rb
@@ -2,9 +2,9 @@ module Grape
   module Validations
     
     class PresenceValidator < Validator
-      def validate_param!(attr_name, params)
-        unless params.has_key?(attr_name)
-          throw :error, :status => 400, :message => "missing parameter: #{attr_name}"
+      def validate_param!(path, params)
+        unless params.has_key?(path)
+          throw :error, :status => 400, :message => "missing parameter: #{path}"
         end
       end
     end

--- a/lib/grape/validations/regexp.rb
+++ b/lib/grape/validations/regexp.rb
@@ -2,9 +2,10 @@ module Grape
   module Validations
     
     class RegexpValidator < SingleOptionValidator
-      def validate_param!(attr_name, params)
-        if params[attr_name] && !( params[attr_name].to_s =~ @option )
-          throw :error, :status => 400, :message => "invalid parameter: #{attr_name}"
+      def validate_param!(path, params)
+        val = params.read(path)
+        if val && !(val.to_s =~ @option )
+          throw :error, :status => 400, :message => "invalid parameter: #{path}"
         end
       end
     end

--- a/spec/grape/params_wrapper_spec.rb
+++ b/spec/grape/params_wrapper_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'hashie'
+
+describe Grape::ParamsWrapper do
+  before do
+    p = Hashie::Mash.new(user: {id: 34, name: "Cherio"})
+    @params = Grape::ParamsWrapper.new(p)
+  end
+  
+  it "can read existing path" do
+    val = @params.read('user.id')
+    val.should == 34
+  end
+  
+  it 'should return nil for unexsiting path' do
+    @params.read('master.id').should == nil
+    @params.read('user.another_id').should == nil
+  end
+  
+  it 'can write value by existing path' do
+    @params.write('user.id', 'something')
+    @params.read('user.id').should == 'something'
+  end
+  
+  it 'can tell if a path is defined' do
+    @params.has_key?('user.id').should == true
+    @params.has_key?('user.uid').should == false
+    @params.has_key?('master.id').should == false
+  end
+  
+  it 'should act as a hash' do
+    @params['user']['id'].should == 34
+  end
+  
+  # TODO: maybe later, could be useful
+  # it 'can write value by unexisting path' do
+  #   @params.write('master.id', '67klop')
+  #   @params.read('master.id').should == '67klop'
+  # end
+  
+end

--- a/spec/grape/validations/coerce_spec.rb
+++ b/spec/grape/validations/coerce_spec.rb
@@ -39,6 +39,23 @@ describe Grape::Validations::CoerceValidator do
           attribute :name, String
         end
       end
+      
+      it 'can validates nested attributs' do
+        subject.params do
+          requires 'user.id', :type => Integer
+          requires 'user.name', :type => String
+        end
+        
+        subject.get('/nested') { "works" }
+        
+        get '/nested', :user => {:id => "bob", :name => "Arnold"}
+        last_response.status.should == 400
+        last_response.body.should == 'invalid parameter: user.id'
+
+        get '/nested', :user => {:id => 34, :name => "Arnold"}
+        last_response.status.should == 200
+        last_response.body.should == 'works'
+      end
 
       it 'error on malformed input for complex objects' do
         subject.params { requires :user, :type => CoerceValidatorSpec::User }

--- a/spec/grape/validations/presence_spec.rb
+++ b/spec/grape/validations/presence_spec.rb
@@ -28,6 +28,21 @@ describe Grape::Validations::PresenceValidator do
     ValidationsSpec::PresenceValidatorSpec::API
   end
   
+  it 'should validates nested values' do
+    app.params{ requires 'user.id', :type => Integer }
+    app.get('/nested')
+    
+    get('/nested')
+    last_response.status.should == 400
+    last_response.body.should == "missing parameter: user.id"
+
+    
+    get('/nested', {}, 'rack.input' => StringIO.new('{ "user" : {"id" : "a56b"}}'))
+    last_response.status.should == 400
+    last_response.body.should == "invalid parameter: user.id"
+    
+  end
+  
   it 'validates id' do
     post('/')
     last_response.status.should == 400

--- a/spec/grape/validations/regexp_spec.rb
+++ b/spec/grape/validations/regexp_spec.rb
@@ -12,6 +12,12 @@ describe Grape::Validations::RegexpValidator do
         get do
           
         end
+        
+        params do
+          requires 'user.id', :regexp => /^[Aa]+$/
+        end
+        get('/nested'){}
+        
       end
     end
   end
@@ -27,6 +33,19 @@ describe Grape::Validations::RegexpValidator do
   
   it 'should accept valid input' do
     get '/', :name => "bob"
+    last_response.status.should == 200
+  end
+  
+  it 'should works with nested attributes' do
+    get '/nested'
+    last_response.status.should == 400
+    last_response.body.should == "missing parameter: user.id"
+    
+    get '/nested', :user => {:id => "tt"}
+    last_response.status.should == 400
+    last_response.body.should == "invalid parameter: user.id"
+
+    get '/nested', :user => {:id => "aAAAaaa"}
     last_response.status.should == 200
   end
   


### PR DESCRIPTION
I added support for nested attribute validations to allow this:

``` ruby
params do
  requires 'user.id', type: Integer
  requires 'user.name', type: String
end
```

This works alongside what I and @adamgotterer did and allow both the symbol syntax as well as this dotted string syntax.

I think we can generate these validations to validate Virtus value objects but there will be some scope issues (a validation should be able to create other validations which create some issues with the current interface).
