### PR TITLE
Virtus is only for test env

### DIFF
--- a/grape.gemspec
+++ b/grape.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'multi_json', '>= 1.3.2'
   s.add_runtime_dependency 'multi_xml', '>= 0.5.2'
   s.add_runtime_dependency 'hashie', '>= 2.1.0'
-  s.add_runtime_dependency 'virtus', '>= 1.0.0'
   s.add_runtime_dependency 'builder'
 
   s.add_development_dependency 'grape-entity', '>= 0.2.0'
@@ -31,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'rspec', '~> 2.9'
   s.add_development_dependency 'bundler'
+  s.add_development_dependency 'virtus', '>= 1.0.0'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Virtus is used only in tests for the gem. Why do we need to include the dependency for all environments?
