### PR TITLE
README references undefined method (requires not required)

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ model you may want to restrict by hashtags that you have previously defined in t
 
 ```ruby
 params do
-  required :hashtag, type: String, values: -> { Hashtag.all.map(&:tag) }
+  requires :hashtag, type: String, values: -> { Hashtag.all.map(&:tag) }
 end
 ```
 


### PR DESCRIPTION
Method is called `requires` not `required`.
