### PR TITLE
changes: nested namespaces enforce their and parent validations; adds HashStack#gather

### DIFF
--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -295,7 +295,8 @@ module Grape
 
       run_filters befores
 
-      Array(settings[:validations]).each do |validator|
+      # Retieve validations from this namespace and all parent namespaces.
+      settings.gather(:validations).each do |validator|
         validator.validate!(params)
       end
 

--- a/lib/grape/util/hash_stack.rb
+++ b/lib/grape/util/hash_stack.rb
@@ -18,7 +18,7 @@ module Grape
       end
 
       # Add a new hash to the top of the stack.
-      # 
+      #
       # @param hash [Hash] optional hash to be pushed. Defaults to empty hash
       # @return [HashStack]
       def push(hash = {})
@@ -31,7 +31,7 @@ module Grape
       end
 
       # Looks through the stack for the first frame that matches :key
-      # 
+      #
       # @param key [Symbol] key to look for in hash frames
       # @return value of given key after merging the stack
       def get(key)
@@ -52,7 +52,7 @@ module Grape
       alias_method :[]=, :set
 
       # Replace multiple values on the top hash of the stack.
-      # 
+      #
       # @param hash [Hash] Hash of values to be merged in.
       def update(hash)
         peek.merge!(hash)
@@ -81,6 +81,15 @@ module Grape
       def concat(hash_stack)
         @stack.concat hash_stack.stack
         self
+      end
+
+      # Looks through the stack for all instances of a given key and returns
+      # them as a flat Array.
+      #
+      # @param key [Symbol] The key to gather
+      # @return [Array]
+      def gather(key)
+        stack.map{|s| s[key] }.flatten.compact.uniq
       end
 
       def to_s


### PR DESCRIPTION
adds test for nested namesapces and params/validators

HashStack#gather provides all values for a given key

When Endpoint#run is called it will gather all :validations, not just
the closest one, and evaluate each one.

resource :machine do
  params do
    requires :serial, :existing_machine_serial => true, :desc => "The machine's serial number, e.g. 965ACD"
  end
  namespace 'serial' do
    # The custom ExistingMachineSerial validator will be called and enforced
    get do
      Machine.find(:serial => params[:serial]).first
    end
    namespace 'power' do
      # The custom ExistingMachineSerial validator will also be called and enforced
      get do
        Machine.find(:serial => params[:serial]).first.power_status
      end
    end
  end
end
