### PR TITLE
Update to README documentation for issue #798

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ module Twitter
   class API < Grape::API
     version 'v1', using: :header, vendor: 'twitter'
     format :json
-    prefix :api # This corresponds to http://[your_domain]/api/...
+    prefix :api
 
     helpers do
       def current_user


### PR DESCRIPTION
Refers to the use of /api/ at the beginning of sample routes to match the use of `prefix :api` in sample code.
