### PR TITLE
Yet more failing tests for optional parameter behavior around Arrays

### DIFF
--- a/spec/grape/validations/validators/default_spec.rb
+++ b/spec/grape/validations/validators/default_spec.rb
@@ -63,12 +63,48 @@ describe Grape::Validations::DefaultValidator do
         get '/array' do
           { array: params[:array] }
         end
+
+        params do
+          requires :thing1
+          optional :more_things, type: Array do
+            requires :nested_thing
+            requires :other_thing, default: 1
+          end
+        end
+        get '/optional_array' do
+          { thing1: params[:thing1], more_things: params[:more_things] }
+        end
+
+        params do
+          optional :some_things, type: Array do
+            requires :foo
+            optional :options, type: Array do
+              requires :name, type: String
+              requires :value, type: String
+            end
+          end
+        end
+        get '/nested_optional_array' do
+          { some_things: params[:some_things] }
+        end
       end
     end
   end
 
   def app
     ValidationsSpec::DefaultValidatorSpec::API
+  end
+
+  it 'lets you leave required values nested inside an optional blank' do
+    get '/optional_array?thing1=stuff'
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq({ thing1: 'stuff' }.to_json)
+  end
+
+  it 'allows optional arrays to be omitted' do
+    get '/nested_optional_array?some_things[][foo]=1&some_things[][foo]=2&some_things[][options][name]=wat&some_things[][options][value]=nope'
+    puts last_response.body
+    expect(last_response.body).to eq({ some_things: [{ foo: '1' }, { foo: 2, options: { name: 'wat', value: 'nope' } }] }.to_json)
   end
 
   it 'set default value for optional param' do


### PR DESCRIPTION
This is another group of failing tests for parameter parsing. See also related issues / PRs:

* #615 encounters similar behavior with defaults inside an optional Array

* #895 tests some of the same behavior, but with optional params inside an optional Array

* #723 encounters identical behavior (nested optional Array containing required params forces all elements of the array to have an optional value)

Creating this PR for discussion of the cases + any resolution I come up with.