### PR TITLE
fix passing string value when hash is expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#809](https://github.com/intridea/grape/pull/809): Removed automatic `(.:format)` suffix on paths if you're using only one format (e.g., with `format :json`, `/path` will respond with JSON but `/path.xml` will be a 404) - [@ajvondrak](https://github.com/ajvondrak).
 * [#816](https://github.com/intridea/grape/pull/816): Added ability to filter out missing params if params is a nested hash with `declared(params, include_missing: false)` - [@georgimitev](https://github.com/georgimitev).
 * [#819](https://github.com/intridea/grape/pull/819): Allowed both `desc` and `description` in the params DSL - [@mzikherman](https://github.com/mzikherman).
+* [#821](https://github.com/intridea/grape/pull/821): Fixed passing string value when hash is expected in params - [@rebelact](https://github.com/rebelact).
 * Your contribution here.
 
 0.9.0 (8/27/2014)

--- a/lib/grape/validations/validators/allow_blank.rb
+++ b/lib/grape/validations/validators/allow_blank.rb
@@ -2,7 +2,7 @@ module Grape
   module Validations
     class AllowBlankValidator < Base
       def validate_param!(attr_name, params)
-        return if @option
+        return if @option || !params.is_a?(Hash)
 
         value = params[attr_name]
         value = value.strip if value.respond_to?(:strip)

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -13,7 +13,7 @@ module Grape
       def validate!(params)
         attributes = AttributesIterator.new(self, @scope, params)
         attributes.each do |resource_params, attr_name|
-          if @required || resource_params.key?(attr_name)
+          if @required || (resource_params.respond_to?(:key?) && resource_params.key?(attr_name))
             validate_param!(attr_name, resource_params)
           end
         end

--- a/spec/grape/validations/validators/allow_blank_spec.rb
+++ b/spec/grape/validations/validators/allow_blank_spec.rb
@@ -45,10 +45,24 @@ describe Grape::Validations::AllowBlankValidator do
 
         params do
           requires :user, type: Hash do
+            requires :name, allow_blank: false
+          end
+        end
+        get '/disallow_string_value_in_a_required_hash_group'
+
+        params do
+          requires :user, type: Hash do
             optional :name, allow_blank: false
           end
         end
         get '/disallow_blank_optional_param_in_a_required_group'
+
+        params do
+          optional :user, type: Hash do
+            optional :name, allow_blank: false
+          end
+        end
+        get '/disallow_string_value_in_an_optional_hash_group'
       end
     end
   end
@@ -129,6 +143,11 @@ describe Grape::Validations::AllowBlankValidator do
         get '/disallow_blank_required_param_in_a_required_group', user: { name: "" }
         expect(last_response.status).to eq(400)
       end
+
+      it 'refuses a string value in a required hash group' do
+        get '/disallow_string_value_in_a_required_hash_group', user: ""
+        expect(last_response.status).to eq(400)
+      end
     end
 
     context 'as an optional param' do
@@ -139,6 +158,11 @@ describe Grape::Validations::AllowBlankValidator do
 
       it 'refuses a blank existing value in an existing scope' do
         get '/disallow_blank_optional_param_in_a_required_group', user: { age: "29", name: "" }
+        expect(last_response.status).to eq(400)
+      end
+
+      it 'refuses a string value in an optional hash group' do
+        get '/disallow_string_value_in_an_optional_hash_group', user: ""
         expect(last_response.status).to eq(400)
       end
     end


### PR DESCRIPTION
This is a pr based on the findings in #818. Basically if you have 

``` ruby
params do
  requires :user, :type => Hash do
    requires :address, allow_blank: false, type: String
  end
end

post :hello do
  { "hello" => "world" }
end
```

You can make the following request:

``` bash
curl -X POST -H "Content-Type: application/json" -d '{"user":"xyz"}' http://localhost:9292/hello
```

which will lead to the following exception:

``` ruby
127.0.0.1 - - "POST /hello HTTP/1.1" 201 17 0.0760
TypeError: no implicit conversion of Symbol into Integer
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/validations/validators/allow_blank.rb:7:in `[]'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/validations/validators/allow_blank.rb:7:in `validate_param!'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/validations/validators/base.rb:17:in `block in validate!'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/validations/attributes_iterator.rb:15:in `block (2 levels) in each'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/validations/attributes_iterator.rb:14:in `each'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/validations/attributes_iterator.rb:14:in `block in each'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/validations/attributes_iterator.rb:13:in `each'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/validations/attributes_iterator.rb:13:in `each'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/validations/validators/base.rb:15:in `validate!'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/endpoint.rb:231:in `block in run'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/endpoint.rb:229:in `each'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/endpoint.rb:229:in `run'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/endpoint.rb:191:in `block in call!'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/middleware/base.rb:24:in `call'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/middleware/base.rb:24:in `call!'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/middleware/base.rb:18:in `call'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/middleware/error.rb:27:in `block in call!'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/middleware/error.rb:26:in `catch'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/middleware/error.rb:26:in `call!'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/middleware/base.rb:18:in `call'
  ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/head.rb:11:in `call'
  ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/builder.rb:138:in `call'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/endpoint.rb:192:in `call!'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/endpoint.rb:180:in `call'
  ~/.rvm/gems/ruby-2.1.1/gems/rack-mount-0.8.3/lib/rack/mount/route_set.rb:152:in `block in call'
  ~/.rvm/gems/ruby-2.1.1/gems/rack-mount-0.8.3/lib/rack/mount/code_generation.rb:96:in `block in recognize'
  ~/.rvm/gems/ruby-2.1.1/gems/rack-mount-0.8.3/lib/rack/mount/code_generation.rb:68:in `optimized_each'
  ~/.rvm/gems/ruby-2.1.1/gems/rack-mount-0.8.3/lib/rack/mount/code_generation.rb:95:in `recognize'
  ~/.rvm/gems/ruby-2.1.1/gems/rack-mount-0.8.3/lib/rack/mount/route_set.rb:141:in `call'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/api.rb:104:in `call'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/api.rb:33:in `call!'
  ~/.rvm/gems/ruby-2.1.1/bundler/gems/grape-2302e2644e50/lib/grape/api.rb:29:in `call'
  ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/cascade.rb:33:in `block in call'
  ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/cascade.rb:24:in `each'
  ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/cascade.rb:24:in `call'
  ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/lint.rb:49:in `_call'
  ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/lint.rb:37:in `call'
  ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/showexceptions.rb:24:in `call'
  ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/commonlogger.rb:33:in `call'
  ~/.rvm/gems/ruby-2.1.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:217:in `call'
  ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/chunked.rb:43:in `call'
  ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/content_length.rb:14:in `call'
  ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/handler/webrick.rb:60:in `service'
  ~/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/webrick/httpserver.rb:138:in `service'
  ~/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/webrick/httpserver.rb:94:in `run'
  ~/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/webrick/server.rb:295:in `block in start_thread~/
```
