### PR TITLE
Raise a warning when `desc` is called with options hash and block 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 * [#1109](https://github.com/ruby-grape/grape/pull/1109): Memoize Virtus attribute and fix memory leak - [@marshall-lee](https://github.com/marshall-lee).
 * [#1101](https://github.com/intridea/grape/pull/1101): Fix: Incorrect media-type `Accept` header now correctly returns 406 with `strict: true` - [@elliotlarson](https://github.com/elliotlarson).
+* [#1108](https://github.com/ruby-grape/grape/pull/1039): Raise a warning when `desc` is called with options hash and block - [@rngtng](https://github.com/rngtng).
 
 0.13.0 (8/10/2015)
 ==================

--- a/lib/grape/dsl/configuration.rb
+++ b/lib/grape/dsl/configuration.rb
@@ -64,6 +64,9 @@ module Grape
             end
 
             config_class.configure(&config_block)
+            unless options.empty?
+              warn '[DEPRECATION] Passing a options hash and a block to `desc` is deprecated. Move all hash options to block.'
+            end
             options = config_class.settings
           else
             options = options.merge(description: description)

--- a/spec/grape/dsl/configuration_spec.rb
+++ b/spec/grape/dsl/configuration_spec.rb
@@ -70,6 +70,19 @@ module Grape
           expect(subject.namespace_setting(:description)).to eq(expected_options)
           expect(subject.route_setting(:description)).to eq(expected_options)
         end
+
+        it 'can be set with options and a block' do
+          expect(subject).to receive(:warn).with('[DEPRECATION] Passing a options hash and a block to `desc` is deprecated. Move all hash options to block.')
+
+          desc_text = 'The description'
+          detail_text = 'more details'
+          options = { message: 'none' }
+          subject.desc desc_text, options do
+            detail detail_text
+          end
+          expect(subject.namespace_setting(:description)).to eq(description: desc_text, detail: detail_text)
+          expect(subject.route_setting(:description)).to eq(description: desc_text, detail: detail_text)
+        end
       end
     end
   end


### PR DESCRIPTION
Raise a warning when `desc` is called with options hash and block.
relates to: #920