### PR TITLE
Change stub! to stub and use doubles

### DIFF
--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -662,18 +662,18 @@ describe Grape::API do
     describe '.middleware' do
       it 'includes middleware arguments from settings' do
         settings = Grape::Util::HashStack.new
-        settings.stub!(:stack).and_return([{:middleware => [[ApiSpec::PhonyMiddleware, 'abc', 123]]}])
-        subject.stub!(:settings).and_return(settings)
+        settings.stub(:stack).and_return([{:middleware => [[ApiSpec::PhonyMiddleware, 'abc', 123]]}])
+        subject.stub(:settings).and_return(settings)
         subject.middleware.should eql [[ApiSpec::PhonyMiddleware, 'abc', 123]]
       end
 
       it 'includes all middleware from stacked settings' do
         settings = Grape::Util::HashStack.new
-        settings.stub!(:stack).and_return [
+        settings.stub(:stack).and_return [
           {:middleware => [[ApiSpec::PhonyMiddleware, 123],[ApiSpec::PhonyMiddleware, 'abc']]},
           {:middleware => [[ApiSpec::PhonyMiddleware, 'foo']]}
         ]
-        subject.stub!(:settings).and_return(settings)
+        subject.stub(:settings).and_return(settings)
 
         subject.middleware.should eql [
           [ApiSpec::PhonyMiddleware, 123],
@@ -997,7 +997,7 @@ describe Grape::API do
     end
 
     it 'can rescue exceptions raised in the formatter' do
-      formatter = stub(:formatter)
+      formatter = double(:formatter)
       formatter.stub(:call) { raise StandardError }
       Grape::Formatter::Base.stub(:formatter_for) { formatter }
 

--- a/spec/grape/entity_spec.rb
+++ b/spec/grape/entity_spec.rb
@@ -25,7 +25,7 @@ describe Grape::Entity do
 
     it 'pulls a representation from the class options if it exists' do
       entity = Class.new(Grape::Entity)
-      entity.stub!(:represent).and_return("Hiya")
+      entity.stub(:represent).and_return("Hiya")
 
       subject.represent Object, :with => entity
       subject.get '/example' do
@@ -37,7 +37,7 @@ describe Grape::Entity do
 
     it 'pulls a representation from the class options if the presented object is a collection of objects' do
       entity = Class.new(Grape::Entity)
-      entity.stub!(:represent).and_return("Hiya")
+      entity.stub(:represent).and_return("Hiya")
 
       class TestObject; end
       class FakeCollection
@@ -62,7 +62,7 @@ describe Grape::Entity do
 
     it 'pulls a representation from the class ancestor if it exists' do
       entity = Class.new(Grape::Entity)
-      entity.stub!(:represent).and_return("Hiya")
+      entity.stub(:represent).and_return("Hiya")
 
       subclass = Class.new(Object)
 
@@ -77,7 +77,7 @@ describe Grape::Entity do
     it 'automatically uses Klass::Entity if that exists' do
       some_model = Class.new
       entity = Class.new(Grape::Entity)
-      entity.stub!(:represent).and_return("Auto-detect!")
+      entity.stub(:represent).and_return("Auto-detect!")
 
       some_model.const_set :Entity, entity
 
@@ -91,7 +91,7 @@ describe Grape::Entity do
     it 'automatically uses Klass::Entity based on the first object in the collection being presented' do
       some_model = Class.new
       entity = Class.new(Grape::Entity)
-      entity.stub!(:represent).and_return("Auto-detect!")
+      entity.stub(:represent).and_return("Auto-detect!")
 
       some_model.const_set :Entity, entity
 

--- a/spec/grape/middleware/base_spec.rb
+++ b/spec/grape/middleware/base_spec.rb
@@ -6,7 +6,7 @@ describe Grape::Middleware::Base do
 
   before do
     # Keep it one object for testing.
-    subject.stub!(:dup).and_return(subject)
+    subject.stub(:dup).and_return(subject)
   end
 
   it 'has the app as an accessor' do

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Grape::Middleware::Formatter do
   subject{ Grape::Middleware::Formatter.new(app) }
-  before{ subject.stub!(:dup).and_return(subject) }
+  before{ subject.stub(:dup).and_return(subject) }
 
   let(:app){ lambda{|env| [200, {}, [@body || { "foo" => "bar" }]]} }
 
@@ -37,7 +37,7 @@ describe Grape::Middleware::Formatter do
   end
 
   context 'error handling' do
-    let(:formatter) { stub(:formatter) }
+    let(:formatter) { double(:formatter) }
     before do
       Grape::Formatter::Base.stub(:formatter_for) { formatter }
     end


### PR DESCRIPTION
Remove RSpec deprecation warnings: 
- `object.stub!` to `object.stub`
- `stub(:foo)` to `double(:foo)`
