### PR TITLE
Fix rescue_from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1040,11 +1040,11 @@ rescue_from APIErrors::ParentError do |e|
 end
 ```
 
-To only rescue the base exception class, set `rescue_subclasses: false`.
-The code below will rescue exceptions of type `RuntimeError` but _not_ its subclasses.
+By default, Grape will only rescue the base exception class. To rescue subclasses, set `rescue_subclasses: true`.
+The code below will rescue exceptions of type `RuntimeError` and all its subclasses.
 
 ```ruby
-rescue_from RuntimeError, rescue_subclasses: false do |e|
+rescue_from RuntimeError, rescue_subclasses: true do |e|
     Rack::Response.new(
       status: e.status,
       message: e.message,


### PR DESCRIPTION
I'm not sure whether this is a bug or intentional, but right now rescue_from **does not** rescue subclasses by default.

This seems to be caused by https://github.com/intridea/grape/blob/master/lib/grape/api.rb#L217

```
handler_type = !!options[:rescue_subclasses] ? :rescue_handlers : :base_only_rescue_handlers
```
