### PR TITLE
Fix hash syntax of hello world example for Sinatra

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ require 'grape'
 
 class API < Grape::API
   get :hello do
-    {hello: "world"}
+    {:hello => "world"}
   end
 end
 


### PR DESCRIPTION
The API class in the Sinatra example previously had {hello: "world"} as the hash. Changed it to {:hello => "world"}.
