### PR TITLE
Replace stub! with stub in examples of tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1700,7 +1700,7 @@ request.
 describe 'an endpoint that needs helpers stubbed' do
   before do
     Grape::Endpoint.before_each do |endpoint|
-      endpoint.stub!(:helper_name).and_return('desired_value')
+      endpoint.stub(:helper_name).and_return('desired_value')
     end
   end
 


### PR DESCRIPTION
I've not found a mock framework which has `stub!` method. In `Rspec` at least default mocking framework doesn't have one. Neither does `mocha`. So I think this is just a typo?
