### PR TITLE
add required option for oauth2 middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Next Release
 
 #### Features
 * [#510](https://github.com/intridea/grape/pull/510): Support lambda-based default values for params - [@myitcv](https://github.com/myitcv).
+* [#511](https://github.com/intridea/grape/pull/511): Add `required` option for OAuth2 middleware - [@bcm](https://github.com/bcm).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/middleware/auth/oauth2.rb
+++ b/lib/grape/middleware/auth/oauth2.rb
@@ -7,7 +7,8 @@ module Grape::Middleware::Auth
         realm: 'OAuth API',
         parameter: %w(bearer_token oauth_token),
         accepted_headers: %w(HTTP_AUTHORIZATION X_HTTP_AUTHORIZATION X-HTTP_AUTHORIZATION REDIRECT_X_HTTP_AUTHORIZATION),
-        header: [/Bearer (.*)/i, /OAuth (.*)/i]
+        header: [/Bearer (.*)/i, /OAuth (.*)/i],
+        required: true
       }
     end
 
@@ -53,7 +54,7 @@ module Grape::Middleware::Auth
             error_out(403, 'insufficient_scope')
           end
         end
-      else
+      elsif !!options[:required]
         error_out(401, 'invalid_token')
       end
     end


### PR DESCRIPTION
this addresses situations where authentication is optional. sometimes you don't want to deny unauthenticated access but allow authentication when a token is actually provided. in this case the token must still be valid if it's provided, but if it's not there then the endpoint will still attempt to handle the request instead of returning a 401.
