### PR TITLE
Unset params as well as declared params

### DIFF
--- a/lib/grape/dsl/validations.rb
+++ b/lib/grape/dsl/validations.rb
@@ -9,6 +9,7 @@ module Grape
 
       module ClassMethods
         def reset_validations!
+          unset_namespace_stackable :params
           unset_namespace_stackable :declared_params
           unset_namespace_stackable :validations
         end


### PR DESCRIPTION
Without this change, I get parameters duplicated in my routes. Here's an example:

```
module API
  module V1
    class Foo < Grape::API      
      desc 'foo'
      resource :foo do

        desc 'list foo' do
          entity FooEntity
          failure [
            [403, "Unauthorized"]
          ]
        end
        params do
          optional :lol, desc: "Type of foo to return", type: String, values: %w{a b c d}
        end
        get do
          @foo = current_account.foo

          present @foo, with: FooEntity
        end

        desc 'create new Foo'
        params do
          requires :foo, desc: "bar"
        end
        post do
          @foo = [create_foo!(params[:foo])]

          present @foo, with: FooEntity
        end
      end
    end
  end
end
```

produces:

```
{
  "apiVersion":"v1",
  "apis":[
    {
      "operations":[
        {
          "method":"GET",
          "nickname":"GET--version-foos---format-",
          "notes":"",
          "parameters":[
            {
              "allowMultiple":false,
              "description":"Type of foos to return",
              "enum":[
                "a",
                "b",
                "c",
                "d"
              ],
              "name":"filter",
              "paramType":"query",
              "required":false,
              "type":"string"
            }
          ],
          "responseMessages":[
            {
              "code":403,
              "message":"Unauthorized"
            }
          ],
          "summary":"list foos",
          "type":"API::V1::FooEntity"
        },
        {
          "method":"POST",
          "nickname":"POST--version-foos---format-",
          "notes":"",
          "parameters":[
            {
              "allowMultiple":false,
              "description":"Type of foos to return",
              "enum":[
                "a",
                "b",
                "c",
                "d"
              ],
              "name":"filter",
              "paramType":"form",
              "required":false,
              "type":"string"
            },
            {
              "allowMultiple":false,
              "description":"bar",
              "name":"lol",
              "paramType":"form",
              "required":true,
              "type":"string"
            }
          ],
          "summary":"create new foo",
          "type":"void"
        }
      ],
      "path":"/v1/foos.{format}"
    }
  ],
  "basePath":"http://localhost:3000/newapi",
  "models":{},
  "produces":[
    "application/json"
  ],
  "resourcePath":"/foos",
  "swaggerVersion":"1.2"
}
```

(This is a redacted version of my real code)

Notice that the filter parameter is present on the get and the post routes, when it should be on just the get route. The patch fixes this problem, bringing the behaviour in line with grape 0.90.

If I have misunderstood something, my apologies.
