### PR TITLE
Convert specs to RSpec 3 syntax with Transpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Next Release
 
 * [#614](https://github.com/intridea/grape/pull/614): Params with `nil` value are now refused by `RegexpValidator` - [@dm1try](https://github.com/dm1try).
 * [#494](https://github.com/intridea/grape/issues/494): Fixed performance issue with requests carrying a large payload - [@dblock](https://github.com/dblock).
+* [#619](https://github.com/intridea/grape/pull/619): Convert specs to RSpec 3 syntax with Transpec - [@danielspector](https://github.com/danielspector).
 
 0.7.0 (4/2/2013)
 =================

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -17,7 +17,7 @@ describe Grape::API do
       end
 
       get 'awesome/sauce/'
-      last_response.body.should eql "Hello there."
+      expect(last_response.body).to eql "Hello there."
     end
 
     it 'routes through with the prefix' do
@@ -27,10 +27,10 @@ describe Grape::API do
       end
 
       get 'awesome/sauce/hello'
-      last_response.body.should eql "Hello there."
+      expect(last_response.body).to eql "Hello there."
 
       get '/hello'
-      last_response.status.should eql 404
+      expect(last_response.status).to eql 404
     end
 
   end
@@ -39,13 +39,13 @@ describe Grape::API do
     context 'when defined' do
       it 'returns version value' do
         subject.version 'v1'
-        subject.version.should == 'v1'
+        expect(subject.version).to eq('v1')
       end
     end
 
     context 'when not defined' do
       it 'returns nil' do
-        subject.version.should be_nil
+        expect(subject.version).to be_nil
       end
     end
   end
@@ -117,7 +117,7 @@ describe Grape::API do
     it 'adds the association to the :representations setting' do
       klass = Class.new
       subject.represent Object, with: klass
-      subject.settings[:representations][Object].should == klass
+      expect(subject.settings[:representations][Object]).to eq(klass)
     end
   end
 
@@ -137,7 +137,7 @@ describe Grape::API do
       end
 
       get "/rad/v1/awesome/hello"
-      last_response.body.should == "worked"
+      expect(last_response.body).to eq("worked")
     end
 
     it 'cancels itself after the block is over' do
@@ -145,7 +145,7 @@ describe Grape::API do
         namespace.should == '/awesome'
       end
 
-      subject.namespace.should == '/'
+      expect(subject.namespace).to eq('/')
     end
 
     it 'is stackable' do
@@ -155,7 +155,7 @@ describe Grape::API do
         end
         namespace.should == '/awesome'
       end
-      subject.namespace.should == '/'
+      expect(subject.namespace).to eq('/')
     end
 
     it 'accepts path segments correctly' do
@@ -168,7 +168,7 @@ describe Grape::API do
         end
       end
       get '/members/23'
-      last_response.body.should == "23"
+      expect(last_response.body).to eq("23")
     end
 
     it 'is callable with nil just to push onto the stack' do
@@ -179,9 +179,9 @@ describe Grape::API do
       subject.get('/hello') { "outer" }
 
       get '/v2/hello'
-      last_response.body.should == "inner"
+      expect(last_response.body).to eq("inner")
       get '/hello'
-      last_response.body.should == "outer"
+      expect(last_response.body).to eq("outer")
     end
 
     %w(group resource resources segment).each do |als|
@@ -204,7 +204,7 @@ describe Grape::API do
       end
 
       get '/users/23'
-      last_response.body.should == '23'
+      expect(last_response.body).to eq('23')
     end
 
     it 'should be able to define requirements with a single hash' do
@@ -217,9 +217,9 @@ describe Grape::API do
       end
 
       get '/users/michael'
-      last_response.status.should == 404
+      expect(last_response.status).to eq(404)
       get '/users/23'
-      last_response.status.should == 200
+      expect(last_response.status).to eq(200)
     end
   end
 
@@ -235,15 +235,15 @@ describe Grape::API do
       end
 
       get '/votes'
-      last_response.body.should eql 'Votes'
+      expect(last_response.body).to eql 'Votes'
       post '/votes'
-      last_response.body.should eql 'Created a Vote'
+      expect(last_response.body).to eql 'Created a Vote'
     end
 
     it 'handles empty calls' do
       subject.get "/"
       get "/"
-      last_response.body.should eql ""
+      expect(last_response.body).to eql ""
     end
 
     describe 'root routes should work with' do
@@ -255,7 +255,7 @@ describe Grape::API do
       end
 
       after do
-        last_response.body.should eql "root"
+        expect(last_response.body).to eql "root"
       end
 
       describe 'path versioned APIs' do
@@ -315,9 +315,9 @@ describe Grape::API do
       end
 
       get '/abc'
-      last_response.body.should eql 'foo'
+      expect(last_response.body).to eql 'foo'
       get '/def'
-      last_response.body.should eql 'foo'
+      expect(last_response.body).to eql 'foo'
     end
 
     context 'format' do
@@ -329,14 +329,14 @@ describe Grape::API do
 
       it 'allows .json' do
         get '/abc.json'
-        last_response.status.should == 200
-        last_response.body.should eql 'abc' # json-encoded symbol
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eql 'abc' # json-encoded symbol
       end
 
       it 'allows .txt' do
         get '/abc.txt'
-        last_response.status.should == 200
-        last_response.body.should eql 'def' # raw text
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eql 'def' # raw text
       end
     end
 
@@ -346,7 +346,7 @@ describe Grape::API do
       end
 
       get '/awesome.json'
-      last_response.body.should eql '{"id":"awesome"}'
+      expect(last_response.body).to eql '{"id":"awesome"}'
     end
 
     it 'allows for format in namespace with no path' do
@@ -357,7 +357,7 @@ describe Grape::API do
       end
 
       get '/abc.json'
-      last_response.body.should eql '["json"]'
+      expect(last_response.body).to eql '["json"]'
     end
 
     it 'allows for multiple verbs' do
@@ -366,13 +366,13 @@ describe Grape::API do
       end
 
       subject.endpoints.first.routes.each do |route|
-        route.route_path.should eql '/abc(.:format)'
+        expect(route.route_path).to eql '/abc(.:format)'
       end
 
       get '/abc'
-      last_response.body.should eql 'hiya'
+      expect(last_response.body).to eql 'hiya'
       post '/abc'
-      last_response.body.should eql 'hiya'
+      expect(last_response.body).to eql 'hiya'
     end
 
     [:put, :post].each do |verb|
@@ -384,9 +384,9 @@ describe Grape::API do
               env['api.request.body']
             end
             send verb, '/', MultiJson.dump(object), 'CONTENT_TYPE' => 'application/json'
-            last_response.status.should == (verb == :post ? 201 : 200)
-            last_response.body.should eql MultiJson.dump(object)
-            last_request.params.should eql Hash.new
+            expect(last_response.status).to eq(verb == :post ? 201 : 200)
+            expect(last_response.body).to eql MultiJson.dump(object)
+            expect(last_request.params).to eql Hash.new
           end
           it "stores input in api.request.input" do
             subject.format :json
@@ -394,8 +394,8 @@ describe Grape::API do
               env['api.request.input']
             end
             send verb, '/', MultiJson.dump(object), 'CONTENT_TYPE' => 'application/json'
-            last_response.status.should == (verb == :post ? 201 : 200)
-            last_response.body.should eql MultiJson.dump(object).to_json
+            expect(last_response.status).to eq(verb == :post ? 201 : 200)
+            expect(last_response.body).to eql MultiJson.dump(object).to_json
           end
           context "chunked transfer encoding" do
             it "stores input in api.request.input" do
@@ -404,8 +404,8 @@ describe Grape::API do
                 env['api.request.input']
               end
               send verb, '/', MultiJson.dump(object), 'CONTENT_TYPE' => 'application/json', 'HTTP_TRANSFER_ENCODING' => 'chunked', 'CONTENT_LENGTH' => nil
-              last_response.status.should == (verb == :post ? 201 : 200)
-              last_response.body.should eql MultiJson.dump(object).to_json
+              expect(last_response.status).to eq(verb == :post ? 201 : 200)
+              expect(last_response.body).to eql MultiJson.dump(object).to_json
             end
           end
         end
@@ -426,15 +426,15 @@ describe Grape::API do
       end
 
       get '/1'
-      last_response.body.should eql 'ola'
+      expect(last_response.body).to eql 'ola'
       post '/1'
-      last_response.body.should eql 'ola'
+      expect(last_response.body).to eql 'ola'
       get '/1/first'
-      last_response.body.should eql 'first'
+      expect(last_response.body).to eql 'first'
       post '/1/first'
-      last_response.body.should eql 'first'
+      expect(last_response.body).to eql 'first'
       get '/1/first/second'
-      last_response.body.should eql 'second'
+      expect(last_response.body).to eql 'second'
 
     end
 
@@ -445,7 +445,7 @@ describe Grape::API do
 
       %w(get post put delete options patch).each do |m|
         send(m, '/abc')
-        last_response.body.should eql 'lol'
+        expect(last_response.body).to eql 'lol'
       end
     end
 
@@ -456,10 +456,10 @@ describe Grape::API do
           verb
         end
         send(verb, '/example')
-        last_response.body.should eql verb == 'head' ? '' : verb
+        expect(last_response.body).to eql verb == 'head' ? '' : verb
         # Call it with a method other than the properly constrained one.
         send(used_verb = verbs[(verbs.index(verb) + 2) % verbs.size], '/example')
-        last_response.status.should eql used_verb == 'options' ? 204 : 405
+        expect(last_response.status).to eql used_verb == 'options' ? 204 : 405
       end
     end
 
@@ -469,8 +469,8 @@ describe Grape::API do
       end
 
       post '/example'
-      last_response.status.should eql 201
-      last_response.body.should eql 'Created'
+      expect(last_response.status).to eql 201
+      expect(last_response.body).to eql 'Created'
     end
 
     it 'returns a 405 for an unsupported method with an X-Custom-Header' do
@@ -479,9 +479,9 @@ describe Grape::API do
         "example"
       end
       put '/example'
-      last_response.status.should eql 405
-      last_response.body.should eql ''
-      last_response.headers['X-Custom-Header'].should eql 'foo'
+      expect(last_response.status).to eql 405
+      expect(last_response.body).to eql ''
+      expect(last_response.headers['X-Custom-Header']).to eql 'foo'
     end
 
     specify '405 responses includes an Allow header specifying supported methods' do
@@ -492,7 +492,7 @@ describe Grape::API do
         "example"
       end
       put '/example'
-      last_response.headers['Allow'].should eql 'OPTIONS, GET, POST, HEAD'
+      expect(last_response.headers['Allow']).to eql 'OPTIONS, GET, POST, HEAD'
     end
 
     specify '405 responses includes an Content-Type header' do
@@ -503,7 +503,7 @@ describe Grape::API do
         "example"
       end
       put '/example'
-      last_response.headers['Content-Type'].should eql 'text/plain'
+      expect(last_response.headers['Content-Type']).to eql 'text/plain'
     end
 
     it 'adds an OPTIONS route that returns a 204, an Allow header and a X-Custom-Header' do
@@ -512,10 +512,10 @@ describe Grape::API do
         "example"
       end
       options '/example'
-      last_response.status.should eql 204
-      last_response.body.should eql ''
-      last_response.headers['Allow'].should eql 'OPTIONS, GET, HEAD'
-      last_response.headers['X-Custom-Header'].should eql 'foo'
+      expect(last_response.status).to eql 204
+      expect(last_response.body).to eql ''
+      expect(last_response.headers['Allow']).to eql 'OPTIONS, GET, HEAD'
+      expect(last_response.headers['X-Custom-Header']).to eql 'foo'
     end
 
     it 'allows HEAD on a GET request' do
@@ -523,8 +523,8 @@ describe Grape::API do
         "example"
       end
       head '/example'
-      last_response.status.should eql 200
-      last_response.body.should eql ''
+      expect(last_response.status).to eql 200
+      expect(last_response.body).to eql ''
     end
 
     it 'overwrites the default HEAD request' do
@@ -535,7 +535,7 @@ describe Grape::API do
         "example"
       end
       head '/example'
-      last_response.status.should eql 400
+      expect(last_response.status).to eql 400
     end
   end
 
@@ -548,13 +548,13 @@ describe Grape::API do
     end
     it 'options does not contain HEAD' do
       options '/example'
-      last_response.status.should eql 204
-      last_response.body.should eql ''
-      last_response.headers['Allow'].should eql 'OPTIONS, GET'
+      expect(last_response.status).to eql 204
+      expect(last_response.body).to eql ''
+      expect(last_response.headers['Allow']).to eql 'OPTIONS, GET'
     end
     it 'does not allow HEAD on a GET request' do
       head '/example'
-      last_response.status.should eql 405
+      expect(last_response.status).to eql 405
     end
   end
 
@@ -567,7 +567,7 @@ describe Grape::API do
     end
     it 'options does not exist' do
       options '/example'
-      last_response.status.should eql 405
+      expect(last_response.status).to eql 405
     end
   end
 
@@ -580,7 +580,7 @@ describe Grape::API do
       end
 
       get '/'
-      last_response.body.should eql 'first second'
+      expect(last_response.body).to eql 'first second'
     end
 
     it 'adds a before filter to current and child namespaces only' do
@@ -601,11 +601,11 @@ describe Grape::API do
       end
 
       get '/'
-      last_response.body.should eql 'root - '
+      expect(last_response.body).to eql 'root - '
       get '/blah'
-      last_response.body.should eql 'blah - foo'
+      expect(last_response.body).to eql 'blah - foo'
       get '/blah/bar'
-      last_response.body.should eql 'blah - bar - foo'
+      expect(last_response.body).to eql 'blah - bar - foo'
     end
 
     it 'adds a after_validation filter' do
@@ -619,7 +619,7 @@ describe Grape::API do
       end
 
       get '/', id: "32"
-      last_response.body.should eql 'first 32:Fixnum second'
+      expect(last_response.body).to eql 'first 32:Fixnum second'
     end
 
     it 'adds a after filter' do
@@ -630,9 +630,9 @@ describe Grape::API do
         @var ||= 'default'
       end
 
-      m.should_receive(:do_something!).exactly(2).times
+      expect(m).to receive(:do_something!).exactly(2).times
       get '/'
-      last_response.body.should eql 'default'
+      expect(last_response.body).to eql 'default'
     end
 
     it 'calls all filters when validation passes' do
@@ -654,14 +654,14 @@ describe Grape::API do
         end
       end
 
-      a.should_receive(:do_something!).exactly(1).times
-      b.should_receive(:do_something!).exactly(1).times
-      c.should_receive(:do_something!).exactly(1).times
-      d.should_receive(:do_something!).exactly(1).times
+      expect(a).to receive(:do_something!).exactly(1).times
+      expect(b).to receive(:do_something!).exactly(1).times
+      expect(c).to receive(:do_something!).exactly(1).times
+      expect(d).to receive(:do_something!).exactly(1).times
 
       get '/123'
-      last_response.status.should eql 200
-      last_response.body.should eql 'got it'
+      expect(last_response.status).to eql 200
+      expect(last_response.body).to eql 'got it'
     end
 
     it 'calls only before filters when validation fails' do
@@ -683,14 +683,14 @@ describe Grape::API do
         end
       end
 
-      a.should_receive(:do_something!).exactly(1).times
-      b.should_receive(:do_something!).exactly(1).times
-      c.should_receive(:do_something!).exactly(0).times
-      d.should_receive(:do_something!).exactly(0).times
+      expect(a).to receive(:do_something!).exactly(1).times
+      expect(b).to receive(:do_something!).exactly(1).times
+      expect(c).to receive(:do_something!).exactly(0).times
+      expect(d).to receive(:do_something!).exactly(0).times
 
       get '/abc'
-      last_response.status.should eql 400
-      last_response.body.should eql 'id is invalid'
+      expect(last_response.status).to eql 400
+      expect(last_response.body).to eql 'id is invalid'
     end
 
     it 'calls filters in the correct order' do
@@ -713,14 +713,14 @@ describe Grape::API do
         end
       end
 
-      a.should_receive(:here).with(1).exactly(1).times
-      b.should_receive(:here).with(2).exactly(1).times
-      c.should_receive(:here).with(3).exactly(1).times
-      d.should_receive(:here).with(4).exactly(1).times
+      expect(a).to receive(:here).with(1).exactly(1).times
+      expect(b).to receive(:here).with(2).exactly(1).times
+      expect(c).to receive(:here).with(3).exactly(1).times
+      expect(d).to receive(:here).with(4).exactly(1).times
 
       get '/123'
-      last_response.status.should eql 200
-      last_response.body.should eql 'got it'
+      expect(last_response.status).to eql 200
+      expect(last_response.body).to eql 'got it'
     end
   end
 
@@ -731,32 +731,32 @@ describe Grape::API do
 
     it 'sets content type for txt format' do
       get '/foo'
-      last_response.headers['Content-Type'].should eql 'text/plain'
+      expect(last_response.headers['Content-Type']).to eql 'text/plain'
     end
 
     it 'sets content type for json' do
       get '/foo.json'
-      last_response.headers['Content-Type'].should eql 'application/json'
+      expect(last_response.headers['Content-Type']).to eql 'application/json'
     end
 
     it 'sets content type for error' do
       subject.get('/error') { error!('error in plain text', 500) }
       get '/error'
-      last_response.headers['Content-Type'].should eql 'text/plain'
+      expect(last_response.headers['Content-Type']).to eql 'text/plain'
     end
 
     it 'sets content type for error' do
       subject.format :json
       subject.get('/error') { error!('error in json', 500) }
       get '/error.json'
-      last_response.headers['Content-Type'].should eql 'application/json'
+      expect(last_response.headers['Content-Type']).to eql 'application/json'
     end
 
     it 'sets content type for xml' do
       subject.format :xml
       subject.get('/error') { error!('error in xml', 500) }
       get '/error.xml'
-      last_response.headers['Content-Type'].should eql 'application/xml'
+      expect(last_response.headers['Content-Type']).to eql 'application/xml'
     end
 
     context 'with a custom content_type' do
@@ -770,12 +770,12 @@ describe Grape::API do
 
       it 'sets content type' do
         get '/custom.custom'
-        last_response.headers['Content-Type'].should eql 'application/custom'
+        expect(last_response.headers['Content-Type']).to eql 'application/custom'
       end
 
       it 'sets content type for error' do
         get '/error.custom'
-        last_response.headers['Content-Type'].should eql 'application/custom'
+        expect(last_response.headers['Content-Type']).to eql 'application/custom'
       end
     end
   end
@@ -801,21 +801,21 @@ describe Grape::API do
     describe '.middleware' do
       it 'includes middleware arguments from settings' do
         settings = Grape::Util::HashStack.new
-        settings.stub(:stack).and_return([{ middleware: [[ApiSpec::PhonyMiddleware, 'abc', 123]] }])
-        subject.stub(:settings).and_return(settings)
-        subject.middleware.should eql [[ApiSpec::PhonyMiddleware, 'abc', 123]]
+        allow(settings).to receive(:stack).and_return([{ middleware: [[ApiSpec::PhonyMiddleware, 'abc', 123]] }])
+        allow(subject).to receive(:settings).and_return(settings)
+        expect(subject.middleware).to eql [[ApiSpec::PhonyMiddleware, 'abc', 123]]
       end
 
       it 'includes all middleware from stacked settings' do
         settings = Grape::Util::HashStack.new
-        settings.stub(:stack).and_return [
+        allow(settings).to receive(:stack).and_return [
           { middleware: [[ApiSpec::PhonyMiddleware, 123], [ApiSpec::PhonyMiddleware, 'abc']] },
           { middleware: [[ApiSpec::PhonyMiddleware, 'foo']] }
         ]
 
-        subject.stub(:settings).and_return(settings)
+        allow(subject).to receive(:settings).and_return(settings)
 
-        subject.middleware.should eql [
+        expect(subject.middleware).to eql [
           [ApiSpec::PhonyMiddleware, 123],
           [ApiSpec::PhonyMiddleware, 'abc'],
           [ApiSpec::PhonyMiddleware, 'foo']
@@ -826,7 +826,7 @@ describe Grape::API do
     describe '.use' do
       it 'adds middleware' do
         subject.use ApiSpec::PhonyMiddleware, 123
-        subject.middleware.should eql [[ApiSpec::PhonyMiddleware, 123]]
+        expect(subject.middleware).to eql [[ApiSpec::PhonyMiddleware, 123]]
       end
 
       it 'does not show up outside the namespace' do
@@ -836,7 +836,7 @@ describe Grape::API do
           middleware.should == [[ApiSpec::PhonyMiddleware, 123], [ApiSpec::PhonyMiddleware, 'abc']]
         end
 
-        subject.middleware.should eql [[ApiSpec::PhonyMiddleware, 123]]
+        expect(subject.middleware).to eql [[ApiSpec::PhonyMiddleware, 123]]
       end
 
       it 'calls the middleware' do
@@ -846,13 +846,13 @@ describe Grape::API do
         end
 
         get '/'
-        last_response.body.should eql 'hello'
+        expect(last_response.body).to eql 'hello'
       end
 
       it 'adds a block if one is given' do
         block = lambda {}
         subject.use ApiSpec::PhonyMiddleware, &block
-        subject.middleware.should eql [[ApiSpec::PhonyMiddleware, block]]
+        expect(subject.middleware).to eql [[ApiSpec::PhonyMiddleware, block]]
       end
 
       it 'uses a block if one is given' do
@@ -863,7 +863,7 @@ describe Grape::API do
         end
 
         get '/'
-        last_response.body.should == 'true'
+        expect(last_response.body).to eq('true')
       end
 
       it 'does not destroy the middleware settings on multiple runs' do
@@ -875,7 +875,7 @@ describe Grape::API do
 
         2.times do
           get '/'
-          last_response.body.should == 'true'
+          expect(last_response.body).to eq('true')
         end
       end
 
@@ -889,8 +889,8 @@ describe Grape::API do
         subject.get "/" do
         end
         get "/"
-        last_response.status.should == 400
-        last_response.body.should == "Caught in the Net"
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq("Caught in the Net")
       end
     end
   end
@@ -901,9 +901,9 @@ describe Grape::API do
       end
       subject.get(:hello) { "Hello, world." }
       get '/hello'
-      last_response.status.should eql 401
+      expect(last_response.status).to eql 401
       get '/hello', {}, 'HTTP_AUTHORIZATION' => encode_basic_auth('allow', 'whatever')
-      last_response.status.should eql 200
+      expect(last_response.status).to eql 200
     end
 
     it 'is scopable' do
@@ -917,9 +917,9 @@ describe Grape::API do
       end
 
       get '/hello'
-      last_response.status.should eql 200
+      expect(last_response.status).to eql 200
       get '/admin/hello'
-      last_response.status.should eql 401
+      expect(last_response.status).to eql 401
     end
 
     it 'is callable via .auth as well' do
@@ -929,9 +929,9 @@ describe Grape::API do
 
       subject.get(:hello) { "Hello, world." }
       get '/hello'
-      last_response.status.should eql 401
+      expect(last_response.status).to eql 401
       get '/hello', {}, 'HTTP_AUTHORIZATION' => encode_basic_auth('allow', 'whatever')
-      last_response.status.should eql 200
+      expect(last_response.status).to eql 200
     end
 
     it 'has access to the current endpoint' do
@@ -945,7 +945,7 @@ describe Grape::API do
 
       subject.get(:hello) { "Hello, world." }
       get '/hello', {}, 'HTTP_AUTHORIZATION' => encode_basic_auth('allow', 'whatever')
-      basic_auth_context.should be_an_instance_of(Grape::Endpoint)
+      expect(basic_auth_context).to be_an_instance_of(Grape::Endpoint)
     end
 
     it 'has access to helper methods' do
@@ -961,9 +961,9 @@ describe Grape::API do
 
       subject.get(:hello) { "Hello, world." }
       get '/hello', {}, 'HTTP_AUTHORIZATION' => encode_basic_auth('allow', 'whatever')
-      last_response.status.should eql 200
+      expect(last_response.status).to eql 200
       get '/hello', {}, 'HTTP_AUTHORIZATION' => encode_basic_auth('disallow', 'whatever')
-      last_response.status.should eql 401
+      expect(last_response.status).to eql 401
     end
 
     it 'can set instance variables accessible to routes' do
@@ -975,27 +975,27 @@ describe Grape::API do
 
       subject.get(:hello) { @hello }
       get '/hello', {}, 'HTTP_AUTHORIZATION' => encode_basic_auth('allow', 'whatever')
-      last_response.status.should eql 200
-      last_response.body.should eql "Hello, world."
+      expect(last_response.status).to eql 200
+      expect(last_response.body).to eql "Hello, world."
     end
   end
 
   describe '.logger' do
     it 'returns an instance of Logger class by default' do
-      subject.logger.class.should eql Logger
+      expect(subject.logger.class).to eql Logger
     end
 
     it 'allows setting a custom logger' do
       mylogger = Class.new
       subject.logger mylogger
-      mylogger.should_receive(:info).exactly(1).times
+      expect(mylogger).to receive(:info).exactly(1).times
       subject.logger.info "this will be logged"
     end
 
     it "defaults to a standard logger log format" do
       t = Time.at(100)
-      Time.stub(:now).and_return(t)
-      STDOUT.should_receive(:write).with("I, [#{Logger::Formatter.new.send(:format_datetime, t)}\##{Process.pid}]  INFO -- : this will be logged\n")
+      allow(Time).to receive(:now).and_return(t)
+      expect(STDOUT).to receive(:write).with("I, [#{Logger::Formatter.new.send(:format_datetime, t)}\##{Process.pid}]  INFO -- : this will be logged\n")
       subject.logger.info "this will be logged"
     end
   end
@@ -1013,7 +1013,7 @@ describe Grape::API do
       end
 
       get '/howdy'
-      last_response.body.should eql 'Hello, world.'
+      expect(last_response.body).to eql 'Hello, world.'
     end
 
     it 'is scopable' do
@@ -1040,9 +1040,9 @@ describe Grape::API do
       end
 
       get '/generic'
-      last_response.body.should eql 'always there:false'
+      expect(last_response.body).to eql 'always there:false'
       get '/admin/secret'
-      last_response.body.should eql 'always there:only in admin'
+      expect(last_response.body).to eql 'always there:only in admin'
     end
 
     it 'is reopenable' do
@@ -1062,7 +1062,7 @@ describe Grape::API do
         [one, two]
       end
 
-      lambda { get '/howdy' }.should_not raise_error
+      expect { get '/howdy' }.not_to raise_error
     end
 
     it 'allows for modules' do
@@ -1078,7 +1078,7 @@ describe Grape::API do
       end
 
       get '/howdy'
-      last_response.body.should eql 'Hello, world.'
+      expect(last_response.body).to eql 'Hello, world.'
     end
 
     it 'allows multiple calls with modules and blocks' do
@@ -1100,7 +1100,7 @@ describe Grape::API do
       subject.get 'howdy' do
         [one, two, three]
       end
-      lambda { get '/howdy' }.should_not raise_error
+      expect { get '/howdy' }.not_to raise_error
     end
   end
 
@@ -1122,13 +1122,13 @@ describe Grape::API do
       end
 
       get '/new/abc'
-      last_response.status.should eql 404
+      expect(last_response.status).to eql 404
       get '/legacy/abc'
-      last_response.status.should eql 200
+      expect(last_response.status).to eql 200
       get '/legacy/def'
-      last_response.status.should eql 404
+      expect(last_response.status).to eql 404
       get '/new/def'
-      last_response.status.should eql 200
+      expect(last_response.status).to eql 200
     end
   end
 
@@ -1137,7 +1137,7 @@ describe Grape::API do
       subject.get '/exception' do
         raise "rain!"
       end
-      lambda { get '/exception' }.should raise_error
+      expect { get '/exception' }.to raise_error
     end
 
     it 'rescues all errors if rescue_from :all is called' do
@@ -1146,7 +1146,7 @@ describe Grape::API do
         raise "rain!"
       end
       get '/exception'
-      last_response.status.should eql 500
+      expect(last_response.status).to eql 500
     end
 
     it 'rescues only certain errors if rescue_from is called with specific errors' do
@@ -1155,9 +1155,9 @@ describe Grape::API do
       subject.get('/unrescued') { raise "beefcake" }
 
       get '/rescued'
-      last_response.status.should eql 500
+      expect(last_response.status).to eql 500
 
-      lambda { get '/unrescued' }.should raise_error
+      expect { get '/unrescued' }.to raise_error
     end
 
     context 'CustomError subclass of Grape::Exceptions::Base' do
@@ -1168,7 +1168,7 @@ describe Grape::API do
       it 'does not re-raise exceptions of type Grape::Exceptions::Base' do
         subject.get('/custom_exception') { raise CustomError }
 
-        lambda { get '/custom_exception' }.should_not raise_error
+        expect { get '/custom_exception' }.not_to raise_error
       end
 
       it 'rescues custom grape exceptions' do
@@ -1180,15 +1180,15 @@ describe Grape::API do
         end
 
         get '/custom_error'
-        last_response.status.should == 400
-        last_response.body.should == 'New Error'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('New Error')
       end
     end
 
     it 'can rescue exceptions raised in the formatter' do
       formatter = double(:formatter)
-      formatter.stub(:call) { raise StandardError }
-      Grape::Formatter::Base.stub(:formatter_for) { formatter }
+      allow(formatter).to receive(:call) { raise StandardError }
+      allow(Grape::Formatter::Base).to receive(:formatter_for) { formatter }
 
       subject.rescue_from :all do |e|
         rack_response('Formatter Error', 500)
@@ -1196,8 +1196,8 @@ describe Grape::API do
       subject.get('/formatter_exception') { 'Hello world' }
 
       get '/formatter_exception'
-      last_response.status.should eql 500
-      last_response.body.should == 'Formatter Error'
+      expect(last_response.status).to eql 500
+      expect(last_response.body).to eq('Formatter Error')
     end
   end
 
@@ -1210,8 +1210,8 @@ describe Grape::API do
         raise "rain!"
       end
       get '/exception'
-      last_response.status.should eql 202
-      last_response.body.should == 'rescued from rain!'
+      expect(last_response.status).to eql 202
+      expect(last_response.body).to eq('rescued from rain!')
     end
 
     context 'custom errors' do
@@ -1229,8 +1229,8 @@ describe Grape::API do
           raise ConnectionError
         end
         get '/exception'
-        last_response.status.should eql 500
-        last_response.body.should == 'rescued from ConnectionError'
+        expect(last_response.status).to eql 500
+        expect(last_response.body).to eq('rescued from ConnectionError')
       end
       it 'rescues a specific error' do
         subject.rescue_from ConnectionError do |e|
@@ -1240,8 +1240,8 @@ describe Grape::API do
           raise ConnectionError
         end
         get '/exception'
-        last_response.status.should eql 500
-        last_response.body.should == 'rescued from ConnectionError'
+        expect(last_response.status).to eql 500
+        expect(last_response.body).to eq('rescued from ConnectionError')
       end
       it 'rescues multiple specific errors' do
         subject.rescue_from ConnectionError do |e|
@@ -1257,11 +1257,11 @@ describe Grape::API do
           raise DatabaseError
         end
         get '/connection'
-        last_response.status.should eql 500
-        last_response.body.should == 'rescued from ConnectionError'
+        expect(last_response.status).to eql 500
+        expect(last_response.body).to eq('rescued from ConnectionError')
         get '/database'
-        last_response.status.should eql 500
-        last_response.body.should == 'rescued from DatabaseError'
+        expect(last_response.status).to eql 500
+        expect(last_response.body).to eq('rescued from DatabaseError')
       end
       it 'does not rescue a different error' do
         subject.rescue_from RuntimeError do |e|
@@ -1270,7 +1270,7 @@ describe Grape::API do
         subject.get '/uncaught' do
           raise CommunicationError
         end
-        lambda { get '/uncaught' }.should raise_error(CommunicationError)
+        expect { get '/uncaught' }.to raise_error(CommunicationError)
       end
     end
   end
@@ -1283,8 +1283,8 @@ describe Grape::API do
       subject.get('/rescue_lambda') { raise ArgumentError }
 
       get '/rescue_lambda'
-      last_response.status.should == 400
-      last_response.body.should == "rescued with a lambda"
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq("rescued with a lambda")
     end
 
     it 'can execute the lambda with an argument' do
@@ -1294,8 +1294,8 @@ describe Grape::API do
       subject.get('/rescue_lambda') { raise ArgumentError, 'lambda takes an argument' }
 
       get '/rescue_lambda'
-      last_response.status.should == 400
-      last_response.body.should == 'lambda takes an argument'
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq('lambda takes an argument')
     end
   end
 
@@ -1309,8 +1309,8 @@ describe Grape::API do
       subject.get('/rescue_method') { raise ArgumentError }
 
       get '/rescue_method'
-      last_response.status.should == 400
-      last_response.body.should == 'rescued with a method'
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq('rescued with a method')
     end
   end
 
@@ -1337,10 +1337,10 @@ describe Grape::API do
       end
 
       get '/caught_child'
-      last_response.status.should eql 500
+      expect(last_response.status).to eql 500
       get '/caught_parent'
-      last_response.status.should eql 500
-      lambda { get '/uncaught_parent' }.should raise_error(StandardError)
+      expect(last_response.status).to eql 500
+      expect { get '/uncaught_parent' }.to raise_error(StandardError)
     end
 
     it 'does not rescue child errors if rescue_subclasses is false' do
@@ -1350,7 +1350,7 @@ describe Grape::API do
       subject.get '/uncaught' do
         raise APIErrors::ChildError
       end
-      lambda { get '/uncaught' }.should raise_error(APIErrors::ChildError)
+      expect { get '/uncaught' }.to raise_error(APIErrors::ChildError)
     end
   end
 
@@ -1362,7 +1362,7 @@ describe Grape::API do
         raise "rain!"
       end
       get '/exception'
-      last_response.body.should eql "rain!"
+      expect(last_response.body).to eql "rain!"
     end
 
     it 'rescues all errors and return :txt with backtrace' do
@@ -1372,7 +1372,7 @@ describe Grape::API do
         raise "rain!"
       end
       get '/exception'
-      last_response.body.start_with?("rain!\r\n").should be true
+      expect(last_response.body.start_with?("rain!\r\n")).to be true
     end
 
     it 'rescues all errors with a default formatter' do
@@ -1383,7 +1383,7 @@ describe Grape::API do
         raise "rain!"
       end
       get '/exception.foo'
-      last_response.body.should start_with "rain!"
+      expect(last_response.body).to start_with "rain!"
     end
 
     it 'defaults the error formatter to format' do
@@ -1395,9 +1395,9 @@ describe Grape::API do
         raise "rain!"
       end
       get '/exception.json'
-      last_response.body.should == '{"error":"rain!"}'
+      expect(last_response.body).to eq('{"error":"rain!"}')
       get '/exception.foo'
-      last_response.body.should == '{"error":"rain!"}'
+      expect(last_response.body).to eq('{"error":"rain!"}')
     end
 
     context 'class' do
@@ -1415,7 +1415,7 @@ describe Grape::API do
           raise "rain!"
         end
         get '/exception'
-        last_response.body.should == "message: rain! @backtrace"
+        expect(last_response.body).to eq("message: rain! @backtrace")
       end
     end
 
@@ -1435,7 +1435,7 @@ describe Grape::API do
           subject.get('/exception') { raise "rain!" }
 
           get '/exception'
-          last_response.body.should == 'message: rain! @backtrace'
+          expect(last_response.body).to eq('message: rain! @backtrace')
         end
       end
     end
@@ -1447,7 +1447,7 @@ describe Grape::API do
         raise "rain!"
       end
       get '/exception'
-      last_response.body.should eql '{"error":"rain!"}'
+      expect(last_response.body).to eql '{"error":"rain!"}'
     end
     it 'rescues all errors and return :json with backtrace' do
       subject.rescue_from :all, backtrace: true
@@ -1457,8 +1457,8 @@ describe Grape::API do
       end
       get '/exception'
       json = MultiJson.load(last_response.body)
-      json["error"].should eql 'rain!'
-      json["backtrace"].length.should > 0
+      expect(json["error"]).to eql 'rain!'
+      expect(json["backtrace"].length).to be > 0
     end
     it 'rescues error! and return txt' do
       subject.format :txt
@@ -1466,7 +1466,7 @@ describe Grape::API do
         error!("Access Denied", 401)
       end
       get '/error'
-      last_response.body.should eql "Access Denied"
+      expect(last_response.body).to eql "Access Denied"
     end
     it 'rescues error! and return json' do
       subject.format :json
@@ -1474,7 +1474,7 @@ describe Grape::API do
         error!("Access Denied", 401)
       end
       get '/error'
-      last_response.body.should eql '{"error":"Access Denied"}'
+      expect(last_response.body).to eql '{"error":"Access Denied"}'
     end
   end
 
@@ -1485,7 +1485,7 @@ describe Grape::API do
         "some binary content"
       end
       get '/excel.xls'
-      last_response.content_type.should == "application/vnd.ms-excel"
+      expect(last_response.content_type).to eq("application/vnd.ms-excel")
     end
     it 'allows to override content-type' do
       subject.get :content do
@@ -1493,7 +1493,7 @@ describe Grape::API do
         "var x = 1;"
       end
       get '/content'
-      last_response.content_type.should == "text/javascript"
+      expect(last_response.content_type).to eq("text/javascript")
     end
     it 'removes existing content types' do
       subject.content_type :xls, "application/vnd.ms-excel"
@@ -1501,8 +1501,8 @@ describe Grape::API do
         "some binary content"
       end
       get '/excel.json'
-      last_response.status.should == 406
-      last_response.body.should == "The requested format 'txt' is not supported."
+      expect(last_response.status).to eq(406)
+      expect(last_response.body).to eq("The requested format 'txt' is not supported.")
     end
   end
 
@@ -1517,11 +1517,11 @@ describe Grape::API do
       end
       it 'sets one formatter' do
         get '/simple.json'
-        last_response.body.should eql '{"custom_formatter":"hash"}'
+        expect(last_response.body).to eql '{"custom_formatter":"hash"}'
       end
       it 'sets another formatter' do
         get '/simple.txt'
-        last_response.body.should eql 'custom_formatter: hash'
+        expect(last_response.body).to eql 'custom_formatter: hash'
       end
     end
     context 'custom formatter' do
@@ -1535,11 +1535,11 @@ describe Grape::API do
       end
       it 'uses json' do
         get '/simple.json'
-        last_response.body.should eql '{"some":"hash"}'
+        expect(last_response.body).to eql '{"some":"hash"}'
       end
       it 'uses custom formatter' do
         get '/simple.custom', 'HTTP_ACCEPT' => 'application/custom'
-        last_response.body.should eql '{"custom_formatter":"hash"}'
+        expect(last_response.body).to eql '{"custom_formatter":"hash"}'
       end
     end
     context 'custom formatter class' do
@@ -1558,11 +1558,11 @@ describe Grape::API do
       end
       it 'uses json' do
         get '/simple.json'
-        last_response.body.should eql '{"some":"hash"}'
+        expect(last_response.body).to eql '{"some":"hash"}'
       end
       it 'uses custom formatter' do
         get '/simple.custom', 'HTTP_ACCEPT' => 'application/custom'
-        last_response.body.should eql '{"custom_formatter":"hash"}'
+        expect(last_response.body).to eql '{"custom_formatter":"hash"}'
       end
     end
   end
@@ -1574,8 +1574,8 @@ describe Grape::API do
         { x: params[:x] }
       end
       post "/data", '{"x":42}', 'CONTENT_TYPE' => 'application/json'
-      last_response.status.should == 201
-      last_response.body.should == '{"x":42}'
+      expect(last_response.status).to eq(201)
+      expect(last_response.body).to eq('{"x":42}')
     end
     context 'lambda parser' do
       before :each do
@@ -1589,8 +1589,8 @@ describe Grape::API do
       ["text/custom", "text/custom; charset=UTF-8"].each do |content_type|
         it "uses parser for #{content_type}" do
           put '/simple', "simple", "CONTENT_TYPE" => content_type
-          last_response.status.should == 200
-          last_response.body.should eql "elpmis"
+          expect(last_response.status).to eq(200)
+          expect(last_response.body).to eql "elpmis"
         end
       end
     end
@@ -1610,8 +1610,8 @@ describe Grape::API do
       end
       it 'uses custom parser' do
         put '/simple', "simple", "CONTENT_TYPE" => "text/custom"
-        last_response.status.should == 200
-        last_response.body.should eql "elpmis"
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eql "elpmis"
       end
     end
     context "multi_xml" do
@@ -1620,8 +1620,8 @@ describe Grape::API do
           params[:tag]
         end
         put '/yaml', '<tag type="symbol">a123</tag>', "CONTENT_TYPE" => "application/xml"
-        last_response.status.should == 400
-        last_response.body.should eql 'Disallowed type attribute: "symbol"'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eql 'Disallowed type attribute: "symbol"'
       end
     end
     context "none parser class" do
@@ -1633,8 +1633,8 @@ describe Grape::API do
       end
       it "does not parse data" do
         put '/data', 'not valid json', "CONTENT_TYPE" => "application/json"
-        last_response.status.should == 200
-        last_response.body.should == "body: not valid json"
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq("body: not valid json")
       end
     end
   end
@@ -1649,16 +1649,16 @@ describe Grape::API do
         { x: 42 }
       end
       get "/data"
-      last_response.status.should == 200
-      last_response.body.should == '{"x":42}'
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq('{"x":42}')
     end
     it 'parses data in default format' do
       subject.post '/data' do
         { x: params[:x] }
       end
       post "/data", '{"x":42}', "CONTENT_TYPE" => ""
-      last_response.status.should == 201
-      last_response.body.should == '{"x":42}'
+      expect(last_response.status).to eq(201)
+      expect(last_response.body).to eq('{"x":42}')
     end
   end
 
@@ -1670,7 +1670,7 @@ describe Grape::API do
         raise "rain!"
       end
       get '/exception'
-      last_response.status.should eql 200
+      expect(last_response.status).to eql 200
     end
     it 'has a default error status' do
       subject.rescue_from :all
@@ -1678,7 +1678,7 @@ describe Grape::API do
         raise "rain!"
       end
       get '/exception'
-      last_response.status.should eql 500
+      expect(last_response.status).to eql 500
     end
     it 'uses the default error status in error!' do
       subject.rescue_from :all
@@ -1687,14 +1687,14 @@ describe Grape::API do
         error! "rain!"
       end
       get '/exception'
-      last_response.status.should eql 400
+      expect(last_response.status).to eql 400
     end
   end
 
   context 'routes' do
     describe 'empty api structure' do
       it 'returns an empty array of routes' do
-        subject.routes.should == []
+        expect(subject.routes).to eq([])
       end
     end
     describe 'single method api structure' do
@@ -1704,11 +1704,11 @@ describe Grape::API do
         end
       end
       it 'returns one route' do
-        subject.routes.size.should == 1
+        expect(subject.routes.size).to eq(1)
         route = subject.routes[0]
-        route.route_version.should be_nil
-        route.route_path.should == "/ping(.:format)"
-        route.route_method.should == "GET"
+        expect(route.route_version).to be_nil
+        expect(route.route_path).to eq("/ping(.:format)")
+        expect(route.route_method).to eq("GET")
       end
     end
     describe 'api structure with two versions and a namespace' do
@@ -1729,25 +1729,25 @@ describe Grape::API do
         end
       end
       it 'returns the latest version set' do
-        subject.version.should == 'v2'
+        expect(subject.version).to eq('v2')
       end
       it 'returns versions' do
-        subject.versions.should == ['v1', 'v2']
+        expect(subject.versions).to eq(['v1', 'v2'])
       end
       it 'sets route paths' do
-        subject.routes.size.should >= 2
-        subject.routes[0].route_path.should == "/:version/version(.:format)"
-        subject.routes[1].route_path.should == "/p/:version/n1/n2/version(.:format)"
+        expect(subject.routes.size).to be >= 2
+        expect(subject.routes[0].route_path).to eq("/:version/version(.:format)")
+        expect(subject.routes[1].route_path).to eq("/p/:version/n1/n2/version(.:format)")
       end
       it 'sets route versions' do
-        subject.routes[0].route_version.should == 'v1'
-        subject.routes[1].route_version.should == 'v2'
+        expect(subject.routes[0].route_version).to eq('v1')
+        expect(subject.routes[1].route_version).to eq('v2')
       end
       it 'sets a nested namespace' do
-        subject.routes[1].route_namespace.should == "/n1/n2"
+        expect(subject.routes[1].route_namespace).to eq("/n1/n2")
       end
       it 'sets prefix' do
-        subject.routes[1].route_prefix.should == 'p'
+        expect(subject.routes[1].route_prefix).to eq('p')
       end
     end
     describe 'api structure with additional parameters' do
@@ -1758,16 +1758,16 @@ describe Grape::API do
       end
       it 'splits a string' do
         get "/split/a,b,c.json", token: ','
-        last_response.body.should == '["a","b","c"]'
+        expect(last_response.body).to eq('["a","b","c"]')
       end
       it 'splits a string with limit' do
         get "/split/a,b,c.json", token: ',', limit: '2'
-        last_response.body.should == '["a","b,c"]'
+        expect(last_response.body).to eq('["a","b,c"]')
       end
       it 'sets route_params' do
-        subject.routes.map { |route|
+        expect(subject.routes.map { |route|
           { params: route.route_params, optional_params: route.route_optional_params }
-        }.should eq [
+        }).to eq [
           { params: { "string" => "", "token" => "a token" }, optional_params: { "limit" => "the limit" } }
       ]
       end
@@ -1776,30 +1776,30 @@ describe Grape::API do
 
   context 'desc' do
     it 'empty array of routes' do
-      subject.routes.should == []
+      expect(subject.routes).to eq([])
     end
     it 'empty array of routes' do
       subject.desc "grape api"
-      subject.routes.should == []
+      expect(subject.routes).to eq([])
     end
     it 'describes a method' do
       subject.desc "first method"
       subject.get :first do ; end
-      subject.routes.length.should == 1
+      expect(subject.routes.length).to eq(1)
       route = subject.routes.first
-      route.route_description.should == "first method"
-      route.route_foo.should be_nil
-      route.route_params.should == {}
+      expect(route.route_description).to eq("first method")
+      expect(route.route_foo).to be_nil
+      expect(route.route_params).to eq({})
     end
     it 'describes methods separately' do
       subject.desc "first method"
       subject.get :first do ; end
       subject.desc "second method"
       subject.get :second do ; end
-      subject.routes.count.should == 2
-      subject.routes.map { |route|
+      expect(subject.routes.count).to eq(2)
+      expect(subject.routes.map { |route|
         { description: route.route_description, params: route.route_params }
-      }.should eq [
+      }).to eq [
         { description: "first method", params: {} },
         { description: "second method", params: {} }
     ]
@@ -1808,9 +1808,9 @@ describe Grape::API do
       subject.desc "first method"
       subject.get :first do ; end
       subject.get :second do ; end
-      subject.routes.map { |route|
+      expect(subject.routes.map { |route|
         { description: route.route_description, params: route.route_params }
-      }.should eq [
+      }).to eq [
         { description: "first method", params: {} },
         { description: nil, params: {} }
     ]
@@ -1820,18 +1820,18 @@ describe Grape::API do
         desc "ns second", foo: "bar"
         get 'second' do ; end
       end
-      subject.routes.map { |route|
+      expect(subject.routes.map { |route|
         { description: route.route_description, foo: route.route_foo, params: route.route_params }
-      }.should eq [
+      }).to eq [
         { description: "ns second", foo: "bar", params: {} }
     ]
     end
     it 'includes details' do
       subject.desc "method", details: "method details"
       subject.get 'method' do ; end
-      subject.routes.map { |route|
+      expect(subject.routes.map { |route|
         { description: route.route_description, details: route.route_details, params: route.route_params }
-      }.should eq [
+      }).to eq [
         { description: "method", details: "method details", params: {} }
     ]
     end
@@ -1840,9 +1840,9 @@ describe Grape::API do
       subject.get 'reverse' do
         params[:s].reverse
       end
-      subject.routes.map { |route|
+      expect(subject.routes.map { |route|
         { description: route.route_description, params: route.route_params }
-      }.should eq [
+      }).to eq [
         { description: "Reverses a string.", params: { "s" => { desc: "string to reverse", type: "string" } } }
     ]
     end
@@ -1858,9 +1858,9 @@ describe Grape::API do
         end
         get 'method' do ; end
       end
-      subject.routes.map { |route|
+      expect(subject.routes.map { |route|
         { description: route.route_description, params: route.route_params }
-      }.should eq [
+      }).to eq [
         { description: "method",
           params: {
             "ns_param" => { required: true, desc: "namespace parameter" },
@@ -1889,9 +1889,9 @@ describe Grape::API do
           get 'method' do ; end
         end
       end
-      subject.routes.map { |route|
+      expect(subject.routes.map { |route|
         { description: route.route_description, params: route.route_params }
-      }.should eq [
+      }).to eq [
         { description: "method",
           params: {
             "ns_param" => { required: true, desc: "ns param 2" },
@@ -1916,9 +1916,9 @@ describe Grape::API do
       end
       subject.get "method" do ; end
 
-      subject.routes.map { |route|
+      expect(subject.routes.map { |route|
         route.route_params
-      }.should eq [{
+      }).to eq [{
         "group1"         => { required: true, type: "Array" },
         "group1[param1]" => { required: false, desc: "group1 param1 desc" },
         "group1[param2]" => { required: true, desc: "group1 param2 desc" },
@@ -1936,9 +1936,9 @@ describe Grape::API do
         end
       end
       subject.get 'method' do ; end
-      subject.routes.map { |route|
+      expect(subject.routes.map { |route|
         { description: route.route_description, params: route.route_params }
-      }.should eq [
+      }).to eq [
         { description: "nesting",
           params: {
             "root_param" => { required: true, desc: "root param" },
@@ -1960,9 +1960,9 @@ describe Grape::API do
         requires :one_param, desc: "one param"
       end
       subject.get 'method' do ; end
-      subject.routes.map { |route|
+      expect(subject.routes.map { |route|
         { description: route.route_description, params: route.route_params }
-      }.should eq [
+      }).to eq [
         { description: nil, params: { "one_param" => { required: true, desc: "one param" } } }
     ]
     end
@@ -1971,9 +1971,9 @@ describe Grape::API do
       subject.get 'reverse/:s' do
         params[:s].reverse
       end
-      subject.routes.map { |route|
+      expect(subject.routes.map { |route|
         { description: route.route_description, params: route.route_params }
-      }.should eq [
+      }).to eq [
         { description: "Reverses a string.", params: { "s" => { desc: "string to reverse", type: "string" } } }
     ]
     end
@@ -1989,12 +1989,12 @@ describe Grape::API do
 
       it 'makes a bare Rack app available at the endpoint' do
         get '/mounty'
-        last_response.body.should == 'MOUNTED'
+        expect(last_response.body).to eq('MOUNTED')
       end
 
       it 'anchors the routes, passing all subroutes to it' do
         get '/mounty/awesome'
-        last_response.body.should == 'MOUNTED'
+        expect(last_response.body).to eq('MOUNTED')
       end
 
       it 'is able to cascade' do
@@ -2005,9 +2005,9 @@ describe Grape::API do
         } => '/'
 
         get '/boo'
-        last_response.body.should == 'Farfegnugen'
+        expect(last_response.body).to eq('Farfegnugen')
         get '/mounty'
-        last_response.body.should == 'MOUNTED'
+        expect(last_response.body).to eq('MOUNTED')
       end
     end
 
@@ -2015,7 +2015,7 @@ describe Grape::API do
       it 'calls through setting the route to "/"' do
         subject.mount mounted_app
         get '/'
-        last_response.body.should == 'MOUNTED'
+        expect(last_response.body).to eq('MOUNTED')
       end
     end
 
@@ -2033,7 +2033,7 @@ describe Grape::API do
         end
 
         get '/v1/cool/awesome'
-        last_response.body.should == 'yo'
+        expect(last_response.body).to eq('yo')
       end
 
       it 'applies the settings to nested mounted apis' do
@@ -2051,7 +2051,7 @@ describe Grape::API do
         end
 
         get '/v1/cool/awesome'
-        last_response.body.should == 'yo'
+        expect(last_response.body).to eq('yo')
       end
 
       it 'inherits rescues even when some defined by mounted' do
@@ -2065,8 +2065,8 @@ describe Grape::API do
           mount app
         end
         get '/mounted/fail'
-        last_response.status.should eql 202
-        last_response.body.should == 'rescued from doh!'
+        expect(last_response.status).to eql 202
+        expect(last_response.body).to eq('rescued from doh!')
       end
 
       it 'collects the routes of the mounted api' do
@@ -2076,9 +2076,9 @@ describe Grape::API do
           app.post('/sauce') {}
           mount app
         end
-        subject.routes.size.should == 2
-        subject.routes.first.route_path.should =~ %r{\/cool\/awesome}
-        subject.routes.last.route_path.should =~ %r{\/cool\/sauce}
+        expect(subject.routes.size).to eq(2)
+        expect(subject.routes.first.route_path).to match(%r{\/cool\/awesome})
+        expect(subject.routes.last.route_path).to match(%r{\/cool\/sauce})
       end
 
       it 'mounts on a path' do
@@ -2090,8 +2090,8 @@ describe Grape::API do
           mount app => '/mounted'
         end
         get "/mounted/cool/awesome"
-        last_response.status.should == 200
-        last_response.body.should == "sauce"
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq("sauce")
       end
 
       it 'mounts on a nested path' do
@@ -2104,10 +2104,10 @@ describe Grape::API do
         subject.mount app1 => '/app1'
         app1.mount app2 => '/app2'
         get "/app1/app2/nice"
-        last_response.status.should == 200
-        last_response.body.should == "play"
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq("play")
         options "/app1/app2/nice"
-        last_response.status.should == 204
+        expect(last_response.status).to eq(204)
       end
 
       it 'responds to options' do
@@ -2124,15 +2124,15 @@ describe Grape::API do
           mount app
         end
         get '/apples/colour'
-        last_response.status.should eql 200
-        last_response.body.should == 'red'
+        expect(last_response.status).to eql 200
+        expect(last_response.body).to eq('red')
         options '/apples/colour'
-        last_response.status.should eql 204
+        expect(last_response.status).to eql 204
         get '/apples/pears/colour'
-        last_response.status.should eql 200
-        last_response.body.should == 'green'
+        expect(last_response.status).to eql 200
+        expect(last_response.body).to eq('green')
         options '/apples/pears/colour'
-        last_response.status.should eql 204
+        expect(last_response.status).to eql 204
       end
 
       it 'responds to options with path versioning' do
@@ -2146,10 +2146,10 @@ describe Grape::API do
         end
 
         get '/v1/apples/colour'
-        last_response.status.should eql 200
-        last_response.body.should == 'red'
+        expect(last_response.status).to eql 200
+        expect(last_response.body).to eq('red')
         options '/v1/apples/colour'
-        last_response.status.should eql 204
+        expect(last_response.status).to eql 204
       end
 
     end
@@ -2159,15 +2159,15 @@ describe Grape::API do
     it 'adds one for each route created' do
       subject.get '/'
       subject.post '/'
-      subject.endpoints.size.should == 2
+      expect(subject.endpoints.size).to eq(2)
     end
   end
 
   describe '.compile' do
     it 'sets the instance' do
-      subject.instance.should be_nil
+      expect(subject.instance).to be_nil
       subject.compile
-      subject.instance.should be_kind_of(subject)
+      expect(subject.instance).to be_kind_of(subject)
     end
   end
 
@@ -2175,7 +2175,7 @@ describe Grape::API do
     it 'invalidates any compiled instance' do
       subject.compile
       subject.change!
-      subject.instance.should be_nil
+      expect(subject.instance).to be_nil
     end
   end
 
@@ -2192,9 +2192,9 @@ describe Grape::API do
     it 'path' do
       get '/endpoint/options'
       options = MultiJson.load(last_response.body)
-      options["path"].should == ["/endpoint/options"]
-      options["source_location"][0].should include "api_spec.rb"
-      options["source_location"][1].to_i.should > 0
+      expect(options["path"]).to eq(["/endpoint/options"])
+      expect(options["source_location"][0]).to include "api_spec.rb"
+      expect(options["source_location"][1].to_i).to be > 0
     end
   end
 
@@ -2210,9 +2210,9 @@ describe Grape::API do
       end
       it 'provides access to route info' do
         get '/'
-        last_response.body.should == "/(.:format)"
+        expect(last_response.body).to eq("/(.:format)")
         get '/path'
-        last_response.body.should == "/path(.:format)"
+        expect(last_response.body).to eq("/path(.:format)")
       end
     end
     context 'with desc' do
@@ -2228,11 +2228,11 @@ describe Grape::API do
       end
       it 'returns route description' do
         get '/description'
-        last_response.body.should == "returns description"
+        expect(last_response.body).to eq("returns description")
       end
       it 'returns route parameters' do
         get '/params/x'
-        last_response.body.should == "y"
+        expect(last_response.body).to eq("y")
       end
     end
   end
@@ -2247,15 +2247,15 @@ describe Grape::API do
       end
       it 'forces txt without an extension' do
         get '/meaning_of_life'
-        last_response.body.should == { meaning_of_life: 42 }.to_s
+        expect(last_response.body).to eq({ meaning_of_life: 42 }.to_s)
       end
       it 'does not force txt with an extension' do
         get '/meaning_of_life.json'
-        last_response.body.should == { meaning_of_life: 42 }.to_json
+        expect(last_response.body).to eq({ meaning_of_life: 42 }.to_json)
       end
       it 'forces txt from a non-accepting header' do
         get '/meaning_of_life', {}, 'HTTP_ACCEPT' => 'application/json'
-        last_response.body.should == { meaning_of_life: 42 }.to_s
+        expect(last_response.body).to eq({ meaning_of_life: 42 }.to_s)
       end
     end
     context ':txt only' do
@@ -2267,15 +2267,15 @@ describe Grape::API do
       end
       it 'forces txt without an extension' do
         get '/meaning_of_life'
-        last_response.body.should == { meaning_of_life: 42 }.to_s
+        expect(last_response.body).to eq({ meaning_of_life: 42 }.to_s)
       end
       it 'forces txt with the wrong extension' do
         get '/meaning_of_life.json'
-        last_response.body.should == { meaning_of_life: 42 }.to_s
+        expect(last_response.body).to eq({ meaning_of_life: 42 }.to_s)
       end
       it 'forces txt from a non-accepting header' do
         get '/meaning_of_life', {}, 'HTTP_ACCEPT' => 'application/json'
-        last_response.body.should == { meaning_of_life: 42 }.to_s
+        expect(last_response.body).to eq({ meaning_of_life: 42 }.to_s)
       end
     end
     context ':json' do
@@ -2288,15 +2288,15 @@ describe Grape::API do
       end
       it 'forces json without an extension' do
         get '/meaning_of_life'
-        last_response.body.should == { meaning_of_life: 42 }.to_json
+        expect(last_response.body).to eq({ meaning_of_life: 42 }.to_json)
       end
       it 'does not force json with an extension' do
         get '/meaning_of_life.txt'
-        last_response.body.should == { meaning_of_life: 42 }.to_s
+        expect(last_response.body).to eq({ meaning_of_life: 42 }.to_s)
       end
       it 'forces json from a non-accepting header' do
         get '/meaning_of_life', {}, 'HTTP_ACCEPT' => 'text/html'
-        last_response.body.should == { meaning_of_life: 42 }.to_json
+        expect(last_response.body).to eq({ meaning_of_life: 42 }.to_json)
       end
       it 'can be overwritten with an explicit content type' do
         subject.get '/meaning_of_life_with_content_type' do
@@ -2304,7 +2304,7 @@ describe Grape::API do
           { meaning_of_life: 42 }.to_s
         end
         get '/meaning_of_life_with_content_type'
-        last_response.body.should == { meaning_of_life: 42 }.to_s
+        expect(last_response.body).to eq({ meaning_of_life: 42 }.to_s)
       end
       it 'raised :error from middleware' do
         middleware = Class.new(Grape::Middleware::Base) do
@@ -2317,8 +2317,8 @@ describe Grape::API do
 
         end
         get "/"
-        last_response.status.should == 42
-        last_response.body.should == { error: "Unauthorized" }.to_json
+        expect(last_response.status).to eq(42)
+        expect(last_response.body).to eq({ error: "Unauthorized" }.to_json)
       end
 
     end
@@ -2336,21 +2336,21 @@ describe Grape::API do
           SerializableHashExample.new
         end
         get '/example'
-        last_response.body.should == '{"abc":"def"}'
+        expect(last_response.body).to eq('{"abc":"def"}')
       end
       it 'root' do
         subject.get '/example' do
           { "root" => SerializableHashExample.new }
         end
         get '/example'
-        last_response.body.should == '{"root":{"abc":"def"}}'
+        expect(last_response.body).to eq('{"root":{"abc":"def"}}')
       end
       it 'array' do
         subject.get '/examples' do
           [SerializableHashExample.new, SerializableHashExample.new]
         end
         get '/examples'
-        last_response.body.should == '[{"abc":"def"},{"abc":"def"}]'
+        expect(last_response.body).to eq('[{"abc":"def"},{"abc":"def"}]')
       end
     end
     context ":xml" do
@@ -2362,8 +2362,8 @@ describe Grape::API do
           "example"
         end
         get '/example'
-        last_response.status.should == 500
-        last_response.body.should == <<-XML
+        expect(last_response.status).to eq(500)
+        expect(last_response.body).to eq <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <error>
   <message>cannot convert String to xml</message>
@@ -2378,8 +2378,8 @@ XML
         ]
         end
         get '/example'
-        last_response.status.should == 200
-        last_response.body.should == <<-XML
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <hash>
   <example1>example1</example1>
@@ -2392,8 +2392,8 @@ XML
           ["example1", "example2"]
         end
         get '/example'
-        last_response.status.should == 200
-        last_response.body.should == <<-XML
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <strings type="array">
   <string>example1</string>
@@ -2412,8 +2412,8 @@ XML
 
         end
         get "/"
-        last_response.status.should == 42
-        last_response.body.should == <<-XML
+        expect(last_response.status).to eq(42)
+        expect(last_response.body).to eq <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <error>
   <message>Unauthorized</message>
@@ -2444,14 +2444,14 @@ XML
           error!("Unrecognized request path: #{params[:path] } - #{env['PATH_INFO'] }#{env['SCRIPT_NAME'] }", 404)
         end
         get "/v1/hello"
-        last_response.status.should == 200
-        last_response.body.should == "v1"
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq("v1")
         get "/v2/hello"
-        last_response.status.should == 200
-        last_response.body.should == "v2"
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq("v2")
         get "/foobar"
-        last_response.status.should == 404
-        last_response.body.should == "Unrecognized request path: foobar - /foobar"
+        expect(last_response.status).to eq(404)
+        expect(last_response.body).to eq("Unrecognized request path: foobar - /foobar")
       end
     end
   end
@@ -2461,28 +2461,28 @@ XML
       it "cascades" do
         subject.version 'v1', using: :path, cascade: true
         get "/v1/hello"
-        last_response.status.should == 404
-        last_response.headers["X-Cascade"].should == "pass"
+        expect(last_response.status).to eq(404)
+        expect(last_response.headers["X-Cascade"]).to eq("pass")
       end
       it "does not cascade" do
         subject.version 'v2', using: :path, cascade: false
         get "/v2/hello"
-        last_response.status.should == 404
-        last_response.headers.keys.should_not include "X-Cascade"
+        expect(last_response.status).to eq(404)
+        expect(last_response.headers.keys).not_to include "X-Cascade"
       end
     end
     context "via endpoint" do
       it "cascades" do
         subject.cascade true
         get "/hello"
-        last_response.status.should == 404
-        last_response.headers["X-Cascade"].should == "pass"
+        expect(last_response.status).to eq(404)
+        expect(last_response.headers["X-Cascade"]).to eq("pass")
       end
       it "does not cascade" do
         subject.cascade false
         get "/hello"
-        last_response.status.should == 404
-        last_response.headers.keys.should_not include "X-Cascade"
+        expect(last_response.status).to eq(404)
+        expect(last_response.headers.keys).not_to include "X-Cascade"
       end
     end
   end
@@ -2495,8 +2495,8 @@ XML
         'foo'
       end
       get '/something'
-      last_response.status.should == 406
-      last_response.body.should == "{\"error\":\"The requested format 'txt' is not supported.\"}"
+      expect(last_response.status).to eq(406)
+      expect(last_response.body).to eq("{\"error\":\"The requested format 'txt' is not supported.\"}")
     end
   end
 end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -22,7 +22,7 @@ describe Grape::Endpoint do
   it 'sets itself in the env upon call' do
     subject.get('/') { "Hello world." }
     get '/'
-    last_request.env['api.endpoint'].should be_kind_of(Grape::Endpoint)
+    expect(last_request.env['api.endpoint']).to be_kind_of(Grape::Endpoint)
   end
 
   describe '#status' do
@@ -33,8 +33,8 @@ describe Grape::Endpoint do
       end
 
       get '/home'
-      last_response.status.should == 206
-      last_response.body.should == "Hello"
+      expect(last_response.status).to eq(206)
+      expect(last_response.body).to eq("Hello")
     end
   end
 
@@ -46,7 +46,7 @@ describe Grape::Endpoint do
       end
 
       get '/hey'
-      last_response.headers['X-Awesome'].should == 'true'
+      expect(last_response.headers['X-Awesome']).to eq('true')
     end
   end
 
@@ -58,20 +58,20 @@ describe Grape::Endpoint do
     end
     it 'includes request headers' do
       get '/headers'
-      JSON.parse(last_response.body).should == {
-        "Host" => "example.org",
-        "Cookie" => ""
-      }
+      expect(JSON.parse(last_response.body)).to eq(
+          "Host" => "example.org",
+          "Cookie" => ""
+      )
     end
     it 'includes additional request headers' do
       get '/headers', nil, "HTTP_X_GRAPE_CLIENT" => "1"
-      JSON.parse(last_response.body)["X-Grape-Client"].should == "1"
+      expect(JSON.parse(last_response.body)["X-Grape-Client"]).to eq("1")
     end
     it 'includes headers passed as symbols' do
       env = Rack::MockRequest.env_for("/headers")
       env["HTTP_SYMBOL_HEADER".to_sym] = "Goliath passes symbols"
       body = subject.call(env)[2].body.first
-      JSON.parse(body)["Symbol-Header"].should == "Goliath passes symbols"
+      expect(JSON.parse(body)["Symbol-Header"]).to eq("Goliath passes symbols")
     end
   end
 
@@ -91,7 +91,7 @@ describe Grape::Endpoint do
 
       get('/get/cookies')
 
-      last_response.headers['Set-Cookie'].split("\n").sort.should eql [
+      expect(last_response.headers['Set-Cookie'].split("\n").sort).to eql [
         "cookie3=symbol",
         "cookie4=secret+code+here",
         "my-awesome-cookie1=is+cool",
@@ -105,9 +105,8 @@ describe Grape::Endpoint do
       end
       get('/username', {}, 'HTTP_COOKIE' => 'username=mrplum; sandbox=true')
 
-      last_response.body.should == 'mrplum'
-      last_response.headers['Set-Cookie'].should_not =~ /username=mrplum/
-      last_response.headers['Set-Cookie'].should_not =~ /sandbox=true/
+      expect(last_response.body).to eq('mrplum')
+      expect(last_response.headers['Set-Cookie']).to be_nil
     end
 
     it 'sets and update browser cookies' do
@@ -116,9 +115,9 @@ describe Grape::Endpoint do
         cookies[:username] += "_test"
       end
       get('/username', {}, 'HTTP_COOKIE' => 'username=user; sandbox=false')
-      last_response.body.should == 'user_test'
-      last_response.headers['Set-Cookie'].should =~ /username=user_test/
-      last_response.headers['Set-Cookie'].should =~ /sandbox=true/
+      expect(last_response.body).to eq('user_test')
+      expect(last_response.headers['Set-Cookie']).to match(/username=user_test/)
+      expect(last_response.headers['Set-Cookie']).to match(/sandbox=true/)
     end
 
     it 'deletes cookie' do
@@ -131,17 +130,17 @@ describe Grape::Endpoint do
         sum
       end
       get '/test', {}, 'HTTP_COOKIE' => 'delete_this_cookie=1; and_this=2'
-      last_response.body.should == '3'
+      expect(last_response.body).to eq('3')
       cookies = Hash[last_response.headers['Set-Cookie'].split("\n").map do |set_cookie|
         cookie = CookieJar::Cookie.from_set_cookie 'http://localhost/test', set_cookie
         [cookie.name, cookie]
       end]
-      cookies.size.should == 2
+      expect(cookies.size).to eq(2)
       ["and_this", "delete_this_cookie"].each do |cookie_name|
         cookie = cookies[cookie_name]
-        cookie.should_not be_nil
-        cookie.value.should == "deleted"
-        cookie.expired?.should be true
+        expect(cookie).not_to be_nil
+        expect(cookie.value).to eq("deleted")
+        expect(cookie.expired?).to be true
       end
     end
 
@@ -155,18 +154,18 @@ describe Grape::Endpoint do
         sum
       end
       get('/test', {}, 'HTTP_COOKIE' => 'delete_this_cookie=1; and_this=2')
-      last_response.body.should == '3'
+      expect(last_response.body).to eq('3')
       cookies = Hash[last_response.headers['Set-Cookie'].split("\n").map do |set_cookie|
         cookie = CookieJar::Cookie.from_set_cookie 'http://localhost/test', set_cookie
         [cookie.name, cookie]
       end]
-      cookies.size.should == 2
+      expect(cookies.size).to eq(2)
       ["and_this", "delete_this_cookie"].each do |cookie_name|
         cookie = cookies[cookie_name]
-        cookie.should_not be_nil
-        cookie.value.should == "deleted"
-        cookie.path.should == "/test"
-        cookie.expired?.should be true
+        expect(cookie).not_to be_nil
+        expect(cookie.value).to eq("deleted")
+        expect(cookie.path).to eq("/test")
+        expect(cookie.expired?).to be true
       end
     end
   end
@@ -190,7 +189,7 @@ describe Grape::Endpoint do
       end
 
       get '/declared?first=present'
-      last_response.status.should == 200
+      expect(last_response.status).to eq(200)
     end
 
     it 'has a optional param with default value all the time' do
@@ -200,7 +199,7 @@ describe Grape::Endpoint do
       end
 
       get '/declared?first=one'
-      last_response.status.should == 200
+      expect(last_response.status).to eq(200)
     end
 
     it 'builds nested params' do
@@ -210,7 +209,7 @@ describe Grape::Endpoint do
       end
 
       get '/declared?first=present&nested[fourth]=1'
-      last_response.status.should == 200
+      expect(last_response.status).to eq(200)
     end
 
     it 'builds nested params when given array' do
@@ -230,7 +229,7 @@ describe Grape::Endpoint do
       end
 
       get '/declared?first=present&nested[][fourth]=1&nested[][fourth]=2'
-      last_response.status.should == 200
+      expect(last_response.status).to eq(200)
     end
 
     it 'filters out any additional params that are given' do
@@ -240,7 +239,7 @@ describe Grape::Endpoint do
       end
 
       get '/declared?first=one&other=two'
-      last_response.status.should == 200
+      expect(last_response.status).to eq(200)
     end
 
     it 'stringifies if that option is passed' do
@@ -250,7 +249,7 @@ describe Grape::Endpoint do
       end
 
       get '/declared?first=one&other=two'
-      last_response.status.should == 200
+      expect(last_response.status).to eq(200)
     end
 
     it 'does not include missing attributes if that option is passed' do
@@ -260,7 +259,7 @@ describe Grape::Endpoint do
       end
 
       get '/declared?first=one&other=two'
-      last_response.status.should == 200
+      expect(last_response.status).to eq(200)
     end
   end
 
@@ -320,7 +319,7 @@ describe Grape::Endpoint do
       end
 
       get '/hey?howdy=hey'
-      last_response.body.should == 'hey'
+      expect(last_response.body).to eq('hey')
     end
 
     it 'parses from path segments' do
@@ -329,7 +328,7 @@ describe Grape::Endpoint do
       end
 
       get '/hey/12'
-      last_response.body.should == '12'
+      expect(last_response.body).to eq('12')
     end
 
     it 'deeply converts nested params' do
@@ -337,7 +336,7 @@ describe Grape::Endpoint do
         params[:location][:city]
       end
       get '/location?location[city]=Dallas'
-      last_response.body.should == 'Dallas'
+      expect(last_response.body).to eq('Dallas')
     end
 
     context 'with special requirements' do
@@ -347,10 +346,10 @@ describe Grape::Endpoint do
         end
 
         get '/someone@example.com'
-        last_response.body.should == 'someone@example.com'
+        expect(last_response.body).to eq('someone@example.com')
 
         get 'someone@example.com.pl'
-        last_response.body.should == 'someone@example.com.pl'
+        expect(last_response.body).to eq('someone@example.com.pl')
       end
 
       it 'parses many params with provided regexps' do
@@ -359,16 +358,16 @@ describe Grape::Endpoint do
         end
 
         get '/someone@example.com/test/1'
-        last_response.body.should == 'someone@example.com1'
+        expect(last_response.body).to eq('someone@example.com1')
 
         get '/someone@testing.wrong/test/1'
-        last_response.status.should == 404
+        expect(last_response.status).to eq(404)
 
         get 'someone@test.com/test/wrong_number'
-        last_response.status.should == 404
+        expect(last_response.status).to eq(404)
 
         get 'someone@test.com/wrong_middle/1'
-        last_response.status.should == 404
+        expect(last_response.status).to eq(404)
       end
 
       context 'namespace requirements' do
@@ -387,16 +386,16 @@ describe Grape::Endpoint do
         end
         it "parse email param with provided requirements for params" do
           get '/outer/abc@example.com'
-          last_response.body.should == 'abc@example.com'
+          expect(last_response.body).to eq('abc@example.com')
         end
 
         it "should override outer namespace's requirements" do
           get '/outer/inner/someone@testing.wrong/test/1'
-          last_response.status.should == 404
+          expect(last_response.status).to eq(404)
 
           get '/outer/inner/someone@testing.com/test/1'
-          last_response.status.should == 200
-          last_response.body.should == 'someone@testing.com1'
+          expect(last_response.status).to eq(200)
+          expect(last_response.body).to eq('someone@testing.com1')
         end
 
       end
@@ -414,22 +413,22 @@ describe Grape::Endpoint do
 
       it 'converts JSON bodies to params' do
         post '/request_body', MultiJson.dump(user: 'Bobby T.'), 'CONTENT_TYPE' => 'application/json'
-        last_response.body.should == 'Bobby T.'
+        expect(last_response.body).to eq('Bobby T.')
       end
 
       it 'does not convert empty JSON bodies to params' do
         put '/request_body', '', 'CONTENT_TYPE' => 'application/json'
-        last_response.body.should == ''
+        expect(last_response.body).to eq('')
       end
 
       it 'converts XML bodies to params' do
         post '/request_body', '<user>Bobby T.</user>', 'CONTENT_TYPE' => 'application/xml'
-        last_response.body.should == 'Bobby T.'
+        expect(last_response.body).to eq('Bobby T.')
       end
 
       it 'converts XML bodies to params' do
         put '/request_body', '<user>Bobby T.</user>', 'CONTENT_TYPE' => 'application/xml'
-        last_response.body.should == 'Bobby T.'
+        expect(last_response.body).to eq('Bobby T.')
       end
 
       it 'does not include parameters not defined by the body' do
@@ -438,8 +437,8 @@ describe Grape::Endpoint do
           params[:user]
         end
         post '/omitted_params', MultiJson.dump(user: 'Bob'), 'CONTENT_TYPE' => 'application/json'
-        last_response.status.should == 201
-        last_response.body.should == "Bob"
+        expect(last_response.status).to eq(201)
+        expect(last_response.body).to eq("Bob")
       end
     end
 
@@ -450,8 +449,8 @@ describe Grape::Endpoint do
         params[:user]
       end
       put '/request_body', '<user>Bobby T.</user>', 'CONTENT_TYPE' => 'application/xml'
-      last_response.status.should == 406
-      last_response.body.should == '{"error":"The requested content-type \'application/xml\' is not supported."}'
+      expect(last_response.status).to eq(406)
+      expect(last_response.body).to eq('{"error":"The requested content-type \'application/xml\' is not supported."}')
     end
 
     context 'content type with params' do
@@ -466,11 +465,11 @@ describe Grape::Endpoint do
       end
 
       it "should not response with 406 for same type without params" do
-        last_response.status.should_not be 406
+        expect(last_response.status).not_to be 406
       end
 
       it "should response with given content type in headers" do
-        last_response.headers['Content-Type'].should eq 'application/json; charset=utf-8'
+        expect(last_response.headers['Content-Type']).to eq 'application/json; charset=utf-8'
       end
 
     end
@@ -523,8 +522,8 @@ describe Grape::Endpoint do
       end
 
       get '/hey'
-      last_response.status.should == 500
-      last_response.body.should == "This is not valid."
+      expect(last_response.status).to eq(500)
+      expect(last_response.body).to eq("This is not valid.")
     end
 
     it 'accepts a code' do
@@ -533,8 +532,8 @@ describe Grape::Endpoint do
       end
 
       get '/hey'
-      last_response.status.should == 401
-      last_response.body.should == "Unauthorized."
+      expect(last_response.status).to eq(401)
+      expect(last_response.body).to eq("Unauthorized.")
     end
 
     it 'accepts an object and render it in format' do
@@ -543,8 +542,8 @@ describe Grape::Endpoint do
       end
 
       get '/hey.json'
-      last_response.status.should == 403
-      last_response.body.should == '{"dude":"rad"}'
+      expect(last_response.status).to eq(403)
+      expect(last_response.body).to eq('{"dude":"rad"}')
     end
 
     it 'can specifiy headers' do
@@ -553,8 +552,8 @@ describe Grape::Endpoint do
       end
 
       get '/hey.json'
-      last_response.status.should == 403
-      last_response.headers['X-Custom'].should == 'value'
+      expect(last_response.status).to eq(403)
+      expect(last_response.headers['X-Custom']).to eq('value')
     end
   end
 
@@ -564,9 +563,9 @@ describe Grape::Endpoint do
         redirect "/ha"
       end
       get '/hey'
-      last_response.status.should eq 302
-      last_response.headers['Location'].should eq "/ha"
-      last_response.body.should eq ""
+      expect(last_response.status).to eq 302
+      expect(last_response.headers['Location']).to eq "/ha"
+      expect(last_response.body).to eq ""
     end
 
     it 'has status code 303 if it is not get request and it is http 1.1' do
@@ -574,8 +573,8 @@ describe Grape::Endpoint do
         redirect "/ha"
       end
       post '/hey', {}, 'HTTP_VERSION' => 'HTTP/1.1'
-      last_response.status.should eq 303
-      last_response.headers['Location'].should eq "/ha"
+      expect(last_response.status).to eq 303
+      expect(last_response.headers['Location']).to eq "/ha"
     end
 
     it 'support permanent redirect' do
@@ -583,9 +582,9 @@ describe Grape::Endpoint do
         redirect "/ha", permanent: true
       end
       get '/hey'
-      last_response.status.should eq 301
-      last_response.headers['Location'].should eq "/ha"
-      last_response.body.should eq ""
+      expect(last_response.status).to eq 301
+      expect(last_response.headers['Location']).to eq "/ha"
+      expect(last_response.body).to eq ""
     end
   end
 
@@ -595,10 +594,10 @@ describe Grape::Endpoint do
     end
 
     post '/new', text: 'abc'
-    last_response.body.should == 'abc'
+    expect(last_response.body).to eq('abc')
 
     post '/new', text: 'def'
-    last_response.body.should == 'def'
+    expect(last_response.body).to eq('def')
   end
 
   it 'resets all instance variables (except block) between calls' do
@@ -613,9 +612,9 @@ describe Grape::Endpoint do
     end
 
     get '/hello?howdy=hey'
-    last_response.body.should == 'hey'
+    expect(last_response.body).to eq('hey')
     get '/hello?howdy=yo'
-    last_response.body.should == 'yo'
+    expect(last_response.body).to eq('yo')
   end
 
   it 'allows explicit return calls' do
@@ -624,8 +623,8 @@ describe Grape::Endpoint do
     end
 
     get '/home'
-    last_response.status.should == 200
-    last_response.body.should == "Hello"
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq("Hello")
   end
 
   describe '.generate_api_method' do
@@ -640,7 +639,7 @@ describe Grape::Endpoint do
       }.to raise_error(ArgumentError)
     end
     it 'returns a Proc' do
-      Grape::Endpoint.generate_api_method("GET test for a proc", &proc {}).should be_a Proc
+      expect(Grape::Endpoint.generate_api_method("GET test for a proc", &proc {})).to be_a Proc
     end
   end
 
@@ -651,7 +650,7 @@ describe Grape::Endpoint do
         subject.get('/before_test') { env['before_test'] }
 
         get '/before_test'
-        last_response.body.should == "OK"
+        expect(last_response.body).to eq("OK")
       end
     end
 
@@ -660,14 +659,14 @@ describe Grape::Endpoint do
         subject.after { body "after" }
         subject.get('/after_test') { "during" }
         get '/after_test'
-        last_response.body.should == 'after'
+        expect(last_response.body).to eq('after')
       end
 
       it 'does not override the response body with its return' do
         subject.after { "after" }
         subject.get('/after_test') { "body" }
         get '/after_test'
-        last_response.body.should == "body"
+        expect(last_response.body).to eq("body")
       end
     end
   end
@@ -681,7 +680,7 @@ describe Grape::Endpoint do
           verb
         end
         send(verb, '/example/and/some/more')
-        last_response.status.should eql 404
+        expect(last_response.status).to eql 404
       end
 
       it 'anchors paths by default for the #{verb.upcase} method' do
@@ -689,7 +688,7 @@ describe Grape::Endpoint do
           verb
         end
         send(verb, '/example/and/some/more')
-        last_response.status.should eql 404
+        expect(last_response.status).to eql 404
       end
 
       it 'responds to /example/and/some/more for the non-anchored #{verb.upcase} method' do
@@ -697,8 +696,8 @@ describe Grape::Endpoint do
           verb
         end
         send(verb, '/example/and/some/more')
-        last_response.status.should eql verb == "post" ? 201 : 200
-        last_response.body.should eql verb == 'head' ? '' : verb
+        expect(last_response.status).to eql verb == "post" ? 201 : 200
+        expect(last_response.body).to eql verb == 'head' ? '' : verb
       end
     end
   end
@@ -709,7 +708,7 @@ describe Grape::Endpoint do
         request.url
       end
       get '/url'
-      last_response.body.should == "http://example.org/url"
+      expect(last_response.body).to eq("http://example.org/url")
     end
     ['v1', :v1].each do |version|
       it 'should include version #{version}' do
@@ -718,7 +717,7 @@ describe Grape::Endpoint do
           request.url
         end
         get "/#{version}/url"
-        last_response.body.should == "http://example.org/#{version}/url"
+        expect(last_response.body).to eq("http://example.org/#{version}/url")
       end
     end
     it 'should include prefix' do
@@ -728,7 +727,7 @@ describe Grape::Endpoint do
         request.url
       end
       get '/api/v1/url'
-      last_response.body.should == "http://example.org/api/v1/url"
+      expect(last_response.body).to eq("http://example.org/api/v1/url")
     end
   end
 
@@ -743,12 +742,12 @@ describe Grape::Endpoint do
 
     it 'result in a 406 response if they are invalid' do
       get '/test', {}, 'HTTP_ACCEPT' => 'application/vnd.ohanapi.v1+json'
-      last_response.status.should == 406
+      expect(last_response.status).to eq(406)
     end
 
     it 'result in a 406 response if they cannot be parsed by rack-accept' do
       get '/test', {}, 'HTTP_ACCEPT' => 'application/vnd.ohanapi.v1+json; version=1'
-      last_response.status.should == 406
+      expect(last_response.status).to eq(406)
     end
   end
 end

--- a/spec/grape/entity_spec.rb
+++ b/spec/grape/entity_spec.rb
@@ -28,19 +28,19 @@ describe Grape::Entity do
 
     it 'pulls a representation from the class options if it exists' do
       entity = Class.new(Grape::Entity)
-      entity.stub(:represent).and_return("Hiya")
+      allow(entity).to receive(:represent).and_return("Hiya")
 
       subject.represent Object, with: entity
       subject.get '/example' do
         present Object.new
       end
       get '/example'
-      last_response.body.should == 'Hiya'
+      expect(last_response.body).to eq('Hiya')
     end
 
     it 'pulls a representation from the class options if the presented object is a collection of objects' do
       entity = Class.new(Grape::Entity)
-      entity.stub(:represent).and_return("Hiya")
+      allow(entity).to receive(:represent).and_return("Hiya")
 
       class TestObject
       end
@@ -61,15 +61,15 @@ describe Grape::Entity do
       end
 
       get '/example'
-      last_response.body.should == "Hiya"
+      expect(last_response.body).to eq("Hiya")
 
       get '/example2'
-      last_response.body.should == "Hiya"
+      expect(last_response.body).to eq("Hiya")
     end
 
     it 'pulls a representation from the class ancestor if it exists' do
       entity = Class.new(Grape::Entity)
-      entity.stub(:represent).and_return("Hiya")
+      allow(entity).to receive(:represent).and_return("Hiya")
 
       subclass = Class.new(Object)
 
@@ -78,13 +78,13 @@ describe Grape::Entity do
         present subclass.new
       end
       get '/example'
-      last_response.body.should == 'Hiya'
+      expect(last_response.body).to eq('Hiya')
     end
 
     it 'automatically uses Klass::Entity if that exists' do
       some_model = Class.new
       entity = Class.new(Grape::Entity)
-      entity.stub(:represent).and_return("Auto-detect!")
+      allow(entity).to receive(:represent).and_return("Auto-detect!")
 
       some_model.const_set :Entity, entity
 
@@ -92,13 +92,13 @@ describe Grape::Entity do
         present some_model.new
       end
       get '/example'
-      last_response.body.should == 'Auto-detect!'
+      expect(last_response.body).to eq('Auto-detect!')
     end
 
     it 'automatically uses Klass::Entity based on the first object in the collection being presented' do
       some_model = Class.new
       entity = Class.new(Grape::Entity)
-      entity.stub(:represent).and_return("Auto-detect!")
+      allow(entity).to receive(:represent).and_return("Auto-detect!")
 
       some_model.const_set :Entity, entity
 
@@ -106,7 +106,7 @@ describe Grape::Entity do
         present [some_model.new]
       end
       get '/example'
-      last_response.body.should == 'Auto-detect!'
+      expect(last_response.body).to eq('Auto-detect!')
     end
 
     it 'does not run autodetection for Entity when explicitely provided' do
@@ -117,7 +117,7 @@ describe Grape::Entity do
         present some_array, with: entity
       end
 
-      some_array.should_not_receive(:first)
+      expect(some_array).not_to receive(:first)
       get '/example'
     end
 
@@ -131,7 +131,7 @@ describe Grape::Entity do
         present some_model
       end
       get '/example'
-      entity.should_not_receive(:represent)
+      expect(entity).not_to receive(:represent)
     end
 
     it 'adds a root key to the output if one is given' do
@@ -161,8 +161,8 @@ describe Grape::Entity do
         end
 
         get '/example'
-        last_response.status.should == 200
-        last_response.body.should == '{"example":{"id":1}}'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('{"example":{"id":1}}')
       end
 
       it 'presents with #{format} collection' do
@@ -183,8 +183,8 @@ describe Grape::Entity do
         end
 
         get '/examples'
-        last_response.status.should == 200
-        last_response.body.should == '{"examples":[{"id":1},{"id":2}]}'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('{"examples":[{"id":1},{"id":2}]}')
       end
 
     end
@@ -206,9 +206,9 @@ describe Grape::Entity do
         present c.new(name: "johnnyiller"), with: entity
       end
       get '/example'
-      last_response.status.should == 200
-      last_response.headers['Content-type'].should == "application/xml"
-      last_response.body.should == <<-XML
+      expect(last_response.status).to eq(200)
+      expect(last_response.headers['Content-type']).to eq("application/xml")
+      expect(last_response.body).to eq <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <hash>
   <example>
@@ -235,9 +235,9 @@ XML
         present c.new(name: "johnnyiller"), with: entity
       end
       get '/example'
-      last_response.status.should == 200
-      last_response.headers['Content-type'].should == "application/json"
-      last_response.body.should == '{"example":{"name":"johnnyiller"}}'
+      expect(last_response.status).to eq(200)
+      expect(last_response.headers['Content-type']).to eq("application/json")
+      expect(last_response.body).to eq('{"example":{"name":"johnnyiller"}}')
     end
 
     it 'presents with jsonp utilising Rack::JSONP' do
@@ -265,9 +265,9 @@ XML
       end
 
       get '/example?callback=abcDef'
-      last_response.status.should == 200
-      last_response.headers['Content-type'].should == "application/javascript"
-      last_response.body.should == 'abcDef({"example":{"name":"johnnyiller"}})'
+      expect(last_response.status).to eq(200)
+      expect(last_response.headers['Content-type']).to eq("application/javascript")
+      expect(last_response.body).to eq('abcDef({"example":{"name":"johnnyiller"}})')
     end
 
     context "present with multiple entities" do
@@ -296,7 +296,7 @@ XML
           "user1" => { "name" => "user1" },
           "user2" => { "name" => "user2" }
         }
-        JSON(last_response.body).should == expect_response_json
+        expect(JSON(last_response.body)).to eq(expect_response_json)
       end
 
     end

--- a/spec/grape/exceptions/invalid_formatter_spec.rb
+++ b/spec/grape/exceptions/invalid_formatter_spec.rb
@@ -8,7 +8,7 @@ describe Grape::Exceptions::InvalidFormatter do
     end
 
     it "contains the problem in the message" do
-      error.message.should include(
+      expect(error.message).to include(
         "cannot convert String to xml"
       )
     end

--- a/spec/grape/exceptions/invalid_versioner_option_spec.rb
+++ b/spec/grape/exceptions/invalid_versioner_option_spec.rb
@@ -8,7 +8,7 @@ describe Grape::Exceptions::InvalidVersionerOption do
     end
 
     it "contains the problem in the message" do
-      error.message.should include(
+      expect(error.message).to include(
         "Unknown :using for versioner: headers"
       )
     end

--- a/spec/grape/exceptions/missing_mime_type_spec.rb
+++ b/spec/grape/exceptions/missing_mime_type_spec.rb
@@ -8,11 +8,11 @@ describe Grape::Exceptions::MissingMimeType do
     end
 
     it "contains the problem in the message" do
-      error.message.should include "missing mime type for new_json"
+      expect(error.message).to include "missing mime type for new_json"
     end
 
     it "contains the resolution in the message" do
-      error.message.should include "or add your own with content_type :new_json, 'application/new_json' "
+      expect(error.message).to include "or add your own with content_type :new_json, 'application/new_json' "
     end
   end
 end

--- a/spec/grape/exceptions/missing_option_spec.rb
+++ b/spec/grape/exceptions/missing_option_spec.rb
@@ -8,7 +8,7 @@ describe Grape::Exceptions::MissingOption do
     end
 
     it "contains the problem in the message" do
-      error.message.should include(
+      expect(error.message).to include(
         "You must specify :path options."
       )
     end

--- a/spec/grape/exceptions/unknown_options_spec.rb
+++ b/spec/grape/exceptions/unknown_options_spec.rb
@@ -8,7 +8,7 @@ describe Grape::Exceptions::UnknownOptions do
     end
 
     it "contains the problem in the message" do
-      error.message.should include(
+      expect(error.message).to include(
         "unknown options: "
       )
     end

--- a/spec/grape/exceptions/unknown_validator_spec.rb
+++ b/spec/grape/exceptions/unknown_validator_spec.rb
@@ -8,7 +8,7 @@ describe Grape::Exceptions::UnknownValidator do
     end
 
     it "contains the problem in the message" do
-      error.message.should include(
+      expect(error.message).to include(
         "unknown validator: gt_10"
       )
     end

--- a/spec/grape/middleware/auth/basic_spec.rb
+++ b/spec/grape/middleware/auth/basic_spec.rb
@@ -16,16 +16,16 @@ describe Grape::Middleware::Auth::Basic do
   it 'throws a 401 if no auth is given' do
     @proc = lambda { false }
     get '/whatever'
-    last_response.status.should == 401
+    expect(last_response.status).to eq(401)
   end
 
   it 'authenticates if given valid creds' do
     get '/whatever', {}, 'HTTP_AUTHORIZATION' => encode_basic_auth('admin', 'admin')
-    last_response.status.should == 200
+    expect(last_response.status).to eq(200)
   end
 
   it 'throws a 401 is wrong auth is given' do
     get '/whatever', {}, 'HTTP_AUTHORIZATION' => encode_basic_auth('admin', 'wrong')
-    last_response.status.should == 401
+    expect(last_response.status).to eq(401)
   end
 end

--- a/spec/grape/middleware/auth/digest_spec.rb
+++ b/spec/grape/middleware/auth/digest_spec.rb
@@ -25,23 +25,23 @@ describe Grape::Middleware::Auth::Digest do
 
   it 'is a digest authentication challenge' do
     get '/test'
-    last_response.should be_challenge
+    expect(last_response).to be_challenge
   end
 
   it 'throws a 401 if no auth is given' do
     get '/test'
-    last_response.status.should == 401
+    expect(last_response.status).to eq(401)
   end
 
   it 'authenticates if given valid creds' do
     digest_authorize "foo", "bar"
     get '/test'
-    last_response.status.should == 200
+    expect(last_response.status).to eq(200)
   end
 
   it 'throws a 401 if given invalid creds' do
     digest_authorize "bar", "foo"
     get '/test'
-    last_response.status.should == 401
+    expect(last_response.status).to eq(401)
   end
 end

--- a/spec/grape/middleware/auth/oauth2_spec.rb
+++ b/spec/grape/middleware/auth/oauth2_spec.rb
@@ -33,7 +33,7 @@ describe Grape::Middleware::Auth::OAuth2 do
       before { get '/awesome?access_token=g123' }
 
       it 'sets env["api.token"]' do
-        last_response.body.should == 'g123'
+        expect(last_response.body).to eq('g123')
       end
     end
 
@@ -45,11 +45,11 @@ describe Grape::Middleware::Auth::OAuth2 do
       end
 
       it 'throws an error' do
-        @err[:status].should == 401
+        expect(@err[:status]).to eq(401)
       end
 
       it 'sets the WWW-Authenticate header in the response' do
-        @err[:headers]['WWW-Authenticate'].should == "OAuth realm='OAuth API', error='invalid_grant'"
+        expect(@err[:headers]['WWW-Authenticate']).to eq("OAuth realm='OAuth API', error='invalid_grant'")
       end
     end
   end
@@ -62,11 +62,11 @@ describe Grape::Middleware::Auth::OAuth2 do
     end
 
     it 'throws an error' do
-      @err[:status].should == 401
+      expect(@err[:status]).to eq(401)
     end
 
     it 'sets the WWW-Authenticate header in the response to error' do
-      @err[:headers]['WWW-Authenticate'].should == "OAuth realm='OAuth API', error='invalid_grant'"
+      expect(@err[:headers]['WWW-Authenticate']).to eq("OAuth realm='OAuth API', error='invalid_grant'")
     end
   end
 
@@ -77,7 +77,7 @@ describe Grape::Middleware::Auth::OAuth2 do
       end
 
       it 'sets env["api.token"]' do
-        last_response.body.should == 'g123'
+        expect(last_response.body).to eq('g123')
       end
     end
   end
@@ -88,7 +88,7 @@ describe Grape::Middleware::Auth::OAuth2 do
     end
 
     it 'sets env["api.token"]' do
-      last_response.body.should == 'g123'
+      expect(last_response.body).to eq('g123')
     end
   end
 
@@ -100,11 +100,11 @@ describe Grape::Middleware::Auth::OAuth2 do
     end
 
     it 'throws an error' do
-      @err[:status].should == 403
+      expect(@err[:status]).to eq(403)
     end
 
     it 'sets the WWW-Authenticate header in the response to error' do
-      @err[:headers]['WWW-Authenticate'].should == "OAuth realm='OAuth API', error='insufficient_scope'"
+      expect(@err[:headers]['WWW-Authenticate']).to eq("OAuth realm='OAuth API', error='insufficient_scope'")
     end
   end
 
@@ -120,7 +120,7 @@ describe Grape::Middleware::Auth::OAuth2 do
       before { post '/awesome' }
 
       it 'succeeds anyway' do
-        last_response.status.should == 200
+        expect(last_response.status).to eq(200)
       end
     end
 
@@ -128,7 +128,7 @@ describe Grape::Middleware::Auth::OAuth2 do
       before { get '/awesome?access_token=g123' }
 
       it 'sets env["api.token"]' do
-        last_response.body.should == 'g123'
+        expect(last_response.body).to eq('g123')
       end
     end
   end

--- a/spec/grape/middleware/base_spec.rb
+++ b/spec/grape/middleware/base_spec.rb
@@ -6,24 +6,24 @@ describe Grape::Middleware::Base do
 
   before do
     # Keep it one object for testing.
-    subject.stub(:dup).and_return(subject)
+    allow(subject).to receive(:dup).and_return(subject)
   end
 
   it 'has the app as an accessor' do
-    subject.app.should == blank_app
+    expect(subject.app).to eq(blank_app)
   end
 
   it 'calls through to the app' do
-    subject.call({}).should == [200, {}, 'Hi there.']
+    expect(subject.call({})).to eq([200, {}, 'Hi there.'])
   end
 
   context 'callbacks' do
     it 'calls #before' do
-      subject.should_receive(:before)
+      expect(subject).to receive(:before)
     end
 
     it 'calls #after' do
-      subject.should_receive(:after)
+      expect(subject).to receive(:after)
     end
 
     after { subject.call!({}) }
@@ -31,12 +31,12 @@ describe Grape::Middleware::Base do
 
   it 'is able to access the response' do
     subject.call({})
-    subject.response.should be_kind_of(Rack::Response)
+    expect(subject.response).to be_kind_of(Rack::Response)
   end
 
   context 'options' do
     it 'persists options passed at initialization' do
-      Grape::Middleware::Base.new(blank_app, abc: true).options[:abc].should be true
+      expect(Grape::Middleware::Base.new(blank_app, abc: true).options[:abc]).to be true
     end
 
     context 'defaults' do
@@ -47,11 +47,11 @@ describe Grape::Middleware::Base do
       end
 
       it 'persists the default options' do
-        ExampleWare.new(blank_app).options[:monkey].should be true
+        expect(ExampleWare.new(blank_app).options[:monkey]).to be true
       end
 
       it 'overrides default options when provided' do
-        ExampleWare.new(blank_app, monkey: false).options[:monkey].should be false
+        expect(ExampleWare.new(blank_app, monkey: false).options[:monkey]).to be false
       end
     end
   end

--- a/spec/grape/middleware/error_spec.rb
+++ b/spec/grape/middleware/error_spec.rb
@@ -22,24 +22,24 @@ describe Grape::Middleware::Error do
   it 'sets the status code appropriately' do
     ErrApp.error = { status: 410 }
     get '/'
-    last_response.status.should == 410
+    expect(last_response.status).to eq(410)
   end
 
   it 'sets the error message appropriately' do
     ErrApp.error = { message: 'Awesome stuff.' }
     get '/'
-    last_response.body.should == 'Awesome stuff.'
+    expect(last_response.body).to eq('Awesome stuff.')
   end
 
   it 'defaults to a 500 status' do
     ErrApp.error = {}
     get '/'
-    last_response.status.should == 500
+    expect(last_response.status).to eq(500)
   end
 
   it 'has a default message' do
     ErrApp.error = {}
     get '/'
-    last_response.body.should == 'Aww, hamburgers.'
+    expect(last_response.body).to eq('Aww, hamburgers.')
   end
 end

--- a/spec/grape/middleware/exception_spec.rb
+++ b/spec/grape/middleware/exception_spec.rb
@@ -57,7 +57,7 @@ describe Grape::Middleware::Error do
       use Grape::Middleware::Error
       run ExceptionApp
     end
-    lambda { get '/' }.should raise_error
+    expect { get '/' }.to raise_error
   end
 
   context 'with rescue_all set to true' do
@@ -67,7 +67,7 @@ describe Grape::Middleware::Error do
         run ExceptionApp
       end
       get '/'
-      last_response.body.should == "rain!"
+      expect(last_response.body).to eq("rain!")
     end
 
     it 'defaults to a 500 status' do
@@ -76,7 +76,7 @@ describe Grape::Middleware::Error do
         run ExceptionApp
       end
       get '/'
-      last_response.status.should == 500
+      expect(last_response.status).to eq(500)
     end
 
     it 'is possible to specify a different default status code' do
@@ -85,7 +85,7 @@ describe Grape::Middleware::Error do
         run ExceptionApp
       end
       get '/'
-      last_response.status.should == 500
+      expect(last_response.status).to eq(500)
     end
 
     it 'is possible to return errors in json format' do
@@ -94,7 +94,7 @@ describe Grape::Middleware::Error do
         run ExceptionApp
       end
       get '/'
-      last_response.body.should == '{"error":"rain!"}'
+      expect(last_response.body).to eq('{"error":"rain!"}')
     end
 
     it 'is possible to return hash errors in json format' do
@@ -103,8 +103,8 @@ describe Grape::Middleware::Error do
         run ErrorHashApp
       end
       get '/'
-      ['{"error":"rain!","detail":"missing widget"}',
-       '{"detail":"missing widget","error":"rain!"}'].should include(last_response.body)
+      expect(['{"error":"rain!","detail":"missing widget"}',
+              '{"detail":"missing widget","error":"rain!"}']).to include(last_response.body)
     end
 
     it 'is possible to return errors in jsonapi format' do
@@ -113,7 +113,7 @@ describe Grape::Middleware::Error do
         run ExceptionApp
       end
       get '/'
-      last_response.body.should == '{"error":"rain!"}'
+      expect(last_response.body).to eq('{"error":"rain!"}')
     end
 
     it 'is possible to return hash errors in jsonapi format' do
@@ -122,8 +122,8 @@ describe Grape::Middleware::Error do
         run ErrorHashApp
       end
       get '/'
-      ['{"error":"rain!","detail":"missing widget"}',
-       '{"detail":"missing widget","error":"rain!"}'].should include(last_response.body)
+      expect(['{"error":"rain!","detail":"missing widget"}',
+              '{"detail":"missing widget","error":"rain!"}']).to include(last_response.body)
     end
 
     it 'is possible to return errors in xml format' do
@@ -132,7 +132,7 @@ describe Grape::Middleware::Error do
         run ExceptionApp
       end
       get '/'
-      last_response.body.should == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<error>\n  <message>rain!</message>\n</error>\n"
+      expect(last_response.body).to eq("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<error>\n  <message>rain!</message>\n</error>\n")
     end
 
     it 'is possible to return hash errors in xml format' do
@@ -141,8 +141,8 @@ describe Grape::Middleware::Error do
         run ErrorHashApp
       end
       get '/'
-      ["<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<error>\n  <detail>missing widget</detail>\n  <error>rain!</error>\n</error>\n",
-       "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<error>\n  <error>rain!</error>\n  <detail>missing widget</detail>\n</error>\n"].should include(last_response.body)
+      expect(["<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<error>\n  <detail>missing widget</detail>\n  <error>rain!</error>\n</error>\n",
+              "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<error>\n  <error>rain!</error>\n  <detail>missing widget</detail>\n</error>\n"]).to include(last_response.body)
     end
 
     it 'is possible to specify a custom formatter' do
@@ -157,7 +157,7 @@ describe Grape::Middleware::Error do
         run ExceptionApp
       end
       get '/'
-      last_response.body.should == '{:custom_formatter=>"rain!"}'
+      expect(last_response.body).to eq('{:custom_formatter=>"rain!"}')
     end
 
     it 'does not trap regular error! codes' do
@@ -166,7 +166,7 @@ describe Grape::Middleware::Error do
         run AccessDeniedApp
       end
       get '/'
-      last_response.status.should == 401
+      expect(last_response.status).to eq(401)
     end
 
     it 'responds to custom Grape exceptions appropriately' do
@@ -176,8 +176,8 @@ describe Grape::Middleware::Error do
       end
 
       get '/'
-      last_response.status.should == 400
-      last_response.body.should == 'failed validation'
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq('failed validation')
     end
 
   end

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Grape::Middleware::Formatter do
   subject { Grape::Middleware::Formatter.new(app) }
-  before { subject.stub(:dup).and_return(subject) }
+  before { allow(subject).to receive(:dup).and_return(subject) }
 
   let(:app) { lambda { |env| [200, {}, [@body || { "foo" => "bar" }]] } }
 
@@ -10,7 +10,7 @@ describe Grape::Middleware::Formatter do
     it 'looks at the bodies for possibly serializable data' do
       @body = { "abc" => "def" }
       _, _, bodies = *subject.call('PATH_INFO' => '/somewhere', 'HTTP_ACCEPT' => 'application/json')
-      bodies.each { |b| b.should == MultiJson.dump(@body) }
+      bodies.each { |b| expect(b).to eq(MultiJson.dump(@body)) }
     end
 
     it 'calls #to_json since default format is json' do
@@ -21,7 +21,7 @@ describe Grape::Middleware::Formatter do
         end
       end
 
-      subject.call('PATH_INFO' => '/somewhere', 'HTTP_ACCEPT' => 'application/json').last.each { |b| b.should == '"bar"' }
+      subject.call('PATH_INFO' => '/somewhere', 'HTTP_ACCEPT' => 'application/json').last.each { |b| expect(b).to eq('"bar"') }
     end
 
     it 'calls #to_json if the content type is jsonapi' do
@@ -32,7 +32,7 @@ describe Grape::Middleware::Formatter do
         end
       end
 
-      subject.call('PATH_INFO' => '/somewhere', 'HTTP_ACCEPT' => 'application/vnd.api+json').last.each { |b| b.should == '{"foos":[{"bar":"baz"}] }' }
+      subject.call('PATH_INFO' => '/somewhere', 'HTTP_ACCEPT' => 'application/vnd.api+json').last.each { |b| expect(b).to eq('{"foos":[{"bar":"baz"}] }') }
     end
 
     it 'calls #to_xml if the content type is xml' do
@@ -43,18 +43,18 @@ describe Grape::Middleware::Formatter do
         end
       end
 
-      subject.call('PATH_INFO' => '/somewhere.xml', 'HTTP_ACCEPT' => 'application/json').last.each { |b| b.should == '<bar/>' }
+      subject.call('PATH_INFO' => '/somewhere.xml', 'HTTP_ACCEPT' => 'application/json').last.each { |b| expect(b).to eq('<bar/>') }
     end
   end
 
   context 'error handling' do
     let(:formatter) { double(:formatter) }
     before do
-      Grape::Formatter::Base.stub(:formatter_for) { formatter }
+      allow(Grape::Formatter::Base).to receive(:formatter_for) { formatter }
     end
 
     it 'rescues formatter-specific exceptions' do
-      formatter.stub(:call) { raise Grape::Exceptions::InvalidFormatter.new(String, 'xml') }
+      allow(formatter).to receive(:call) { raise Grape::Exceptions::InvalidFormatter.new(String, 'xml') }
 
       expect {
         catch(:error) { subject.call('PATH_INFO' => '/somewhere.xml', 'HTTP_ACCEPT' => 'application/json') }
@@ -62,7 +62,7 @@ describe Grape::Middleware::Formatter do
     end
 
     it 'does not rescue other exceptions' do
-      formatter.stub(:call) { raise StandardError }
+      allow(formatter).to receive(:call) { raise StandardError }
 
       expect {
         catch(:error) { subject.call('PATH_INFO' => '/somewhere.xml', 'HTTP_ACCEPT' => 'application/json') }
@@ -74,94 +74,94 @@ describe Grape::Middleware::Formatter do
 
     it 'uses the xml extension if one is provided' do
       subject.call('PATH_INFO' => '/info.xml')
-      subject.env['api.format'].should == :xml
+      expect(subject.env['api.format']).to eq(:xml)
     end
 
     it 'uses the json extension if one is provided' do
       subject.call('PATH_INFO' => '/info.json')
-      subject.env['api.format'].should == :json
+      expect(subject.env['api.format']).to eq(:json)
     end
 
     it 'uses the format parameter if one is provided' do
       subject.call('PATH_INFO' => '/info', 'QUERY_STRING' => 'format=json')
-      subject.env['api.format'].should == :json
+      expect(subject.env['api.format']).to eq(:json)
       subject.call('PATH_INFO' => '/info', 'QUERY_STRING' => 'format=xml')
-      subject.env['api.format'].should == :xml
+      expect(subject.env['api.format']).to eq(:xml)
     end
 
     it 'uses the default format if none is provided' do
       subject.call('PATH_INFO' => '/info')
-      subject.env['api.format'].should == :txt
+      expect(subject.env['api.format']).to eq(:txt)
     end
 
     it 'uses the requested format if provided in headers' do
       subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/json')
-      subject.env['api.format'].should == :json
+      expect(subject.env['api.format']).to eq(:json)
     end
 
     it 'uses the file extension format if provided before headers' do
       subject.call('PATH_INFO' => '/info.txt', 'HTTP_ACCEPT' => 'application/json')
-      subject.env['api.format'].should == :txt
+      expect(subject.env['api.format']).to eq(:txt)
     end
   end
 
   context 'accept header detection' do
     it 'detects from the Accept header' do
       subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/xml')
-      subject.env['api.format'].should == :xml
+      expect(subject.env['api.format']).to eq(:xml)
     end
 
     it 'looks for case-indifferent headers' do
       subject.call('PATH_INFO' => '/info', 'http_accept' => 'application/xml')
-      subject.env['api.format'].should == :xml
+      expect(subject.env['api.format']).to eq(:xml)
     end
 
     it 'uses quality rankings to determine formats' do
       subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/json; q=0.3,application/xml; q=1.0')
-      subject.env['api.format'].should == :xml
+      expect(subject.env['api.format']).to eq(:xml)
       subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/json; q=1.0,application/xml; q=0.3')
-      subject.env['api.format'].should == :json
+      expect(subject.env['api.format']).to eq(:json)
     end
 
     it 'handles quality rankings mixed with nothing' do
       subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/json,application/xml; q=1.0')
-      subject.env['api.format'].should == :xml
+      expect(subject.env['api.format']).to eq(:xml)
     end
 
     it 'parses headers with other attributes' do
       subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/json; abc=2.3; q=1.0,application/xml; q=0.7')
-      subject.env['api.format'].should == :json
+      expect(subject.env['api.format']).to eq(:json)
     end
 
     it 'parses headers with vendor and api version' do
       subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/vnd.test-v1+xml')
-      subject.env['api.format'].should == :xml
+      expect(subject.env['api.format']).to eq(:xml)
     end
 
     it 'parses headers with symbols as hash keys' do
       subject.call('PATH_INFO' => '/info', 'http_accept' => 'application/xml', system_time: '091293')
-      subject.env[:system_time].should == '091293'
+      expect(subject.env[:system_time]).to eq('091293')
     end
   end
 
   context 'content-type' do
     it 'is set for json' do
       _, headers, _ = subject.call('PATH_INFO' => '/info.json')
-      headers['Content-type'].should == 'application/json'
+      expect(headers['Content-type']).to eq('application/json')
     end
     it 'is set for xml' do
       _, headers, _ = subject.call('PATH_INFO' => '/info.xml')
-      headers['Content-type'].should == 'application/xml'
+      expect(headers['Content-type']).to eq('application/xml')
     end
     it 'is set for txt' do
       _, headers, _ = subject.call('PATH_INFO' => '/info.txt')
-      headers['Content-type'].should == 'text/plain'
+      expect(headers['Content-type']).to eq('text/plain')
     end
     it 'is set for custom' do
       subject.options[:content_types] = {}
       subject.options[:content_types][:custom] = 'application/x-custom'
       _, headers, _ = subject.call('PATH_INFO' => '/info.custom')
-      headers['Content-type'].should == 'application/x-custom'
+      expect(headers['Content-type']).to eq('application/x-custom')
     end
   end
 
@@ -171,17 +171,17 @@ describe Grape::Middleware::Formatter do
       subject.options[:content_types][:custom] = "don't care"
       subject.options[:formatters][:custom] = lambda { |obj, env| 'CUSTOM FORMAT' }
       _, _, body = subject.call('PATH_INFO' => '/info.custom')
-      body.body.should == ['CUSTOM FORMAT']
+      expect(body.body).to eq(['CUSTOM FORMAT'])
     end
     it 'uses default json formatter' do
       @body = ['blah']
       _, _, body = subject.call('PATH_INFO' => '/info.json')
-      body.body.should == ['["blah"]']
+      expect(body.body).to eq(['["blah"]'])
     end
     it 'uses custom json formatter' do
       subject.options[:formatters][:json] = lambda { |obj, env| 'CUSTOM JSON FORMAT' }
       _, _, body = subject.call('PATH_INFO' => '/info.json')
-      body.body.should == ['CUSTOM JSON FORMAT']
+      expect(body.body).to eq(['CUSTOM JSON FORMAT'])
     end
   end
 
@@ -198,8 +198,8 @@ describe Grape::Middleware::Formatter do
               'rack.input' => io,
               'CONTENT_LENGTH' => io.length
             )
-            subject.env['rack.request.form_hash']['is_boolean'].should be true
-            subject.env['rack.request.form_hash']['string'].should == 'thing'
+            expect(subject.env['rack.request.form_hash']['is_boolean']).to be true
+            expect(subject.env['rack.request.form_hash']['string']).to eq('thing')
           end
         end
       end
@@ -212,8 +212,8 @@ describe Grape::Middleware::Formatter do
           'rack.input' => io,
           'HTTP_TRANSFER_ENCODING' => 'chunked'
         )
-        subject.env['rack.request.form_hash']['is_boolean'].should be true
-        subject.env['rack.request.form_hash']['string'].should == 'thing'
+        expect(subject.env['rack.request.form_hash']['is_boolean']).to be true
+        expect(subject.env['rack.request.form_hash']['string']).to eq('thing')
       end
       it "rewinds IO" do
         io = StringIO.new('{"is_boolean":true,"string":"thing"}')
@@ -225,8 +225,8 @@ describe Grape::Middleware::Formatter do
           'rack.input' => io,
           'HTTP_TRANSFER_ENCODING' => 'chunked'
         )
-        subject.env['rack.request.form_hash']['is_boolean'].should be true
-        subject.env['rack.request.form_hash']['string'].should == 'thing'
+        expect(subject.env['rack.request.form_hash']['is_boolean']).to be true
+        expect(subject.env['rack.request.form_hash']['string']).to eq('thing')
       end
       it 'parses the body from an xml #{method} and copies values into rack.request.from_hash' do
         io = StringIO.new('<thing><name>Test</name></thing>')
@@ -237,7 +237,7 @@ describe Grape::Middleware::Formatter do
           'rack.input' => io,
           'CONTENT_LENGTH' => io.length
         )
-        subject.env['rack.request.form_hash']['thing']['name'].should == 'Test'
+        expect(subject.env['rack.request.form_hash']['thing']['name']).to eq('Test')
       end
       [Rack::Request::FORM_DATA_MEDIA_TYPES, Rack::Request::PARSEABLE_DATA_MEDIA_TYPES].flatten.each do |content_type|
         it "ignores #{content_type}" do
@@ -249,7 +249,7 @@ describe Grape::Middleware::Formatter do
             'rack.input' => io,
             'CONTENT_LENGTH' => io.length
           )
-          subject.env['rack.request.form_hash'].should be_nil
+          expect(subject.env['rack.request.form_hash']).to be_nil
         end
       end
     end

--- a/spec/grape/middleware/versioner/accept_version_header_spec.rb
+++ b/spec/grape/middleware/versioner/accept_version_header_spec.rb
@@ -19,14 +19,14 @@ describe Grape::Middleware::Versioner::AcceptVersionHeader do
 
     it 'is set' do
       status, _, env = subject.call('HTTP_ACCEPT_VERSION' => 'v1')
-      env['api.version'].should eql 'v1'
-      status.should == 200
+      expect(env['api.version']).to eql 'v1'
+      expect(status).to eq(200)
     end
 
     it 'is set if format provided' do
       status, _, env = subject.call('HTTP_ACCEPT_VERSION' => 'v1')
-      env['api.version'].should eql 'v1'
-      status.should == 200
+      expect(env['api.version']).to eql 'v1'
+      expect(status).to eq(200)
     end
 
     it 'fails with 406 Not Acceptable if version is not supported' do
@@ -42,14 +42,14 @@ describe Grape::Middleware::Versioner::AcceptVersionHeader do
   end
 
   it 'succeeds if :strict is not set' do
-    subject.call('HTTP_ACCEPT_VERSION' => '').first.should == 200
-    subject.call({}).first.should == 200
+    expect(subject.call('HTTP_ACCEPT_VERSION' => '').first).to eq(200)
+    expect(subject.call({}).first).to eq(200)
   end
 
   it 'succeeds if :strict is set to false' do
     @options[:version_options][:strict] = false
-    subject.call('HTTP_ACCEPT_VERSION' => '').first.should == 200
-    subject.call({}).first.should == 200
+    expect(subject.call('HTTP_ACCEPT_VERSION' => '').first).to eq(200)
+    expect(subject.call({}).first).to eq(200)
   end
 
   context 'when :strict is set' do
@@ -81,7 +81,7 @@ describe Grape::Middleware::Versioner::AcceptVersionHeader do
     end
 
     it 'succeeds if proper header is set' do
-      subject.call('HTTP_ACCEPT_VERSION' => 'v1').first.should == 200
+      expect(subject.call('HTTP_ACCEPT_VERSION' => 'v1').first).to eq(200)
     end
   end
 
@@ -115,7 +115,7 @@ describe Grape::Middleware::Versioner::AcceptVersionHeader do
     end
 
     it 'succeeds if proper header is set' do
-      subject.call('HTTP_ACCEPT_VERSION' => 'v1').first.should == 200
+      expect(subject.call('HTTP_ACCEPT_VERSION' => 'v1').first).to eq(200)
     end
   end
 end

--- a/spec/grape/middleware/versioner/header_spec.rb
+++ b/spec/grape/middleware/versioner/header_spec.rb
@@ -16,37 +16,37 @@ describe Grape::Middleware::Versioner::Header do
   context 'api.type and api.subtype' do
     it 'sets type and subtype to first choice of content type if no preference given' do
       status, _, env = subject.call('HTTP_ACCEPT' => '*/*')
-      env['api.type'].should eql 'application'
-      env['api.subtype'].should eql 'vnd.vendor+xml'
-      status.should == 200
+      expect(env['api.type']).to eql 'application'
+      expect(env['api.subtype']).to eql 'vnd.vendor+xml'
+      expect(status).to eq(200)
     end
 
     it 'sets preferred type' do
       status, _, env = subject.call('HTTP_ACCEPT' => 'application/*')
-      env['api.type'].should eql 'application'
-      env['api.subtype'].should eql 'vnd.vendor+xml'
-      status.should == 200
+      expect(env['api.type']).to eql 'application'
+      expect(env['api.subtype']).to eql 'vnd.vendor+xml'
+      expect(status).to eq(200)
     end
 
     it 'sets preferred type and subtype' do
       status, _, env = subject.call('HTTP_ACCEPT' => 'text/plain')
-      env['api.type'].should eql 'text'
-      env['api.subtype'].should eql 'plain'
-      status.should == 200
+      expect(env['api.type']).to eql 'text'
+      expect(env['api.subtype']).to eql 'plain'
+      expect(status).to eq(200)
     end
   end
 
   context 'api.format' do
     it 'is set' do
       status, _, env = subject.call('HTTP_ACCEPT' => 'application/vnd.vendor+json')
-      env['api.format'].should eql 'json'
-      status.should == 200
+      expect(env['api.format']).to eql 'json'
+      expect(status).to eq(200)
     end
 
     it 'is nil if not provided' do
       status, _, env = subject.call('HTTP_ACCEPT' => 'application/vnd.vendor')
-      env['api.format'].should eql nil
-      status.should == 200
+      expect(env['api.format']).to eql nil
+      expect(status).to eq(200)
     end
 
     ['v1', :v1].each do |version|
@@ -57,14 +57,14 @@ describe Grape::Middleware::Versioner::Header do
 
         it 'is set' do
           status, _, env =  subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1+json')
-          env['api.format'].should eql 'json'
-          status.should == 200
+          expect(env['api.format']).to eql 'json'
+          expect(status).to eq(200)
         end
 
         it 'is nil if not provided' do
           status, _, env =  subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1')
-          env['api.format'].should eql nil
-          status.should == 200
+          expect(env['api.format']).to eql nil
+          expect(status).to eq(200)
         end
       end
     end
@@ -73,14 +73,14 @@ describe Grape::Middleware::Versioner::Header do
   context 'api.vendor' do
     it 'is set' do
       status, _, env =  subject.call('HTTP_ACCEPT' => 'application/vnd.vendor')
-      env['api.vendor'].should eql 'vendor'
-      status.should == 200
+      expect(env['api.vendor']).to eql 'vendor'
+      expect(status).to eq(200)
     end
 
     it 'is set if format provided' do
       status, _, env =  subject.call('HTTP_ACCEPT' => 'application/vnd.vendor+json')
-      env['api.vendor'].should eql 'vendor'
-      status.should == 200
+      expect(env['api.vendor']).to eql 'vendor'
+      expect(status).to eq(200)
     end
 
     it 'fails with 406 Not Acceptable if vendor is invalid' do
@@ -101,14 +101,14 @@ describe Grape::Middleware::Versioner::Header do
 
       it 'is set' do
         status, _, env =  subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1')
-        env['api.vendor'].should eql 'vendor'
-        status.should == 200
+        expect(env['api.vendor']).to eql 'vendor'
+        expect(status).to eq(200)
       end
 
       it 'is set if format provided' do
         status, _, env =  subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1+json')
-        env['api.vendor'].should eql 'vendor'
-        status.should == 200
+        expect(env['api.vendor']).to eql 'vendor'
+        expect(status).to eq(200)
       end
 
       it 'fails with 406 Not Acceptable if vendor is invalid' do
@@ -131,14 +131,14 @@ describe Grape::Middleware::Versioner::Header do
 
     it 'is set' do
       status, _, env =  subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1')
-      env['api.version'].should eql 'v1'
-      status.should == 200
+      expect(env['api.version']).to eql 'v1'
+      expect(status).to eq(200)
     end
 
     it 'is set if format provided' do
       status, _, env =  subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1+json')
-      env['api.version'].should eql 'v1'
-      status.should == 200
+      expect(env['api.version']).to eql 'v1'
+      expect(status).to eq(200)
     end
 
     it 'fails with 406 Not Acceptable if version is invalid' do
@@ -154,14 +154,14 @@ describe Grape::Middleware::Versioner::Header do
   end
 
   it 'succeeds if :strict is not set' do
-    subject.call('HTTP_ACCEPT' => '').first.should == 200
-    subject.call({}).first.should == 200
+    expect(subject.call('HTTP_ACCEPT' => '').first).to eq(200)
+    expect(subject.call({}).first).to eq(200)
   end
 
   it 'succeeds if :strict is set to false' do
     @options[:version_options][:strict] = false
-    subject.call('HTTP_ACCEPT' => '').first.should == 200
-    subject.call({}).first.should == 200
+    expect(subject.call('HTTP_ACCEPT' => '').first).to eq(200)
+    expect(subject.call({}).first).to eq(200)
   end
 
   context 'when :strict is set' do
@@ -215,7 +215,7 @@ describe Grape::Middleware::Versioner::Header do
     end
 
     it 'succeeds if proper header is set' do
-      subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1+json').first.should == 200
+      expect(subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1+json').first).to eq(200)
     end
   end
 
@@ -271,7 +271,7 @@ describe Grape::Middleware::Versioner::Header do
     end
 
     it 'succeeds if proper header is set' do
-      subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1+json').first.should == 200
+      expect(subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1+json').first).to eq(200)
     end
   end
 
@@ -281,11 +281,11 @@ describe Grape::Middleware::Versioner::Header do
     end
 
     it 'succeeds with v1' do
-      subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1+json').first.should == 200
+      expect(subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1+json').first).to eq(200)
     end
 
     it 'succeeds with v2' do
-      subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v2+json').first.should == 200
+      expect(subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v2+json').first).to eq(200)
     end
 
     it 'fails with another version' do

--- a/spec/grape/middleware/versioner/param_spec.rb
+++ b/spec/grape/middleware/versioner/param_spec.rb
@@ -7,30 +7,30 @@ describe Grape::Middleware::Versioner::Param do
 
   it 'sets the API version based on the default param (apiver)' do
     env = Rack::MockRequest.env_for("/awesome", params: { "apiver" => "v1" })
-    subject.call(env)[1]["api.version"].should == 'v1'
+    expect(subject.call(env)[1]["api.version"]).to eq('v1')
   end
 
   it 'cuts (only) the version out of the params', focus: true do
     env = Rack::MockRequest.env_for("/awesome", params: { "apiver" => "v1", "other_param" => "5" })
     env['rack.request.query_hash'] = Rack::Utils.parse_nested_query(env['QUERY_STRING'])
-    subject.call(env)[1]['rack.request.query_hash']["apiver"].should be_nil
-    subject.call(env)[1]['rack.request.query_hash']["other_param"].should == "5"
+    expect(subject.call(env)[1]['rack.request.query_hash']["apiver"]).to be_nil
+    expect(subject.call(env)[1]['rack.request.query_hash']["other_param"]).to eq("5")
   end
 
   it 'provides a nil version if no version is given' do
     env = Rack::MockRequest.env_for("/")
-    subject.call(env).last.should be_nil
+    expect(subject.call(env).last).to be_nil
   end
 
   context 'with specified parameter name' do
     before { @options = { parameter: 'v' } }
     it 'sets the API version based on the custom parameter name' do
       env = Rack::MockRequest.env_for("/awesome", params: { "v" => "v1" })
-      subject.call(env)[1]["api.version"].should == "v1"
+      expect(subject.call(env)[1]["api.version"]).to eq("v1")
     end
     it 'does not set the API version based on the default param' do
       env = Rack::MockRequest.env_for("/awesome", params: { "apiver" => "v1" })
-      subject.call(env)[1]["api.version"].should be_nil
+      expect(subject.call(env)[1]["api.version"]).to be_nil
     end
   end
 
@@ -38,11 +38,11 @@ describe Grape::Middleware::Versioner::Param do
     before { @options = { versions: ['v1', 'v2'] } }
     it 'throws an error if a non-allowed version is specified' do
       env = Rack::MockRequest.env_for("/awesome", params: { "apiver" => "v3" })
-      catch(:error) { subject.call(env) }[:status].should == 404
+      expect(catch(:error) { subject.call(env) }[:status]).to eq(404)
     end
     it 'allows versions that have been specified' do
       env = Rack::MockRequest.env_for("/awesome", params: { "apiver" => "v1" })
-      subject.call(env)[1]["api.version"].should == 'v1'
+      expect(subject.call(env)[1]["api.version"]).to eq('v1')
     end
   end
 
@@ -52,7 +52,7 @@ describe Grape::Middleware::Versioner::Param do
       version_options: { using: :header }
     }
     env = Rack::MockRequest.env_for("/awesome", params: {})
-    subject.call(env).first.should == 200
+    expect(subject.call(env).first).to eq(200)
   end
 
 end

--- a/spec/grape/middleware/versioner/path_spec.rb
+++ b/spec/grape/middleware/versioner/path_spec.rb
@@ -5,25 +5,25 @@ describe Grape::Middleware::Versioner::Path do
   subject { Grape::Middleware::Versioner::Path.new(app, @options || {}) }
 
   it 'sets the API version based on the first path' do
-    subject.call('PATH_INFO' => '/v1/awesome').last.should == 'v1'
+    expect(subject.call('PATH_INFO' => '/v1/awesome').last).to eq('v1')
   end
 
   it 'does not cut the version out of the path' do
-    subject.call('PATH_INFO' => '/v1/awesome')[1]['PATH_INFO'].should == '/v1/awesome'
+    expect(subject.call('PATH_INFO' => '/v1/awesome')[1]['PATH_INFO']).to eq('/v1/awesome')
   end
 
   it 'provides a nil version if no path is given' do
-    subject.call('PATH_INFO' => '/').last.should be_nil
+    expect(subject.call('PATH_INFO' => '/').last).to be_nil
   end
 
   context 'with a pattern' do
     before { @options = { pattern: /v./i } }
     it 'sets the version if it matches' do
-      subject.call('PATH_INFO' => '/v1/awesome').last.should == 'v1'
+      expect(subject.call('PATH_INFO' => '/v1/awesome').last).to eq('v1')
     end
 
     it 'ignores the version if it fails to match' do
-      subject.call('PATH_INFO' => '/awesome/radical').last.should be_nil
+      expect(subject.call('PATH_INFO' => '/awesome/radical').last).to be_nil
     end
   end
 
@@ -32,11 +32,11 @@ describe Grape::Middleware::Versioner::Path do
       before { @options = { versions: versions } }
 
       it 'throws an error if a non-allowed version is specified' do
-        catch(:error) { subject.call('PATH_INFO' => '/v3/awesome') }[:status].should == 404
+        expect(catch(:error) { subject.call('PATH_INFO' => '/v3/awesome') }[:status]).to eq(404)
       end
 
       it 'allows versions that have been specified' do
-        subject.call('PATH_INFO' => '/v1/asoasd').last.should == 'v1'
+        expect(subject.call('PATH_INFO' => '/v1/asoasd').last).to eq('v1')
       end
     end
   end

--- a/spec/grape/middleware/versioner_spec.rb
+++ b/spec/grape/middleware/versioner_spec.rb
@@ -5,18 +5,18 @@ describe Grape::Middleware::Versioner do
   let(:klass) { Grape::Middleware::Versioner }
 
   it 'recognizes :path' do
-    klass.using(:path).should == Grape::Middleware::Versioner::Path
+    expect(klass.using(:path)).to eq(Grape::Middleware::Versioner::Path)
   end
 
   it 'recognizes :header' do
-    klass.using(:header).should == Grape::Middleware::Versioner::Header
+    expect(klass.using(:header)).to eq(Grape::Middleware::Versioner::Header)
   end
 
   it 'recognizes :param' do
-    klass.using(:param).should == Grape::Middleware::Versioner::Param
+    expect(klass.using(:param)).to eq(Grape::Middleware::Versioner::Param)
   end
 
   it 'recognizes :accept_version_header' do
-    klass.using(:accept_version_header).should == Grape::Middleware::Versioner::AcceptVersionHeader
+    expect(klass.using(:accept_version_header)).to eq(Grape::Middleware::Versioner::AcceptVersionHeader)
   end
 end

--- a/spec/grape/path_spec.rb
+++ b/spec/grape/path_spec.rb
@@ -185,7 +185,7 @@ module Grape
       context "when path versioning is used" do
         it "includes a '/'" do
           path = Path.new(nil, nil, {})
-          path.stub(:uses_path_versioning?) { true }
+          allow(path).to receive(:uses_path_versioning?) { true }
 
           expect(path.suffix).to eql('(/.:format)')
         end
@@ -194,21 +194,21 @@ module Grape
       context "when path versioning is not used" do
         it "does not include a '/' when the path has a namespace" do
           path = Path.new(nil, 'namespace', {})
-          path.stub(:uses_path_versioning?) { true }
+          allow(path).to receive(:uses_path_versioning?) { true }
 
           expect(path.suffix).to eql('(.:format)')
         end
 
         it "does not include a '/' when the path has a path" do
           path = Path.new('/path', nil, {})
-          path.stub(:uses_path_versioning?) { true }
+          allow(path).to receive(:uses_path_versioning?) { true }
 
           expect(path.suffix).to eql('(.:format)')
         end
 
         it "includes a '/' otherwise" do
           path = Path.new(nil, nil, {})
-          path.stub(:uses_path_versioning?) { true }
+          allow(path).to receive(:uses_path_versioning?) { true }
 
           expect(path.suffix).to eql('(/.:format)')
         end
@@ -218,8 +218,8 @@ module Grape
     describe "#path_with_suffix" do
       it "combines the path and suffix" do
         path = Path.new(nil, nil, {})
-        path.stub(:path) { '/the/path' }
-        path.stub(:suffix) { 'suffix' }
+        allow(path).to receive(:path) { '/the/path' }
+        allow(path).to receive(:suffix) { 'suffix' }
 
         expect(path.path_with_suffix).to eql('/the/pathsuffix')
       end

--- a/spec/grape/util/hash_stack_spec.rb
+++ b/spec/grape/util/hash_stack_spec.rb
@@ -6,11 +6,11 @@ describe Grape::Util::HashStack do
     it 'finds the first available key' do
       subject[:abc] = 123
       subject.push(abc: 345)
-      subject.get(:abc).should == 345
+      expect(subject.get(:abc)).to eq(345)
     end
 
     it 'is nil if the key has not been set' do
-      subject[:abc].should be_nil
+      expect(subject[:abc]).to be_nil
     end
   end
 
@@ -18,7 +18,7 @@ describe Grape::Util::HashStack do
     it 'sets a value on the highest frame' do
       subject.push
       subject.set(:abc, 123)
-      subject.stack.last[:abc].should == 123
+      expect(subject.stack.last[:abc]).to eq(123)
     end
   end
 
@@ -27,96 +27,96 @@ describe Grape::Util::HashStack do
       subject[:abc] = []
       subject.imbue :abc, [123]
       subject.imbue :abc, [456]
-      subject[:abc].should == [123, 456]
+      expect(subject[:abc]).to eq([123, 456])
     end
 
     it 'merges a hash that is passed' do
       subject[:abc] = { foo: 'bar' }
       subject.imbue :abc, baz: 'wich'
-      subject[:abc].should == { foo: 'bar', baz: 'wich' }
+      expect(subject[:abc]).to eq(foo: 'bar', baz: 'wich')
     end
 
     it 'sets the value if not a hash or array' do
       subject.imbue :abc, 123
-      subject[:abc].should == 123
+      expect(subject[:abc]).to eq(123)
     end
 
     it 'is able to imbue an array without explicit setting' do
       subject.imbue :arr, [1]
       subject.imbue :arr, [2]
-      subject[:arr].should == [1, 2]
+      expect(subject[:arr]).to eq([1, 2])
     end
 
     it 'is able to imbue a hash without explicit setting' do
       subject.imbue :hash, foo: 'bar'
       subject.imbue :hash, baz: 'wich'
-      subject[:hash].should == { foo: 'bar', baz: 'wich' }
+      expect(subject[:hash]).to eq(foo: 'bar', baz: 'wich')
     end
   end
 
   describe '#push' do
     it 'returns a HashStack' do
-      subject.push(Grape::Util::HashStack.new).should be_kind_of(Grape::Util::HashStack)
+      expect(subject.push(Grape::Util::HashStack.new)).to be_kind_of(Grape::Util::HashStack)
     end
 
     it 'places the passed value on the top of the stack' do
       subject.push(abc: 123)
-      subject.stack.should == [{}, { abc: 123 }]
+      expect(subject.stack).to eq([{}, { abc: 123 }])
     end
 
     it 'pushes an empty hash by default' do
       subject[:abc] = 123
       subject.push
-      subject.stack.should == [{ abc: 123 }, {}]
+      expect(subject.stack).to eq([{ abc: 123 }, {}])
     end
   end
 
   describe '#pop' do
     it 'removes and return the top frame' do
       subject.push(abc: 123)
-      subject.pop.should == { abc: 123 }
-      subject.stack.size.should == 1
+      expect(subject.pop).to eq(abc: 123)
+      expect(subject.stack.size).to eq(1)
     end
   end
 
   describe '#peek' do
     it 'returns the top frame without removing it' do
       subject.push(abc: 123)
-      subject.peek.should == { abc: 123 }
-      subject.stack.size.should == 2
+      expect(subject.peek).to eq(abc: 123)
+      expect(subject.stack.size).to eq(2)
     end
   end
 
   describe '#prepend' do
     it 'returns a HashStack' do
-      subject.prepend(Grape::Util::HashStack.new).should be_kind_of(Grape::Util::HashStack)
+      expect(subject.prepend(Grape::Util::HashStack.new)).to be_kind_of(Grape::Util::HashStack)
     end
 
     it "prepends a HashStack's stack onto its own stack" do
       other = Grape::Util::HashStack.new.push(abc: 123)
-      subject.prepend(other).stack.should == [{}, { abc: 123 }, {}]
+      expect(subject.prepend(other).stack).to eq([{}, { abc: 123 }, {}])
     end
   end
 
   describe '#concat' do
     it 'returns a HashStack' do
-      subject.concat(Grape::Util::HashStack.new).should be_kind_of(Grape::Util::HashStack)
+      expect(subject.concat(Grape::Util::HashStack.new)).to be_kind_of(Grape::Util::HashStack)
     end
 
     it "appends a HashStack's stack onto its own stack" do
       other = Grape::Util::HashStack.new.push(abc: 123)
-      subject.concat(other).stack.should == [{}, {}, { abc: 123 }]
+      expect(subject.concat(other).stack).to eq([{}, {}, { abc: 123 }])
     end
   end
 
   describe '#update' do
     it 'merges! into the top frame' do
       subject.update(abc: 123)
-      subject.stack.should == [{ abc: 123 }]
+      expect(subject.stack).to eq([{ abc: 123 }])
     end
 
     it 'returns a HashStack' do
-      subject.update(abc: 123).should be_kind_of(Grape::Util::HashStack)
+      expect(subject.update(abc: 123)).to be_kind_of(Grape::Util::HashStack)
     end
   end
 
@@ -126,7 +126,7 @@ describe Grape::Util::HashStack do
       subject.push def: 234
       clone = subject.clone
       clone[:def] = 345
-      subject[:def].should == 234
+      expect(subject[:def]).to eq(234)
     end
   end
 end

--- a/spec/grape/validations/coerce_spec.rb
+++ b/spec/grape/validations/coerce_spec.rb
@@ -30,8 +30,8 @@ describe Grape::Validations::CoerceValidator do
         end
 
         get '/single', age: '43a'
-        last_response.status.should == 400
-        last_response.body.should == '年龄格式不正确'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('年龄格式不正确')
       end
 
       it 'gives an english fallback error when default locale message is blank' do
@@ -44,8 +44,8 @@ describe Grape::Validations::CoerceValidator do
         end
 
         get '/single', age: '43a'
-        last_response.status.should == 400
-        last_response.body.should == 'age is invalid'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('age is invalid')
       end
 
     end
@@ -59,12 +59,12 @@ describe Grape::Validations::CoerceValidator do
       end
 
       get '/single', int: '43a'
-      last_response.status.should == 400
-      last_response.body.should == 'int is invalid'
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq('int is invalid')
 
       get '/single', int: '43'
-      last_response.status.should == 200
-      last_response.body.should == 'int works'
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq('int works')
     end
 
     it 'error on malformed input (Array)' do
@@ -76,12 +76,12 @@ describe Grape::Validations::CoerceValidator do
       end
 
       get 'array', ids: ['1', '2', 'az']
-      last_response.status.should == 400
-      last_response.body.should == 'ids is invalid'
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq('ids is invalid')
 
       get 'array', ids: ['1', '2', '890']
-      last_response.status.should == 200
-      last_response.body.should == 'array int works'
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq('array int works')
     end
 
     context 'complex objects' do
@@ -102,12 +102,12 @@ describe Grape::Validations::CoerceValidator do
         end
 
         get '/user', user: "32"
-        last_response.status.should == 400
-        last_response.body.should == 'user is invalid'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('user is invalid')
 
         get '/user', user: { id: 32, name: 'Bob' }
-        last_response.status.should == 200
-        last_response.body.should == 'complex works'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('complex works')
       end
     end
 
@@ -121,8 +121,8 @@ describe Grape::Validations::CoerceValidator do
         end
 
         get '/int', int: "45"
-        last_response.status.should == 200
-        last_response.body.should == 'Fixnum'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('Fixnum')
       end
 
       it 'Array of Integers' do
@@ -134,8 +134,8 @@ describe Grape::Validations::CoerceValidator do
         end
 
         get '/array', arry: ['1', '2', '3']
-        last_response.status.should == 200
-        last_response.body.should == 'Fixnum'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('Fixnum')
       end
 
       it 'Array of Bools' do
@@ -147,8 +147,8 @@ describe Grape::Validations::CoerceValidator do
         end
 
         get 'array', arry: [1, 0]
-        last_response.status.should == 200
-        last_response.body.should == 'TrueClass'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('TrueClass')
       end
 
       it 'Bool' do
@@ -160,20 +160,20 @@ describe Grape::Validations::CoerceValidator do
         end
 
         get '/bool', bool: 1
-        last_response.status.should == 200
-        last_response.body.should == 'TrueClass'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('TrueClass')
 
         get '/bool', bool: 0
-        last_response.status.should == 200
-        last_response.body.should == 'FalseClass'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('FalseClass')
 
         get '/bool', bool: 'false'
-        last_response.status.should == 200
-        last_response.body.should == 'FalseClass'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('FalseClass')
 
         get '/bool', bool: 'true'
-        last_response.status.should == 200
-        last_response.body.should == 'TrueClass'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('TrueClass')
       end
 
       it 'file' do
@@ -185,8 +185,8 @@ describe Grape::Validations::CoerceValidator do
         end
 
         post '/upload', file: Rack::Test::UploadedFile.new(__FILE__)
-        last_response.status.should == 201
-        last_response.body.should == File.basename(__FILE__).to_s
+        expect(last_response.status).to eq(201)
+        expect(last_response.body).to eq(File.basename(__FILE__).to_s)
       end
 
       it 'Nests integers' do
@@ -200,8 +200,8 @@ describe Grape::Validations::CoerceValidator do
         end
 
         get '/int', integers: { int: "45" }
-        last_response.status.should == 200
-        last_response.body.should == 'Fixnum'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('Fixnum')
       end
     end
   end

--- a/spec/grape/validations/default_spec.rb
+++ b/spec/grape/validations/default_spec.rb
@@ -74,50 +74,50 @@ describe Grape::Validations::DefaultValidator do
 
   it 'set default value for optional param' do
     get("/")
-    last_response.status.should == 200
-    last_response.body.should == { id: nil, type: 'default-type' }.to_json
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq({ id: nil, type: 'default-type' }.to_json)
   end
 
   it 'set default values for optional params' do
     get("/user")
-    last_response.status.should == 200
-    last_response.body.should == { type1: 'default-type1', type2: 'default-type2' }.to_json
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq({ type1: 'default-type1', type2: 'default-type2' }.to_json)
   end
 
   it 'set default values for missing params in the request' do
     get("/user?type2=value2")
-    last_response.status.should == 200
-    last_response.body.should == { type1: 'default-type1', type2: 'value2' }.to_json
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq({ type1: 'default-type1', type2: 'value2' }.to_json)
   end
 
   it 'set default values for optional params and allow to use required fields in the same time' do
     get("/message?id=1")
-    last_response.status.should == 200
-    last_response.body.should == { id: '1', type1: 'default-type1', type2: 'default-type2' }.to_json
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq({ id: '1', type1: 'default-type1', type2: 'default-type2' }.to_json)
   end
 
   it 'sets lambda based defaults at the time of call' do
     get("/numbers")
-    last_response.status.should == 200
+    expect(last_response.status).to eq(200)
     before = JSON.parse(last_response.body)
     get("/numbers")
-    last_response.status.should == 200
+    expect(last_response.status).to eq(200)
     after = JSON.parse(last_response.body)
 
-    before['non_random_number'].should == after['non_random_number']
-    before['random_number'].should_not == after['random_number']
+    expect(before['non_random_number']).to eq(after['non_random_number'])
+    expect(before['random_number']).not_to eq(after['random_number'])
   end
 
   it 'set default values for optional grouped params' do
     get('/group')
-    last_response.status.should == 200
-    last_response.body.should == { foo_bar: 'foo-bar' }.to_json
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq({ foo_bar: 'foo-bar' }.to_json)
   end
 
   it 'sets default values for grouped arrays' do
     get('/array?array[][name]=name&array[][name]=name2&array[][with_default]=bar2')
-    last_response.status.should == 200
-    last_response.body.should == { array: [{ name: "name", with_default: "default" }, { name: "name2", with_default: "bar2" }] }.to_json
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq({ array: [{ name: "name", with_default: "default" }, { name: "name2", with_default: "bar2" }] }.to_json)
   end
 
 end

--- a/spec/grape/validations/presence_spec.rb
+++ b/spec/grape/validations/presence_spec.rb
@@ -61,82 +61,82 @@ describe Grape::Validations::PresenceValidator do
 
   it 'does not validate for any params' do
     get "/bacons"
-    last_response.status.should == 200
-    last_response.body.should == "All the bacon".to_json
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq("All the bacon".to_json)
   end
 
   it 'validates id' do
     post '/'
-    last_response.status.should == 400
-    last_response.body.should == '{"error":"id is missing"}'
+    expect(last_response.status).to eq(400)
+    expect(last_response.body).to eq('{"error":"id is missing"}')
 
     io = StringIO.new('{"id" : "a56b"}')
     post '/', {}, 'rack.input' => io, 'CONTENT_TYPE' => 'application/json', 'CONTENT_LENGTH' => io.length
-    last_response.body.should == '{"error":"id is invalid"}'
-    last_response.status.should == 400
+    expect(last_response.body).to eq('{"error":"id is invalid"}')
+    expect(last_response.status).to eq(400)
 
     io = StringIO.new('{"id" : 56}')
     post '/', {}, 'rack.input' => io, 'CONTENT_TYPE' => 'application/json', 'CONTENT_LENGTH' => io.length
-    last_response.body.should == '{"ret":56}'
-    last_response.status.should == 201
+    expect(last_response.body).to eq('{"ret":56}')
+    expect(last_response.status).to eq(201)
   end
 
   it 'validates name, company' do
     get '/'
-    last_response.status.should == 400
-    last_response.body.should == '{"error":"name is missing"}'
+    expect(last_response.status).to eq(400)
+    expect(last_response.body).to eq('{"error":"name is missing"}')
 
     get '/', name: "Bob"
-    last_response.status.should == 400
-    last_response.body.should == '{"error":"company is missing"}'
+    expect(last_response.status).to eq(400)
+    expect(last_response.body).to eq('{"error":"company is missing"}')
 
     get '/', name: "Bob", company: "TestCorp"
-    last_response.status.should == 200
-    last_response.body.should == "Hello".to_json
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq("Hello".to_json)
   end
 
   it 'validates nested parameters' do
     get '/nested'
-    last_response.status.should == 400
-    last_response.body.should == '{"error":"user is missing, user[first_name] is missing, user[last_name] is missing"}'
+    expect(last_response.status).to eq(400)
+    expect(last_response.body).to eq('{"error":"user is missing, user[first_name] is missing, user[last_name] is missing"}')
 
     get '/nested', user: { first_name: "Billy" }
-    last_response.status.should == 400
-    last_response.body.should == '{"error":"user[last_name] is missing"}'
+    expect(last_response.status).to eq(400)
+    expect(last_response.body).to eq('{"error":"user[last_name] is missing"}')
 
     get '/nested', user: { first_name: "Billy", last_name: "Bob" }
-    last_response.status.should == 200
-    last_response.body.should == "Nested".to_json
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq("Nested".to_json)
   end
 
   it 'validates triple nested parameters' do
     get '/nested_triple'
-    last_response.status.should == 400
-    last_response.body.should include '{"error":"admin is missing'
+    expect(last_response.status).to eq(400)
+    expect(last_response.body).to include '{"error":"admin is missing'
 
     get '/nested_triple', user: { first_name: "Billy" }
-    last_response.status.should == 400
-    last_response.body.should include '{"error":"admin is missing'
+    expect(last_response.status).to eq(400)
+    expect(last_response.body).to include '{"error":"admin is missing'
 
     get '/nested_triple', admin: { super: { first_name: "Billy" } }
-    last_response.status.should == 400
-    last_response.body.should == '{"error":"admin[admin_name] is missing, admin[super][user] is missing, admin[super][user][first_name] is missing, admin[super][user][last_name] is missing"}'
+    expect(last_response.status).to eq(400)
+    expect(last_response.body).to eq('{"error":"admin[admin_name] is missing, admin[super][user] is missing, admin[super][user][first_name] is missing, admin[super][user][last_name] is missing"}')
 
     get '/nested_triple', super: { user: { first_name: "Billy", last_name: "Bob" } }
-    last_response.status.should == 400
-    last_response.body.should include '{"error":"admin is missing'
+    expect(last_response.status).to eq(400)
+    expect(last_response.body).to include '{"error":"admin is missing'
 
     get '/nested_triple', admin: { super: { user: { first_name: "Billy" } } }
-    last_response.status.should == 400
-    last_response.body.should == '{"error":"admin[admin_name] is missing, admin[super][user][last_name] is missing"}'
+    expect(last_response.status).to eq(400)
+    expect(last_response.body).to eq('{"error":"admin[admin_name] is missing, admin[super][user][last_name] is missing"}')
 
     get '/nested_triple', admin: { admin_name: 'admin', super: { user: { first_name: "Billy" } } }
-    last_response.status.should == 400
-    last_response.body.should == '{"error":"admin[super][user][last_name] is missing"}'
+    expect(last_response.status).to eq(400)
+    expect(last_response.body).to eq('{"error":"admin[super][user][last_name] is missing"}')
 
     get '/nested_triple', admin: { admin_name: 'admin', super: { user: { first_name: "Billy", last_name: "Bob" } } }
-    last_response.status.should == 200
-    last_response.body.should == "Nested triple".to_json
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq("Nested triple".to_json)
   end
 
 end

--- a/spec/grape/validations/regexp_spec.rb
+++ b/spec/grape/validations/regexp_spec.rb
@@ -23,18 +23,18 @@ describe Grape::Validations::RegexpValidator do
   context 'invalid input' do
     it 'refuses inapppopriate' do
       get '/', name: "invalid name"
-      last_response.status.should == 400
+      expect(last_response.status).to eq(400)
     end
 
     it 'refuses nil' do
       get '/', name: nil
-      last_response.status.should == 400
+      expect(last_response.status).to eq(400)
     end
   end
 
   it 'accepts valid input' do
     get '/', name: "bob"
-    last_response.status.should == 200
+    expect(last_response.status).to eq(200)
   end
 
 end

--- a/spec/grape/validations/values_spec.rb
+++ b/spec/grape/validations/values_spec.rb
@@ -59,54 +59,54 @@ describe Grape::Validations::ValuesValidator do
 
   it 'allows a valid value for a parameter' do
     get("/", type: 'valid-type1')
-    last_response.status.should eq 200
-    last_response.body.should eq({ type: "valid-type1" }.to_json)
+    expect(last_response.status).to eq 200
+    expect(last_response.body).to eq({ type: "valid-type1" }.to_json)
   end
 
   it 'does not allow an invalid value for a parameter' do
     get("/", type: 'invalid-type')
-    last_response.status.should eq 400
-    last_response.body.should eq({ error: "type does not have a valid value" }.to_json)
+    expect(last_response.status).to eq 400
+    expect(last_response.body).to eq({ error: "type does not have a valid value" }.to_json)
   end
 
   it 'does not allow nil value for a parameter' do
     get("/", type: nil)
-    last_response.status.should eq 400
-    last_response.body.should eq({ error: "type does not have a valid value" }.to_json)
+    expect(last_response.status).to eq 400
+    expect(last_response.body).to eq({ error: "type does not have a valid value" }.to_json)
   end
 
   it 'allows a valid default value' do
     get("/default/valid")
-    last_response.status.should eq 200
-    last_response.body.should eq({ type: "valid-type2" }.to_json)
+    expect(last_response.status).to eq 200
+    expect(last_response.body).to eq({ type: "valid-type2" }.to_json)
   end
 
   it 'allows a proc for values' do
     get('/lambda', type: 'valid-type1')
-    last_response.status.should eq 200
-    last_response.body.should eq({ type: "valid-type1" }.to_json)
+    expect(last_response.status).to eq 200
+    expect(last_response.body).to eq({ type: "valid-type1" }.to_json)
   end
 
   it 'does not validate updated values without proc' do
     ValuesModel.add_value('valid-type4')
 
     get('/', type: 'valid-type4')
-    last_response.status.should eq 400
-    last_response.body.should eq({ error: "type does not have a valid value" }.to_json)
+    expect(last_response.status).to eq 400
+    expect(last_response.body).to eq({ error: "type does not have a valid value" }.to_json)
   end
 
   it 'validates against values in a proc' do
     ValuesModel.add_value('valid-type4')
 
     get('/lambda', type: 'valid-type4')
-    last_response.status.should eq 200
-    last_response.body.should eq({ type: "valid-type4" }.to_json)
+    expect(last_response.status).to eq 200
+    expect(last_response.body).to eq({ type: "valid-type4" }.to_json)
   end
 
   it 'does not allow an invalid value for a parameter using lambda' do
     get("/lambda", type: 'invalid-type')
-    last_response.status.should eq 400
-    last_response.body.should eq({ error: "type does not have a valid value" }.to_json)
+    expect(last_response.status).to eq 400
+    expect(last_response.body).to eq({ error: "type does not have a valid value" }.to_json)
   end
 
   it 'raises IncompatibleOptionValues on an invalid default value' do
@@ -125,8 +125,8 @@ describe Grape::Validations::ValuesValidator do
 
   it 'allows values to be a kind of the coerced type not just an instance of it' do
     get("/values/coercion", type: 10)
-    last_response.status.should eq 200
-    last_response.body.should eq({ type: 10 }.to_json)
+    expect(last_response.status).to eq 200
+    expect(last_response.body).to eq({ type: 10 }.to_json)
   end
 
   it 'raises IncompatibleOptionValues when values contains a value that is not a kind of the type' do

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -19,12 +19,12 @@ describe Grape::Validations do
         end
 
         get '/optional', a_number: 'string'
-        last_response.status.should == 400
-        last_response.body.should == 'a_number is invalid'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('a_number is invalid')
 
         get '/optional', a_number: 45
-        last_response.status.should == 200
-        last_response.body.should == 'optional works!'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('optional works!')
       end
 
       it "doesn't validate when param not present" do
@@ -36,15 +36,15 @@ describe Grape::Validations do
         end
 
         get '/optional'
-        last_response.status.should == 200
-        last_response.body.should == 'optional works!'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('optional works!')
       end
 
       it 'adds to declared parameters' do
         subject.params do
           optional :some_param
         end
-        subject.settings[:declared_params].should == [:some_param]
+        expect(subject.settings[:declared_params]).to eq([:some_param])
       end
     end
 
@@ -60,21 +60,21 @@ describe Grape::Validations do
 
       it 'errors when param not present' do
         get '/required'
-        last_response.status.should == 400
-        last_response.body.should == 'key is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('key is missing')
       end
 
       it "doesn't throw a missing param when param is present" do
         get '/required', key: 'cool'
-        last_response.status.should == 200
-        last_response.body.should == 'required works'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('required works')
       end
 
       it 'adds to declared parameters' do
         subject.params do
           requires :some_param
         end
-        subject.settings[:declared_params].should == [:some_param]
+        expect(subject.settings[:declared_params]).to eq([:some_param])
       end
     end
 
@@ -97,19 +97,19 @@ describe Grape::Validations do
 
       it 'adds entity documentation to declared params' do
         define_requires_all
-        subject.settings[:declared_params].should == [:required_field, :optional_field]
+        expect(subject.settings[:declared_params]).to eq([:required_field, :optional_field])
       end
 
       it 'errors when required_field is not present' do
         get '/required'
-        last_response.status.should == 400
-        last_response.body.should == 'required_field is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('required_field is missing')
       end
 
       it 'works when required_field is present' do
         get '/required', required_field: 'woof'
-        last_response.status.should == 200
-        last_response.body.should == 'required works'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('required works')
       end
     end
 
@@ -132,19 +132,19 @@ describe Grape::Validations do
 
       it 'adds entity documentation to declared params' do
         define_requires_none
-        subject.settings[:declared_params].should == [:required_field, :optional_field]
+        expect(subject.settings[:declared_params]).to eq([:required_field, :optional_field])
       end
 
       it 'errors when required_field is not present' do
         get '/required'
-        last_response.status.should == 400
-        last_response.body.should == 'required_field is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('required_field is missing')
       end
 
       it 'works when required_field is present' do
         get '/required', required_field: 'woof'
-        last_response.status.should == 200
-        last_response.body.should == 'required works'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('required works')
       end
     end
 
@@ -162,24 +162,24 @@ describe Grape::Validations do
 
       it 'errors when param not present' do
         get '/required'
-        last_response.status.should == 400
-        last_response.body.should == 'items is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('items is missing')
       end
 
       it "errors when param is not an Array" do
         get '/required', items: "hello"
-        last_response.status.should == 400
-        last_response.body.should == 'items is invalid, items[key] is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('items is invalid, items[key] is missing')
 
         get '/required', items: { key: 'foo' }
-        last_response.status.should == 400
-        last_response.body.should == 'items is invalid'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('items is invalid')
       end
 
       it "doesn't throw a missing param when param is present" do
         get '/required', items: [{ key: 'hello' }, { key: 'world' }]
-        last_response.status.should == 200
-        last_response.body.should == 'required works'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('required works')
       end
 
       it "doesn't allow any key in the options hash other than type" do
@@ -198,7 +198,7 @@ describe Grape::Validations do
             requires :key
           end
         end
-        subject.settings[:declared_params].should == [items: [:key]]
+        expect(subject.settings[:declared_params]).to eq([items: [:key]])
       end
     end
 
@@ -216,24 +216,24 @@ describe Grape::Validations do
 
       it 'errors when param not present' do
         get '/required'
-        last_response.status.should == 400
-        last_response.body.should == 'items is missing, items[key] is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('items is missing, items[key] is missing')
       end
 
       it "errors when param is not a Hash" do
         get '/required', items: "hello"
-        last_response.status.should == 400
-        last_response.body.should == 'items is invalid, items[key] is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('items is invalid, items[key] is missing')
 
         get '/required', items: [{ key: 'foo' }]
-        last_response.status.should == 400
-        last_response.body.should == 'items is invalid'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('items is invalid')
       end
 
       it "doesn't throw a missing param when param is present" do
         get '/required', items: { key: 'hello' }
-        last_response.status.should == 200
-        last_response.body.should == 'required works'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('required works')
       end
 
       it "doesn't allow any key in the options hash other than type" do
@@ -252,7 +252,7 @@ describe Grape::Validations do
             requires :key
           end
         end
-        subject.settings[:declared_params].should == [items: [:key]]
+        expect(subject.settings[:declared_params]).to eq([items: [:key]])
       end
     end
 
@@ -270,14 +270,14 @@ describe Grape::Validations do
 
       it 'errors when param not present' do
         get '/required'
-        last_response.status.should == 400
-        last_response.body.should == 'items is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('items is missing')
       end
 
       it "doesn't throw a missing param when param is present" do
         get '/required', items: [key: 'hello', key: 'world']
-        last_response.status.should == 200
-        last_response.body.should == 'required works'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('required works')
       end
 
       it 'adds to declared parameters' do
@@ -286,7 +286,7 @@ describe Grape::Validations do
             requires :key
           end
         end
-        subject.settings[:declared_params].should == [items: [:key]]
+        expect(subject.settings[:declared_params]).to eq([items: [:key]])
       end
     end
 
@@ -310,8 +310,8 @@ describe Grape::Validations do
           { name: 'John', parents: [{ name: 'Jane' }, { name: 'Bob' }] },
           { name: 'Joe', parents: [{ name: 'Josie' }] }
         ]
-        last_response.status.should == 200
-        last_response.body.should == 'within array works'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('within array works')
       end
 
       it 'errors when a parameter is not present' do
@@ -321,34 +321,34 @@ describe Grape::Validations do
         ]
         # NOTE: with body parameters in json or XML or similar this
         # should actually fail with: children[parents][name] is missing.
-        last_response.status.should == 400
-        last_response.body.should == 'children[parents] is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('children[parents] is missing')
       end
 
       it 'safely handles empty arrays and blank parameters' do
         # NOTE: with body parameters in json or XML or similar this
         # should actually return 200, since an empty array is valid.
         get '/within_array', children: []
-        last_response.status.should == 400
-        last_response.body.should == 'children is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('children is missing')
         get '/within_array', children: [name: 'Jay']
-        last_response.status.should == 400
-        last_response.body.should == 'children[parents] is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('children[parents] is missing')
       end
 
       it "errors when param is not an Array" do
         # NOTE: would be nicer if these just returned 'children is invalid'
         get '/within_array', children: "hello"
-        last_response.status.should == 400
-        last_response.body.should == 'children is invalid, children[name] is missing, children[parents] is missing, children[parents] is invalid, children[parents][name] is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('children is invalid, children[name] is missing, children[parents] is missing, children[parents] is invalid, children[parents][name] is missing')
 
         get '/within_array', children: { name: 'foo' }
-        last_response.status.should == 400
-        last_response.body.should == 'children is invalid, children[parents] is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('children is invalid, children[parents] is missing')
 
         get '/within_array', children: [name: 'Jay', parents: { name: 'Fred' }]
-        last_response.status.should == 400
-        last_response.body.should == 'children[parents] is invalid'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('children[parents] is invalid')
       end
     end
 
@@ -394,53 +394,53 @@ describe Grape::Validations do
 
       it 'requires defaults to Array type' do
         get '/req', planets: "Jupiter, Saturn"
-        last_response.status.should == 400
-        last_response.body.should == 'planets is invalid, planets[name] is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('planets is invalid, planets[name] is missing')
 
         get '/req', planets: { name: 'Jupiter' }
-        last_response.status.should == 400
-        last_response.body.should == 'planets is invalid'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('planets is invalid')
 
         get '/req', planets: [{ name: 'Venus' }, { name: 'Mars' }]
-        last_response.status.should == 200
+        expect(last_response.status).to eq(200)
 
         put_with_json '/req', planets: []
-        last_response.status.should == 200
+        expect(last_response.status).to eq(200)
       end
 
       it 'optional defaults to Array type' do
         get '/opt', name: "Jupiter", moons: "Europa, Ganymede"
-        last_response.status.should == 400
-        last_response.body.should == 'moons is invalid, moons[name] is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('moons is invalid, moons[name] is missing')
 
         get '/opt', name: "Jupiter", moons: { name: 'Ganymede' }
-        last_response.status.should == 400
-        last_response.body.should == 'moons is invalid'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('moons is invalid')
 
         get '/opt', name: "Jupiter", moons: [{ name: 'Io' }, { name: 'Callisto' }]
-        last_response.status.should == 200
+        expect(last_response.status).to eq(200)
 
         put_with_json '/opt', name: "Venus"
-        last_response.status.should == 200
+        expect(last_response.status).to eq(200)
 
         put_with_json '/opt', name: "Mercury", moons: []
-        last_response.status.should == 200
+        expect(last_response.status).to eq(200)
       end
 
       it 'group defaults to Array type' do
         get '/grp', stars: "Sun"
-        last_response.status.should == 400
-        last_response.body.should == 'stars is invalid, stars[name] is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('stars is invalid, stars[name] is missing')
 
         get '/grp', stars: { name: 'Sun' }
-        last_response.status.should == 400
-        last_response.body.should == 'stars is invalid'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('stars is invalid')
 
         get '/grp', stars: [{ name: 'Sun' }]
-        last_response.status.should == 200
+        expect(last_response.status).to eq(200)
 
         put_with_json '/grp', stars: []
-        last_response.status.should == 200
+        expect(last_response.status).to eq(200)
       end
     end
 
@@ -464,8 +464,8 @@ describe Grape::Validations do
           { name: 'John', parents: [{ name: 'Jane' }, { name: 'Bob' }] },
           { name: 'Joe', parents: [{ name: 'Josie' }] }
         ]
-        last_response.status.should == 200
-        last_response.body.should == 'within array works'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('within array works')
       end
 
       it 'errors when a parameter is not present' do
@@ -473,16 +473,16 @@ describe Grape::Validations do
           { name: 'Jim', parents: [{}] },
           { name: 'Job', parents: [{ name: 'Joy' }] }
         ]
-        last_response.status.should == 400
-        last_response.body.should == 'children[parents][name] is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('children[parents][name] is missing')
       end
 
       it 'safely handles empty arrays and blank parameters' do
         put_with_json '/within_array', children: []
-        last_response.status.should == 200
+        expect(last_response.status).to eq(200)
         put_with_json '/within_array', children: [name: 'Jay']
-        last_response.status.should == 400
-        last_response.body.should == 'children[parents] is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('children[parents] is missing')
       end
     end
 
@@ -500,30 +500,30 @@ describe Grape::Validations do
 
       it "doesn't throw a missing param when the group isn't present" do
         get '/optional_group'
-        last_response.status.should == 200
-        last_response.body.should == 'optional group works'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('optional group works')
       end
 
       it "doesn't throw a missing param when both group and param are given" do
         get '/optional_group', items: [{ key: 'foo' }]
-        last_response.status.should == 200
-        last_response.body.should == 'optional group works'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('optional group works')
       end
 
       it "errors when group is present, but required param is not" do
         get '/optional_group', items: [{ not_key: 'foo' }]
-        last_response.status.should == 400
-        last_response.body.should == 'items[key] is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('items[key] is missing')
       end
 
       it "errors when param is present but isn't an Array" do
         get '/optional_group', items: "hello"
-        last_response.status.should == 400
-        last_response.body.should == 'items is invalid, items[key] is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('items is invalid, items[key] is missing')
 
         get '/optional_group', items: { key: 'foo' }
-        last_response.status.should == 400
-        last_response.body.should == 'items is invalid'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('items is invalid')
       end
 
       it 'adds to declared parameters' do
@@ -532,7 +532,7 @@ describe Grape::Validations do
             requires :key
           end
         end
-        subject.settings[:declared_params].should == [items: [:key]]
+        expect(subject.settings[:declared_params]).to eq([items: [:key]])
       end
     end
 
@@ -550,42 +550,42 @@ describe Grape::Validations do
 
       it 'does no internal validations if the outer group is blank' do
         get '/nested_optional_group'
-        last_response.status.should == 200
-        last_response.body.should == 'nested optional group works'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('nested optional group works')
       end
 
       it 'does internal validations if the outer group is present' do
         get '/nested_optional_group', items: [{ key: 'foo' }]
-        last_response.status.should == 400
-        last_response.body.should == 'items[required_subitems] is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('items[required_subitems] is missing')
 
         get '/nested_optional_group', items: [{ key: 'foo', required_subitems: [{ value: 'bar' }] }]
-        last_response.status.should == 200
-        last_response.body.should == 'nested optional group works'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('nested optional group works')
       end
 
       it 'handles deep nesting' do
         get '/nested_optional_group', items: [{ key: 'foo', required_subitems: [{ value: 'bar' }], optional_subitems: [{ not_value: 'baz' }] }]
-        last_response.status.should == 400
-        last_response.body.should == 'items[optional_subitems][value] is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('items[optional_subitems][value] is missing')
 
         get '/nested_optional_group', items: [{ key: 'foo', required_subitems: [{ value: 'bar' }], optional_subitems: [{ value: 'baz' }] }]
-        last_response.status.should == 200
-        last_response.body.should == 'nested optional group works'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('nested optional group works')
       end
 
       it 'handles validation within arrays' do
         get '/nested_optional_group', items: [{ key: 'foo' }]
-        last_response.status.should == 400
-        last_response.body.should == 'items[required_subitems] is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('items[required_subitems] is missing')
 
         get '/nested_optional_group', items: [{ key: 'foo', required_subitems: [{ value: 'bar' }] }]
-        last_response.status.should == 200
-        last_response.body.should == 'nested optional group works'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('nested optional group works')
 
         get '/nested_optional_group', items: [{ key: 'foo', required_subitems: [{ value: 'bar' }], optional_subitems: [{ not_value: 'baz' }] }]
-        last_response.status.should == 400
-        last_response.body.should == 'items[optional_subitems][value] is missing'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('items[optional_subitems][value] is missing')
       end
 
       it 'adds to declared parameters' do
@@ -596,7 +596,7 @@ describe Grape::Validations do
             requires(:required_subitems) { requires :value }
           end
         end
-        subject.settings[:declared_params].should == [items: [:key, { optional_subitems: [:value] }, { required_subitems: [:value] }]]
+        expect(subject.settings[:declared_params]).to eq([items: [:key, { optional_subitems: [:value] }, { required_subitems: [:value] }]])
       end
     end
 
@@ -613,9 +613,9 @@ describe Grape::Validations do
 
       it 'throws the validation errors' do
         get '/two_required'
-        last_response.status.should == 400
-        last_response.body.should =~ /yolo is missing/
-        last_response.body.should =~ /swag is missing/
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to match(/yolo is missing/)
+        expect(last_response.body).to match(/swag is missing/)
       end
     end
 
@@ -642,18 +642,18 @@ describe Grape::Validations do
 
         it 'validates when param is present' do
           get '/optional_custom', custom: 'im custom'
-          last_response.status.should == 200
-          last_response.body.should == 'optional with custom works!'
+          expect(last_response.status).to eq(200)
+          expect(last_response.body).to eq('optional with custom works!')
 
           get '/optional_custom', custom: 'im wrong'
-          last_response.status.should == 400
-          last_response.body.should == 'custom is not custom!'
+          expect(last_response.status).to eq(400)
+          expect(last_response.body).to eq('custom is not custom!')
         end
 
         it "skips validation when parameter isn't present" do
           get '/optional_custom'
-          last_response.status.should == 200
-          last_response.body.should == 'optional with custom works!'
+          expect(last_response.status).to eq(200)
+          expect(last_response.body).to eq('optional with custom works!')
         end
 
         it 'validates with custom validator when param present and incorrect type' do
@@ -662,8 +662,8 @@ describe Grape::Validations do
           end
 
           get '/optional_custom', custom: 123
-          last_response.status.should == 400
-          last_response.body.should == 'custom is not custom!'
+          expect(last_response.status).to eq(400)
+          expect(last_response.body).to eq('custom is not custom!')
         end
       end
 
@@ -679,18 +679,18 @@ describe Grape::Validations do
 
         it 'validates when param is present' do
           get '/required_custom', custom: 'im wrong, validate me'
-          last_response.status.should == 400
-          last_response.body.should == 'custom is not custom!'
+          expect(last_response.status).to eq(400)
+          expect(last_response.body).to eq('custom is not custom!')
 
           get '/required_custom', custom: 'im custom'
-          last_response.status.should == 200
-          last_response.body.should == 'required with custom works!'
+          expect(last_response.status).to eq(200)
+          expect(last_response.body).to eq('required with custom works!')
         end
 
         it 'validates when param is not present' do
           get '/required_custom'
-          last_response.status.should == 400
-          last_response.body.should == 'custom is missing, custom is not custom!'
+          expect(last_response.status).to eq(400)
+          expect(last_response.body).to eq('custom is missing, custom is not custom!')
         end
 
         context 'nested namespaces' do
@@ -737,33 +737,33 @@ describe Grape::Validations do
 
           specify 'the parent namespace uses the validator' do
             get '/nested/one', custom: 'im wrong, validate me'
-            last_response.status.should == 400
-            last_response.body.should == 'custom is not custom!'
+            expect(last_response.status).to eq(400)
+            expect(last_response.body).to eq('custom is not custom!')
           end
 
           specify 'the nested namesapce inherits the custom validator' do
             get '/nested/nested/two', custom: 'im wrong, validate me'
-            last_response.status.should == 400
-            last_response.body.should == 'custom is not custom!'
+            expect(last_response.status).to eq(400)
+            expect(last_response.body).to eq('custom is not custom!')
           end
 
           specify 'peer namesapces does not have the validator' do
             get '/peer/one', custom: 'im not validated'
-            last_response.status.should == 200
-            last_response.body.should == 'no validation required'
+            expect(last_response.status).to eq(200)
+            expect(last_response.body).to eq('no validation required')
           end
 
           specify 'namespaces nested in peers should also not have the validator' do
             get '/peer/nested/two', custom: 'im not validated'
-            last_response.status.should == 200
-            last_response.body.should == 'no validation required'
+            expect(last_response.status).to eq(200)
+            expect(last_response.body).to eq('no validation required')
           end
 
           specify 'when nested, specifying a route should clear out the validations for deeper nested params' do
             get '/unrelated/one'
-            last_response.status.should == 400
+            expect(last_response.status).to eq(400)
             get '/unrelated/double/two'
-            last_response.status.should == 200
+            expect(last_response.status).to eq(200)
           end
         end
       end
@@ -811,14 +811,14 @@ describe Grape::Validations do
           subject.params do
             use :pagination
           end
-          subject.settings[:declared_params].should eq [:page, :per_page]
+          expect(subject.settings[:declared_params]).to eq [:page, :per_page]
         end
 
         it 'by #use with multiple params' do
           subject.params do
             use :pagination, :period
           end
-          subject.settings[:declared_params].should eq [:page, :per_page, :start_date, :end_date]
+          expect(subject.settings[:declared_params]).to eq [:page, :per_page, :start_date, :end_date]
         end
 
       end
@@ -834,7 +834,7 @@ describe Grape::Validations do
         subject.get '/' do
         end
 
-        subject.routes.first.route_params['first_name'][:documentation].should eq(documentation)
+        expect(subject.routes.first.route_params['first_name'][:documentation]).to eq(documentation)
       end
     end
   end

--- a/spec/shared/versioning_examples.rb
+++ b/spec/shared/versioning_examples.rb
@@ -6,7 +6,7 @@ shared_examples_for 'versioning' do
       "Version: #{request.env['api.version'] }"
     end
     versioned_get '/hello', 'v1', macro_options
-    last_response.body.should eql "Version: v1"
+    expect(last_response.body).to eql "Version: v1"
   end
 
   it 'adds the prefix before the API version' do
@@ -17,7 +17,7 @@ shared_examples_for 'versioning' do
       "Version: #{request.env['api.version'] }"
     end
     versioned_get '/hello', 'v1', macro_options.merge(prefix: 'api')
-    last_response.body.should eql "Version: v1"
+    expect(last_response.body).to eql "Version: v1"
   end
 
   it 'is able to specify version as a nesting' do
@@ -33,14 +33,14 @@ shared_examples_for 'versioning' do
     end
 
     versioned_get '/awesome', 'v1', macro_options
-    last_response.status.should eql 404
+    expect(last_response.status).to eql 404
 
     versioned_get '/awesome', 'v2', macro_options
-    last_response.status.should eql 200
+    expect(last_response.status).to eql 200
     versioned_get '/legacy', 'v1', macro_options
-    last_response.status.should eql 200
+    expect(last_response.status).to eql 200
     versioned_get '/legacy', 'v2', macro_options
-    last_response.status.should eql 404
+    expect(last_response.status).to eql 404
   end
 
   it 'is able to specify multiple versions' do
@@ -50,11 +50,11 @@ shared_examples_for 'versioning' do
     end
 
     versioned_get '/awesome', 'v1', macro_options
-    last_response.status.should eql 200
+    expect(last_response.status).to eql 200
     versioned_get '/awesome', 'v2', macro_options
-    last_response.status.should eql 200
+    expect(last_response.status).to eql 200
     versioned_get '/awesome', 'v3', macro_options
-    last_response.status.should eql 404
+    expect(last_response.status).to eql 404
   end
 
   context 'with different versions for the same endpoint' do
@@ -73,11 +73,11 @@ shared_examples_for 'versioning' do
         end
 
         versioned_get '/version', 'v2', macro_options
-        last_response.status.should == 200
-        last_response.body.should == 'v2'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('v2')
         versioned_get '/version', 'v1', macro_options
-        last_response.status.should == 200
-        last_response.body.should == 'version v1'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('version v1')
       end
     end
 
@@ -97,12 +97,12 @@ shared_examples_for 'versioning' do
         end
 
         versioned_get '/version', 'v1', macro_options.merge(prefix: subject.prefix)
-        last_response.status.should == 200
-        last_response.body.should == 'version v1'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('version v1')
 
         versioned_get '/version', 'v2', macro_options.merge(prefix: subject.prefix)
-        last_response.status.should == 200
-        last_response.body.should == 'v2'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('v2')
       end
     end
   end
@@ -115,7 +115,7 @@ shared_examples_for 'versioning' do
       params[:version]
     end
     versioned_get '/api_version_with_version_param?version=1', 'v1', macro_options
-    last_response.body.should eql '1'
+    expect(last_response.body).to eql '1'
   end
 
 end


### PR DESCRIPTION
Converted suite to RSpec 3 syntax with [Transpec](https://github.com/yujinakayama/transpec).

Additionally, I updated a test from endpoint_spec.rb on Line 108. Test checks whether response cookies are set. Appropriate test would be to check for nil rather than using a match keyword. Previous versions of RSpec would allow checking against nil using the `=~` syntax. RSpec 3 does not allow nil to be checked with the `match` matcher. The test was updated to reflect this change.

Test Before Change:

``` ruby
it 'sets browser cookies and does not set response cookies' do
      subject.get('/username') do
        cookies[:username]
      end
      get('/username', {}, 'HTTP_COOKIE' => 'username=mrplum; sandbox=true')

      last_response.body.should == 'mrplum'
      last_response.headers['Set-Cookie'].should_not =~ /username=mrplum/
      last_response.headers['Set-Cookie'].should_not =~ /sandbox=true/
    end
```

Test After Change:

``` ruby
it 'sets browser cookies and does not set response cookies' do
      subject.get('/username') do
        cookies[:username]
      end
      get('/username', {}, 'HTTP_COOKIE' => 'username=mrplum; sandbox=true')

      expect(last_response.body).to eq('mrplum')
      expect(last_response.headers['Set-Cookie']).to be_nil
    end
```

This conversion is done by Transpec 1.10.4 with the following command:
    transpec
- 826 conversions
  from: obj.should
    to: expect(obj).to
- 572 conversions
  from: == expected
    to: eq(expected)
- 23 conversions
  from: obj.stub(:message)
    to: allow(obj).to receive(:message)
- 17 conversions
  from: obj.should_receive(:message)
    to: expect(obj).to receive(:message)
- 8 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 8 conversions
  from: =~ /pattern/
    to: match(/pattern/)
- 6 conversions
  from: lambda { }.should
    to: expect { }.to
- 3 conversions
  from: lambda { }.should_not
    to: expect { }.not_to
- 2 conversions
  from: > expected
    to: be > expected
- 2 conversions
  from: obj.should_not_receive(:message)
    to: expect(obj).not_to receive(:message)
- 1 conversion
  from: >= expected
    to: be >= expected
