### PR TITLE
API version overriding version parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Next Release
 * [#381](https://github.com/intridea/grape/issues/381): Added `cascade false` definition at API level to remove the `X-Cascade: true` header from the API response - [@dblock](https://github.com/dblock).
 * [#376](https://github.com/intridea/grape/pull/376): Added `route_param`, syntax sugar for quick declaration of route parameters - [@mbleigh](https://github.com/mbleigh).
 * [#347](https://github.com/intridea/grape/issues/347): Handle non-hash body params. - [@paulnicholon](https://github.com/paulnicholson).
-* Your contribution here.
+* [#394](https://github.com/intridea/grape/pull/394): path version no longer overwrites version param - [@tmornini](https://github.com/tmornini)
 
 0.4.1 (4/1/2013)
 ================

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -532,6 +532,5 @@ module Grape
         end
       end
     end
-
   end
 end

--- a/lib/grape/http/request.rb
+++ b/lib/grape/http/request.rb
@@ -2,9 +2,15 @@ module Grape
   class Request < Rack::Request
 
     def params
-      @env['grape.request.params'] ||= Hashie::Mash.new.
-        deep_merge(super).
-        deep_merge(env['rack.routing_args'] || {})
+      params = Hashie::Mash.new.deep_merge super
+
+      version = params.version
+
+      params = params.deep_merge( env['rack.routing_args'] || {} )
+
+      params.version = version
+
+      params
     end
 
     def headers

--- a/lib/grape/middleware/versioner/path.rb
+++ b/lib/grape/middleware/versioner/path.rb
@@ -7,15 +7,16 @@ module Grape
       # based on the uri path and removes the version substring from the uri
       # path. If the version substring does not match any potential initialized
       # versions, a 404 error is thrown.
-      # 
+      #
       # Example: For a uri path
       #   /v1/resource
-      # 
+      #
       # The following rack env variables are set and path is rewritten to
       # '/resource':
-      # 
+      #
       #   env['api.version'] => 'v1'
-      # 
+      #
+
       class Path < Base
         def default_options
           {
@@ -25,12 +26,10 @@ module Grape
 
         def before
           path = env['PATH_INFO'].dup
-
           if prefix && path.index(prefix) == 0
             path.sub!(prefix, '')
             path = Rack::Mount::Utils.normalize_path(path)
           end
-
           pieces = path.split('/')
           potential_version = pieces[1]
           if potential_version =~ options[:pattern]
@@ -45,10 +44,9 @@ module Grape
 
         private
 
-          def prefix
-            Rack::Mount::Utils.normalize_path(options[:prefix].to_s) if options[:prefix]
-          end
-
+        def prefix
+          Rack::Mount::Utils.normalize_path(options[:prefix].to_s) if options[:prefix]
+        end
       end
     end
   end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -62,8 +62,8 @@ describe Grape::API do
     it_should_behave_like 'versioning' do
       let(:macro_options) do
         {
-          :using => :param,
-          :parameter => "apiver"
+          :using     => :param,
+          :parameter => 'apiver'
         }
       end
     end

--- a/spec/shared/versioning_examples.rb
+++ b/spec/shared/versioning_examples.rb
@@ -1,4 +1,16 @@
 shared_examples_for 'versioning' do
+  it 'does not overwrite version parameter with API version' do
+    subject.format :txt
+    subject.version 'v1', macro_options
+    subject.params { requires :version }
+    subject.get :api_version_with_version_param do
+      params[:version]
+    end
+
+    versioned_get '/api_version_with_version_param?version=1', 'v1', macro_options
+    last_response.body.should eql '1'
+  end
+
   it 'sets the API version' do
     subject.format :txt
     subject.version 'v1', macro_options
@@ -11,7 +23,8 @@ shared_examples_for 'versioning' do
 
   it 'adds the prefix before the API version' do
     subject.format :txt
-    subject.prefix 'api'    
+    subject.prefix 'api'
+
     subject.version 'v1', macro_options
     subject.get :hello do
       "Version: #{request.env['api.version']}"


### PR DESCRIPTION
Hello there fine fellows!

Beginning to use and love Grape, but have run into a serious issue which I am unable to resolve myself.

I have an endpoint described as such:

```
params do
  optional :description, :type => String,  :desc => 'Book description'
  optional :reference,   :type => String,  :desc => 'Book reference'
  requires :version,     :type => Integer, :desc => 'Book current version'
end
```

This works fine with API versioning via headers when I pass in this body:

```
{"description":"Updated Description","reference":"b:a","version":2}
```

However, when I use API versioning via path, the version parameter is set to the API version from the path, which results in a 403 with this body:

```
{"error":"invalid parameter: version"}
```

I verified this at coerce.rb by adding these lines after line 14:

```
puts attr_name
puts params[attr_name]
```

This produces:

```
version
pacioli
```

where pacioli is my API version from:

```
class App < ::Grape::API
  version 'pacioli', :using => :path
```

I believe this to be 100% incorrect. :-)

Let me know if I can help in any way!

P.S. The 403 is weird in itself as line 15 of coerce.rb certainly appears to throw a 400.
