### PR TITLE
Enable trace verb

### DIFF
--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -172,7 +172,18 @@ module Grape
               end
             end
 
-            not_allowed_methods = %w(GET PUT POST DELETE PATCH HEAD) - allowed_methods
+            unless self.class.namespace_inheritable(:do_not_route_trace)
+              unless allowed_methods.include?(Grape::Http::Headers::TRACE)
+                self.class.options(path, {}) do
+                  status 200
+                  # TODO: Call downstream code and catch result
+                  #       Stitch together request as it would have looked to last receiver in the chain
+                  #       Return that stitched-together requets
+                end
+              end
+            end
+
+            not_allowed_methods = %w(GET PUT POST DELETE PATCH HEAD TRACE) - allowed_methods
             not_allowed_methods << Grape::Http::Headers::OPTIONS if self.class.namespace_inheritable(:do_not_route_options)
             self.class.route(not_allowed_methods, path) do
               header 'Allow', allow_header

--- a/lib/grape/http/headers.rb
+++ b/lib/grape/http/headers.rb
@@ -14,6 +14,7 @@ module Grape
       DELETE  = 'DELETE'.freeze
       HEAD    = 'HEAD'.freeze
       OPTIONS = 'OPTIONS'.freeze
+      TRACE   = 'TRACE'.freeze
 
       HTTP_ACCEPT_VERSION    = 'HTTP_ACCEPT_VERSION'.freeze
       X_CASCADE              = 'X-Cascade'.freeze


### PR DESCRIPTION
Initial idea for enabling the [TRACE verb](http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html) as discussed in #1060 
