### PR TITLE
Call rescue_from with a method instead of a block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Next Release
 * [#442](https://github.com/intridea/grape/issues/442): API `version` can now take an array of multiple versions - [@dblock](https://github.com/dblock).
 * [#444](https://github.com/intridea/grape/issues/444): Added :en as fallback locale for I18n - [@aew](https://github.com/aew).
 * [#448](https://github.com/intridea/grape/pull/448): Adding POST style parameters for DELETE request - [@dquimper](https://github.com/dquimper).
+* [#450](https://github.com/intridea/grape/pull/450): Added option to pass an exception handler lambda as an argument to rescue_from - [@robertopedroso](https://github.com/robertopedroso)
 * Your contribution here.
 
 #### Fixes


### PR DESCRIPTION
This PR adds a simple DSL for passing methods to rescue_from, much like Rails permits:

``` ruby
rescue_from Sequel::NoMatchingRow, with: rescue_missing_record

def rescue_missing_record
  Rack::Response.new('Missing Record', 404)
end
```

This means you can implement and call custom methods in your rescue handlers. At the moment, this is impossible because the passed block is executed via an instance_exec in the context of Grape::Middleware::Error.

The only problem is that this implementation cannot incorporate exception messages into the rescue method. Rails overcomes this limitation by passing the method as a symbol. It then calls the method with something like:

``` ruby
handler = method(rescuer)
handler.arity != 0 ? handler.call(exception) : handler.call
```

I'm not quite sure what changes would have to be made to Grape::Middleware::Error to enable this kind of functionality, but I'm hoping this PR is at least a start.
