### PR TITLE
fix syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1360,9 +1360,10 @@ module API
   class Statuses < Grape::API
     version 'v1'
 
-    desc 'Create a status', {
+    desc 'Create a status'
+    params do
       requires :all, except: [:ip], using: API::Entities::Status.documentation.except(:id)
-    }
+    end
     post '/status' do
       Status.create! params
     end


### PR DESCRIPTION
The `requires` statement should be in a `params` block according to #560.
