### PR TITLE
Fix #305: presenting arrays of objects when the entity class isn't explicitly passed into present

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,7 @@
 0.2.5 (Next Release)
 ====================
 
+* [#305](https://github.com/intridea/grape/issues/305): Fix: presenting arrays of objects didn't work when declaring representations via `represent` or when auto-detecting an `Entity` constant in the objects being presented - [@brandonweiss](https://github.com/brandonweiss).
 * Your Contribution Here
 
 0.2.4 (01/06/2013)

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -314,11 +314,12 @@ module Grape
     def present(object, options = {})
       entity_class = options.delete(:with)
 
-      object.class.ancestors.each do |potential|
+      (object.is_a?(Array) ? object.first : object).class.ancestors.each do |potential|
         entity_class ||= (settings[:representations] || {})[potential]
       end
 
       entity_class ||= object.class.const_get(:Entity) if object.class.const_defined?(:Entity)
+      entity_class ||= object.first.class.const_get(:Entity) if object.is_a?(Array) && object.first.class.const_defined?(:Entity)
 
       root = options.delete(:root)
 


### PR DESCRIPTION
I wrote two failing specs and then refactored the code a little to make them pass. I tried to mirror the formatting as much as possible.

I had to manually create a named class in one place in order to properly create a failing test. Using `Object` wouldn't work because of the way `present` walks up the ancestor tree.

I also made an explicit choice to derive to auto-detect the entity from the first object in the collection because it was the simplest solution. It might make sense to expand it to auto-detect the entity of each object in the collection, in case someone returns a collection with different types of objects.
