### PR TITLE
Proposal: extract dsl methods into modules

### DIFF
--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -94,6 +94,17 @@ module Grape
   module Util
     autoload :HashStack,         'grape/util/hash_stack'
   end
+
+  module DSL
+    autoload :Callbacks,         'grape/dsl/callbacks'
+    autoload :Configuration,     'grape/dsl/configuration'
+    autoload :Helpers,           'grape/dsl/helpers'
+    autoload :Middleware,        'grape/dsl/middleware'
+    autoload :Parameters,        'grape/dsl/parameters'
+    autoload :RequestResponse,   'grape/dsl/request_response'
+    autoload :Routing,           'grape/dsl/routing'
+    autoload :Validations,       'grape/dsl/validations'
+  end
 end
 
 require 'grape/version'

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -3,22 +3,20 @@ module Grape
   # creating Grape APIs.Users should subclass this
   # class in order to build an API.
   class API
-    extend Validations::ClassMethods
     extend Grape::Middleware::Auth::DSL
 
+    include Grape::DSL::Validations
+    include Grape::DSL::Callbacks
+    include Grape::DSL::Configuration
+    include Grape::DSL::Helpers
+    include Grape::DSL::Middleware
+    include Grape::DSL::RequestResponse
+    include Grape::DSL::Routing
+
     class << self
-      attr_reader :endpoints, :instance, :routes, :route_set, :settings, :versions
-      attr_writer :logger
+      attr_reader :instance
 
       LOCK = Mutex.new
-
-      def logger(logger = nil)
-        if logger
-          @logger = logger
-        else
-          @logger ||= Logger.new($stdout)
-        end
-      end
 
       def reset!
         @settings  = Grape::Util::HashStack.new
@@ -45,6 +43,21 @@ module Grape
         instance.call(env)
       end
 
+      # Create a scope without affecting the URL.
+      #
+      # @param name [Symbol] Purely placebo, just allows to to name the scope to make the code more readable.
+      def scope(name = nil, &block)
+        nest(block)
+      end
+
+      def cascade(value = nil)
+        if value.nil?
+          settings.key?(:cascade) ? !!settings[:cascade] : true
+        else
+          set(:cascade, value)
+        end
+      end
+
       # Set a configuration value for this namespace.
       #
       # @param key [Symbol] The key of the configuration variable.
@@ -60,408 +73,6 @@ module Grape
       # @param value [Object] The value to which to set the configuration variable.
       def imbue(key, value)
         settings.imbue(key, value)
