### PR TITLE
Add test for OPTIONS and HEAD requests with catch-all

### DIFF
--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -2857,6 +2857,12 @@ XML
         get '/v2/hello'
         expect(last_response.status).to eq(200)
         expect(last_response.body).to eq('v2')
+        options '/v2/hello'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to be_blank
+        head '/v2/hello'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to be_blank
         get '/foobar'
         expect(last_response.status).to eq(404)
         expect(last_response.body).to eq('Unrecognized request path: foobar - /foobar')


### PR DESCRIPTION
This illustrates the issue described in #1056 by adding a options and
head request when the catch-all route is enabled.

This fails intentionally. It illustrates my confusion about the HEAD and OPTIONS requests failing when a catch-all route is enabled.