### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -242,12 +242,12 @@ Namespaces allow parameter definitions and apply to every method within the name
 ```ruby
 namespace :shelves do
   params do
-    requires :shelf_id, type => Integer, desc: "A shelf."
+    requires :shelf_id, :type => Integer, desc: "A shelf."
   end
   namespace ":shelf_id" do
     desc "Retrieve a book from a shelf."
     params do
-      requires :book_id, type => Integer, desc: "A book."
+      requires :book_id, :type => Integer, desc: "A book."
     end
     get ":book_id" do
       # params[:shelf_id] defines a shelf


### PR DESCRIPTION
Looks like part of the documentation was using incorrect syntax for type checking (type: <primitive> rather than type => <primitive>).
