### PR TITLE
Prefer custom #to_json implementations over #serializable_hash

### DIFF
--- a/lib/grape/middleware/base.rb
+++ b/lib/grape/middleware/base.rb
@@ -111,6 +111,11 @@ module Grape
           MultiJson.load(object)
         end
 
+        def defines_own_to_json?(object)
+          return false unless object.respond_to?(:to_json)
+          object.method(:to_json).owner.name =~ /^JSON::Ext::Generator::GeneratorMethods/ ? false : true
+        end
+
         def serializable?(object)
          object.respond_to?(:serializable_hash) ||
            object.kind_of?(Array) && !object.map {|o| o.respond_to? :serializable_hash }.include?(false) ||
@@ -131,6 +136,7 @@ module Grape
 
         def encode_json(object)
           return object if object.is_a?(String)
+          return object.to_json if defines_own_to_json?(object)
           return MultiJson.dump(serialize(object)) if serializable?(object)
           return object.to_json if object.respond_to?(:to_json)
 

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -24,6 +24,22 @@ describe Grape::Middleware::Formatter do
       subject.call({'PATH_INFO' => '/somewhere', 'HTTP_ACCEPT' => 'application/json'}).last.each{|b| b.should == '"bar"'}
     end
 
+    it 'should call #to_json if custom defined instead of #serializable_hash' do
+      class SimpleJsonExample
+        def serializable_hash
+          {:abc => 'def'}
+        end
+
+        def to_json
+          '{"123":"456"}'
+        end
+      end
+
+      @body = SimpleJsonExample.new
+
+      subject.call({'PATH_INFO' => '/somewhere', 'HTTP_ACCEPT' => 'application/json'}).last.each{|b| b.should == '{"123":"456"}'}
+    end
+
     it 'should serialize the #serializable_hash if that is available' do
       class SimpleExample
         def serializable_hash


### PR DESCRIPTION
As discussed on the mailing list, this is the change for json formatting to prefer #to_json over #serializable_hash when a custom implementation is found. 

I had mentioned on the mailing list that a comparison to Object looked to be all that was needed. It turns out, however, that it's a bit muddier than that. Object was appearing as the method owner due to the object I was using being a Mongoid document.

The solution that worked ended up being a regex comparison for the owner matching `/^JSON::Ext::Generator::GeneratorMethods/` as there are multiple GeneratorMethods(Object, Array, Hash, etc...). It feels dirty, but I can't come up with a better solution at the moment. 

I could possibly change it to just check for the presence of more than one ancestor as well, but I'm not entirely sure how foolproof that is.
