### PR TITLE
Correct default versioning strategy in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -604,6 +604,11 @@ You can also set the default format. The order for choosing the format is the fo
 ``` ruby
 class Twitter::API < Grape::API
   format :json
+end
+```
+
+``` ruby
+class Twitter::API < Grape::API
   default_format :json
 end
 ```


### PR DESCRIPTION
The default is `:path`, not `:header`. See https://github.com/jpmckinney/grape/blob/master/lib/grape/api.rb#L102
