### PR TITLE
Fix after boot thread-safety issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Next Release
 * [#538](https://github.com/intridea/grape/pull/538): Fixed default values for grouped params - [@dm1try](https://github.com/dm1try).
 * [#549](https://github.com/intridea/grape/pull/549): Fixed handling of invalid version headers to return 406 if a header cannot be parsed - [@bwalex](https://github.com/bwalex).
 * [#557](https://github.com/intridea/grape/pull/557): Pass `content_types` option to `Grape::Middleware::Error` to fix the content-type header for custom formats. - [@bernd](https://github.com/bernd).
-
+* [#585](https://github.com/intridea/grape/pull/585): Fix after boot thread-safety issue - [@etehtsea](https://github.com/etehtsea).
 
 0.6.1 (10/19/2013)
 ==================

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -17,6 +17,7 @@ require 'multi_json'
 require 'multi_xml'
 require 'virtus'
 require 'i18n'
+require 'thread'
 
 I18n.load_path << File.expand_path('../grape/locale/en.yml', __FILE__)
 

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -9,6 +9,8 @@ module Grape
       attr_reader :endpoints, :instance, :routes, :route_set, :settings, :versions
       attr_writer :logger
 
+      LOCK = Mutex.new
+
       def logger(logger = nil)
         if logger
           @logger = logger
@@ -26,7 +28,7 @@ module Grape
       end
 
       def compile
-        @instance = new
+        @instance ||= new
       end
 
       def change!
@@ -34,7 +36,7 @@ module Grape
       end
 
       def call(env)
-        compile unless instance
+        LOCK.synchronize { compile } unless instance
         call!(env)
       end
 


### PR DESCRIPTION
Demo to reproduce: https://gist.github.com/etehtsea/9143028

Example stacktrace:

```
[INFO ] TorqBox::Server  - TorqBox 0.1.7 starting...
[INFO ] org.projectodd.wunderboss.web.WebComponent  - Undertow listening on localhost:8080
[INFO ] org.projectodd.wunderboss.web.WebComponent  - Started web context /
[ERROR] io.undertow.request  - Blocking request failed HttpServerExchange{ GET /}
org.jruby.exceptions.RaiseException: (NameError) method "OPTIONS   /" already exists and cannot be used as an unbound method name
    at RUBY.generate_api_method(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/endpoint.rb:26)
    at RUBY.initialize(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/endpoint.rb:50)
    at RUBY.route(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/api.rb:353)
    at RUBY.options(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/api.rb:396)
    at RUBY.add_head_not_allowed_methods_and_options_methods(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/api.rb:578)
    at org.jruby.RubyHash.each(org/jruby/RubyHash.java:1338)
    at RUBY.add_head_not_allowed_methods_and_options_methods(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/api.rb:572)
    at RUBY.initialize(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/api.rb:527)
    at RUBY.compile(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/api.rb:29)
    at RUBY.call(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/api.rb:37)
    at RUBY.call(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/gems/rack-1.5.2/lib/rack/commonlogger.rb:33)
[ERROR] io.undertow.request  - Blocking request failed HttpServerExchange{ GET /}
org.jruby.exceptions.RaiseException: (NameError) method "   /" already exists and cannot be used as an unbound method name
    at RUBY.generate_api_method(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/endpoint.rb:26)
    at RUBY.initialize(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/endpoint.rb:50)
    at RUBY.route(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/api.rb:353)
    at RUBY.add_head_not_allowed_methods_and_options_methods(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/api.rb:586)
    at org.jruby.RubyHash.each(org/jruby/RubyHash.java:1338)
    at RUBY.add_head_not_allowed_methods_and_options_methods(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/api.rb:572)
    at RUBY.initialize(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/api.rb:527)
    at RUBY.compile(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/api.rb:29)
    at RUBY.call(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/api.rb:37)
    at RUBY.call(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/gems/rack-1.5.2/lib/rack/commonlogger.rb:33)
[ERROR] io.undertow.request  - Blocking request failed HttpServerExchange{ GET /}
org.jruby.exceptions.RaiseException: (NameError) method 'PUT POST DELETE PATCH   /' not defined in Grape::Endpoint
    at org.jruby.RubyModule.remove_method(org/jruby/RubyModule.java:2344)
    at RUBY.generate_api_method(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/endpoint.rb:30)
    at RUBY.initialize(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/endpoint.rb:50)
    at RUBY.route(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/api.rb:353)
    at RUBY.add_head_not_allowed_methods_and_options_methods(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/api.rb:586)
    at org.jruby.RubyHash.each(org/jruby/RubyHash.java:1338)
    at RUBY.add_head_not_allowed_methods_and_options_methods(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/api.rb:572)
    at RUBY.initialize(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/api.rb:527)
    at RUBY.compile(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/api.rb:29)
    at RUBY.call(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/bundler/gems/grape-466579209276/lib/grape/api.rb:37)
    at RUBY.call(/Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/gems/rack-1.5.2/lib/rack/commonlogger.rb:33)
127.0.0.1 - - [22/Feb/2014 00:43:26] "GET / " 200 5 2.7050
127.0.0.1 - - [22/Feb/2014 00:43:26] "GET / " 200 5 2.8660
127.0.0.1 - - [22/Feb/2014 00:43:26] "GET / " 200 5 2.8530
127.0.0.1 - - [22/Feb/2014 00:43:26] "GET / " 200 5 2.8620
127.0.0.1 - - [22/Feb/2014 00:43:26] "GET / " 200 5 2.8560
127.0.0.1 - - [22/Feb/2014 00:43:26] "GET / " 200 5 2.8740
```