-      end
-
-      # Define a root URL prefix for your entire API.
-      def prefix(prefix = nil)
-        prefix ? set(:root_prefix, prefix) : settings[:root_prefix]
-      end
-
-      # Do not route HEAD requests to GET requests automatically
-      def do_not_route_head!
-        set(:do_not_route_head, true)
-      end
-
-      # Do not automatically route OPTIONS
-      def do_not_route_options!
-        set(:do_not_route_options, true)
-      end
-
-      # Specify an API version.
-      #
-      # @example API with legacy support.
-      #   class MyAPI < Grape::API
-      #     version 'v2'
-      #
-      #     get '/main' do
-      #       {some: 'data'}
-      #     end
-      #
-      #     version 'v1' do
-      #       get '/main' do
-      #         {legacy: 'data'}
-      #       end
-      #     end
-      #   end
-      #
-      def version(*args, &block)
-        if args.any?
-          options = args.pop if args.last.is_a? Hash
-          options ||= {}
-          options = { using: :path }.merge(options)
-
-          raise Grape::Exceptions::MissingVendorOption.new if options[:using] == :header && !options.key?(:vendor)
-
-          @versions = versions | args
-          nest(block) do
-            set(:version, args)
-            set(:version_options, options)
-          end
-        end
-
-        @versions.last unless @versions.nil?
-      end
-
-      # Add a description to the next namespace or function.
-      def desc(description, options = {})
-        @last_description = options.merge(description: description)
-      end
-
-      # Specify the default format for the API's serializers.
-      # May be `:json` or `:txt` (default).
-      def default_format(new_format = nil)
-        new_format ? set(:default_format, new_format.to_sym) : settings[:default_format]
-      end
-
-      # Specify the format for the API's serializers.
-      # May be `:json`, `:xml`, `:txt`, etc.
-      def format(new_format = nil)
-        if new_format
-          set(:format, new_format.to_sym)
-          # define the default error formatters
-          set(:default_error_formatter, Grape::ErrorFormatter::Base.formatter_for(new_format, {}))
-          # define a single mime type
-          mime_type = content_types[new_format.to_sym]
-          raise Grape::Exceptions::MissingMimeType.new(new_format) unless mime_type
-          settings.imbue(:content_types, new_format.to_sym => mime_type)
-        else
-          settings[:format]
-        end
-      end
-
-      # Specify a custom formatter for a content-type.
-      def formatter(content_type, new_formatter)
-        settings.imbue(:formatters, content_type.to_sym => new_formatter)
-      end
-
-      # Specify a custom parser for a content-type.
-      def parser(content_type, new_parser)
-        settings.imbue(:parsers, content_type.to_sym => new_parser)
-      end
-
-      # Specify a default error formatter.
-      def default_error_formatter(new_formatter_name = nil)
-        if new_formatter_name
-          new_formatter = Grape::ErrorFormatter::Base.formatter_for(new_formatter_name, {})
-          set(:default_error_formatter, new_formatter)
-        else
-          settings[:default_error_formatter]
-        end
-      end
-
-      def error_formatter(format, options)
-        if options.is_a?(Hash) && options.key?(:with)
-          formatter = options[:with]
-        else
-          formatter = options
-        end
-
-        settings.imbue(:error_formatters, format.to_sym => formatter)
-      end
-
-      # Specify additional content-types, e.g.:
-      #   content_type :xls, 'application/vnd.ms-excel'
-      def content_type(key, val)
-        settings.imbue(:content_types, key.to_sym => val)
-      end
-
-      # All available content types.
-      def content_types
-        Grape::ContentTypes.content_types_for(settings[:content_types])
-      end
-
-      # Specify the default status code for errors.
-      def default_error_status(new_status = nil)
-        new_status ? set(:default_error_status, new_status) : settings[:default_error_status]
-      end
-
-      # Allows you to rescue certain exceptions that occur to return
-      # a grape error rather than raising all the way to the
-      # server level.
-      #
-      # @example Rescue from custom exceptions
-      #     class ExampleAPI < Grape::API
-      #       class CustomError < StandardError; end
-      #
-      #       rescue_from CustomError
-      #     end
-      #
-      # @overload rescue_from(*exception_classes, options = {})
-      #   @param [Array] exception_classes A list of classes that you want to rescue, or
-      #     the symbol :all to rescue from all exceptions.
-      #   @param [Block] block Execution block to handle the given exception.
-      #   @param [Hash] options Options for the rescue usage.
-      #   @option options [Boolean] :backtrace Include a backtrace in the rescue response.
-      #   @option options [Boolean] :rescue_subclasses Also rescue subclasses of exception classes
-      #   @param [Proc] handler Execution proc to handle the given exception as an
-      #     alternative to passing a block
-      def rescue_from(*args, &block)
-        if args.last.is_a?(Proc)
-          handler = args.pop
-        elsif block_given?
-          handler = block
-        end
-
-        options = args.last.is_a?(Hash) ? args.pop : {}
-        handler ||= proc { options[:with] } if options.key?(:with)
-
-        if args.include?(:all)
-          set(:rescue_all, true)
-          imbue :all_rescue_handler, handler
-        else
-          handler_type =
-            case options[:rescue_subclasses]
-            when nil, true
-              :rescue_handlers
-            else
-              :base_only_rescue_handlers
-            end
-
-          imbue handler_type, Hash[args.map { |arg| [arg, handler] }]
-        end
-
-        imbue(:rescue_options, options)
-      end
-
-      # Allows you to specify a default representation entity for a
-      # class. This allows you to map your models to their respective
-      # entities once and then simply call `present` with the model.
-      #
-      # @example
-      #   class ExampleAPI < Grape::API
-      #     represent User, with: Entity::User
-      #
-      #     get '/me' do
-      #       present current_user # with: Entity::User is assumed
-      #     end
-      #   end
-      #
-      # Note that Grape will automatically go up the class ancestry to
-      # try to find a representing entity, so if you, for example, define
-      # an entity to represent `Object` then all presented objects will
-      # bubble up and utilize the entity provided on that `represent` call.
-      #
-      # @param model_class [Class] The model class that will be represented.
-      # @option options [Class] :with The entity class that will represent the model.
-      def represent(model_class, options)
-        raise Grape::Exceptions::InvalidWithOptionForRepresent.new unless options[:with] && options[:with].is_a?(Class)
-        imbue(:representations, model_class => options[:with])
-      end
-
-      # Add helper methods that will be accessible from any
-      # endpoint within this namespace (and child namespaces).
-      #
-      # When called without a block, all known helpers within this scope
-      # are included.
-      #
-      # @param [Module] new_mod optional module of methods to include
-      # @param [Block] block optional block of methods to include
-      #
-      # @example Define some helpers.
-      #
-      #     class ExampleAPI < Grape::API
-      #       helpers do
-      #         def current_user
-      #           User.find_by_id(params[:token])
-      #         end
-      #       end
-      #     end
-      #
-      def helpers(new_mod = nil, &block)
-        if block_given? || new_mod
-          mod = settings.peek[:helpers] || Module.new
-          if new_mod
-            inject_api_helpers_to_mod(new_mod) if new_mod.is_a?(Helpers)
-            mod.class_eval do
-              include new_mod
-            end
-          end
-          if block_given?
-            inject_api_helpers_to_mod(mod) do
-              mod.class_eval(&block)
-            end
-          end
-          set(:helpers, mod)
-        else
-          mod = Module.new
-          settings.stack.each do |s|
-            mod.send :include, s[:helpers] if s[:helpers]
-          end
-          change!
-          mod
-        end
-      end
-
-      def mount(mounts)
-        mounts = { mounts => '/' } unless mounts.respond_to?(:each_pair)
-        mounts.each_pair do |app, path|
-          if app.respond_to?(:inherit_settings, true)
-            app_settings = settings.clone
-            mount_path = Rack::Mount::Utils.normalize_path([settings[:mount_path], path].compact.join("/"))
-            app_settings.set :mount_path, mount_path
-            app.inherit_settings(app_settings)
-          end
-          endpoints << Grape::Endpoint.new(
-            settings.clone,
-            method: :any,
-            path: path,
-            app: app
-          )
-        end
-      end
-
-      # Defines a route that will be recognized
-      # by the Grape API.
-      #
-      # @param methods [HTTP Verb] One or more HTTP verbs that are accepted by this route. Set to `:any` if you want any verb to be accepted.
-      # @param paths [String] One or more strings representing the URL segment(s) for this route.
-      #
-      # @example Defining a basic route.
-      #   class MyAPI < Grape::API
-      #     route(:any, '/hello') do
-      #       {hello: 'world'}
-      #     end
-      #   end
-      def route(methods, paths = ['/'], route_options = {}, &block)
-        endpoint_options = {
-          method: methods,
-          path: paths,
-          route_options: (@namespace_description || {}).deep_merge(@last_description || {}).deep_merge(route_options || {})
-        }
-        endpoints << Grape::Endpoint.new(settings.clone, endpoint_options, &block)
-
-        @last_description = nil
-        reset_validations!
-      end
-
-      def before(&block)
-        imbue(:befores, [block])
-      end
-
-      def before_validation(&block)
-        imbue(:before_validations, [block])
-      end
-
-      def after_validation(&block)
-        imbue(:after_validations, [block])
-      end
-
-      def after(&block)
-        imbue(:afters, [block])
-      end
-
-      def get(paths = ['/'], options = {}, &block)
-        route('GET', paths, options, &block)
-      end
-
-      def post(paths = ['/'], options = {}, &block)
-        route('POST', paths, options, &block)
-      end
-
-      def put(paths = ['/'], options = {}, &block)
-        route('PUT', paths, options, &block)
-      end
-
-      def head(paths = ['/'], options = {}, &block)
-        route('HEAD', paths, options, &block)
-      end
-
-      def delete(paths = ['/'], options = {}, &block)
-        route('DELETE', paths, options, &block)
-      end
-
-      def options(paths = ['/'], options = {}, &block)
-        route('OPTIONS', paths, options, &block)
-      end
-
-      def patch(paths = ['/'], options = {}, &block)
-        route('PATCH', paths, options, &block)
-      end
-
-      def namespace(space = nil, options = {},  &block)
-        if space || block_given?
-          previous_namespace_description = @namespace_description
-          @namespace_description = (@namespace_description || {}).deep_merge(@last_description || {})
-          @last_description = nil
-          nest(block) do
-            set(:namespace, Namespace.new(space, options)) if space
-          end
-          @namespace_description = previous_namespace_description
-        else
-          Namespace.joined_space_path(settings)
-        end
-      end
-
-      # Thie method allows you to quickly define a parameter route segment
-      # in your API.
-      #
-      # @param param [Symbol] The name of the parameter you wish to declare.
-      # @option options [Regexp] You may supply a regular expression that the declared parameter must meet.
-      def route_param(param, options = {}, &block)
-        options = options.dup
-        options[:requirements] = { param.to_sym => options[:requirements] } if options[:requirements].is_a?(Regexp)
-        namespace(":#{param}", options, &block)
-      end
-
-      alias_method :group, :namespace
-      alias_method :resource, :namespace
-      alias_method :resources, :namespace
-      alias_method :segment, :namespace
-
-      # Create a scope without affecting the URL.
-      #
-      # @param name [Symbol] Purely placebo, just allows to to name the scope to make the code more readable.
-      def scope(name = nil, &block)
-        nest(block)
-      end
-
-      # Apply a custom middleware to the API. Applies
-      # to the current namespace and any children, but
-      # not parents.
-      #
-      # @param middleware_class [Class] The class of the middleware you'd like
-      #   to inject.
-      def use(middleware_class, *args, &block)
-        arr = [middleware_class, *args]
-        arr << block if block_given?
-        imbue(:middleware, [arr])
-      end
-
-      # Retrieve an array of the middleware classes
-      # and arguments that are currently applied to the
-      # application.
-      def middleware
-        settings.stack.inject([]) do |a, s|
-          a += s[:middleware] if s[:middleware]
-          a
-        end
-      end
-
-      # An array of API routes.
-      def routes
-        @routes ||= prepare_routes
-      end
-
-      def versions
-        @versions ||= []
-      end
-
-      def cascade(value = nil)
-        if value.nil?
-          settings.key?(:cascade) ? !!settings[:cascade] : true
-        else
-          set(:cascade, value)
-        end
       end
 
       protected
