### PR TITLE
Avoid requiring non-existent fields when using Grape::Entity documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Next Release
 * [#626](https://github.com/intridea/grape/pull/626): Mutually exclusive params - [@oliverbarnes](https://github.com/oliverbarnes).
 * [#617](https://github.com/intridea/grape/pull/617): Running tests on Ruby 2.1.1, Rubinius 2.1 and 2.2, Ruby and JRuby HEAD - [@dblock](https://github.com/dblock).
 * [#397](https://github.com/intridea/grape/pull/397): Adds `Grape::Endpoint.before_each` to allow easy helper stubbing - [@mbleigh](https://github.com/mbleigh).
+* [#673](https://github.com/intridea/grape/pull/673): Avoid requiring non-existent fields when using Grape::Entity documentation - [@qqshfox](https://github.com/qqshfox).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/validations.rb
+++ b/lib/grape/validations.rb
@@ -191,10 +191,13 @@ module Grape
           optional_fields = opts[:using].keys - required_fields
         end
         required_fields.each do |field|
-          requires(field, opts[:using][field])
+          field_opts = opts[:using][field]
+          raise ArgumentError, "required field not exist: #{field}" unless field_opts
+          requires(field, field_opts)
         end
         optional_fields.each do |field|
-          optional(field, opts[:using][field])
+          field_opts = opts[:using][field]
+          optional(field, field_opts) if field_opts
         end
       end
 

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -148,6 +148,41 @@ describe Grape::Validations do
       end
     end
 
+    context 'requires :all or :none but except a non-existent field using Grape::Entity documentation' do
+      context 'requires :all' do
+        def define_requires_all
+          documentation = {
+            required_field: { type: String },
+            optional_field: { type: String }
+          }
+          subject.params do
+            requires :all, except: :non_existent_field, using: documentation
+          end
+        end
+
+        it 'adds only the entity documentation to declared params, nothing more' do
+          define_requires_all
+          expect(subject.settings[:declared_params]).to eq([:required_field, :optional_field])
+        end
+      end
+
+      context 'requires :none' do
+        def define_requires_none
+          documentation = {
+            required_field: { type: String },
+            optional_field: { type: String }
+          }
+          subject.params do
+            requires :none, except: :non_existent_field, using: documentation
+          end
+        end
+
+        it 'adds only the entity documentation to declared params, nothing more' do
+          expect { define_requires_none }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
     context 'required with an Array block' do
       before do
         subject.params do


### PR DESCRIPTION
When `requires :none, except: [:non_existent_field], using: documentation`, it may generate the params like this

```
{
    "paramType": "form",
    "name": "non_existent_field",
    "description": null,
    "type": "String",
    "dataType": "String",
    "required": true
},
{
    "paramType": "path",
    "name": "",
    "description": null,
    "type": "String",
    "dataType": "String",
    "required": true
},
{
    "paramType": "form",
    "name": "required_field",
    "description": null,
    "type": "String",
    "dataType": "String",
    "required": false
}
```
