### PR TITLE
Fix #383: Inherit settings correctly when performing nested mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Next Release
 * [#407](https://github.com/intridea/grape/issues/407): Specifying `default_format` will also set the default POST/PUT data parser to the given format - [@dblock](https://github.com/dblock).
 * [#241](https://github.com/intridea/grape/issues/241): Present with multiple entities using an optional Symbol - [@niedhui](https://github.com/niedhui).
 * [#412](https://github.com/intridea/grape/issues/412): Fix: specifying `content_type` will also override the selection of the data formatter - [@dblock](https://github.com/dblock).
+* [#383](https://github.com/intridea/grape/issues/383): Fix: Mounted APIs not inheriting settings (such as before/after filters) properly [@seanmoon](https://github.com/seanmoon).
 * Your contribution here.
 
 0.4.1 (4/1/2013)

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -460,7 +460,10 @@ module Grape
 
       def inherit_settings(other_stack)
         settings.prepend other_stack
-        endpoints.each{|e| e.settings.prepend(other_stack)}
+        endpoints.each do |e|
+          e.settings.prepend(other_stack)
+          e.options[:app].inherit_settings(other_stack) if e.options[:app].respond_to?(:inherit_settings, true)
+        end
       end
     end
 

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1720,6 +1720,24 @@ describe Grape::API do
         last_response.body.should == 'yo'
       end
 
+      it 'applies the settings to nested mounted apis' do
+        subject.version 'v1', :using => :path
+
+        subject.namespace :cool do
+          inner_app = Class.new(Grape::API)
+          inner_app.get('/awesome') do
+            "yo"
+          end
+
+          app = Class.new(Grape::API)
+          app.mount inner_app
+          mount app
+        end
+
+        get '/v1/cool/awesome'
+        last_response.body.should == 'yo'
+      end
+
       it 'inherits rescues even when some defined by mounted' do
         subject.rescue_from :all do |e|
           rack_response("rescued from #{e.message}", 202)


### PR DESCRIPTION
Fixes https://github.com/intridea/grape/issues/383

Also fixes the test shown here https://github.com/seanmoon/grape/commit/bc3b04872ee21bb6de4e958a56365348ec979249 but I didn't include the test in this commit as it's redundant and it turned out to be `api.rb`, not `endpoint.rb` that needed the update anyway.

This does not fix https://github.com/intridea/grape/issues/369 but it may improve situations where the `prefix` DSL has been used, but not when the mount point is set dynamically.

May be able to fix that issue with a little more digging.

I also confirmed that the `before` is being called in the correct order (inner child last) when you have nested `before`s using this code.

Since we can't predict when `mount` may be called on an API, I think we will need to propagate the settings each time recursively as this code does.
