### PR TITLE
Memoize Virtus attribute and fix memory leak.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 0.13.1 (Next)
 =============
 
+#### Features
+
+* Your contribution here.
+
+#### Fixes
+
+* [#1109](https://github.com/ruby-grape/grape/pull/1109): Memoize Virtus attribute and fix memory leak - [@marshall-lee](https://github.com/marshall-lee).
 * Your contribution here.
 
 0.13.0 (8/10/2015)

--- a/spec/grape/validations/validators/coerce_spec.rb
+++ b/spec/grape/validations/validators/coerce_spec.rb
@@ -252,5 +252,18 @@ describe Grape::Validations::CoerceValidator do
         expect(last_response.body).to eq('Fixnum')
       end
     end
+
+    context 'converter' do
+      it 'does not build Virtus::Attribute multiple times' do
+        subject.params do
+          requires :something, type: Array[String]
+        end
+        subject.get do
+        end
+
+        expect(Virtus::Attribute).to receive(:build).at_most(2).times.and_call_original
+        10.times { get '/' }
+      end
+    end
   end
 end


### PR DESCRIPTION
This one fixes a serious problem we faced in production under a heavy load. Investigation led us to the fact that it happens only when params are defined with `type: Array[SomeClass]`. In this case `Virtus` dynamically create some virtual classes (with `Class.new`) which inherits from base class with `DescendantsTracker` added which saves descendant classes into the array. Here we have a leak because garbage collector doesn't free these classes because an array still holds a reference to them.

So at least I can say that `Virtus` isn't designed for creating things *dynamically*. They should be stored somehow statically.

@dblock 
Look, this is funny! Remember https://github.com/ruby-grape/grape-entity/pull/161 ? This is why it is bad to store descendant classes in the array. Look at the [implementation of `DescendantsTracker`](https://github.com/dkubb/descendants_tracker/blob/da06ed0b19af023c8e27656bebbc6af692cdb0f7/lib/descendants_tracker.rb) — is it similar, right? 