### PR TITLE
bump hashie required version to >= 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Next Release
 ============
 
 * Your contribution here.
+* [#355](https://github.com/intridea/grape/issues/355): Relax dependency constraint on Hashie
 
 0.3.1 (2/25/2013)
 =================

--- a/grape.gemspec
+++ b/grape.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activesupport'
   s.add_runtime_dependency 'multi_json', '>= 1.3.2'
   s.add_runtime_dependency 'multi_xml', '>= 0.5.2'
-  s.add_runtime_dependency 'hashie', '>= 2.0.2'
+  s.add_runtime_dependency 'hashie', '>= 1.2.0'
   s.add_runtime_dependency 'virtus'
   s.add_runtime_dependency 'builder'
 


### PR DESCRIPTION
Hashie has seen some improvements. Do you think we could bump the required version?

[it's important to lock to 2.0.2](https://github.com/intridea/hashie/pull/81)
