### PR TITLE
Add possibility to define reusable params.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Next Release
 * [#540](https://github.com/intridea/grape/pull/540): Ruby 2.1.0 is now supported - [@salimane](https://github.com/salimane).
 * [#544](https://github.com/intridea/grape/pull/544): The `rescue_from` keyword now handles subclasses of exceptions by default - [@xevix](https://github.com/xevix).
 * [#545](https://github.com/intridea/grape/pull/545): Added `type` (Array or Hash) support to `requires`, `optional` and `group` - [@bwalex](https://github.com/bwalex).
+* [#550](https://github.com/intridea/grape/pull/550): Added possibility to define reusable params - [@dm1try](https://github.com/dm1try).
 * Your contribution here.
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -576,6 +576,58 @@ class API < Grape::API
 end
 ```
 
+You can define reusable `params` using `helpers`.
+
+```ruby
+class API < Grape::API
+  helpers do
+    params :pagination do
+      optional :page, type: Integer
+      optional :per_page, type: Integer
+    end
+  end
+
+  desc "Get collection"
+  params do
+    use :pagination # aliases: includes, use_scope
+  end
+  get do
+    Collection.page(params[:page]).per(params[:per_page])
+  end
+end
+```
+
+You can also define reusable `params` using shared helpers.
+
+```ruby
+module SharedParams
+  extend Grape::API::Helpers
+
+  params :period do
+    optional :start_date
+    optional :end_date
+  end
+
+  params :pagination do
+    optional :page, type: Integer
+    optional :per_page, type: Integer
+  end
+end
+
+class API < Grape::API
+  helpers SharedParams
+
+  desc "Get collection"
+  params do
+    use :period, :pagination
+  end
+  get do
+    Collection.from(params[:start_date]).to(params[:end_date])
+              .page(params[:page]).per(params[:per_page])
+  end
+end
+```
+
 ## Cookies
 
 You can set, get and delete your cookies very simply using `cookies` method.

--- a/lib/grape/validations.rb
+++ b/lib/grape/validations.rb
@@ -147,6 +147,18 @@ module Grape
         params
       end
 
+      def use(*names)
+        named_params = @api.settings[:named_params] || {}
+        names.each do |name|
+          params_block = named_params.fetch(name) do
+            raise "Params :#{name} not found!"
+          end
+          instance_eval(&params_block)
+        end
+      end
+      alias_method :use_scope, :use
+      alias_method :includes, :use
+
       def full_name(name)
         return "#{@parent.full_name(@element)}[#{name}]" if @parent
         name.to_s

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -698,5 +698,60 @@ describe Grape::Validations do
         end
       end
     end # end custom validation
+
+    context 'named' do
+      context 'can be defined' do
+        it 'in helpers' do
+          subject.helpers do
+            params :pagination do
+            end
+          end
+        end
+
+        it 'in helper module which kind of Grape::API::Helpers' do
+          module SharedParams
+            extend Grape::API::Helpers
+            params :pagination do
+            end
+          end
+          subject.helpers SharedParams
+        end
+      end
+
+      context 'can be included in usual params' do
+        before do
+          module SharedParams
+            extend Grape::API::Helpers
+            params :period do
+              optional :start_date
+              optional :end_date
+            end
+          end
+          subject.helpers SharedParams
+
+          subject.helpers do
+            params :pagination do
+              optional :page, type: Integer
+              optional :per_page, type: Integer
+            end
+          end
+        end
+
+        it 'by #use' do
+          subject.params do
+            use :pagination
+          end
+          subject.settings[:declared_params].should eq [:page, :per_page]
+        end
+
+        it 'by #use with multiple params' do
+          subject.params do
+            use :pagination, :period
+          end
+          subject.settings[:declared_params].should eq [:page, :per_page, :start_date, :end_date]
+        end
+
+      end
+    end
   end
 end


### PR DESCRIPTION
Another one concept :)

Examples:

``` ruby
helpers do
  params :pagination do
    optional :page, type: Integer
    optional :per_page, type: Integer   
  end
end

desc "Get collection"
params do
  use :pagination
end
```

using module:

``` ruby
# shared_params.rb
module SharedParams
  extend Grape::ApiHelpers

  params :period do
    optional :start_date
    optional :end_date
  end

  params :pagination do
    optional :page, type: Integer
    optional :per_page, type: Integer   
  end
end
```

``` ruby
helpers SharedParams

desc "Get collection"
params do
  use :pagination, :period
end
```
