### PR TITLE
use default_error_status if set in error! function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Next Release
 
 * [#510](https://github.com/intridea/grape/pull/510): Support lambda-based default values for params - [@myitcv](https://github.com/myitcv).
 * [#511](https://github.com/intridea/grape/pull/511): Add `required` option for OAuth2 middleware - [@bcm](https://github.com/bcm).
+* [#520](https://github.com/intridea/grape/pull/520): Use default_error_status if set in error! function - [@salimane](https://github.com/salimane).
 * Your contribution here.
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -688,6 +688,22 @@ instead of a message.
 error!({ "error" => "unexpected error", "detail" => "missing widget" }, 500)
 ```
 
+### Default Error HTTP Status Code
+
+You can specify the default error http status code sent if none is specified when calling the error functions.
+
+``` ruby
+class API < Grape::API
+
+  default_error_status 400
+
+  get '/example' do
+    error! "This should have http status code 400"
+  end
+
+end
+```
+
 ### Handling 404
 
 For Grape to handle all the 404s for your API, it can be useful to use a catch-all.

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -204,7 +204,7 @@ module Grape
     # @param message [String] The message to display.
     # @param status [Integer] the HTTP Status Code. Defaults to default_error_status, 403 if not set.
     def error!(message, status = nil)
-      status = settings[:default_error_status] if not status
+      status = settings[:default_error_status] unless status
       throw :error, message: message, status: status
     end
 

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1479,6 +1479,15 @@ describe Grape::API do
       get '/exception'
       last_response.status.should eql 403
     end
+    it 'uses the default error status in error!' do
+      subject.rescue_from :all
+      subject.default_error_status 400
+      subject.get '/exception' do
+        error! "rain!"
+      end
+      get '/exception'
+      last_response.status.should eql 400
+    end
   end
 
   context 'routes' do


### PR DESCRIPTION
If `default_error_status` is set, the endpoint `error!` function still uses a hardcoded `403` http status code.
This pr sets the http status code used in the `error!` function to use the `default_error_status` whatever it is.
Thanks