@@ -501,12 +112,6 @@ module Grape
           e.settings.prepend(other_stack)
           e.options[:app].inherit_settings(other_stack) if e.options[:app].respond_to?(:inherit_settings, true)
         end
-      end
-
-      def inject_api_helpers_to_mod(mod, &block)
-        mod.extend(Helpers)
-        yield if block_given?
-        mod.api_changed(self)
       end
     end
 
@@ -594,29 +199,6 @@ module Grape
       self.class.settings.push(version: nil, version_options: nil)
       yield
       self.class.settings.pop
-    end
-
-    # This module extends user defined helpers
-    # to provide some API-specific functionality
-    module Helpers
-      attr_accessor :api
-      def params(name, &block)
-        @named_params ||= {}
-        @named_params.merge! name => block
-      end
-
-      def api_changed(new_api)
-        @api = new_api
-        process_named_params
-      end
-
-      protected
-
-      def process_named_params
-        if @named_params && @named_params.any?
-          api.imbue(:named_params, @named_params)
-        end
-      end
     end
   end
 end

--- a/lib/grape/dsl/callbacks.rb
+++ b/lib/grape/dsl/callbacks.rb
@@ -1,0 +1,31 @@
+require 'active_support/concern'
+
+module Grape
+  module DSL
+    module Callbacks
+      extend ActiveSupport::Concern
+
+      included do
+
+      end
+
+      module ClassMethods
+        def before(&block)
+          imbue(:befores, [block])
+        end
+
+        def before_validation(&block)
+          imbue(:before_validations, [block])
+        end
+
+        def after_validation(&block)
+          imbue(:after_validations, [block])
+        end
+
+        def after(&block)
+          imbue(:afters, [block])
+        end
+      end
+    end
+  end
+end

--- a/lib/grape/dsl/configuration.rb
+++ b/lib/grape/dsl/configuration.rb
@@ -1,0 +1,31 @@
+require 'active_support/concern'
+
+module Grape
+  module DSL
+    module Configuration
+      extend ActiveSupport::Concern
+
+      included do
+
+      end
+
+      module ClassMethods
+        attr_writer :logger
+        attr_reader :settings
+
+        def logger(logger = nil)
+          if logger
+            @logger = logger
+          else
+            @logger ||= Logger.new($stdout)
+          end
+        end
+
+        # Add a description to the next namespace or function.
+        def desc(description, options = {})
+          @last_description = options.merge(description: description)
+        end
+      end
+    end
+  end
+end

