### PR TITLE
goliath passes request header keys as symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Next Release
 * [#241](https://github.com/intridea/grape/issues/241): Present with multiple entities using an optional Symbol - [@niedhui](https://github.com/niedhui).
 * [#412](https://github.com/intridea/grape/issues/412): Fix: specifying `content_type` will also override the selection of the data formatter - [@dblock](https://github.com/dblock).
 * [#383](https://github.com/intridea/grape/issues/383): Fix: Mounted APIs aren't inheriting settings (including `before` and `after` filters) - [@seanmoon](https://github.com/seanmoon).
+* [#408](https://github.com/intridea/grape/pull/408): Fix: Goliath passes request header keys as symbols not strings - [@bobek](https://github.com/bobek).
 * Your contribution here.
 
 0.4.1 (4/1/2013)

--- a/lib/grape/http/request.rb
+++ b/lib/grape/http/request.rb
@@ -16,7 +16,7 @@ module Grape
 
     def headers
       @env['grape.request.headers'] ||= @env.dup.inject({}) { |h, (k, v)|
-        if k.start_with? 'HTTP_'
+        if k.to_s.start_with? 'HTTP_'
           k = k[5..-1].gsub('_', '-').downcase.gsub(/^.|[-_\s]./) { |x| x.upcase }
           h[k] = v
         end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -64,6 +64,12 @@ describe Grape::Endpoint do
       get '/headers', nil, { "HTTP_X_GRAPE_CLIENT" => "1" }
       JSON.parse(last_response.body)["X-Grape-Client"].should == "1"
     end
+    it 'includes headers passed as symbols' do
+      env = Rack::MockRequest.env_for("/headers")
+      env[:HTTP_SYMBOL_HEADER] = "Goliath passes symbols"
+      body = subject.call(env)[2].body.first
+      JSON.parse(body)["Symbol-Header"].should == "Goliath passes symbols"
+    end
   end
 
   describe '#cookies' do


### PR DESCRIPTION
Hi,

goliath passes key in headers hash as symbols. This trivial patch fixes the undefined start_with for symbol error otherwise causing crash of the app.

  Antonin
