### PR TITLE
Custom validators should inherit from Grape::Validations::Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -903,7 +903,7 @@ end
 ### Custom Validators
 
 ```ruby
-class AlphaNumeric < Grape::Validations::Validator
+class AlphaNumeric < Grape::Validations::Base
   def validate_param!(attr_name, params)
     unless params[attr_name] =~ /^[[:alnum:]]+$/
       raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: "must consist of alpha-numeric characters"


### PR DESCRIPTION
This is a small README change, i believe when you have custom validators they should inherit from `Grape::Validations::Base` and not from  `Grape::Validations::Validator`. I've extracted a small example here - https://github.com/rebelact/grape-validator-issue. When i inherit from `Grape::Validations::Validator` i get the following error:

``` ruby
~/grape-validation-issue/config.ru:7:in `<class:API>': uninitialized constant Grape::Validations::Validator (NameError)
  from ~/grape-validation-issue/config.ru:4:in `block in <main>'
  from ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/builder.rb:55:in `instance_eval'
  from ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/builder.rb:55:in `initialize'
  from ~/grape-validation-issue/config.ru:in `new'
  from ~/grape-validation-issue/config.ru:in `<main>'
  from ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/builder.rb:49:in `eval'
  from ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/builder.rb:49:in `new_from_string'
  from ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/builder.rb:40:in `parse_file'
  from ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/server.rb:277:in `build_app_and_options_from_config'
  from ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/server.rb:199:in `app'
  from ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/server.rb:314:in `wrapped_app'
  from ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/server.rb:250:in `start'
  from ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/lib/rack/server.rb:141:in `start'
  from ~/.rvm/gems/ruby-2.1.1/gems/rack-1.5.2/bin/rackup:4:in `<top (required)>'
  from ~/.rvm/gems/ruby-2.1.1/bin/rackup:23:in `load'
  from ~/.rvm/gems/ruby-2.1.1/bin/rackup:23:in `<main>'
  from ~/.rvm/gems/ruby-2.1.1/bin/ruby_executable_hooks:15:in `eval'
  from ~/.rvm/gems/ruby-2.1.1/bin/ruby_executable_hooks:15:in `<main>'
```

When i inherit from `Grape::Validations::Base` it works as expected. 
