### PR TITLE
Document filters and add before_validation alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -1197,7 +1197,20 @@ end
 
 ## Before and After
 
-Execute a block before or after every API call with `before` and `after`.
+Blocks can be executed before or after every API call, using `before`, `after`,
+`before_validation` and `after_validation`.
+
+Before and after callbacks execute in the following order:
+
+1. `before` and `before_validation` (these are aliases - no ordering between them,
+execution could be interleaved)
+2. `after_validation`
+3. the API call
+4. `after`
+
+Steps 2, 3 and 4 only happen if validation succeeds.
+
+E.g. using `before`:
 
 ```ruby
 before do
@@ -1225,6 +1238,7 @@ class MyAPI < Grape::API
       end
     end
   end
+
 end
 ```
 
@@ -1234,6 +1248,35 @@ The behaviour is then:
 GET /           # 'root - '
 GET /foo        # 'root - foo - blah'
 GET /foo/bar    # 'root - foo - bar - blah'
+```
+
+Params on a `namespace` (or whatever alias you are using) also work when using
+`before_validation` or `after_validation`:
+
+```ruby
+class MyAPI < Grape::API
+  params do
+    requires :blah, type: Integer
+  end
+  resource ':blah' do
+    after_validation {
+      # if we reach this point validations will have passed
+      @blah = declared(params, include_missing: false)[:blah]
+    }
+    get '/' do
+      @blah.class
+    end
+
+  end
+
+end
+```
+
+The behaviour is then:
+
+```bash
+GET /123        # 'Fixnum'
+GET /foo        # 400 error - 'blah is invalid'
 ```
 
 ## Anchoring

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -361,6 +361,8 @@ module Grape
         imbue(:befores, [block])
       end
 
+      alias_method :before_validation, :before
+
       def after_validation(&block)
         imbue(:after_validations, [block])
       end


### PR DESCRIPTION
Per comments in #516. Tests also added to affirm the new statement in the readme that `after_validation` and `after` are only called if validation succeeds.
