### PR TITLE
fix bug for default value as proc when there is given options values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 0.9.1 (Next)
 ============
 
+* [#779](https://github.com/intridea/grape/pull/779): Bugfix for params option `default` with proc value when used together with params option `values` - [@ShPakvel](https://github.com/ShPakvel).
 * [#774](https://github.com/intridea/grape/pull/774): Extended `mutually_exclusive`, `exactly_one_of`, `at_least_one_of` to work inside any kind of group: `requires` or `optional`, `Hash` or `Array` - [@ShPakvel](https://github.com/ShPakvel).
 * [#743](https://github.com/intridea/grape/pull/743): Added `allow_blank` parameter validator to validate non-empty strings - [@elado](https://github.com/elado).
-* Your contribution here.
 * [#745](https://github.com/intridea/grape/pull/745): Removed `atom+xml`, `rss+xml`, and `jsonapi` content-types - [@akabraham](https://github.com/akabraham).
 * [#745](https://github.com/intridea/grape/pull/745): Added `:binary, application/octet-stream` content-type - [@akabraham](https://github.com/akabraham).
 * [#757](https://github.com/intridea/grape/pull/757): Changed `desc` can now be used with a block syntax - [@dspaeth-faber](https://github.com/dspaeth-faber).

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -104,10 +104,12 @@ module Grape
         default = validations[:default]
         doc_attrs[:default] = default if default
 
+        default = default.call if default.is_a?(Proc)
+
         values = validations[:values]
         doc_attrs[:values] = values if values
 
-        values = (values.is_a?(Proc) ? values.call : values)
+        values = values.call if values.is_a?(Proc)
 
         # default value should be present in values array, if both exist
         if default && values && !values.include?(default)


### PR DESCRIPTION
When you have option `default` as a proc and also any kind of option `values` (as a proc or normal) the gem is crashed. This small change solves it.
