### PR TITLE
We want to use a delimiter agnostic path generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1550,8 +1550,8 @@ Add API paths to `config/application.rb`.
 
 ```ruby
 # Auto-load API and its subdirectories
-config.paths.add "app/api", glob: "**/*.rb"
-config.autoload_paths += Dir["#{Rails.root}/app/api/*"]
+config.paths.add File.join("app", "api"), glob: File.join("**", "*.rb")
+config.autoload_paths += Dir[Rails.root.join("app", "api", "*")]
 ```
 
 Create `config/initializers/reload_api.rb`.


### PR DESCRIPTION
Path delimiter is specific to operating systems and luckily we have an agnostic and easy way to generate these paths!
