### PR TITLE
Fixed minor scoping error causing tests to fail in 1.9.2 and 1.9.3

### DIFF
--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -46,7 +46,7 @@ module Grape
         rescue Exception => e
           is_rescuable = rescuable?(e.class)
           if e.is_a?(Grape::Exceptions::Base) && !is_rescuable
-            handler = lambda { error_response(e) }
+            handler = lambda {|e| error_response(e) }
           else
             raise unless is_rescuable
             handler = options[:rescue_handlers][e.class] || options[:rescue_handlers][:all]


### PR DESCRIPTION
This should fix the validation exceptions being thrown in #221
