### PR TITLE
Don't allow to have nil value when required & have allowed values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Next Release
 
 * Your contribution here.
 
+#### Fixes
+
+* [#492](https://github.com/intridea/grape/pull/492): Don't allow to have nil value when a param is required and has a list of allowed values. - [@Antti](https://github.com/Antti)
+
 0.6.1
 =====
 

--- a/lib/grape/validations/values.rb
+++ b/lib/grape/validations/values.rb
@@ -3,11 +3,12 @@ module Grape
     class ValuesValidator < Validator
       def initialize(attrs, options, required, scope)
         @values = options
+        @required = required
         super
       end
 
       def validate_param!(attr_name, params)
-        if params[attr_name] && !@values.include?(params[attr_name])
+        if (params[attr_name] || @required) && !@values.include?(params[attr_name])
           raise Grape::Exceptions::Validation, param: @scope.full_name(attr_name), message_key: :values
         end
       end

--- a/spec/grape/validations/values_spec.rb
+++ b/spec/grape/validations/values_spec.rb
@@ -41,6 +41,12 @@ describe Grape::Validations::ValuesValidator do
     last_response.body.should eq({ error: "type does not have a valid value" }.to_json)
   end
 
+  it 'does not allow nil value for a parameter' do
+    get("/", type: nil)
+    last_response.status.should eq 400
+    last_response.body.should eq({ error: "type does not have a valid value" }.to_json)
+  end
+
   it 'allows a valid default value' do
     get("/default/valid")
     last_response.status.should eq 200


### PR DESCRIPTION
This fixes the case when we want to filter nil values in params,
and we provide allowed values using ValuesValidator.
