### PR TITLE
Added support for raw input endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 0.9.1 (Next)
 ============
 
+* [#776](https://github.com/intridea/grape/pull/776): Added a `raw_input` option
+that disable the parsing of the request body.
 * [#774](https://github.com/intridea/grape/pull/774): Extended `mutually_exclusive`, `exactly_one_of`, `at_least_one_of` to work inside any kind of group: `requires` or `optional`, `Hash` or `Array` - [@ShPakvel](https://github.com/ShPakvel).
 * [#743](https://github.com/intridea/grape/pull/743): Added `allow_blank` parameter validator to validate non-empty strings - [@elado](https://github.com/elado).
 * Your contribution here.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
   - [CORS](#cors)
 - [Content-type](#content-type)
 - [API Data Formats](#api-data-formats)
+  - [Raw Input](#raw-input)
 - [RESTful Model Representations](#restful-model-representations)
   - [Grape Entities](#grape-entities)
   - [Hypermedia](#hypermedia)
@@ -1484,6 +1485,32 @@ curl -X PUT -d 'data' 'http://localhost:9292/value' -H Content-Type:text/custom 
 ```
 
 You can disable parsing for a content-type with `nil`. For example, `parser :json, nil` will disable JSON parsing altogether. The request data is then available as-is in `env['api.request.body']`.
+
+### Raw Input
+
+You may also make your endpoint "raw" by using the `raw_input` method.
+
+This will bypass the parsing of the request entierly.
+
+```ruby
+format :json # This will still be used to format the response
+raw_input # This will set the endpoint to use raw input mode for this namespace
+
+put "/upload" do
+  # You must access the request input directly through rack
+  input = env['rack.input']
+
+  # Incoming Content-Type is ignored, everything is accepted
+  request_content_type = env['CONTENT_TYPE']
+
+  # You must check the content type yourself
+  request_content_type =~ %r{video/.+} or error!('Content type not supported', 406)
+
+  # The response will be formated as usual
+  {:success => 'Upload was successful'}
+end
+```
+
 
 ## RESTful Model Representations
 

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -66,6 +66,13 @@ module Grape
           namespace_stackable(:content_types, key.to_sym => val)
         end
 
+        # Put the endpoint in raw mode input
+        # this bypass content type checking and
+        # input parsing
+        def raw_input(enabled = true)
+          namespace_inheritable(:raw_input, enabled)
+        end
+
         # All available content types.
         def content_types
           c_types = Grape::DSL::Configuration.stacked_hash_to_hash(namespace_stackable(:content_types))

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -284,6 +284,7 @@ module Grape
       b.use Grape::Middleware::Formatter,
             format: namespace_inheritable(:format),
             default_format: namespace_inheritable(:default_format) || :txt,
+            raw_input: namespace_inheritable(:raw_input),
             content_types: Grape::DSL::Configuration.stacked_hash_to_hash(namespace_stackable(:content_types)),
             formatters: Grape::DSL::Configuration.stacked_hash_to_hash(namespace_stackable(:formatters)),
             parsers: Grape::DSL::Configuration.stacked_hash_to_hash(namespace_stackable(:parsers))

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -50,6 +50,7 @@ module Grape
         if (request.post? || request.put? || request.patch? || request.delete?) &&
           (!request.form_data? || !request.media_type) &&
           (!request.parseable_data?) &&
+          (!options[:raw_input]) &&
           (request.content_length.to_i > 0 || request.env['HTTP_TRANSFER_ENCODING'] == 'chunked')
 
           if (input = env['rack.input'])

--- a/spec/grape/dsl/request_response_spec.rb
+++ b/spec/grape/dsl/request_response_spec.rb
@@ -84,6 +84,13 @@ module Grape
         end
       end
 
+      describe '.raw_input' do
+        it 'sets raw_input' do
+          expect(subject).to receive(:namespace_inheritable).with(:raw_input, true)
+          subject.raw_input
+        end
+      end
+
       describe '.content_types' do
         it 'returns all content types' do
           expect(subject.content_types).to eq(xml: "application/xml",

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -239,6 +239,21 @@ describe Grape::Middleware::Formatter do
         )
         expect(subject.env['rack.request.form_hash']['thing']['name']).to eq('Test')
       end
+      it 'ignores the input' do
+        io = StringIO.new(SecureRandom.random_bytes(512 * SecureRandom.random_number(10) + 1024))
+        subject.options[:raw_input] = true
+        subject.call(
+          'PATH_INFO' => '/upload',
+          'REQUEST_METHOD' => method,
+          'CONTENT_TYPE' => 'video/mp4',
+          'rack.input' => io,
+          'CONTENT_LENGTH' => io.length
+        )
+        expect(subject.env['api.request.body']).to be_nil
+        expect(subject.env['api.request.input']).to be_nil
+        expect(subject.env['rack.input'].length).to eq(io.length)
+        expect(subject.env['api.format']).to eq(:txt)
+      end
       [Rack::Request::FORM_DATA_MEDIA_TYPES, Rack::Request::PARSEABLE_DATA_MEDIA_TYPES].flatten.each do |content_type|
         it "ignores #{content_type}" do
           io = StringIO.new('name=Other+Test+Thing')


### PR DESCRIPTION
This add a setting called `raw_input`.

It disable the parsing of the request and let this responsibility to the developer.

It also covers support for wildcard incoming content type. I thought some time about this, and I think it would be a lot of refactor for a feature that has not real meaning without "disabling" the parsing of the input. That's why `raw_input` also bypass the check of the incoming content type and let the developer do that too.

I added an example to the README explaining the use of this option.
