### PR TITLE
Support lambda-based default values for params

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Excludes:
     - vendor/**
+    - bin/**
 
 LineLength:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Next Release
 ============
 
+#### Features
+* [#510](https://github.com/intridea/grape/pull/510): Support lambda-based default values for params - [@myitcv](https://github.com/myitcv).
 * Your contribution here.
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -359,10 +359,16 @@ Optional parameters can have a default value.
 ```ruby
 params do
   optional :color, type: String, default: 'blue'
+  optional :random_number, type: Integer, default: -> { Random.rand(1..100) }
+  optional :non_random_number, type: Integer, default:  Random.rand(1..100) 
 end
 ```
 
 Parameters can be restricted to a specific set of values with the `:values` option.
+
+Default values are eagerly evaluated. Above `:non_random_number` will evaluate to the same
+number for each call to the endpoint of this `params` block. To have the default evaluate 
+at calltime use a lambda, like `:random_number` above.
 
 ```ruby
 params do

--- a/lib/grape/validations/default.rb
+++ b/lib/grape/validations/default.rb
@@ -7,7 +7,7 @@ module Grape
       end
 
       def validate_param!(attr_name, params)
-        params[attr_name] = @default unless params.has_key?(attr_name)
+        params[attr_name] = @default.is_a?(Proc) ? @default.call : @default unless params.has_key?(attr_name)
       end
 
       def validate!(params)

--- a/spec/grape/validations/default_spec.rb
+++ b/spec/grape/validations/default_spec.rb
@@ -32,6 +32,14 @@ describe Grape::Validations::DefaultValidator do
         get '/message' do
           { id: params[:id], type1: params[:type1], type2: params[:type2] }
         end
+
+        params do
+          optional :random, default: -> { Random.rand }
+          optional :not_random, default: Random.rand
+        end
+        get '/numbers' do
+          { random_number: params[:random], non_random_number: params[:non_random_number] }
+        end
       end
     end
   end
@@ -62,5 +70,17 @@ describe Grape::Validations::DefaultValidator do
     get("/message?id=1")
     last_response.status.should == 200
     last_response.body.should == { id: '1', type1: 'default-type1', type2: 'default-type2' }.to_json
+  end
+
+  it 'sets lambda based defaults at the time of call' do
+    get("/numbers")
+    last_response.status.should == 200
+    before = JSON.parse(last_response.body)
+    get("/numbers")
+    last_response.status.should == 200
+    after = JSON.parse(last_response.body)
+
+    before['non_random_number'].should == after['non_random_number']
+    before['random_number'].should_not == after['random_number']
   end
 end


### PR DESCRIPTION
The test gives an example of what we're looking for here:

``` ruby
params do
  optional :random, default: -> { Random.rand }
  optional :not_random, default: Random.rand
end
get '/numbers' do
  { random_number: params[:random], non_random_number: params[:non_random_number] }
end
```
