### PR TITLE
do not use any Entity constant that is available in namespace, as it can...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Next Release
 
 #### Fixes
 
+* [#600](https://github.com/intridea/grape/pull/600): Do not use any Entity constant that is available in namespace as presenter - [@fuksito](https://github.com/fuksito)
 * [#590](https://github.com/intridea/grape/pull/590): Fix Issue Where Endpoint Param of Type Integer Cannot Set Values Array - [@xevix](https://github.com/xevix)
 * [#586](https://github.com/intridea/grape/pull/586): Do not repeat the same validation error messages - [@kiela](https://github.com/kiela)
 * [#508](https://github.com/intridea/grape/pull/508): Allow parameters, such as content encoding, in `content_type` - [@dm1try](https://github.com/dm1try).

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -332,7 +332,7 @@ module Grape
           entity_class ||= (settings[:representations] || {})[potential]
         end
 
-        entity_class ||= object_instance.class.const_get(:Entity) if object_instance.class.const_defined?(:Entity)
+        entity_class ||= object_instance.class.const_get(:Entity) if object_instance.class.const_defined?(:Entity) && object_instance.class.const_get(:Entity).respond_to?(:represent)
       end
 
       root = options.delete(:root)

--- a/spec/grape/entity_spec.rb
+++ b/spec/grape/entity_spec.rb
@@ -121,6 +121,19 @@ describe Grape::Entity do
       get '/example'
     end
 
+    it 'autodetection does not use Entity if it is not a presenter' do
+      some_model = Class.new
+      entity = Class.new
+
+      some_model.class.const_set :Entity, entity
+
+      subject.get '/example' do
+        present some_model
+      end
+      get '/example'
+      entity.should_not_receive(:represent)
+    end
+
     it 'adds a root key to the output if one is given' do
       subject.get '/example' do
         present({ abc: 'def' }, root: :root)


### PR DESCRIPTION
I experienced problem with grape when I had an active record model in my project with name Entity. This model is not connected with grape at all, but grape looks for any constant with name Entity, and tries to use it to present values that does not have explicit presenter, like simple strings. So it is usual case to see errors like:

```
undefined method `represent' for #<Class:0x00000102bd1f70>
```

by this PL I suggest to make at least check that an object has such method before calling it. Ideally I suppose would be ability to config the name of an auto-detect entity class or be able to disable it
