### PR TITLE
Adding 'json' gem into the spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ require 'rack/test'
 require 'pry'
 require 'base64'
 require 'cookiejar'
+require 'json'
 
 Dir["#{File.dirname(__FILE__)}/support/*.rb"].each do |file|
   require file


### PR DESCRIPTION
I was trying to add a failing spec for another problem (CORS headers related) and noticed that the spec was already failing.  It was simply due to not have the json gem in the test environment