--- a/lib/grape/dsl/helpers.rb
+++ b/lib/grape/dsl/helpers.rb
@@ -1,0 +1,90 @@
+require 'active_support/concern'
+
+module Grape
+  module DSL
+    module Helpers
+      extend ActiveSupport::Concern
+
+      included do
+
+      end
+
+      module ClassMethods
+        # Add helper methods that will be accessible from any
+        # endpoint within this namespace (and child namespaces).
+        #
+        # When called without a block, all known helpers within this scope
+        # are included.
+        #
+        # @param [Module] new_mod optional module of methods to include
+        # @param [Block] block optional block of methods to include
+        #
+        # @example Define some helpers.
+        #
+        #     class ExampleAPI < Grape::API
+        #       helpers do
+        #         def current_user
+        #           User.find_by_id(params[:token])
+        #         end
+        #       end
+        #     end
+        #
+        def helpers(new_mod = nil, &block)
+          if block_given? || new_mod
+            mod = settings.peek[:helpers] || Module.new
+            if new_mod
+              inject_api_helpers_to_mod(new_mod) if new_mod.is_a?(BaseHelper)
+              mod.class_eval do
+                include new_mod
+              end
+            end
+            if block_given?
+              inject_api_helpers_to_mod(mod) do
+                mod.class_eval(&block)
+              end
+            end
+            set(:helpers, mod)
+          else
+            mod = Module.new
+            settings.stack.each do |s|
+              mod.send :include, s[:helpers] if s[:helpers]
+            end
+            change!
+            mod
+          end
+        end
+
+        protected
+
+        def inject_api_helpers_to_mod(mod, &block)
+          mod.extend(BaseHelper)
+          yield if block_given?
+          mod.api_changed(self)
+        end
+      end
+
+      # This module extends user defined helpers
+      # to provide some API-specific functionality
+      module BaseHelper
+        attr_accessor :api
+        def params(name, &block)
+          @named_params ||= {}
+          @named_params.merge! name => block
+        end
+
+        def api_changed(new_api)
+          @api = new_api
+          process_named_params
+        end
+
+        protected
+
+        def process_named_params
+          if @named_params && @named_params.any?
+            api.imbue(:named_params, @named_params)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/grape/dsl/middleware.rb
+++ b/lib/grape/dsl/middleware.rb
@@ -1,0 +1,37 @@
+require 'active_support/concern'
+
+module Grape
+  module DSL
+    module Middleware
+      extend ActiveSupport::Concern
+
+      included do
+
+      end
+
+      module ClassMethods
+        # Apply a custom middleware to the API. Applies
+        # to the current namespace and any children, but
+        # not parents.
+        #
+        # @param middleware_class [Class] The class of the middleware you'd like
+        #   to inject.
+        def use(middleware_class, *args, &block)
+          arr = [middleware_class, *args]
+          arr << block if block_given?
+          imbue(:middleware, [arr])
+        end
+
+        # Retrieve an array of the middleware classes
+        # and arguments that are currently applied to the
+        # application.
+        def middleware
+          settings.stack.inject([]) do |a, s|
+            a += s[:middleware] if s[:middleware]
+            a
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -1,0 +1,86 @@
+require 'active_support/concern'
+
+module Grape
+  module DSL
+    module Parameters
+      extend ActiveSupport::Concern
+
+      included do
+
+      end
+
+      module ClassMethods
+      end
+
+      def use(*names)
+        named_params = @api.settings[:named_params] || {}
+        options = names.last.is_a?(Hash) ? names.pop : {}
+        names.each do |name|
+          params_block = named_params.fetch(name) do
+            raise "Params :#{name} not found!"
+          end
+          instance_exec(options, &params_block)
+        end
+      end
+      alias_method :use_scope, :use
+      alias_method :includes, :use
+
+      def requires(*attrs, &block)
+        orig_attrs = attrs.clone
+
+        opts = attrs.last.is_a?(Hash) ? attrs.pop : nil
+
+        if opts && opts[:using]
+          require_required_and_optional_fields(attrs.first, opts)
+        else
+          validate_attributes(attrs, opts, &block)
+
+          block_given? ? new_scope(orig_attrs, &block) :
+              push_declared_params(attrs)
+        end
+      end
+
+      def optional(*attrs, &block)
+        orig_attrs = attrs
+
+        validations = {}
+        validations.merge!(attrs.pop) if attrs.last.is_a?(Hash)
+        validations[:type] ||= Array if block_given?
+        validates(attrs, validations)
+
+        block_given? ? new_scope(orig_attrs, true, &block) :
+            push_declared_params(attrs)
+      end
+
+      def mutually_exclusive(*attrs)
+        validates(attrs, mutual_exclusion: true)
+      end
+
+      def exactly_one_of(*attrs)
+        validates(attrs, exactly_one_of: true)
+      end
+
+      def at_least_one_of(*attrs)
+        validates(attrs, at_least_one_of: true)
+      end
+
+      def group(*attrs, &block)
+        requires(*attrs, &block)
+      end
+
+      def params(params)
+        params = @parent.params(params) if @parent
+        if @element
+          if params.is_a?(Array)
+            params = params.flat_map { |el| el[@element] || {} }
+          elsif params.is_a?(Hash)
+            params = params[@element] || {}
+          else
+            params = {}
+          end
+        end
+        params
+      end
+    end
+  end
+end

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -1,0 +1,156 @@
+require 'active_support/concern'
+
+module Grape
+  module DSL
+    module RequestResponse
+      extend ActiveSupport::Concern
+
+      included do
+
+      end
+
+      module ClassMethods
+        # Specify the default format for the API's serializers.
+        # May be `:json` or `:txt` (default).
+        def default_format(new_format = nil)
+          new_format ? set(:default_format, new_format.to_sym) : settings[:default_format]
+        end
+
+        # Specify the format for the API's serializers.
+        # May be `:json`, `:xml`, `:txt`, etc.
+        def format(new_format = nil)
+          if new_format
+            set(:format, new_format.to_sym)
+            # define the default error formatters
+            set(:default_error_formatter, Grape::ErrorFormatter::Base.formatter_for(new_format, {}))
+            # define a single mime type
+            mime_type = content_types[new_format.to_sym]
+            raise Grape::Exceptions::MissingMimeType.new(new_format) unless mime_type
+            settings.imbue(:content_types, new_format.to_sym => mime_type)
+          else
+            settings[:format]
+          end
+        end
+
+        # Specify a custom formatter for a content-type.
+        def formatter(content_type, new_formatter)
+          settings.imbue(:formatters, content_type.to_sym => new_formatter)
+        end
+
+        # Specify a custom parser for a content-type.
+        def parser(content_type, new_parser)
+          settings.imbue(:parsers, content_type.to_sym => new_parser)
+        end
+
+        # Specify a default error formatter.
+        def default_error_formatter(new_formatter_name = nil)
+          if new_formatter_name
+            new_formatter = Grape::ErrorFormatter::Base.formatter_for(new_formatter_name, {})
+            set(:default_error_formatter, new_formatter)
+          else
+            settings[:default_error_formatter]
+          end
+        end
+
+        def error_formatter(format, options)
+          if options.is_a?(Hash) && options.key?(:with)
+            formatter = options[:with]
+          else
+            formatter = options
+          end
+
+          settings.imbue(:error_formatters, format.to_sym => formatter)
+        end
+
+        # Specify additional content-types, e.g.:
+        #   content_type :xls, 'application/vnd.ms-excel'
+        def content_type(key, val)
+          settings.imbue(:content_types, key.to_sym => val)
+        end
+
+        # All available content types.
+        def content_types
+          Grape::ContentTypes.content_types_for(settings[:content_types])
+        end
+
+        # Specify the default status code for errors.
+        def default_error_status(new_status = nil)
+          new_status ? set(:default_error_status, new_status) : settings[:default_error_status]
+        end
+
+        # Allows you to rescue certain exceptions that occur to return
+        # a grape error rather than raising all the way to the
+        # server level.
+        #
+        # @example Rescue from custom exceptions
+        #     class ExampleAPI < Grape::API
+        #       class CustomError < StandardError; end
+        #
+        #       rescue_from CustomError
+        #     end
+        #
+        # @overload rescue_from(*exception_classes, options = {})
+        #   @param [Array] exception_classes A list of classes that you want to rescue, or
+        #     the symbol :all to rescue from all exceptions.
+        #   @param [Block] block Execution block to handle the given exception.
+        #   @param [Hash] options Options for the rescue usage.
+        #   @option options [Boolean] :backtrace Include a backtrace in the rescue response.
+        #   @option options [Boolean] :rescue_subclasses Also rescue subclasses of exception classes
+        #   @param [Proc] handler Execution proc to handle the given exception as an
+        #     alternative to passing a block
+        def rescue_from(*args, &block)
+          if args.last.is_a?(Proc)
+            handler = args.pop
+          elsif block_given?
+            handler = block
+          end
+
+          options = args.last.is_a?(Hash) ? args.pop : {}
+          handler ||= proc { options[:with] } if options.key?(:with)
+
+          if args.include?(:all)
+            set(:rescue_all, true)
+            imbue :all_rescue_handler, handler
+          else
+            handler_type =
+                case options[:rescue_subclasses]
+                when nil, true
+                  :rescue_handlers
+                else
+                  :base_only_rescue_handlers
+                end
+
+            imbue handler_type, Hash[args.map { |arg| [arg, handler] }]
+          end
+
+          imbue(:rescue_options, options)
+        end
+
+        # Allows you to specify a default representation entity for a
+        # class. This allows you to map your models to their respective
+        # entities once and then simply call `present` with the model.
+        #
+        # @example
+        #   class ExampleAPI < Grape::API
+        #     represent User, with: Entity::User
+        #
+        #     get '/me' do
+        #       present current_user # with: Entity::User is assumed
+        #     end
+        #   end
+        #
+        # Note that Grape will automatically go up the class ancestry to
+        # try to find a representing entity, so if you, for example, define
+        # an entity to represent `Object` then all presented objects will
+        # bubble up and utilize the entity provided on that `represent` call.
+        #
+        # @param model_class [Class] The model class that will be represented.
+        # @option options [Class] :with The entity class that will represent the model.
+        def represent(model_class, options)
+          raise Grape::Exceptions::InvalidWithOptionForRepresent.new unless options[:with] && options[:with].is_a?(Class)
+          imbue(:representations, model_class => options[:with])
+        end
+      end
+    end
+  end
+end

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -1,0 +1,176 @@
+require 'active_support/concern'
+
+module Grape
+  module DSL
+    module Routing
+      extend ActiveSupport::Concern
+
+      included do
+
+      end
+
+      module ClassMethods
+        attr_reader :endpoints, :routes, :route_set
+
+        # Specify an API version.
+        #
+        # @example API with legacy support.
+        #   class MyAPI < Grape::API
+        #     version 'v2'
+        #
+        #     get '/main' do
+        #       {some: 'data'}
+        #     end
+        #
+        #     version 'v1' do
+        #       get '/main' do
+        #         {legacy: 'data'}
+        #       end
+        #     end
+        #   end
+        #
+        def version(*args, &block)
+          if args.any?
+            options = args.pop if args.last.is_a? Hash
+            options ||= {}
+            options = { using: :path }.merge(options)
+
+            raise Grape::Exceptions::MissingVendorOption.new if options[:using] == :header && !options.key?(:vendor)
+
+            @versions = versions | args
+            nest(block) do
+              set(:version, args)
+              set(:version_options, options)
+            end
+          end
+
+          @versions.last unless @versions.nil?
+        end
+
+        # Define a root URL prefix for your entire API.
+        def prefix(prefix = nil)
+          prefix ? set(:root_prefix, prefix) : settings[:root_prefix]
+        end
+
+        # Do not route HEAD requests to GET requests automatically
+        def do_not_route_head!
+          set(:do_not_route_head, true)
+        end
+
+        # Do not automatically route OPTIONS
+        def do_not_route_options!
+          set(:do_not_route_options, true)
+        end
+
+        def mount(mounts)
+          mounts = { mounts => '/' } unless mounts.respond_to?(:each_pair)
+          mounts.each_pair do |app, path|
+            if app.respond_to?(:inherit_settings, true)
+              app_settings = settings.clone
+              mount_path = Rack::Mount::Utils.normalize_path([settings[:mount_path], path].compact.join("/"))
+              app_settings.set :mount_path, mount_path
+              app.inherit_settings(app_settings)
+            end
+            endpoints << Grape::Endpoint.new(
+                settings.clone,
+                method: :any,
+                path: path,
+                app: app
+            )
+          end
+        end
+
+        # Defines a route that will be recognized
+        # by the Grape API.
+        #
+        # @param methods [HTTP Verb] One or more HTTP verbs that are accepted by this route. Set to `:any` if you want any verb to be accepted.
+        # @param paths [String] One or more strings representing the URL segment(s) for this route.
+        #
+        # @example Defining a basic route.
+        #   class MyAPI < Grape::API
+        #     route(:any, '/hello') do
+        #       {hello: 'world'}
+        #     end
+        #   end
+        def route(methods, paths = ['/'], route_options = {}, &block)
+          endpoint_options = {
+            method: methods,
+            path: paths,
+            route_options: (@namespace_description || {}).deep_merge(@last_description || {}).deep_merge(route_options || {})
+          }
+          endpoints << Grape::Endpoint.new(settings.clone, endpoint_options, &block)
+
+          @last_description = nil
+          reset_validations!
+        end
+
+        def get(paths = ['/'], options = {}, &block)
+          route('GET', paths, options, &block)
+        end
+
+        def post(paths = ['/'], options = {}, &block)
+          route('POST', paths, options, &block)
+        end
+
+        def put(paths = ['/'], options = {}, &block)
+          route('PUT', paths, options, &block)
+        end
+
+        def head(paths = ['/'], options = {}, &block)
+          route('HEAD', paths, options, &block)
+        end
+
+        def delete(paths = ['/'], options = {}, &block)
+          route('DELETE', paths, options, &block)
+        end
+
+        def options(paths = ['/'], options = {}, &block)
+          route('OPTIONS', paths, options, &block)
+        end
+
+        def patch(paths = ['/'], options = {}, &block)
+          route('PATCH', paths, options, &block)
+        end
+
+        def namespace(space = nil, options = {},  &block)
+          if space || block_given?
+            previous_namespace_description = @namespace_description
+            @namespace_description = (@namespace_description || {}).deep_merge(@last_description || {})
+            @last_description = nil
+            nest(block) do
+              set(:namespace, Namespace.new(space, options)) if space
+            end
+            @namespace_description = previous_namespace_description
+          else
+            Namespace.joined_space_path(settings)
+          end
+        end
+
+        alias_method :group, :namespace
+        alias_method :resource, :namespace
+        alias_method :resources, :namespace
+        alias_method :segment, :namespace
+
+        # An array of API routes.
+        def routes
+          @routes ||= prepare_routes
+        end
+
+        # Thie method allows you to quickly define a parameter route segment
+        # in your API.
+        #
+        # @param param [Symbol] The name of the parameter you wish to declare.
+        # @option options [Regexp] You may supply a regular expression that the declared parameter must meet.
+        def route_param(param, options = {}, &block)
+          options = options.dup
+          options[:requirements] = { param.to_sym => options[:requirements] } if options[:requirements].is_a?(Regexp)
+          namespace(":#{param}", options, &block)
+        end
+
+        def versions
+          @versions ||= []
+        end
+      end
+    end
+  end
+end

