### PR TITLE
Call to_ary on objects that respond to it, like ActiveRecord::Relations.

### DIFF
--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -311,6 +311,12 @@ module Grape
     def present(object, options = {})
       entity_class = options.delete(:with)
 
+      # Prevent additional queries when using ActiveRecord.
+      # Since calling `.first` on an ActiveRecord::Relation will
+      # trigger a `LIMIT 1` query, we convert the collection into
+      # an array first.
+      object = object.to_ary if object.respond_to?(:to_ary)
+
       # auto-detect the entity from the first object in the collection
       object_instance = object.respond_to?(:first) ? object.first : object
 


### PR DESCRIPTION
Currently, if you use `.present` with ActiveRecord, you will get double queries on collections, because `.first` [gets called](https://github.com/intridea/grape/blob/85c3424011fc6ec6d623895278d2808680f5491c/lib/grape/endpoint.rb#L315) on the ActiveRecord::Relation object, which triggers a `LIMIT 1` query.

This patch calls .to_ary on objects that respond to it, like ActiveRecord::Relations, converting it to any array before calling `.first` on it, which will prevent the additional query.

**Before**

```
SELECT "items".* FROM "items" LIMIT 1
SELECT "items".* FROM "items"
```

**After**

```
SELECT "items".* FROM "items"
```
