### PR TITLE
Find coerce_type for Array when not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#821](https://github.com/intridea/grape/pull/821): Fixed passing string value when hash is expected in params - [@rebelact](https://github.com/rebelact).
 * [#824](https://github.com/intridea/grape/pull/824): Validate array params against list of acceptable values - [@dnd](https://github.com/dnd).
 * [#813](https://github.com/intridea/grape/pull/813): Routing methods dsl refactored to get rid of explicit `paths` parameter - [@AlexYankee](https://github.com/AlexYankee).
+* [#826](https://github.com/intridea/grape/pull/826): Find coerce_type for Array when not specified - [@manovotn](https://github.com/manovotn).
 * Your contribution here.
 
 0.9.0 (8/27/2014)

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -97,6 +97,7 @@ module Grape
         validations[:coerce] = validations.delete(:type) if validations.key?(:type)
 
         coerce_type = validations[:coerce]
+
         doc_attrs[:type] = coerce_type.to_s if coerce_type
 
         desc = validations.delete(:desc) || validations.delete(:description)
@@ -111,6 +112,8 @@ module Grape
         doc_attrs[:values] = values if values
 
         values = values.call if values.is_a?(Proc)
+
+        coerce_type = values.first.class if values && coerce_type == Array && !values.empty?
 
         # default value should be present in values array, if both exist
         if default && values && !values.include?(default)

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -24,4 +24,35 @@ describe Grape::Validations::ParamsScope do
       end
     end
   end
+
+  context 'array without coerce type explicitly given' do
+
+    it 'sets the type based on first element' do
+      subject.params do
+        requires :periods, type: Array, values: -> { ['day', 'month'] }
+      end
+      subject.get('/required') { 'required works' }
+
+      get '/required', periods: ['day', 'month']
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq('required works')
+    end
+
+    it 'fails to call API without Array type' do
+      subject.params do
+        requires :periods, type: Array, values: -> { ['day', 'month'] }
+      end
+      subject.get('/required') { 'required works' }
+
+      get '/required', periods: 'day'
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq('periods is invalid')
+    end
+
+    it 'raises exception when values are of different type' do
+      expect {
+        subject.params { requires :numbers, type: Array, values: -> { [1, "definitely not a number", 3] } }
+      }.to raise_error Grape::Exceptions::IncompatibleOptionValues
+    end
+  end
 end


### PR DESCRIPTION
This PR is an attempt to address issue #795 . 
I am not sure I understood it correctly, but it seemed to me that @maxd wanted to create an Array type without specifying what's inside the Array.
I also added one test to make sure this works.
