### PR TITLE
declared(params) breaks when params contains array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Next Release
 * [#408](https://github.com/intridea/grape/pull/408): Fix: Goliath passes request header keys as symbols not strings - [@bobek](https://github.com/bobek).
 * [#417](https://github.com/intridea/grape/issues/417): Fix: Rails 4 does not rewind input, causes POSTed data to be empty - [@dblock](https://github.com/dblock).
 * [#423](https://github.com/intridea/grape/pull/423): Fix: `Grape::Endpoint#declared` now correctly handles nested params (ie. params declared with `group`) - [@jbarreneche](https://github.com/jbarreneche).
+* [#427](https://github.com/intridea/grape/issues/427): Fix: `declared(params)` breaks when `params` contains array - [@timhabermaas](https://github.com/timhabermaas)
 * Your contribution here.
 
 0.4.1 (4/1/2013)

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -185,21 +185,27 @@ module Grape
         raise ArgumentError, "Tried to filter for declared parameters but none exist."
       end
 
-      declared_params.inject({}) do |hash, key|
-        key = { key => nil } unless key.is_a? Hash
+      if params.is_a? Array
+        params.map do |param|
+          declared(param || {}, options, declared_params)
+        end
+      else
+        declared_params.inject({}) do |hash, key|
+          key = { key => nil } unless key.is_a? Hash
 
-        key.each_pair do |parent, children|
-          output_key = options[:stringify] ? parent.to_s : parent.to_sym
-          if params.key?(parent) || options[:include_missing]
-            hash[output_key] = if children
-              declared(params[parent] || {}, options, Array(children))
-            else
-              params[parent]
+          key.each_pair do |parent, children|
+            output_key = options[:stringify] ? parent.to_s : parent.to_sym
+            if params.key?(parent) || options[:include_missing]
+              hash[output_key] = if children
+                declared(params[parent] || {}, options, Array(children))
+              else
+                params[parent]
+              end
             end
           end
-        end
 
-        hash
+          hash
+        end
       end
     end
 

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -210,6 +210,16 @@ describe Grape::Endpoint do
       last_response.status.should == 200
     end
 
+    it 'builds nested params when given array' do
+      subject.get '/declared' do
+        declared(params)[:nested].size.should == 2
+        ""
+      end
+
+      get '/declared?first=present&nested[][fourth]=1&nested[][fourth]=2'
+      last_response.status.should == 200
+    end
+
     it 'filters out any additional params that are given' do
       subject.get '/declared' do
         declared(params).key?(:other).should == false


### PR DESCRIPTION
When given

```
params do
  group :nested do
    requires :inner
  end
end
```

and request parameters

```
params = {nested: [ {inner: 1}, {inner: 3} ]}
```

trying to call `declared(params)` leads to an

```
undefined method `key?' for [#<Hashie::Mash inner=1>, #<Hashie::Mash inner=3>]:Array
```

exception.

Since arrays generally work fine when using the `params` block, they should probably work with `declared` as well.

I believe I've already fixed this issue, I'll add a pull request shortly.
