### PR TITLE
Issues/677 require regexp validator bug

### DIFF
--- a/lib/grape/dsl/validations.rb
+++ b/lib/grape/dsl/validations.rb
@@ -8,7 +8,7 @@ module Grape
       module ClassMethods
         def reset_validations!
           settings.peek[:declared_params] = []
-          settings.peek[:validations] = []
+          settings.peek[:validations] = nil
         end
 
         def params(&block)

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -78,6 +78,29 @@ describe Grape::Validations do
       end
     end
 
+    context 'required with regexp validator' do
+      before do
+        subject.params do
+          requires :key, type: String, regexp: /^[0-9]$/
+        end
+        subject.get '/required' do
+          'required works'
+        end
+      end
+
+      it 'provides the right error message when the key is not provided' do
+        get '/required'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('key is missing')
+      end
+
+      it 'provides the right error message when the key is present but invalid' do
+        get '/required', key: "ABC"
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('key is invalid')
+      end
+    end
+
     context 'requires :all using Grape::Entity documentation' do
       def define_requires_all
         documentation = {


### PR DESCRIPTION
For more information (see the actual Github [issue](https://github.com/intridea/grape/issues/677)) that this describes.

Based on the failing specs in this PR I think the way validation errors are handled may be able to be simplified which solves the original issue I had (see [this comment](https://github.com/intridea/grape/issues/677#issuecomment-53008917)). If that's the case then this code here can be even further simplified (and likely most of it deleted).

If that's not the case then I will continue exploring the validation chain logic and update the PR to intelligently group validation errors that must run together and allow others to be short-circuited.

_Note: I do not expect this to be accepted as is, using it currently to get feedback on what the final outcome should be_.
