### PR TITLE
use full attribute name for validation

### DIFF
--- a/lib/grape/validations/coerce.rb
+++ b/lib/grape/validations/coerce.rb
@@ -12,7 +12,8 @@ module Grape
         if valid_type?(new_value)
           params[attr_name] = new_value
         else
-          raise Grape::Exceptions::Validation, :status => 400, :param => attr_name, :message_key => :coerce
+          raise Grape::Exceptions::Validation, :status => 400,
+            :param => @scope.full_name(attr_name), :message_key => :coerce
         end
       end
 

--- a/lib/grape/validations/presence.rb
+++ b/lib/grape/validations/presence.rb
@@ -3,7 +3,8 @@ module Grape
     class PresenceValidator < Validator
       def validate_param!(attr_name, params)
         unless params.has_key?(attr_name)
-          raise Grape::Exceptions::Validation, :status => 400, :param => attr_name, :message_key => :presence
+          raise Grape::Exceptions::Validation, :status => 400,
+            :param => @scope.full_name(attr_name), :message_key => :presence
         end
       end
     end

--- a/lib/grape/validations/regexp.rb
+++ b/lib/grape/validations/regexp.rb
@@ -4,7 +4,8 @@ module Grape
     class RegexpValidator < SingleOptionValidator
       def validate_param!(attr_name, params)
         if params[attr_name] && !( params[attr_name].to_s =~ @option )
-          raise Grape::Exceptions::Validation, :status => 400, :param => attr_name, :message_key => :regexp
+          raise Grape::Exceptions::Validation, :status => 400,
+            :param => @scope.full_name(attr_name), :message_key => :regexp
         end
       end
     end

--- a/spec/grape/validations/presence_spec.rb
+++ b/spec/grape/validations/presence_spec.rb
@@ -100,11 +100,11 @@ describe Grape::Validations::PresenceValidator do
   it 'validates nested parameters' do
     get('/nested')
     last_response.status.should == 400
-    last_response.body.should == '{"error":"missing parameter: first_name"}'
+    last_response.body.should == '{"error":"missing parameter: user[first_name]"}'
 
     get('/nested', :user => {:first_name => "Billy"})
     last_response.status.should == 400
-    last_response.body.should == '{"error":"missing parameter: last_name"}'
+    last_response.body.should == '{"error":"missing parameter: user[last_name]"}'
 
     get('/nested', :user => {:first_name => "Billy", :last_name => "Bob"})
     last_response.status.should == 200
@@ -114,27 +114,27 @@ describe Grape::Validations::PresenceValidator do
   it 'validates triple nested parameters' do
     get('/nested_triple')
     last_response.status.should == 400
-    last_response.body.should == '{"error":"missing parameter: admin_name"}'
+    last_response.body.should == '{"error":"missing parameter: admin[admin_name]"}'
 
     get('/nested_triple', :user => {:first_name => "Billy"})
     last_response.status.should == 400
-    last_response.body.should == '{"error":"missing parameter: admin_name"}'
+    last_response.body.should == '{"error":"missing parameter: admin[admin_name]"}'
 
     get('/nested_triple', :admin => {:super => {:first_name => "Billy"}})
     last_response.status.should == 400
-    last_response.body.should == '{"error":"missing parameter: admin_name"}'
+    last_response.body.should == '{"error":"missing parameter: admin[admin_name]"}'
 
     get('/nested_triple', :super => {:user => {:first_name => "Billy", :last_name => "Bob"}})
     last_response.status.should == 400
-    last_response.body.should == '{"error":"missing parameter: admin_name"}'
+    last_response.body.should == '{"error":"missing parameter: admin[admin_name]"}'
 
     get('/nested_triple', :admin => {:super => {:user => {:first_name => "Billy"}}})
     last_response.status.should == 400
-    last_response.body.should == '{"error":"missing parameter: admin_name"}'
+    last_response.body.should == '{"error":"missing parameter: admin[admin_name]"}'
 
     get('/nested_triple', :admin => { :admin_name => 'admin', :super => {:user => {:first_name => "Billy"}}})
     last_response.status.should == 400
-    last_response.body.should == '{"error":"missing parameter: last_name"}'
+    last_response.body.should == '{"error":"missing parameter: admin[super][user][last_name]"}'
 
     get('/nested_triple', :admin => { :admin_name => 'admin', :super => {:user => {:first_name => "Billy", :last_name => "Bob"}}})
     last_response.status.should == 200


### PR DESCRIPTION
I have changed validators to use full name for validation message #330

I'm not sure about splitting long line with parameters ;)