--- a/lib/grape/dsl/validations.rb
+++ b/lib/grape/dsl/validations.rb
@@ -1,0 +1,33 @@
+require 'active_support/concern'
+
+module Grape
+  module DSL
+    module Validations
+      extend ActiveSupport::Concern
+
+      included do
+
+      end
+
+      module ClassMethods
+        def reset_validations!
+          settings.peek[:declared_params] = []
+          settings.peek[:validations] = []
+        end
+
+        def params(&block)
+          Grape::Validations::ParamsScope.new(api: self, type: Hash, &block)
+        end
+
+        def document_attribute(names, opts)
+          @last_description ||= {}
+          @last_description[:params] ||= {}
+          Array(names).each do |name|
+            @last_description[:params][name[:full_name].to_s] ||= {}
+            @last_description[:params][name[:full_name].to_s].merge!(opts)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/grape/validations.rb
+++ b/lib/grape/validations.rb
@@ -84,6 +84,8 @@ module Grape
     class ParamsScope
       attr_accessor :element, :parent
 
+      include Grape::DSL::Parameters
+
       def initialize(opts, &block)
         @element  = opts[:element]
         @parent   = opts[:parent]
@@ -102,76 +104,6 @@ module Grape
         return true if parent.nil?
         parent.should_validate?(parameters)
       end
