### PR TITLE
Allow desc or description to be used for parameter descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#799](https://github.com/intridea/grape/pull/799): Fixed custom validators with required `Hash`, `Array` types - [@bwalex](https://github.com/bwalex).
 * [#784](https://github.com/intridea/grape/pull/784): Fixed `present` to not overwrite the previously added contents of the response body whebn called more than once - [@mfunaro](https://github.com/mfunaro).
 * [#809](https://github.com/intridea/grape/pull/809): Removed automatic `(.:format)` suffix on paths if you're using only one format (e.g., with `format :json`, `/path` will respond with JSON but `/path.xml` will be a 404) - [@ajvondrak](https://github.com/ajvondrak).
+* [#819](https://github.com/intridea/grape/pull/819): Allowed either desc or description to be used for parameter descriptions - [@mzikherman](https://github.com/mzikherman).
 * Your contribution here.
 
 0.9.0 (8/27/2014)

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -97,7 +97,7 @@ module Grape
         coerce_type = validations[:coerce]
         doc_attrs[:type] = coerce_type.to_s if coerce_type
 
-        desc = validations.delete(:desc)
+        desc = validations.delete(:desc) || validations.delete(:description)
         doc_attrs[:desc] = desc if desc
 
         default = validations[:default]

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -1,4 +1,27 @@
 require 'spec_helper'
 
 describe Grape::Validations::ParamsScope do
+  subject do
+    Class.new(Grape::API)
+  end
+
+  def app
+    subject
+  end
+
+  context 'setting description' do
+    [:desc, :description].each do |description_type|
+      it "allows setting #{description_type}" do
+        subject.params do
+          requires :int, type: Integer, description_type => 'My very nice integer'
+        end
+        subject.get '/single' do
+          'int works'
+        end
+        get '/single', int: 420
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('int works')
+      end
+    end
+  end
 end


### PR DESCRIPTION
I was surprised that you had to use `desc` to describe parameters. Using `description` would throw an `unknown validator` error as Grape interpreted it as a custom validation (ie- `regexp`, etc.).

I added a spec that setting either `desc` or `description` **works** (returns a 200, currently this will crash if you use `description`). 

Let me know if that's an odd spec or if you'd like something in addition. Was a bit unsure where such a seemingly-simple spec should go. Thanks! great gem btw :smile: 
