### PR TITLE
fixed assignment default_error_formatter

### DIFF
--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -147,8 +147,13 @@ module Grape
       end
 
       # Specify a default error formatter.
-      def default_error_formatter(new_formatter = nil)
-        new_formatter ? set(:default_error_formatter, new_formatter) : settings[:default_error_formatter]
+      def default_error_formatter(new_formatter_name = nil)
+        if new_formatter_name
+          new_formatter = Grape::ErrorFormatter::Base.formatter_for(new_formatter_name, {})
+          set(:default_error_formatter, new_formatter)
+        else
+          settings[:default_error_formatter]
+        end
       end
 
       def error_formatter(format, options)

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -2191,4 +2191,17 @@ XML
       end
     end
   end
+
+  context 'with json default_error_formatter' do
+    it 'return json error' do
+      subject.content_type :json, "application/json"
+      subject.default_error_formatter :json
+      subject.get '/something' do
+        'foo'
+      end
+      get '/something'
+      last_response.status.should == 406
+      last_response.body.should == "{\"error\":\"The requested format 'txt' is not supported.\"}"
+    end
+  end
 end


### PR DESCRIPTION
I created json api with settings:

``` ruby
class Application < Grape::API
  ...
  content_type :json, "application/json"
  default_error_formatter :json
  error_formatter :json, ::Userbase::Errors::JsonFormatter
  ...
end
```

When I make request '/something' without '.json' I get rescue

``` ruby
NoMethodError:
 undefined method `call' for :json:Symbol
# ./lib/grape/middleware/error.rb:75:in `format_message'
# ./lib/grape/middleware/error.rb:63:in `error_response'
# ./lib/grape/middleware/error.rb:27:in `call!'
# ./lib/grape/middleware/base.rb:18:in `call'
# ./lib/grape/endpoint.rb:155:in `call!'
# ./lib/grape/endpoint.rb:145:in `call'
# ./lib/grape/api.rb:493:in `call'
# ./lib/grape/api.rb:42:in `call!'
# ./lib/grape/api.rb:38:in `call'
```

Because in method `default_error_formatter` assigned name formatter instead of being looking for via formatter_for.
