### PR TITLE
refs: #185 gemspec requires multi_json >= 1.3.2

### DIFF
--- a/grape.gemspec
+++ b/grape.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rack'
   s.add_runtime_dependency 'rack-mount'
   # s.add_runtime_dependency 'rack-jsonp'
-  s.add_runtime_dependency 'multi_json'
+  s.add_runtime_dependency 'multi_json', '>= 1.3.2'
   s.add_runtime_dependency 'multi_xml'
   s.add_runtime_dependency 'hashie', '~> 1.2'
   s.add_runtime_dependency 'virtus'


### PR DESCRIPTION
MultiJson.dump was introduced in version 1.3.2.

An alternative approach would be to use MultiJson.encode if
MultiJson.dump is not available.
