### PR TITLE
use flat_map instead of map.flatten

### DIFF
--- a/lib/grape/util/hash_stack.rb
+++ b/lib/grape/util/hash_stack.rb
@@ -100,7 +100,7 @@ module Grape
       # @param key [Symbol] The key to gather
       # @return [Array]
       def gather(key)
-        stack.map { |s| s[key] }.flatten.compact.uniq
+        stack.flat_map { |s| s[key] }.compact.uniq
       end
 
       def to_s

--- a/lib/grape/validations.rb
+++ b/lib/grape/validations.rb
@@ -140,7 +140,7 @@ module Grape
         params = @parent.params(params) if @parent
         if @element
           if params.is_a?(Array)
-            params = params.map { |el| el[@element] || {} }.flatten
+            params = params.flat_map { |el| el[@element] || {} }
           elsif params.is_a?(Hash)
             params = params[@element] || {}
           else


### PR DESCRIPTION
Benchmarks from @sferik on https://github.com/rails/rails/pull/14240 , shows that `flat_map` is faster than `map.flatten` and also more readable.

All tests are green with this change, so IMO it is worth it.
