### PR TITLE
need to match builder version of activemodel

### DIFF
--- a/grape.gemspec
+++ b/grape.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'multi_xml', '>= 0.5.2'
   s.add_runtime_dependency 'hashie', '>= 1.2.0'
   s.add_runtime_dependency 'virtus', '>= 1.0.0'
-  s.add_runtime_dependency 'builder'
+  s.add_runtime_dependency 'builder', '~> 3.1'
 
   s.add_development_dependency 'grape-entity', '>= 0.2.0'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Test suite seems to pass. CI will tell for sure. 

Before:

```
$ bundle
...
Bundler could not find compatible versions for gem "builder":
  In Gemfile:
    mongoid (~> 4.0.0.alpha2) ruby depends on
      builder (~> 3.1.0) ruby

    grape (>= 0) ruby depends on
      builder (3.2.2)
```

After:

```
$ bundle
...
Your bundle is complete!
Use `bundle show [gemname]` to see where a bundled gem is installed.
```
