### PR TITLE
Explain `namespace` aliases in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -290,6 +290,9 @@ namespace :statuses do
 end
 ```
 
+The `namespace` method has a number of aliases, including: `group`, `resource`, 
+`resources`, and `segment`. Use whichever reads the best for your API.
+
 ### Custom Validators
 
 ```ruby


### PR DESCRIPTION
I was confused by the `resource` method used in the very first example in the README, because it was not mentioned anywhere else. Searching the source showed it was just an alias of `namespace`.

It looks like this has confused other people as well:
https://groups.google.com/forum/?fromgroups=#!topic/ruby-grape/H4BU573Lb9E

This PR adds some very brief explanation.
