### PR TITLE
Revise #582 by changing the way how OPTIONS routes are added

### DIFF
--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -2099,14 +2099,21 @@ describe Grape::API do
         get "/app1/app2/nice"
         last_response.status.should == 200
         last_response.body.should == "play"
+        options "/app1/app2/nice"
+        last_response.status.should == 204
       end
 
       it 'responds to options' do
-        subject.namespace :apples do
-          app = Class.new(Grape::API)
-          app.get('/colour') do
-            "red"
+        app = Class.new(Grape::API)
+        app.get '/colour' do
+          'red'
+        end
+        app.namespace :pears do
+          get '/colour' do
+            'green'
           end
+        end
+        subject.namespace :apples do
           mount app
         end
         get '/apples/colour'
@@ -2114,9 +2121,14 @@ describe Grape::API do
         last_response.body.should == 'red'
         options '/apples/colour'
         last_response.status.should eql 204
+        get '/apples/pears/colour'
+        last_response.status.should eql 200
+        last_response.body.should == 'green'
+        options '/apples/pears/colour'
+        last_response.status.should eql 204
       end
 
-      it 'responds to options with versioning' do
+      it 'responds to options with path versioning' do
         subject.version 'v1', using: :path
         subject.namespace :apples do
           app = Class.new(Grape::API)


### PR DESCRIPTION
This PR addresses the issue described in #598. The culprit was the PR #582 which addressed #572 (OPTIONS was broken for paths with versioning). My solution to the problem back then was to work with the "raw" path information of all endpoints instead of using the final routes, because latter contain the `/:version` information already. The solution was too simple to address complex nesting and namespacing.

This PR reverts the way the OPTIONS paths are collected and addresses the `/:version` issue (of #572) by disabling the addition of path url versioning when the OPTIONS routes are added. I'm not sold on this solution however (feels like a hack), but it might help someone to find a more elegant solution. 
