### PR TITLE
The class ValidationError should be inside Grape module. Fixes #264

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,7 @@
 0.2.3 (Next Release)
 ====================
 
+* [#265](https://github.com/intridea/grape/issues/264): Fix: The class ValidationError should be in the module "Grape::Exceptions". Fixes [#264](https://github.com/intridea/grape/issues/264) - [@thepumpkin1979](https://github.com/thepumpkin1979).
 * Your contribution here.
 
 0.2.2

--- a/README.markdown
+++ b/README.markdown
@@ -299,12 +299,12 @@ end
 
 ### Validation Errors
 
-When validation and coercion erros occur an exception of type `ValidationError` is raised.
+When validation and coercion erros occur an exception of type `Grape::Exceptions::ValidationError` is raised.
 If the exception goes uncaught it will respond with a status of 400 and an error message.
-You can rescue a `ValidationError` and respond with a custom response.
+You can rescue a `Grape::Exceptions::ValidationError` and respond with a custom response.
 
 ```ruby
-rescue_from ValidationError do |e|
+rescue_from Grape::Exceptions::ValidationError do |e|
     Rack::Response.new({
         'status' => e.status,
         'message' => e.message,

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -13,8 +13,8 @@ module Grape
 
   module Exceptions
     autoload :Base, 'grape/exceptions/base'
+    autoload :ValidationError, 'grape/exceptions/validation_error'
   end
-  autoload :ValidationError, 'grape/exceptions/validation_error'
 
   module Middleware
     autoload :Base,      'grape/middleware/base'

--- a/lib/grape/exceptions/validation_error.rb
+++ b/lib/grape/exceptions/validation_error.rb
@@ -1,10 +1,14 @@
 require 'grape/exceptions/base'
 
-class ValidationError < Grape::Exceptions::Base
-  attr_accessor :param
+module Grape
+  module Exceptions
+    class ValidationError < Grape::Exceptions::Base
+      attr_accessor :param
 
-  def initialize(args = {})
-    @param = args[:param].to_s if args.has_key? :param
-    super
+      def initialize(args = {})
+        @param = args[:param].to_s if args.has_key? :param
+        super
+      end
+    end
   end
 end

--- a/lib/grape/validations/coerce.rb
+++ b/lib/grape/validations/coerce.rb
@@ -12,7 +12,7 @@ module Grape
         if valid_type?(new_value)
           params[attr_name] = new_value
         else
-          raise ValidationError, :status => 400, :param => attr_name, :message => "invalid parameter: #{attr_name}"
+          raise Grape::Exceptions::ValidationError, :status => 400, :param => attr_name, :message => "invalid parameter: #{attr_name}"
         end
       end
   

--- a/lib/grape/validations/presence.rb
+++ b/lib/grape/validations/presence.rb
@@ -3,7 +3,7 @@ module Grape
     class PresenceValidator < Validator
       def validate_param!(attr_name, params)
         unless params.has_key?(attr_name)
-          raise ValidationError, :status => 400, :param => attr_name, :message => "missing parameter: #{attr_name}"
+          raise Grape::Exceptions::ValidationError, :status => 400, :param => attr_name, :message => "missing parameter: #{attr_name}"
         end
       end
     end

--- a/lib/grape/validations/regexp.rb
+++ b/lib/grape/validations/regexp.rb
@@ -4,7 +4,7 @@ module Grape
     class RegexpValidator < SingleOptionValidator
       def validate_param!(attr_name, params)
         if params[attr_name] && !( params[attr_name].to_s =~ @option )
-          raise ValidationError, :status => 400, :param => attr_name, :message => "invalid parameter: #{attr_name}"
+          raise Grape::Exceptions::ValidationError, :status => 400, :param => attr_name, :message => "invalid parameter: #{attr_name}"
         end
       end
     end


### PR DESCRIPTION
Hi.

Please see https://github.com/intridea/grape/issues/264

These changes put the class `ValidationError` inside the module `Grape` where it should be according to the `autoload` listed in `grape.rb`.

IMHO, I think the class should be inside `Grape::Exceptions` since it's where the file is.
