### PR TITLE
do not create extenstion symbol if extension does not exist

### DIFF
--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -42,10 +42,10 @@ module Grape
 
       def format_from_extension
         parts = request.path.split('.')
-        extension = parts.last.to_sym
 
-        if parts.size > 1 && content_types.key?(extension)
-          return extension
+        if parts.size > 1
+          extension = parts.last.to_sym
+          return extension if content_types.key?(extension)
         end
         nil
       end


### PR DESCRIPTION
for request like http://localhost/v1/test without .json at the end, it will create symbol :"/v1/test", which leads to memory leak
