### PR TITLE
Pass options when using child representations in Grape::Entity

### DIFF
--- a/lib/grape/entity.rb
+++ b/lib/grape/entity.rb
@@ -342,7 +342,10 @@ module Grape
       if exposure_options[:proc]
         exposure_options[:proc].call(object, options)
       elsif exposure_options[:using]
-        exposure_options[:using].represent(object.send(attribute), :root => nil)
+        using_options = options.dup
+        using_options.delete(:collection)
+        using_options[:root] = nil
+        exposure_options[:using].represent(object.send(attribute), using_options)
       elsif exposure_options[:format_with]
         format_with = exposure_options[:format_with]
 


### PR DESCRIPTION
This is a pull request to resolve issue #247.

The code change is basically as described there - the options passed into value_for is duplicated and slightly massaged to ensure :root is nil and that the :collection key is deleted from the duplicated hash. 

In addition to the code change I added a couple of tests to validate this behavior.
