### PR TITLE
Prevent endpoints from duplicating

### DIFF
--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -352,10 +352,20 @@ module Grape
           path: paths,
           route_options: (@namespace_description || {}).deep_merge(@last_description || {}).deep_merge(route_options || {})
         }
-        endpoints << Grape::Endpoint.new(settings.clone, endpoint_options, &block)
+        endpoints << Grape::Endpoint.new(settings.clone, endpoint_options, &block) if unique_endpoint(endpoints, endpoint_options)
 
         @last_description = nil
         reset_validations!
+      end
+
+      def unique_endpoint(endpoints, endpoint_options)
+        endpoints.each_with_index do |endpoint, n|
+          if n == 0
+            endpoint_options[:method] = [endpoint_options[:method]]
+            endpoint_options[:path] = [endpoint_options[:path]]
+          end
+          return false if endpoint.options == endpoint_options
+        end
       end
 
       def before(&block)

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -2161,6 +2161,12 @@ describe Grape::API do
       subject.post '/'
       subject.endpoints.size.should == 2
     end
+
+    it "should not duplicate routes" do
+      subject.get "/test_route"
+      subject.get "/test_route"
+      subject.endpoints.size.should == 1
+    end
   end
 
   describe '.compile' do


### PR DESCRIPTION
Fixes confirmed bug from issue [#552](https://github.com/intridea/grape/issues/552). I included a test that fails on master and passes in my current branch.

However, there are breaking changes to the spec. I am not familiar enough yet with the codebase in order to properly debug. Would love it if someone more experienced could take a look and try to parse out the error. It appear that my changes fails tests where the endpoints should be nil.

Would appreciate any feedback.
