### PR TITLE
Cors doc fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,9 +889,8 @@ end
 ### CORS
 
 Grape supports CORS via [Rack::CORS](https://github.com/cyu/rack-cors), part of the
-[rack-cors](https://github.com/cyu/rack-cors) gem. Add `rack-cors` to your `Gemfile`.
-
-Then, use the middleware in your config.ru file.  
+[rack-cors](https://github.com/cyu/rack-cors) gem. Add `rack-cors` to your `Gemfile`,
+then use the middleware in your config.ru file.  
 
 ```ruby
 require 'rack/cors'


### PR DESCRIPTION
When the `use Rack::Cors` is placed in the Grape::API subclass instead of the config.ru, the middleware stack execution stops when OPTIONS methods are made, and when the Grape::API rescues from an exception.  

Placing `use Rack::Cors` in config.ru maintains the middleware execution chain, and prevents the above errors.
