### PR TITLE
added after_validation callback

### DIFF
--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -299,6 +299,10 @@ module Grape
       def before(&block)
         imbue(:befores, [block])
       end
+      
+      def after_validation(&block)
+        imbue(:after_validations, [block])
+      end
 
       def after(&block)
         imbue(:afters, [block])

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -299,6 +299,8 @@ module Grape
         validator.validate!(params)
       end
 
+      run_filters after_validations
+
       response_text = instance_eval &self.block
       run_filters afters
       cookies.write(header)
@@ -372,6 +374,7 @@ module Grape
     end
 
     def befores; aggregate_setting(:befores) end
+    def after_validations; aggregate_setting(:after_validations) end
     def afters; aggregate_setting(:afters) end
   end
 end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -313,6 +313,20 @@ describe Grape::API do
       get '/'
       last_response.body.should eql 'first second'
     end
+    
+    it 'should add a after_validation filter' do
+      subject.after_validation { @foo = "first #{params[:id]}:#{params[:id].class}"  }
+      subject.after_validation { @bar = 'second' }
+      subject.params do
+        requires :id, :type => Integer
+      end
+      subject.get '/' do
+        "#{@foo} #{@bar}"
+      end
+
+      get '/', :id => "32"
+      last_response.body.should eql 'first 32:Fixnum second'
+    end
 
     it 'should add a after filter' do
       m = double('after mock')


### PR DESCRIPTION
Now that before filters are run before validation/coercion happens I added a filter which is run before the action but after the validation/coercion.
