### PR TITLE
Updated rspec testing for Rails in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1664,8 +1664,6 @@ end
 ### Writing Tests with Rails
 
 ```ruby
-require 'spec_helper'
-
 describe Twitter::API do
   describe "GET /api/v1/statuses" do
     it "returns an empty array of statuses" do


### PR DESCRIPTION
I updated the README to remind users that since RSpec 3.x, rspec-rails is using `rails_helper` instead of  `spec_helper`.
