### PR TITLE
Make before_validation its own distinct callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Next Release
 * [#525](https://github.com/intridea/grape/pull/525): The default status code returned from `error!` has been changed from 403 to 500 - [@dblock](https://github.com/dblock).
 * [#526](https://github.com/intridea/grape/pull/526): Allow specifying headers in `error!` - [@dblock](https://github.com/dblock).
 * [#523](https://github.com/intridea/grape/pull/523): Aliased `before` as `before_validation` - [@myitcv](https://github.com/myitcv).
+* [#527](https://github.com/intridea/grape/pull/527): `before_validation` now a distinct callback (supersedes [#523](https://github.com/intridea/grape/pull/523)) - [@myitcv](https://github.com/myitcv).
 * Your contribution here.
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -1211,11 +1211,12 @@ Blocks can be executed before or after every API call, using `before`, `after`,
 
 Before and after callbacks execute in the following order:
 
-1. `before` and `before_validation` (these are aliases - no ordering between them,
-execution could be interleaved)
-2. `after_validation`
-3. the API call
-4. `after`
+1. `before`
+2. `before_validation`
+3. _validations_
+4. `after_validation`
+5. _the API call_
+6. `after`
 
 Steps 2, 3 and 4 only happen if validation succeeds.
 

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -361,7 +361,9 @@ module Grape
         imbue(:befores, [block])
       end
 
-      alias_method :before_validation, :before
+      def before_validation(&block)
+        imbue(:before_validations, [block])
+      end
 
       def after_validation(&block)
         imbue(:after_validations, [block])

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -377,6 +377,8 @@ module Grape
 
       run_filters befores
 
+      run_filters before_validations
+
       # Retieve validations from this namespace and all parent namespaces.
       validation_errors = []
       settings.gather(:validations).each do |validator|
@@ -473,6 +475,10 @@ module Grape
 
     def befores
       aggregate_setting(:befores)
+    end
+
+    def before_validations
+      aggregate_setting(:before_validations)
     end
 
     def after_validations


### PR DESCRIPTION
Per the discussion [here](https://github.com/intridea/grape/pull/523#issuecomment-29899530)

`before_validation` is now its own, distinct callback. 

Before and after callbacks now execute in the following well defined order:
1. `before`
2. `before_validation`
3. _validations_
4. `after_validation`
5. _the API call_
6. `after`
