### PR TITLE
Also parse params when no description is given

### DIFF
--- a/lib/grape/validations.rb
+++ b/lib/grape/validations.rb
@@ -172,13 +172,12 @@ module Grape
       end
       
       def document_attribute(names, opts)
-        if @last_description
-          @last_description[:params] ||= {}
+        @last_description ||= {}
+        @last_description[:params] ||= {}
 
-          Array(names).each do |name|
-            @last_description[:params][name[:name].to_s] ||= {}
-            @last_description[:params][name[:name].to_s].merge!(opts).merge!({:full_name => name[:full_name]})
-          end
+        Array(names).each do |name|
+          @last_description[:params][name[:name].to_s] ||= {}
+          @last_description[:params][name[:name].to_s].merge!(opts).merge!({:full_name => name[:full_name]})
         end
       end
       

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1073,6 +1073,17 @@ describe Grape::API do
         { :description => "nesting", :params => { "root_param" => { :required => true, :desc => "root param", :full_name=>"root_param" }, "nested_param" => { :required => true, :desc => "nested param", :full_name=>"nested[nested_param]" } } }
       ]
     end
+    it "should parse parameters when no description is given" do
+      subject.params do
+        requires :one_param, :desc => "one param"
+      end
+      subject.get "method" do ; end
+      subject.routes.map { |route|
+        { :description => route.route_description, :params => route.route_params }
+      }.should eq [
+        { :description => nil, :params => { "one_param" => { :required => true, :desc => "one param", :full_name=>"one_param" } } }
+      ]
+    end
     it "should not symbolize params" do
       subject.desc "Reverses a string.", { :params =>
         { "s" => { :desc => "string to reverse", :type => "string" }}


### PR DESCRIPTION
Something that was bothering me for a while now: if no description is given, the params would not be evaluated, so

``` ruby
params do
  requires :one_param, :desc => "one param"
end
get "method" do ; end
```

would do nothing, you would need to do

``` ruby
desc 'some description to make the below work'
params do
  requires :one_param, :desc => "one param"
end
get "method" do ; end
```
