### PR TITLE
Removed unnecessary conditional in `call!`

### DIFF
--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -188,7 +188,7 @@ module Grape
         options[:app].call(env)
       else
         builder = build_middleware
-        builder.run options[:app] || lambda { |arg| run(arg) }
+        builder.run lambda { |arg| run(arg) }
         builder.call(env)
       end
     end


### PR DESCRIPTION
If `options[:app]` has been set, then it wouldn't get to this code path,
thus rendering the extra check in the call to `builder.run` unnecessary.
This also has the effect of making this code a little easier to read.
