### PR TITLE
Allow parameters, such as content encoding, in content_type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Next Release
 
 #### Fixes
 
+* [#508](https://github.com/intridea/grape/pull/508): Allow parameters, such as content encoding, in `content_type`. - [@dm1try](https://github.com/dm1try).
 * [#492](https://github.com/intridea/grape/pull/492): Don't allow to have nil value when a param is required and has a list of allowed values. - [@Antti](https://github.com/Antti)
 * [#495](https://github.com/intridea/grape/pull/495): Fix `ParamsScope#params` for parameters nested inside arrays - [@asross](https://github.com/asross).
 * [#498](https://github.com/intridea/grape/pull/498): Dry up options and headers logic, allow headers to be passed to OPTIONS requests  - [@karlfreeman](https://github.com/karlfreeman).

--- a/lib/grape/middleware/base.rb
+++ b/lib/grape/middleware/base.rb
@@ -54,7 +54,9 @@ module Grape
       end
 
       def mime_types
-        content_types.invert
+        content_types.each_with_object({}) { |(k, v), types_without_params|
+          types_without_params[k] = v.split(';').first
+        }.invert
       end
 
     end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -395,6 +395,27 @@ describe Grape::Endpoint do
       last_response.body.should == '{"error":"The requested content-type \'application/xml\' is not supported."}'
     end
 
+    context 'content type with params' do
+      before do
+        subject.format :json
+        subject.content_type :json, 'application/json; charset=utf-8'
+
+        subject.post do
+          params[:data]
+        end
+        post '/', MultiJson.dump(data: { some: 'payload' }), { 'CONTENT_TYPE' => 'application/json' }
+      end
+
+      it "should not response with 406 for same type without params" do
+        last_response.status.should_not be 406
+      end
+
+      it "should response with given content type in headers" do
+        last_response.headers['Content-Type'].should eq 'application/json; charset=utf-8'
+      end
+
+    end
+
     context 'precedence' do
 
       before do


### PR DESCRIPTION
For example, if we define :json content type as "application/json; charset=utf-8"
and client do payload(POST/PUT) request with "application/json" type then response should be successful.
For now we have an error "The requested content-type 'application/json' is not supported".