-
-      def requires(*attrs, &block)
-        orig_attrs = attrs.clone
-
-        opts = attrs.last.is_a?(Hash) ? attrs.pop : nil
-
-        if opts && opts[:using]
-          require_required_and_optional_fields(attrs.first, opts)
-        else
-          validate_attributes(attrs, opts, &block)
-
-          block_given? ? new_scope(orig_attrs, &block) :
-            push_declared_params(attrs)
-        end
-      end
-
-      def optional(*attrs, &block)
-        orig_attrs = attrs
-
-        validations = {}
-        validations.merge!(attrs.pop) if attrs.last.is_a?(Hash)
-        validations[:type] ||= Array if block_given?
-        validates(attrs, validations)
-
-        block_given? ? new_scope(orig_attrs, true, &block) :
-          push_declared_params(attrs)
-      end
-
-      def mutually_exclusive(*attrs)
-        validates(attrs, mutual_exclusion: true)
-      end
-
-      def exactly_one_of(*attrs)
-        validates(attrs, exactly_one_of: true)
-      end
-
-      def at_least_one_of(*attrs)
-        validates(attrs, at_least_one_of: true)
-      end
-
-      def group(*attrs, &block)
-        requires(*attrs, &block)
-      end
-
-      def params(params)
-        params = @parent.params(params) if @parent
-        if @element
-          if params.is_a?(Array)
-            params = params.flat_map { |el| el[@element] || {} }
-          elsif params.is_a?(Hash)
-            params = params[@element] || {}
-          else
-            params = {}
-          end
-        end
-        params
-      end
-
-      def use(*names)
-        named_params = @api.settings[:named_params] || {}
-        options = names.last.is_a?(Hash) ? names.pop : {}
-        names.each do |name|
-          params_block = named_params.fetch(name) do
-            raise "Params :#{name} not found!"
-          end
-          instance_exec(options, &params_block)
-        end
-      end
-      alias_method :use_scope, :use
-      alias_method :includes, :use
 
       def full_name(name)
         return "#{@parent.full_name(@element)}[#{name}]" if @parent
@@ -293,27 +225,6 @@ module Grape
           (@api.settings.peek[:validations] ||= []) << validator_class.new(attrs, options, doc_attrs[:required], self)
         else
           raise Grape::Exceptions::UnknownValidator.new(type)
-        end
-      end
-    end
-
-    # This module is mixed into the API Class.
-    module ClassMethods
-      def reset_validations!
-        settings.peek[:declared_params] = []
-        settings.peek[:validations] = []
-      end
-
-      def params(&block)
-        ParamsScope.new(api: self, type: Hash, &block)
-      end
-
-      def document_attribute(names, opts)
-        @last_description ||= {}
-        @last_description[:params] ||= {}
-        Array(names).each do |name|
-          @last_description[:params][name[:full_name].to_s] ||= {}
-          @last_description[:params][name[:full_name].to_s].merge!(opts)
         end
       end
     end

--- a/spec/grape/dsl/callbacks_spec.rb
+++ b/spec/grape/dsl/callbacks_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+module Grape
+  module DSL
+    module CallbacksSpec
+      class Dummy
+        include Grape::DSL::Callbacks
+      end
+    end
+
+    describe Callbacks do
+      subject { Class.new(CallbacksSpec::Dummy) }
+      let(:proc) { ->() {} }
+
+      describe '.before' do
+        it 'adds a block to "before"' do
+          expect(subject).to receive(:imbue).with(:befores, [proc])
+          subject.before(&proc)
+        end
+      end
+
+      describe '.before_validation' do
+        it 'adds a block to "before_validation"' do
+          expect(subject).to receive(:imbue).with(:before_validations, [proc])
+          subject.before_validation(&proc)
+        end
+      end
+
+      describe '.after_validation' do
+        it 'adds a block to "after_validation"' do
+          expect(subject).to receive(:imbue).with(:after_validations, [proc])
+          subject.after_validation(&proc)
+        end
+      end
+
+      describe '.after' do
+        it 'adds a block to "after"' do
+          expect(subject).to receive(:imbue).with(:afters, [proc])
+          subject.after(&proc)
+        end
+      end
+    end
+  end
+end

