### PR TITLE
Ensure Travis runs tests and Rubocop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ rvm:
   - jruby-19mode
   - rbx-19mode
 script:
+ - "bundle exec rake spec"
  - "bundle exec rubocop"


### PR DESCRIPTION
Not sure if this was intended but the I've just noticed that Travis reports 'green' test suites even though no tests are being run?
