### PR TITLE
Adds automatic detection of Model::Entity representations

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -629,6 +629,32 @@ module API
 end
 ```
 
+### Entity Organization
+
+In addition to separately organizing entities, it may be useful to
+put them as namespaced classes underneath the model they represent.
+For example:
+
+```ruby
+class User
+  def entity
+    Entity.new(self)
+  end
+
+  class Entity < Grape::Entity
+    expose :name, :email
+  end
+end
+```
+
+If you organize your entities this way, Grape will automatically
+detect the `Entity` class and use it to present your models. In
+this example, if you added `present User.new` to your endpoint,
+Grape would automatically detect that there is a `User::Entity`
+class and use that as the representative entity. This can still
+be overridden by using the `:with` option or an explicit
+`represents` call.
+
 ### Caveats
 
 Entities with duplicate exposure names and conditions will silently overwrite one another.

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -255,6 +255,8 @@ module Grape
         entity_class ||= (settings[:representations] || {})[potential]
       end
 
+      entity_class ||= object.class.const_get(:Entity) if object.class.const_defined?(:Entity)
+
       root = options.delete(:root)
 
       representation = if entity_class

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -347,6 +347,20 @@ describe Grape::Endpoint do
       last_response.body.should == 'Hiya'
     end
 
+    it 'should automatically use Klass::Entity if that exists' do
+      some_model = Class.new
+      entity = Class.new(Grape::Entity)
+      entity.stub!(:represent).and_return("Auto-detect!")
+
+      some_model.const_set :Entity, entity
+
+      subject.get '/example' do
+        present some_model.new
+      end
+      get '/example'
+      last_response.body.should == 'Auto-detect!'
+    end
+
     it 'should add a root key to the output if one is given' do
       subject.get '/example' do
         present({:abc => 'def'}, :root => :root)


### PR DESCRIPTION
I've found it useful to add entities as a namespaced inner class for my models. This adds functionality to automatically detect this when using Grape's `present` method. Wanted to get some opinion before I merged it in...do you guys like this pattern?
