### PR TITLE
Nested mount points don't inherit parent declared params

### DIFF
--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -508,7 +508,7 @@ describe Grape::Endpoint do
       end
     end
 
-    it "can access parent attributes" do
+    it 'can access parent attributes' do
       get '/something/123/mount_space/456'
       expect(last_response.status).to eq 200
       json = JSON.parse(last_response.body, symbolize_names: true)

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -509,7 +509,7 @@ describe Grape::Endpoint do
     end
 
     it 'can access parent attributes' do
-      get '/something/123/mount_space/456'
+      get '/something/123/another/456'
       expect(last_response.status).to eq 200
       json = JSON.parse(last_response.body, symbolize_names: true)
       expect(json[:declared_params][:id]).to eq 123


### PR DESCRIPTION
Not sure if this is documented elsewhere, but I would expect the following to work:

```ruby
class Another < Grape::API
  namespace :another do
    params do
      required :my_id, type: Integer
    end
    route_param :my_id do
    get do
      declared(params)
    end
  end
end

class Something < Grape::API
  format :json
  namespace :something do
    params do
       requires :id
    end
    route_param :id do
      mount Another
    end
  end
end
```

And for the request `get /something/123/another/456`

to return `{ id: 123, my_id: 456 }`, but I only get `{ my_id: 456 }`

I have attached a failing test case to this PR to demonstrate the issue, though I am unsure as of yet how to go about fixing.