### PR TITLE
added cookie deletion params

### DIFF
--- a/lib/grape/cookies.rb
+++ b/lib/grape/cookies.rb
@@ -34,8 +34,9 @@ module Grape
         @cookies.each(&block)
       end
 
-      def delete(name)
-        self.[]=(name, { :value => 'deleted', :expires => Time.at(0) })
+      def delete(name, opts = {})
+        options = opts.merge(value: 'deleted', expires: Time.at(0))
+        self.[]=(name, options)
       end
     end
 end


### PR DESCRIPTION
w/o such modification API servers ain't able to remove cookies set for different paths

e.g.:
  `cookies[:token] = { value: 'here is a token cookie', path: '/', httponly: true }`
won't be deleted by simply
  `cookies.delete :token`
instead you have to pass additional path option to remove proper cookie
  `cookies.delete :token, path: '/'`

tested on Firefox 18 Mac, Ruby 1.9.3
