### PR TITLE
Add reference to grape-librato gem to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1217,7 +1217,9 @@ See [StackOverflow #3282655](http://stackoverflow.com/questions/3282655/ruby-on-
 
 ## Performance Monitoring
 
-Grape integrates with NewRelic via the [newrelic-grape](https://github.com/flyerhzm/newrelic-grape) gem.
+Grape integrates with NewRelic via the
+[newrelic-grape](https://github.com/flyerhzm/newrelic-grape) gem, and
+with Librato Metrics with the [grape-librato](https://github.com/seanmoon/grape-librato) gem.
 
 ## Contributing to Grape
 


### PR DESCRIPTION
Hey there.

Based on the `newrelic-grape` gem, I wanted to get some similar functionality into my [Librato Metrics](http://librato.com) setup, where it automatically creates a metric for each Grape endpoint. If you're not familiar with Librato, they're a metrics/monitoring solution that's integrated with Heroku. 

The result is the [grape-librato](https://github.com/seanmoon/grape-librato) gem.

I added a reference to it in the README, if you'd rather leave it out, no worries. If you'd like it in, merge this in.

Thanks!

Sean
