### PR TITLE
paginate - params and header

### DIFF
--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -340,8 +340,8 @@ module Grape
           page = params[:page].to_i ||= options[:default_page]
           error!("Invalid page: #{page}", 400) if page < 0
           size = unless (params[:size].nil? || params[:size].to_i.zero?)
-            params[:size].to_i 
-          else if params[:size].to_i > object.count
+              params[:size].to_i 
+            else if params[:size].to_i > object.count
               object.count
             else 
               options[:default_page_size]
@@ -349,10 +349,10 @@ module Grape
           end
           error!("Invalid page size: #{size}", 400) if size <= 0
           page_count = if (object.count%size).zero?
-            object.count/size
-          else
-            object.count/size + 1
-          end
+              object.count/size
+            else
+              object.count/size + 1
+            end
           error!("Page #{page} out!", 400) if page > page_count || page.zero?
           # page = 1 if page >= total_pages
           object = object[((page - 1) * size)...(page * size)]


### PR DESCRIPTION
I wrote this little edit in `lib/grape/endpoint.rb` in order to achieve a basic feature of pagination when grape is managing an `Array` of entries.
It makes just a little bit of 'cut and slice', check some params like `:page` and `:size` and set some headers that can be useful in the MViewC prospective.
There are also a couple of, mandatory, rspec...

I hope someone can find this snippet interesting at least as starting point... but I'm totally looking for some suggestions.
Is this the best, grape-ish, approach to the problem?
Maybe something more complex could be moved and promoted as 'middleware'...

Meanwhile here you can find a simple working example of what this monkeypatching code want to do. 
It require the beautiful 'grape-entity'.

https://github.com/zeroed/acinus
https://github.com/zeroed/acinus#paginate-something

`http://localhost:9292/news?page=2&size=3`

Thanks.
