### PR TITLE
Inspect the options hash on a route object

### DIFF
--- a/lib/grape/route.rb
+++ b/lib/grape/route.rb
@@ -1,6 +1,8 @@
 module Grape
   # A compiled route for inspection.
   class Route
+    attr_reader :options
+    
     def initialize(options = {})
       @options = options || {}
     end


### PR DESCRIPTION
Don't want to parse the output from `to_s`.
