### PR TITLE
Adds Grape::Endpoint.setup for pre-run endpoint config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Next Release
 #### Features
 
 * [#617](https://github.com/intridea/grape/pull/617): Running tests on Ruby 2.1.1, Rubinius 2.1 and 2.2, Ruby and JRuby HEAD - [@dblock](https://github.com/dblock).
+* [#397](https://github.com/intridea/grape/pull/397): Adds `Grape::Endpoint.before_each` to allow easy helper stubbing - [@mbleigh](https://github.com/mbleigh).
 * Your contribution here.
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@
 - [Writing Tests](#writing-tests)
   - [Writing Tests with Rack](#writing-tests-with-rack)
   - [Writing Tests with Rails](#writing-tests-with-rails)
+  - [Stubbing Helpers](#stubbing-helpers)
 - [Reloading API Changes in Development](#reloading-api-changes-in-development)
   - [Rails 3.x](#rails-3x)
 - [Performance Monitoring](#performance-monitoring)
@@ -1603,6 +1604,31 @@ RSpec.configure do |config|
   config.include RSpec::Rails::RequestExampleGroup, type: :request, example_group: {
     file_path: /spec\/api/
   }
+end
+```
+
+### Stubbing Helpers
+
+Because helpers are mixed in based on the context when an endpoint is defined, it can
+be difficult to stub or mock them for testing. The `Grape::Endpoint.before_each` method
+can help by allowing you to define behavior on the endpoint that will run before every
+request.
+
+```ruby
+describe 'an endpoint that needs helpers stubbed' do
+  before do
+    Grape::Endpoint.before_each do |endpoint|
+      endpoint.stub!(:helper_name).and_return('desired_value')
+    end
+  end
+  
+  after do
+    Grape::Endpoint.before_each nil
+  end
+  
+  it 'should properly stub the helper' do
+    # ...
+  end
 end
 ```
 

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -8,6 +8,18 @@ module Grape
     attr_reader :env, :request, :headers, :params
 
     class << self
+      def before_each(new_setup = false, &block)
+        if new_setup == false
+          if block_given?
+            @before_each = block
+          else
+            return @before_each
+          end
+        else
+          @before_each = new_setup
+        end
+      end
+
       # @api private
       #
       # Create an UnboundMethod that is appropriate for executing an endpoint
@@ -382,6 +394,8 @@ module Grape
       @headers = @request.headers
 
       cookies.read(@request)
+
+      self.class.before_each.call(self) if self.class.before_each
 
       run_filters befores
 

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -7,6 +7,37 @@ describe Grape::Endpoint do
     subject
   end
 
+  describe '.before_each' do
+    after { Grape::Endpoint.before_each(nil) }
+
+    it 'should be settable via block' do
+      block = lambda { |endpoint| "noop" }
+      Grape::Endpoint.before_each(&block)
+      expect(Grape::Endpoint.before_each).to eq(block)
+    end
+
+    it 'should be settable via reference' do
+      block = lambda { |endpoint| "noop" }
+      Grape::Endpoint.before_each block
+      expect(Grape::Endpoint.before_each).to eq(block)
+    end
+
+    it 'should be able to override a helper' do
+      subject.get("/") { current_user }
+      expect { get '/' }.to raise_error(NameError)
+
+      Grape::Endpoint.before_each do |endpoint|
+        endpoint.stub(:current_user).and_return("Bob")
+      end
+
+      get '/'
+      expect(last_response.body).to eq("Bob")
+
+      Grape::Endpoint.before_each(nil)
+      expect { get '/' }.to raise_error(NameError)
+    end
+  end
+
   describe '#initialize' do
     it 'takes a settings stack, options, and a block' do
       p = proc {}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require 'rubygems'
 require 'bundler'
 Bundler.setup :default, :test
 
+require 'json'
 require 'rack/test'
 require 'base64'
 require 'cookiejar'


### PR DESCRIPTION
This pull request addresses #396 by providing a `Grape::Endpoint.setup` class method which can be used to manipulate an Endpoint just before it begins executing. The use of this in a test suite would go something like this:

Let's say I have a `current_user` helper that I want to stub. Let's say I don't even have it implemented yet, but I don't want it to error out while I'm building my library. Simple!

``` ruby
describe MyAPI do
  let(:app){ MyAPI }

  context 'with a logged in user' do
    before do
      Grape::Endpoint.setup do |endpoint|
        endpoint.stub(:current_user).and_return mock(:User, name: "Bob Example")
      end
    end

    after{ Grape::Endpoint.setup nil }
  end
end
```

I'm entering this as a pull request for a few reasons:
1. It adds code that will be conditionally executed every time any endpoint is called. I don't take that super lightly.
2. Right now there is only the ability to do a single `setup` step which precludes nesting or multiple layers of setup. I'm not sure if this is the right way to go, but I wanted to start with a straightforward implementation.

Thoughts?
