### PR TITLE
Update Rspec RequestExampleGroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1830,9 +1830,7 @@ In Rails, HTTP request tests would go into the `spec/requests` group. You may wa
 
 ```ruby
 RSpec.configure do |config|
-  config.include RSpec::Rails::RequestExampleGroup, type: :request, example_group: {
-    file_path: /spec\/api/
-  }
+  config.include RSpec::Rails::RequestExampleGroup, type: :request, file_path: /spec\/api/
 end
 ```
 


### PR DESCRIPTION
I get this warning:

```
Deprecation Warnings:

Filtering by an `:example_group` subhash is deprecated. Use the subhash to filter directly instead.
```

I've changed for this new way and It's working very well.
