### PR TITLE
Test and docs for params precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ get :public_timeline do
 end
 ```
 
-Parameters are automatically populated from the request body on POST and PUT for form input, JSON and
+Parameters are automatically populated from the request body on `POST` and `PUT` for form input, JSON and
 XML content-types.
 
 The request:
@@ -322,6 +322,14 @@ post "upload" do
   # file in params[:image_file]
 end
 ```
+
+In the case of conflict between either of:
+
+* route string parameters
+* `GET`, `POST` and `PUT` parameters
+* the contents of the request body on `POST` and `PUT` 
+
+route string parameters will have precedence. 
 
 ## Parameter Validation and Coercion
 

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -395,6 +395,44 @@ describe Grape::Endpoint do
       last_response.body.should == '{"error":"The requested content-type \'application/xml\' is not supported."}'
     end
 
+    context 'precedence' do
+
+      before do
+        subject.format :json
+        subject.namespace '/:id' do
+          get do
+            {
+              params: params[:id]
+            }
+          end
+          post do
+            {
+              params: params[:id]
+            }
+          end
+          put do
+            {
+              params: params[:id]
+            }
+          end
+        end
+      end
+
+      it 'route string params have higher precedence than body params' do
+        post '/123', { id: 456 }.to_json
+        expect(JSON.parse(last_response.body)['params']).to eq '123'
+        put '/123', { id: 456 }.to_json
+        expect(JSON.parse(last_response.body)['params']).to eq '123'
+      end
+
+      it 'route string params have higher precedence than URL params' do
+        get '/123?id=456'
+        expect(JSON.parse(last_response.body)['params']).to eq '123'
+        post '/123?id=456'
+        expect(JSON.parse(last_response.body)['params']).to eq '123'
+      end
+    end
+
   end
 
   describe '#error!' do


### PR DESCRIPTION
Unless I've missed something in the docs and or tests, the behaviour of ambiguous `params` wasn't immediately obvious. 

Hopefully this clears things up on both fronts.