--- a/spec/grape/dsl/configuration_spec.rb
+++ b/spec/grape/dsl/configuration_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+module Grape
+  module DSL
+    module ConfigurationSpec
+      class Dummy
+        include Grape::DSL::Configuration
+
+        # rubocop:disable TrivialAccessors
+        def self.last_desc
+          @last_description
+        end
+        # rubocop:enable TrivialAccessors
+      end
+    end
+    describe Configuration do
+      subject { Class.new(ConfigurationSpec::Dummy) }
+      let(:logger) { double(:logger) }
+
+      describe '.logger' do
+        it 'sets a logger' do
+          subject.logger logger
+          expect(subject.logger).to eq logger
+        end
+      end
+
+      describe '.desc' do
+        it 'sets a description' do
+          options = { message: 'none' }
+          subject.desc options
+          expect(subject.last_desc).to eq(description: options)
+        end
+      end
+
+    end
+  end
+end

--- a/spec/grape/dsl/helpers_spec.rb
+++ b/spec/grape/dsl/helpers_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+module Grape
+  module DSL
+    module HelpersSpec
+      class Dummy
+        include Grape::DSL::Helpers
+
+        def self.settings
+          @settings ||= Grape::Util::HashStack.new
+        end
+
+        def self.set(_, mod)
+          @mod = mod
+        end
+
+        # rubocop:disable TrivialAccessors
+        def self.mod
+          @mod
+        end
+        # rubocop:enable TrivialAccessors
+      end
+    end
+    describe Helpers do
+      subject { Class.new(HelpersSpec::Dummy) }
+      let(:proc) do
+        ->(*) do
+          def test
+            :test
+          end
+        end
+      end
+
+      describe '.helpers' do
+        it 'adds a module with the given block' do
+          expect(subject).to receive(:set).with(:helpers, kind_of(Grape::DSL::Helpers::BaseHelper)).and_call_original
+          subject.helpers(&proc)
+
+          expect(subject.mod.instance_methods).to include(:test)
+        end
+
+        it 'uses provided modules' do
+          mod = Module.new
+
+          expect(subject).to receive(:set).with(:helpers,  kind_of(Grape::DSL::Helpers::BaseHelper)).and_call_original
+          subject.helpers(mod, &proc)
+
+          expect(subject.mod).not_to eq mod
+          expect(subject.mod).to include mod
+        end
+      end
+    end
+  end
+end

--- a/spec/grape/dsl/middleware_spec.rb
+++ b/spec/grape/dsl/middleware_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+module Grape
+  module DSL
+    module MiddlewareSpec
+      class Dummy
+        include Grape::DSL::Middleware
+
+        def self.settings
+          @settings ||= Grape::Util::HashStack.new
+        end
+
+        def self.imbue(key, value)
+          settings.imbue(key, value)
+        end
+      end
+    end
+    describe Middleware do
+      subject { Class.new(MiddlewareSpec::Dummy) }
+      let(:proc) { ->() {} }
+
+      describe '.use' do
+        it 'adds a middleware' do
+          expect(subject).to receive(:imbue).with(:middleware, [[:my_middleware, :arg1, proc]])
+
+          subject.use :my_middleware, :arg1, &proc
+        end
+
+      end
+
+      describe '.middleware' do
+        it 'returns the middleware stack' do
+          subject.use :my_middleware, :arg1, &proc
+
+          expect(subject.middleware).to eq [[:my_middleware, :arg1, proc]]
+        end
+      end
+    end
+  end
+end

--- a/spec/grape/dsl/parameters_spec.rb
+++ b/spec/grape/dsl/parameters_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+module Grape
+  module DSL
+    module ParametersSpec
+      class Dummy
+        include Grape::DSL::Parameters
+      end
+    end
+
+    describe Parameters do
+      subject { Class.new(ParametersSpec::Dummy) }
+
+      xdescribe '.use' do
+        it 'does some thing'
+      end
+
+      xdescribe '.use_scope' do
+        it 'does some thing'
+      end
+
+      xdescribe '.includes' do
+        it 'does some thing'
+      end
+
+      xdescribe '.requires' do
+        it 'does some thing'
+      end
+
+      xdescribe '.optional' do
+        it 'does some thing'
+      end
+
+      xdescribe '.mutually_exclusive' do
+        it 'does some thing'
+      end
+
+      xdescribe '.exactly_one_of' do
+        it 'does some thing'
+      end
+
+      xdescribe '.at_least_one_of' do
+        it 'does some thing'
+      end
+
+      xdescribe '.group' do
+        it 'does some thing'
+      end
+
+      xdescribe '.params' do
+        it 'does some thing'
+      end
+
+    end
+  end
+end

