### PR TITLE
Fix: Parameter parsing when `rack.input` is a Tempfile #694

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ============
 
 * [#687](https://github.com/intridea/grape/pull/687): Fix: `mutually_exclusive` and `exactly_one_of` validation error messages now label parameters as strings, consistently with `requires` and `optional` - [@dblock](https://github.com/dblock).
+* [#700](https://github.com/intridea/grape/pull/700): Fix: Parameter parsing when `rack.input` is a Tempfile [@dspaeth-faber](https://github.com/dspaeth-faber).
 * Your contribution here.
 
 0.8.0 (7/10/2014)

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -73,12 +73,18 @@ module Grape
           if parser
             begin
               body = (env['api.request.body'] = parser.call(body, env))
+
               if body.is_a?(Hash)
                 if env['rack.request.form_hash']
                   env['rack.request.form_hash'] = env['rack.request.form_hash'].merge(body)
                 else
                   env['rack.request.form_hash'] = body
                 end
+
+                unless env['rack.input'].eql?(env['rack.input'])
+                  env['rack.input'] = StringIO.new(env['api.request.input']) # dirty walkaround that Tempfiles are not eql?
+                end
+
                 env['rack.request.form_input'] = env['rack.input']
               end
             rescue StandardError => e

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -253,6 +253,28 @@ describe Grape::Middleware::Formatter do
         end
       end
     end
+
+    it 'parses the body when the body is a TempFile' do
+      method = 'POST'
+      content_type = 'application/json'
+
+      io = Tempfile.new('body.txt')
+      io.write('{"is_boolean":true,"string":"thing"}')
+      io.rewind
+
+      subject.call(
+                'PATH_INFO' => '/info',
+                'REQUEST_METHOD' => method,
+                'CONTENT_TYPE' => content_type,
+                'rack.input' => io,
+                'CONTENT_LENGTH' => io.length
+      )
+
+      params = subject.send(:request).params
+
+      expect(params).to eq('is_boolean' => true, 'string' => 'thing')
+    end
+
   end
 
 end


### PR DESCRIPTION
This PR fixes an issue when `rack.input` is a Tempfile instead of a `StringIO` refs: #694
