### PR TITLE
Validation and before block ordering

### DIFF
--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -322,6 +322,7 @@ describe Grape::Validations do
       end
     end
 
+
     context 'custom validation' do
       module CustomValidations
         class Customvalidator < Grape::Validations::Validator
@@ -330,6 +331,28 @@ describe Grape::Validations do
               raise Grape::Exceptions::Validation, param: @scope.full_name(attr_name), message: "is not custom!"
             end
           end
+        end
+      end
+
+      context 'before block ordering' do
+        it 'should not evaluate a before block before validating surrounding namespace params' do
+          val = nil
+          subject.params do
+            requires :custom, customvalidator: true
+          end
+          subject.resource ':custom' do
+            before do
+              val = params[:custom]
+            end
+            get do
+              'anything here'
+            end
+          end
+          
+          get '/blahblah'
+          last_response.status.should == 400
+          last_response.body.should == 'custom is not custom!'
+          val.should == nil
         end
       end
 


### PR DESCRIPTION
The test case as part of this PR highlights the problem in more detail, but the gist of it is:

``` ruby
module CustomValidations
  class Customvalidator < Grape::Validations::Validator
    def validate_param!(attr_name, params)
      unless params[attr_name] == 'im custom'
        raise Grape::Exceptions::Validation, param: @scope.full_name(attr_name), message: "is not custom!"
      end
    end
  end
end

# elsewhere...

params do
  requires :custom, customvalidator: true
end
resource ':custom' do
  before do
    val = params[:custom]
  end
  get do
    'anything here'
  end
end
```

The `before` block defined in the `namespace/resource` is evaluated before (no pun intended) the custom validator define on the params block of said namespace.

This doesn't seem to make much sense; I was expecting the validation to run before anything in the namespace (including the, now slightly confusingly called, `before` block)

Thoughts?
