### PR TITLE
accept format query parameter like rails to steer the response format

### DIFF
--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -19,7 +19,7 @@ module Grape
       end
 
       def before
-        fmt = format_from_extension || options[:format] || format_from_header || options[:default_format]
+        fmt = format_from_extension || format_from_params || options[:format] || format_from_header || options[:default_format]
         if content_types.key?(fmt)
           if !env['rack.input'].nil? and (body = env['rack.input'].read).strip.length != 0
             parser = parser_for fmt
@@ -48,6 +48,15 @@ module Grape
           return extension
         end
         nil
+      end
+
+      def format_from_params
+        if env['QUERY_STRING']
+          format_query = env['QUERY_STRING'].split('&').reject{|q| !q.include?('format=')} 
+          return format_query[0].split('=').last.to_sym if (format_query && !format_query.empty?)
+        else
+          nil
+        end 
       end
 
       def format_from_header

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -68,6 +68,13 @@ describe Grape::Middleware::Formatter do
       subject.env['api.format'].should == :json
     end
 
+    it 'should use the format parameter if one is provided' do 
+      subject.call({'PATH_INFO' => '/somewhere','QUERY_STRING' => 'format=json'})
+      subject.env['api.format'].should == :json
+      subject.call({'PATH_INFO' => '/somewhere','QUERY_STRING' => 'format=xml'})
+      subject.env['api.format'].should == :xml
+    end
+
     it 'should use the default format if none is provided' do
       subject.call({'PATH_INFO' => '/info'})
       subject.env['api.format'].should == :txt


### PR DESCRIPTION
This emulates the Rails behavior of identifying the expected response format from format query parameter if available. With this resolution Grape would be able to decipher that the expected response format is json from a URL like this -  http://myblog.com/updates?format=json.   This is from an issue that I reported in Grape google group - https://groups.google.com/forum/?fromgroups=#!topic/ruby-grape/uUFd-OcNwDM where the solution was accepted and suggested to do git pull for the same. 
