### PR TITLE
OPTIONS regression 2

### DIFF
--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -2102,17 +2102,31 @@ describe Grape::API do
       end
 
       it 'responds to options' do
-        subject.namespace :apples do
-          app = Class.new(Grape::API)
-          app.get('/colour') do
-            "red"
+        app = Class.new(Grape::API)
+
+        app.get('/colour') do
+          "red"
+        end
+
+        app.namespace :pears do
+          get('/colour') do
+            "green"
           end
+        end
+
+        subject.namespace :apples do
           mount app
         end
+
         get '/apples/colour'
         last_response.status.should eql 200
         last_response.body.should == 'red'
         options '/apples/colour'
+        last_response.status.should eql 204
+        get '/apples/pears/colour'
+        last_response.status.should eql 200
+        last_response.body.should == 'green'
+        options '/apples/pears/colour'
         last_response.status.should eql 204
       end
 


### PR DESCRIPTION
Having pulled down the [latest master](https://github.com/intridea/grape/commit/a936f83704bcb27150edf5486b75da0b74d64a12) which includes #582. It appears that my test suite exploded.

Turns out [the fix](https://github.com/intridea/grape/pull/582) to [fix a regression](https://github.com/intridea/grape/issues/573) has regressed :bug:.

``` ruby
class NamespacedEndpoint < Grape::API
  namespace :foo do
    get 'regression'
      'no-fun'
    end
  end
end
class CollectionOfEndpoints < Grape::API
  get 'no-regression'
    'fun'
  end
  mount NamespacedEndpoint
end
class Root < Grape::API
  mount CollectionOfEndpoints
end
```

Going to try and look at this myself but limited on time. Not sure what the best way to go forward with these OPTIONS regressions are. The tests we have clearly aren't capturing the use cases which means we're somewhat chasing our tails :unamused:.
