### PR TITLE
Handle non-hash body params.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Next Release
 * [#344](https://github.com/intridea/grape/pull/344): Added `parser :type, nil` which disables input parsing for a given content-type - [@dblock](https://github.com/dblock).
 * [#381](https://github.com/intridea/grape/issues/381): Added `cascade false` definition at API level to remove the `X-Cascade: true` header from the API response - [@dblock](https://github.com/dblock).
 * [#376](https://github.com/intridea/grape/pull/376): Added `route_param`, syntax sugar for quick declaration of route parameters - [@mbleigh](https://github.com/mbleigh).
+* [#347](https://github.com/intridea/grape/issues/347): Handle non-hash body params. - [@paulnicholon](https://github.com/paulnicholson).
 * Your contribution here.
 
 0.4.1 (4/1/2013)

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -59,11 +59,11 @@ module Grape
                 begin
                   body = (env['api.request.body'] = parser.call(body, env))
                   if body.is_a?(Hash)
-                    env['rack.request.form_hash'] = env['rack.request.form_hash'] ? 
-                      env['rack.request.form_hash'].merge(body) : 
+                    env['rack.request.form_hash'] = env['rack.request.form_hash'] ?
+                      env['rack.request.form_hash'].merge(body) :
                       body
+                    env['rack.request.form_input'] = env['rack.input']
                   end
-                  env['rack.request.form_input'] = env['rack.input']
                 rescue Exception => e
                   throw :error, :status => 400, :message => e.message
                 end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -359,6 +359,7 @@ describe Grape::API do
             send verb, '/', MultiJson.dump(object), { 'CONTENT_TYPE' => 'application/json' }
             last_response.status.should == (verb == :post ? 201 : 200)
             last_response.body.should eql MultiJson.dump(object)
+            last_request.params.should eql Hash.new
           end
           it "stores input in api.request.input" do
             subject.format :json


### PR DESCRIPTION
This is related to #347. When the body of the request is not a hash, do not modify the request's form_input since this breaks the Rack::Request#params method by allowing Rack::Request#POST to return nil.
https://github.com/rack/rack/blob/da7efac44c7c463fb39e82d40c4a23403db383de/lib/rack/request.rb#L227
https://github.com/rack/rack/blob/da7efac44c7c463fb39e82d40c4a23403db383de/lib/rack/request.rb#L201
