### PR TITLE
extract headers and params from Endpoint to Grape::Request

### DIFF
--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -25,6 +25,7 @@ module Grape
   autoload :Namespace,           'grape/namespace'
   autoload :Cookies,             'grape/cookies'
   autoload :Validations,         'grape/validations'
+  autoload :Request,             'grape/http/request'
 
   module Exceptions
     autoload :Base,                           'grape/exceptions/base'

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -169,9 +169,7 @@ module Grape
     # The parameters passed into the request as
     # well as parsed from URL segments.
     def params
-      @params ||= Hashie::Mash.new.
-        deep_merge(request.params).
-        deep_merge(env['rack.routing_args'] || {})
+      @params ||= @request.params
     end
 
     # A filtering method that will return a hash
@@ -257,13 +255,7 @@ module Grape
 
     # Retrieves all available request headers.
     def headers
-      @headers ||= @env.dup.inject({}) { |h, (k, v)|
-        if k.start_with? 'HTTP_'
-          k = k[5..-1].gsub('_', '-').downcase.gsub(/^.|[-_\s]./) { |x| x.upcase }
-          h[k] = v
-        end
-        h
-      }
+      @headers ||= @request.headers
     end
 
     # Set response content-type
@@ -369,7 +361,7 @@ module Grape
     def run(env)
       @env = env
       @header = {}
-      @request = Rack::Request.new(@env)
+      @request = Grape::Request.new(@env)
 
       self.extend helpers
       cookies.read(@request)

--- a/lib/grape/http/request.rb
+++ b/lib/grape/http/request.rb
@@ -1,0 +1,21 @@
+module Grape
+  class Request < Rack::Request
+
+    def params
+      @env['grape.request.params'] ||= Hashie::Mash.new.
+        deep_merge(super).
+        deep_merge(env['rack.routing_args'] || {})
+    end
+
+    def headers
+      @env['grape.request.headers'] ||= @env.dup.inject({}) { |h, (k, v)|
+        if k.start_with? 'HTTP_'
+          k = k[5..-1].gsub('_', '-').downcase.gsub(/^.|[-_\s]./) { |x| x.upcase }
+          h[k] = v
+        end
+        h
+      }
+    end
+
+  end
+end

--- a/lib/grape/middleware/base.rb
+++ b/lib/grape/middleware/base.rb
@@ -34,7 +34,7 @@ module Grape
       def after; end
 
       def request
-        Rack::Request.new(self.env)
+        Grape::Request.new(self.env)
       end
 
       def response


### PR DESCRIPTION
By doing this, other middleware can access the params and headers through request, just like the Endpoint class