--- a/spec/grape/dsl/request_response_spec.rb
+++ b/spec/grape/dsl/request_response_spec.rb
@@ -1,0 +1,115 @@
+require 'spec_helper'
+
+module Grape
+  module DSL
+    module RequestResponseSpec
+      class Dummy
+        include Grape::DSL::RequestResponse
+
+        def self.settings
+          @settings ||= Grape::Util::HashStack.new
+        end
+
+        def self.set(key, value)
+          settings[key.to_sym] = value
+        end
+
+        def self.imbue(key, value)
+          settings.imbue(key, value)
+        end
+      end
+    end
+
+    describe RequestResponse do
+      subject { Class.new(RequestResponseSpec::Dummy) }
+      let(:c_type) { 'application/json' }
+      let(:format) { 'txt' }
+
+      describe '.default_format' do
+        it 'sets the default format' do
+          expect(subject).to receive(:set).with(:default_format, :format)
+          subject.default_format :format
+        end
+
+        it 'returns the format without paramter' do
+          subject.default_format :format
+
+          expect(subject.default_format).to eq :format
+        end
+      end
+
+      xdescribe '.format' do
+
+      end
+
+      describe '.formatter' do
+        it 'sets the formatter for a content type' do
+          expect(subject.settings).to receive(:imbue).with(:formatters, c_type.to_sym => :formatter)
+          subject.formatter c_type, :formatter
+        end
+      end
+
+      describe '.parser' do
+        it 'sets a parser for a content type' do
+          expect(subject.settings).to receive(:imbue).with(:parsers, c_type.to_sym => :parser)
+          subject.parser c_type, :parser
+        end
+      end
+
+      xdescribe '.default_error_formatter' do
+        it 'does some thing'
+      end
+
+      describe '.error_formatter' do
+        it 'sets a error_formatter' do
+          format = 'txt'
+          expect(subject.settings).to receive(:imbue).with(:error_formatters, format.to_sym => :error_formatter)
+          subject.error_formatter format, :error_formatter
+        end
+
+        it 'understands syntactic sugar' do
+          expect(subject.settings).to receive(:imbue).with(:error_formatters, format.to_sym => :error_formatter)
+          subject.error_formatter format, with: :error_formatter
+        end
+      end
+
+      describe '.content_type' do
+        it 'sets a content type for a format' do
+          expect(subject.settings).to receive(:imbue).with(:content_types, format.to_sym => c_type)
+          subject.content_type format, c_type
+        end
+      end
+
+      describe '.content_types' do
+        it 'returns all content types' do
+          expect(subject.content_types).to eq(xml: "application/xml",
+                                              serializable_hash: "application/json",
+                                              json: "application/json",
+                                              jsonapi: "application/vnd.api+json",
+                                              atom: "application/atom+xml",
+                                              rss: "application/rss+xml",
+                                              txt: "text/plain")
+        end
+      end
+
+      describe '.default_error_status' do
+        it 'sets a default error status' do
+          expect(subject).to receive(:set).with(:default_error_status, 500)
+          subject.default_error_status 500
+        end
+      end
+
+      xdescribe '.rescue_from' do
+        it 'does some thing'
+      end
+
+      describe '.represent' do
+        it 'sets a presenter for a class' do
+          presenter = Class.new
+          expect(subject).to receive(:imbue).with(:representations, ThisClass: presenter)
+          subject.represent :ThisClass, with: presenter
+        end
+      end
+    end
+  end
+end

--- a/spec/grape/dsl/routing_spec.rb
+++ b/spec/grape/dsl/routing_spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+
+module Grape
+  module DSL
+    module RoutingSpec
+      class Dummy
+        include Grape::DSL::Routing
+      end
+    end
+
+    describe Routing do
+      subject { Class.new(RoutingSpec::Dummy) }
+      let(:proc) { ->() {} }
+      let(:options) { { a: :b } }
+      let(:path) { '/dummy' }
+
+      xdescribe '.version' do
+        it 'does some thing'
+      end
+      xdescribe '.prefix' do
+        it 'does some thing'
+      end
+      xdescribe '.do_not_route_head!' do
+        it 'does some thing'
+      end
+      xdescribe '.do_not_route_options!' do
+        it 'does some thing'
+      end
+      xdescribe '.mount' do
+        it 'does some thing'
+      end
+      xdescribe '.route' do
+        it 'does some thing'
+      end
+
+      describe '.get' do
+        it 'delegates to .route' do
+          expect(subject).to receive(:route).with('GET', path, options)
+          subject.get path, options, &proc
+        end
+      end
+
+      describe '.post' do
+        it 'delegates to .route' do
+          expect(subject).to receive(:route).with('POST', path, options)
+          subject.post path, options, &proc
+        end
+      end
+
+      describe '.put' do
+        it 'delegates to .route' do
+          expect(subject).to receive(:route).with('PUT', path, options)
+          subject.put path, options, &proc
+        end
+      end
+
+      describe '.head' do
+        it 'delegates to .route' do
+          expect(subject).to receive(:route).with('HEAD', path, options)
+          subject.head path, options, &proc
+        end
+      end
+
+      describe '.delete' do
+        it 'delegates to .route' do
+          expect(subject).to receive(:route).with('DELETE', path, options)
+          subject.delete path, options, &proc
+        end
+      end
+
+      describe '.options' do
+        it 'delegates to .route' do
+          expect(subject).to receive(:route).with('OPTIONS', path, options)
+          subject.options path, options, &proc
+        end
+      end
+
+      describe '.patch' do
+        it 'delegates to .route' do
+          expect(subject).to receive(:route).with('PATCH', path, options)
+          subject.patch path, options, &proc
+        end
+      end
+
+      xdescribe '.namespace' do
+        it 'does some thing'
+      end
+
+      xdescribe '.group' do
+        it 'does some thing'
+      end
+      xdescribe '.resource' do
+        it 'does some thing'
+      end
+      xdescribe '.resources' do
+        it 'does some thing'
+      end
+      xdescribe '.segment' do
+        it 'does some thing'
+      end
+
+      xdescribe '.routes' do
+        it 'does some thing'
+      end
+      xdescribe '.route_param' do
+        it 'does some thing'
+      end
+      xdescribe '.versions' do
+        it 'does some thing'
+      end
+    end
+  end
+end

--- a/spec/grape/dsl/validations_spec.rb
+++ b/spec/grape/dsl/validations_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+module Grape
+  module DSL
+    module ValidationsSpec
+      class Dummy
+        include Grape::DSL::Validations
+      end
+    end
+
+    describe Validations do
+      subject { Class.new(ValidationsSpec::Dummy) }
+
+      xdescribe '.reset_validations!' do
+        it 'does some thing'
+      end
+
+      xdescribe '.params' do
+        it 'does some thing'
+      end
+
+      xdescribe '.document_attribute' do
+        it 'does some thing'
+      end
+    end
+  end
+end

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -813,9 +813,9 @@ describe Grape::Validations do
           end
         end
 
-        it 'in helper module which kind of Grape::API::Helpers' do
+        it 'in helper module which kind of Grape::DSL::Helpers::BaseHelper' do
           module SharedParams
-            extend Grape::API::Helpers
+            extend Grape::DSL::Helpers::BaseHelper
             params :pagination do
             end
           end
@@ -826,7 +826,7 @@ describe Grape::Validations do
       context 'can be included in usual params' do
         before do
           module SharedParams
-            extend Grape::API::Helpers
+            extend Grape::DSL::Helpers::BaseHelper
             params :period do
               optional :start_date
               optional :end_date


### PR DESCRIPTION
I would like to suggest that DSL methods are extracted to seperate modules. This way it is easier to lookup DSL methods and see what I can use for my API definition.
