### PR TITLE
Readable content negotiation

### DIFF
--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -111,7 +111,7 @@ module Grape
           )x  # x = extended regular expression with comments etc
           vendor_prefix_pattern = %r(vnd\.[^+]+\+)
 
-          accept.gsub(/\b/,'').scan(accept_into_mime_and_quality).
+          accept.scan(accept_into_mime_and_quality).
             sort_by { |_, quality_preference| -quality_preference.to_f }.
             map {|mime, _| mime.sub(vendor_prefix_pattern, '') }
         end


### PR DESCRIPTION
While tracing through the format negotiation code, I found it helpful to make a couple of readability improvements to the big regular expression used in Accept-header parsing.

While I was there, I also took out what seemed to be a no-operation replacement (though I suspect there was _some_ reason for it going in there in the first place, I couldn't think why).

They're separate commits, in case I'm wrong about the no-op :-)
