### PR TITLE
Pass content_types option to Grape::Middleware::Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Next Release
 * [#512](https://github.com/intridea/grape/pull/512): Don't create `Grape::Request` multiple times - [@dblock](https://github.com/dblock).
 * [#538](https://github.com/intridea/grape/pull/538): Fixed default values for grouped params - [@dm1try](https://github.com/dm1try).
 * [#549](https://github.com/intridea/grape/pull/549): Fixed handling of invalid version headers to return 406 if a header cannot be parsed - [@bwalex](https://github.com/bwalex).
+* [#557](https://github.com/intridea/grape/pull/557): Pass `content_types` option to `Grape::Middleware::Error` to fix the content-type header for custom formats. - [@bernd](https://github.com/bernd).
 
 
 0.6.1

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -417,6 +417,7 @@ module Grape
       b.use Rack::Head
       b.use Grape::Middleware::Error,
             format: settings[:format],
+            content_types: settings[:content_types],
             default_status: settings[:default_error_status] || 500,
             rescue_all: settings[:rescue_all],
             default_error_formatter: settings[:default_error_formatter],

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -758,6 +758,26 @@ describe Grape::API do
       get '/error.xml'
       last_response.headers['Content-Type'].should eql 'application/xml'
     end
+
+    context 'with a custom content_type' do
+      before do
+        subject.content_type :custom, 'application/custom'
+        subject.formatter :custom, lambda { |object, env| "custom" }
+
+        subject.get('/custom') { 'bar' }
+        subject.get('/error') { error!('error in custom', 500) }
+      end
+
+      it 'sets content type' do
+        get '/custom.custom'
+        last_response.headers['Content-Type'].should eql 'application/custom'
+      end
+
+      it 'sets content type for error' do
+        get '/error.custom'
+        last_response.headers['Content-Type'].should eql 'application/custom'
+      end
+    end
   end
 
   context 'custom middleware' do


### PR DESCRIPTION
This fixes the Content-Type header on error responses with a custom
format. It wasn't able to find the custom format and used the default
of "text/html".
