### PR TITLE
Support Angular.JS array multipart post format

### DIFF
--- a/lib/grape/validations/validators/coerce.rb
+++ b/lib/grape/validations/validators/coerce.rb
@@ -46,6 +46,15 @@ module Grape
       end
 
       def coerce_value(type, val)
+        # Try to convert from JSON if an array or hash is expected
+        if [Array, Hash].include?(type) && val.kind_of?(String)
+          begin
+            json = JSON.parse(val)
+            return json if json.kind_of?(type)
+          rescue
+          end
+        end
+
         # Don't coerce things other than nil to Arrays or Hashes
         return val || [] if type == Array
         return val || {} if type == Hash


### PR DESCRIPTION
The multipart post requests from Angular.JS send the arrays in the json format (like tag_ids=[1,2], not tag_ids[]=1&tag_ids[]=2) which is not getting recognized. If an array or hash is expected while the string is provided, I try to convert it from the JSON.
Found this one using the angular-file-upload gem (https://github.com/danialfarid/angular-file-upload).
