### PR TITLE
Adding Grape Environment Custom DSL.

### DIFF
--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -141,6 +141,7 @@ module Grape
       autoload :RequestResponse
       autoload :Routing
       autoload :Validations
+      autoload :Environment
     end
   end
 

--- a/lib/grape/dsl/api.rb
+++ b/lib/grape/dsl/api.rb
@@ -14,6 +14,7 @@ module Grape
       include Grape::DSL::Middleware
       include Grape::DSL::RequestResponse
       include Grape::DSL::Routing
+      include Grape::DSL::Environment
     end
   end
 end

--- a/lib/grape/dsl/environment.rb
+++ b/lib/grape/dsl/environment.rb
@@ -1,0 +1,17 @@
+require 'active_support/concern'
+
+module Grape
+  module DSL
+    module Environment
+      extend ActiveSupport::Concern
+        included do
+          attr_reader :env
+        end
+      
+        def original_path
+          request = Rack::Request.new(env)
+          request.path
+        end
+    end
+  end
+end

--- a/spec/grape/dsl/environment_spec.rb
+++ b/spec/grape/dsl/environment_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+module Grape
+  module DSL
+    module EnvironmentSpec
+       class Dummy
+         include Grape::DSL::Environment
+         
+       end
+    end
+    describe Environment do
+      subject { EnvironmentSpec::Dummy.new }
+
+      describe ".original_fullpath" do
+        it "should return original_fullpath" do
+          request = Grape::Request.new(Rack::MockRequest.env_for('/hello', method: 'GET'))
+          expect(subject.original_path).to eq('/hello')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
A failing test case to access Grape @env information outside an endpoint or inside a custom DSL extension.
