### PR TITLE
Remove unwanted test

### DIFF
--- a/spec/grape/integration/rack_spec.rb
+++ b/spec/grape/integration/rack_spec.rb
@@ -21,7 +21,7 @@ describe Rack do
 
       unless RUBY_PLATFORM == 'java'
         major, minor, release = Rack.release.split('.').map(&:to_i)
-        pending 'Rack 1.5.3 or 1.6.1 required' unless major >= 1 && ((minor == 5 && release >= 3) || (minor >= 6))
+        pending 'Rack >= 1.5 required' unless ((major == 1 && minor >= 5) || (major > 1))
       end
 
       expect(JSON.parse(app.call(env)[2].body.first)['params_keys']).to match_array('test')

--- a/spec/grape/integration/rack_spec.rb
+++ b/spec/grape/integration/rack_spec.rb
@@ -18,6 +18,12 @@ describe Rack do
         'CONTENT_TYPE' => 'application/json'
       }
       env = Rack::MockRequest.env_for('/', options)
+
+      unless RUBY_PLATFORM == 'java'
+        major, minor, release = Rack.release.split('.').map(&:to_i)
+        pending 'Rack 1.5.3 or 1.6.1 required' unless major >= 1 && ((minor == 5 && release >= 3) || (minor >= 6))
+      end
+
       expect(JSON.parse(app.call(env)[2].body.first)['params_keys']).to match_array('test')
     ensure
       input.close

--- a/spec/grape/integration/rack_spec.rb
+++ b/spec/grape/integration/rack_spec.rb
@@ -21,7 +21,7 @@ describe Rack do
 
       unless RUBY_PLATFORM == 'java'
         major, minor, release = Rack.release.split('.').map(&:to_i)
-        pending 'Rack >= 1.5 required' unless ((major == 1 && minor >= 5) || (major > 1))
+        pending 'Rack >= 1.5 required' unless (major == 1 && minor >= 5) || major > 1
       end
 
       expect(JSON.parse(app.call(env)[2].body.first)['params_keys']).to match_array('test')

--- a/spec/grape/integration/rack_spec.rb
+++ b/spec/grape/integration/rack_spec.rb
@@ -18,12 +18,6 @@ describe Rack do
         'CONTENT_TYPE' => 'application/json'
       }
       env = Rack::MockRequest.env_for('/', options)
-
-      unless RUBY_PLATFORM == 'java'
-        major, minor, release = Rack.release.split('.').map(&:to_i)
-        pending 'Rack 1.5.3 or 1.6.1 required' unless major >= 1 && ((minor == 5 && release >= 3) || (minor >= 6))
-      end
-
       expect(JSON.parse(app.call(env)[2].body.first)['params_keys']).to match_array('test')
     ensure
       input.close


### PR DESCRIPTION
Remove the unwanted version checking test. Tests run fine with Ruby 1.5.2 and 1.6.4 perfectly. So the test is unnecessary.