### PR TITLE
Added possibility to define reusable params

### DIFF
--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -472,4 +472,29 @@ describe Grape::Validations do
       end
     end # end custom validation
   end
+
+  describe 'concern params' do
+
+    before do
+      subject.param_concern :pageable do
+        optional :page
+        optional :per_page
+      end
+    end
+
+    it 'should be added as usual params defined in block' do
+      subject.params concerns: :pageable do
+        requires :id
+      end
+
+      subject.settings[:declared_params].should == [:page, :per_page, :id]
+    end
+
+    it 'can be used without block' do
+      subject.params concerns: :pageable
+      subject.settings[:declared_params].should == [:page, :per_page]
+    end
+
+  end
+
 end


### PR DESCRIPTION
It is so-called params concern, usage:

```
param_concern :pageable do
  optional :page, type: Integer
  optional :per_page, type: Integer
end

desc "Get some collection"
params concerns: :pageble

desc "Get some collection from date"
params concerns: :pageable do
  optional :from_date
end
```
