### PR TITLE
Default values don't work for grouped parameters

### DIFF
--- a/spec/grape/validations/default_spec.rb
+++ b/spec/grape/validations/default_spec.rb
@@ -40,6 +40,15 @@ describe Grape::Validations::DefaultValidator do
         get '/numbers' do
           { random_number: params[:random], non_random_number: params[:non_random_number] }
         end
+
+        params do
+          group :foo do
+            optional :bar, default: 'foo-bar'
+          end
+        end
+        get '/group' do
+          { foo_bar: params[:foo][:bar] }
+        end
       end
     end
   end
@@ -83,4 +92,11 @@ describe Grape::Validations::DefaultValidator do
     before['non_random_number'].should == after['non_random_number']
     before['random_number'].should_not == after['random_number']
   end
+
+  it 'set default values for optional grouped params' do
+    get('/group')
+    last_response.status.should == 200
+    last_response.body.should == { foo_bar: 'foo-bar' }.to_json
+  end
+
 end


### PR DESCRIPTION
I added a spec that fails because default values are not present for grouped parameters. I'll try to implement a fix and add it to this PR... 
It seems like the default-value-validator isn't aware that it's handling a grouped parameter. Most probably it doesn't have to, but I suppose this might somehow cause the default value to be ignored.

If anyone knows an easy way how to fix this or sees the problem, any help is appreciated!
