### PR TITLE
Specs for Mutually Exclusive and Exactly one of in groups (References #699)

### DIFF
--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -1084,10 +1084,9 @@ describe Grape::Validations do
           'exactly_one_of_group works!'
         end
 
-        get '/exactly_one_of_group', drink: {  }
+        get '/exactly_one_of_group', drink: {}
         expect(last_response.status).to eq(400)
       end
-
 
       it 'errors when more than one from the set is present' do
         subject.params do


### PR DESCRIPTION
This adds (currently failing) tests for the `mutually_exclusive` and `exactly_one_of`
behaviour in a param group.
