### PR TITLE
Fix oauth2 compatibility with draft-ietf-oauth-v2-31

### DIFF
--- a/lib/grape/middleware/auth/oauth2.rb
+++ b/lib/grape/middleware/auth/oauth2.rb
@@ -56,7 +56,7 @@ module Grape
           token = token_class.verify(token)
           if token
             if token.respond_to?(:expired?) && token.expired?
-              error_out(401, 'invalid_grant')
+              error_out(400, 'invalid_grant')
             else
               if !token.respond_to?(:permission_for?) || token.permission_for?(env)
                 env['api.token'] = token
@@ -65,7 +65,7 @@ module Grape
               end
             end
           elsif !!options[:required]
-            error_out(401, 'invalid_grant')
+            error_out(400, 'invalid_grant')
           end
         end
 

--- a/spec/grape/middleware/auth/oauth2_spec.rb
+++ b/spec/grape/middleware/auth/oauth2_spec.rb
@@ -45,7 +45,7 @@ describe Grape::Middleware::Auth::OAuth2 do
       end
 
       it 'throws an error' do
-        expect(@err[:status]).to eq(401)
+        expect(@err[:status]).to eq(400)
       end
 
       it 'sets the WWW-Authenticate header in the response' do
@@ -62,7 +62,7 @@ describe Grape::Middleware::Auth::OAuth2 do
     end
 
     it 'throws an error' do
-      expect(@err[:status]).to eq(401)
+      expect(@err[:status]).to eq(400)
     end
 
     it 'sets the WWW-Authenticate header in the response to error' do


### PR DESCRIPTION
http://tools.ietf.org/id/draft-ietf-oauth-v2-31.html#rfc.section.5.2
As far as I see status codes for `invalid_grant` should be `400`.
