### PR TITLE
Preserve `doc_attrs` so that custom param attributes are available at runtime

### DIFF
--- a/lib/grape/validations.rb
+++ b/lib/grape/validations.rb
@@ -6,12 +6,13 @@ module Grape
     # All validators must inherit from this class.
     #
     class Validator
-      attr_reader :attrs
+      attr_reader :attrs, :doc_attrs
 
-      def initialize(attrs, options, required, scope)
+      def initialize(attrs, options, required, scope, doc_attrs)
         @attrs = Array(attrs)
         @required = required
         @scope = scope
+        @doc_attrs = doc_attrs
 
         if options.is_a?(Hash) && !options.empty?
           raise Grape::Exceptions.UnknownOptions.new(options.keys)
@@ -60,7 +61,7 @@ module Grape
     ##
     # Base class for all validators taking only one param.
     class SingleOptionValidator < Validator
-      def initialize(attrs, options, required, scope)
+      def initialize(attrs, options, required, scope, doc_attrs)
         @option = options
         super
       end
@@ -177,7 +178,7 @@ module Grape
         validator_class = Validations::validators[type.to_s]
 
         if validator_class
-          (@api.settings.peek[:validations] ||= []) << validator_class.new(attrs, options, doc_attrs[:required], self)
+          (@api.settings.peek[:validations] ||= []) << validator_class.new(attrs, options, doc_attrs[:required], self, doc_attrs)
         else
           raise Grape::Exceptions::UnknownValidator.new(type)
         end

--- a/lib/grape/validations/default.rb
+++ b/lib/grape/validations/default.rb
@@ -1,7 +1,7 @@
 module Grape
   module Validations
     class DefaultValidator < Validator
-      def initialize(attrs, options, required, scope)
+      def initialize(attrs, options, required, scope, doc_attrs)
         @default = options
         super
       end


### PR DESCRIPTION
The `doc_attrs` variable, which contains the `:desc` attribute (as well as any other custom attributes), is not passed to the validator and therefore not available at runtime.  This PR passes `doc_attrs` as another argument to the validator's constructor, thereby preserving them for later access.
