### PR TITLE
added a spec and documentation for default status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ============
 
 * [#687](https://github.com/intridea/grape/pull/687): Fix: `mutually_exclusive` and `exactly_one_of` validation error messages now label parameters as strings, consistently with `requires` and `optional` - [@dblock](https://github.com/dblock).
-* [#698](https://github.com/intridea/grape/pull/698): `error!` sets `status` for `Endpoint` to [@dspaeth-faber](https://github.com/dspaeth-faber).
+* [#698](https://github.com/intridea/grape/pull/698): `error!` sets `status` for `Endpoint` too - [@dspaeth-faber](https://github.com/dspaeth-faber).
 * Your contribution here.
 
 0.8.0 (7/10/2014)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 - [Helpers](#helpers)
 - [Parameter Documentation](#parameter-documentation)
 - [Cookies](#cookies)
+- [HTTP Status Code](#http-status-code)
 - [Redirecting](#redirecting)
 - [Allowed Methods](#allowed-methods)
 - [Raising Exceptions](#raising-exceptions)
@@ -300,6 +301,21 @@ is returned when no correct `Accept` header is supplied.
 When an invalid `Accept` header is supplied, a `406 Not Acceptable` error is returned if the `:cascade`
 option is set to `false`. Otherwise a `404 Not Found` error is returned by Rack if no other route
 matches.
+
+### HTTP Status Code
+
+By default Grape returns a 200 status code for `GET`-Requests and 201 for `POST`-Requests.
+You can use `status` to query and set the actual HTTP Status Code
+
+```ruby
+post do
+  status 202
+  
+  if status == 200
+     # do some thing
+  end 
+end
+```
 
 ### Accept-Version Header
 

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -67,6 +67,33 @@ describe Grape::Endpoint do
       expect(last_response.status).to eq(206)
       expect(last_response.body).to eq("Hello")
     end
+
+    it 'is set as default to 200 for get' do
+      memoized_status = nil
+      subject.get('/home') do
+        memoized_status = status
+        "Hello"
+      end
+
+      get '/home'
+      expect(last_response.status).to eq(200)
+      expect(memoized_status).to eq(200)
+      expect(last_response.body).to eq("Hello")
+    end
+
+    it 'is set as default to 201 for post' do
+      memoized_status = nil
+      subject.post('/home') do
+        memoized_status = status
+        "Hello"
+      end
+
+      post '/home'
+      expect(last_response.status).to eq(201)
+      expect(memoized_status).to eq(201)
+      expect(last_response.body).to eq("Hello")
+    end
+
   end
 
   describe '#header' do


### PR DESCRIPTION
This PR adds documentation and a spec for the default HTTP-Status-Codes.
