### PR TITLE
recognize Array type declarations that also specify the type of elements

### DIFF
--- a/lib/grape/validations/coerce.rb
+++ b/lib/grape/validations/coerce.rb
@@ -47,7 +47,7 @@ module Grape
 
       def coerce_value(type, val)
         # Don't coerce things other than nil to Arrays or Hashes
-        return val || [] if type == Array
+        return val || [] if type == Array || type.is_a?(Array)
         return val || {} if type == Hash
 
         converter = Virtus::Attribute.build(type)


### PR DESCRIPTION
When a parameter declaration specifies the array element type for validation (e.g. `type: [Integer]`), then `type` is actually equal to `Class` because it **is** an array, so we need to also evaluate `type.is_a?(Array)`.
