### PR TITLE
Allow to skip reading body of input so route can accept all sort of content types

### DIFF
--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -18,7 +18,8 @@ module Grape
 
       def before
         negotiate_content_type
-        read_body_input
+        endpoint = request.env['api.endpoint']
+        read_body_input if endpoint.nil? || !endpoint.options[:route_options][:skip_read_body]
       end
 
       def after


### PR DESCRIPTION
This is useful for implementing routes that are used for uploading files.
