### PR TITLE
Implement to_ary to avoid calls to method_missing

### DIFF
--- a/lib/grape/route.rb
+++ b/lib/grape/route.rb
@@ -18,6 +18,11 @@ module Grape
     def to_s
       "version=#{route_version}, method=#{route_method}, path=#{route_path}"
     end
-    
+
+    private
+    def to_ary
+      nil
+    end
+
   end
 end


### PR DESCRIPTION
- I'm not gonna lie, I totally ripped this from @tenderlove
- See bundler/bundler#1274

Not only does this reduce calls to `method_missing`, but it makes debug output much quieter :sparkles: 
