### PR TITLE
Set status for endpoints when an error occours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ============
 
 * [#687](https://github.com/intridea/grape/pull/687): Fix: `mutually_exclusive` and `exactly_one_of` validation error messages now label parameters as strings, consistently with `requires` and `optional` - [@dblock](https://github.com/dblock).
+* [#698](https://github.com/intridea/grape/pull/698): `error!` sets `status` for `Endpoint` to [@dspaeth-faber](https://github.com/dspaeth-faber).
 * Your contribution here.
 
 0.8.0 (7/10/2014)

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -49,6 +49,8 @@ module Grape
       require_option(options, :method)
 
       @settings = settings
+      @settings[:default_error_status] ||= 500
+
       @options = options
 
       @options[:path] = Array(options[:path])
@@ -225,8 +227,8 @@ module Grape
     # @param message [String] The message to display.
     # @param status [Integer] the HTTP Status Code. Defaults to default_error_status, 500 if not set.
     def error!(message, status = nil, headers = nil)
-      status = settings[:default_error_status] unless status
-      throw :error, message: message, status: status, headers: headers
+      self.status(status || settings[:default_error_status])
+      throw :error, message: message, status: self.status, headers: headers
     end
 
     # Redirect to a new url.
@@ -435,7 +437,7 @@ module Grape
       b.use Grape::Middleware::Error,
             format: settings[:format],
             content_types: settings[:content_types],
-            default_status: settings[:default_error_status] || 500,
+            default_status: settings[:default_error_status],
             rescue_all: settings[:rescue_all],
             default_error_formatter: settings[:default_error_formatter],
             error_formatters: settings[:error_formatters],

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -586,6 +586,19 @@ describe Grape::Endpoint do
       expect(last_response.status).to eq(403)
       expect(last_response.headers['X-Custom']).to eq('value')
     end
+
+    it 'sets the status code for the endpoint' do
+      memoized_endpoint = nil
+
+      subject.get '/hey' do
+        memoized_endpoint = self
+        error!({ 'dude' => 'rad' }, 403, 'X-Custom' => 'value')
+      end
+
+      get '/hey.json'
+
+      expect(memoized_endpoint.status).to eq(403)
+    end
   end
 
   describe '#redirect' do


### PR DESCRIPTION
With this PR  `status` for `EndPoint` is set when an error accour's like mentioned in #697.
So a ErrorFormatter can use the status.
