### PR TITLE
Adds root and exclude to oauth2

### DIFF
--- a/lib/grape/middleware/auth/oauth2.rb
+++ b/lib/grape/middleware/auth/oauth2.rb
@@ -18,7 +18,7 @@ module Grape::Middleware::Auth
     end
 
     def can_verify?(env)
-      path_info = env['PATH_INFO']
+      path_info = env['PATH_INFO'][/([^.]*).*/, 1]
       path_info.start_with?(options[:root]) && !path_info.end_with?(*options[:exclude])
     end
 

--- a/spec/grape/middleware/auth/oauth2_spec.rb
+++ b/spec/grape/middleware/auth/oauth2_spec.rb
@@ -204,12 +204,9 @@ describe Grape::Middleware::Auth::OAuth2 do
     end
 
     context 'calling the excluded urls' do
-      %w(version ping).each do |url|
-        before do
-          get "/api/#{url}"
-        end
-
+      %w(version ping ping.json).each do |url|
         it 'succeeds' do
+          get "/api/#{url}"
           last_response.status.should == 200
         end
       end


### PR DESCRIPTION
please merge #603 first

After merging this pull request the oauth2 middelware can be user like this:

``` ruby
use Grape::Middleware::Auth::OAuth2, token_class: 'FakeToken', root: '/api', exclude: %w(version ping)
```

This means that the filter will apply only to urls under `/api` and it will exclude `version` and `ping` so you can call `/api/v1/version` without warring about access_token.

The `require` option is not powerful enough to cover all scenarios.
