### PR TITLE
Fix typo in rescue_from unit test (Communication --> Communications).

### DIFF
--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1342,9 +1342,9 @@ describe Grape::API do
         rack_response("rescued from #{e.class.name}", 500)
       end
       subject.get '/uncaught' do
-        raise CommunicationError
+        raise CommunicationsError
       end
-      lambda { get '/uncaught' }.should raise_error(CommunicationError)
+      lambda { get '/uncaught' }.should raise_error(CommunicationsError)
     end
   end
 


### PR DESCRIPTION
Typo on one of the unit tests which made it pass falsely (fixing the typo it still passes, but now correctly).
