### PR TITLE
Clarified the code structure for Rails.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,9 @@ run Rack::Cascade.new [API, Web]
 
 ### Rails
 
-Place API files into `app/api` and modify `application.rb`.
+Place API files into `app/api`. Rails expects a subdirectory that matches the name of the Ruby module and a file name that matches the name of the class. In our example, the file name location and directory for `Twitter::API` should be `app/api/twitter/api.rb`.
+
+Modify `application.rb`:
 
 ```ruby
 config.paths.add File.join('app', 'api'), glob: File.join('**', '*.rb')


### PR DESCRIPTION
I ran into an issue running a very simple Grape API within a Rails 4 application that has to do with the directory structure in Rails. 

It wasn't clear to me in http://intridea.github.io/grape/docs/index.html#Rails, that underneath the `app/api` directory, you need to create yet another subdirectory which name matches the name of the module that implements the Grape API.

For example, if your API is implemented in a file called `api.rb` as:

``` ruby
module Twitter
  class API < Grape::API
    version 'v1', using: :path
    format :json

    resource :statuses do
      desc "Return a public timeline."
      get :public_timeline do
        Status.limit(20)
      end
    end
  end
end
```

The file `api.rb` needs to live in `app/api/twitter/api.rb`, otherwise, Rails does not recognize the name of the module and throws the following error when trying to run the rails server: 

`/config/routes.rb:[line number]:in`block in <top (required)>': uninitialized constant Twitter (NameError)`
