### PR TITLE
Describe rescuing of Grape::Exceptions::Validation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,12 +364,12 @@ end
 
 ### Validation Errors
 
-When validation and coercion errors occur an exception of type `Grape::Exceptions::ValidationError` is raised.
+When validation and coercion errors occur an exception of type `Grape::Exceptions::Validation` is raised.
 If the exception goes uncaught it will respond with a status of 400 and an error message.
-You can rescue a `Grape::Exceptions::ValidationError` and respond with a custom response.
+You can rescue a `Grape::Exceptions::Validation` and respond with a custom response.
 
 ```ruby
-rescue_from Grape::Exceptions::ValidationError do |e|
+rescue_from Grape::Exceptions::Validation do |e|
     Rack::Response.new({
         'status' => e.status,
         'message' => e.message,


### PR DESCRIPTION
Hi there,

Found this tiny error in the readme. Under ”Validation Errors” it is describe that you should rescue `Grape::Exceptions::ValidationError`, but the exception class is called `Grape::Exceptions::Validation`. 

I guess it was introduced with f8bc19a6b2e864893c5e82fd5917a918ba8f1fe3.

Thanks for a great framework! 
