### PR TITLE
Fix rescue all header versioning regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Fixes
 
+* [#1114](https://github.com/ruby-grape/grape/pull/1114): Fix regression which broke identical endpoints with different versions - [@suan](https://github.com/suan).
 * [#1109](https://github.com/ruby-grape/grape/pull/1109): Memoize Virtus attribute and fix memory leak - [@marshall-lee](https://github.com/marshall-lee).
 * [#1101](https://github.com/intridea/grape/pull/1101): Fix: Incorrect media-type `Accept` header now correctly returns 406 with `strict: true` - [@elliotlarson](https://github.com/elliotlarson).
 * [#1108](https://github.com/ruby-grape/grape/pull/1039): Raise a warning when `desc` is called with options hash and block - [@rngtng](https://github.com/rngtng).

--- a/README.md
+++ b/README.md
@@ -1608,6 +1608,10 @@ rescue_from RuntimeError, rescue_subclasses: false do |e|
 end
 ```
 
+#### Unrescuable Exceptions
+
+`Grape::Exceptions::InvalidVersionHeader`, which is raised when the version in the request header doesn't match the currently evaluated version for the endpoint, will _never_ be rescued from a `rescue_from` block (even a `rescue_from :all`) This is because Grape relies on Rack to catch that error and try the next versioned-route for cases where there exist identical Grape endpoints with different versions.
+
 ### Rails 3.x
 
 When mounted inside containers, such as Rails 3.x, errors like "404 Not Found" or

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,14 @@
 Upgrading Grape
 ===============
 
+### Upgrading to >= 0.13.1
+
+#### Changes to header versioning and invalid header version handling
+
+Identical endpoints with different versions now work correctly. A regression introduced in Grape 0.11.0 caused all but the first-mounted version for such an endpoint to wrongly throw an `InvalidAcceptHeader`. As a side effect, requests with a correct vendor but invalid version can no longer be rescued from a `rescue_from` block.
+
+See [#1114](https://github.com/ruby-grape/grape/pull/1114) for more information.
+
 ### Upgrading to >= 0.12.0
 
 #### Changes in middleware

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -68,6 +68,7 @@ module Grape
     autoload :UnsupportedGroupTypeError,      'grape/exceptions/unsupported_group_type'
     autoload :InvalidMessageBody
     autoload :InvalidAcceptHeader
+    autoload :InvalidVersionHeader
   end
 
   module ErrorFormatter

--- a/lib/grape/exceptions/invalid_version_header.rb
+++ b/lib/grape/exceptions/invalid_version_header.rb
@@ -1,0 +1,10 @@
+# encoding: utf-8
+module Grape
+  module Exceptions
+    class InvalidVersionHeader < Base
+      def initialize(message, headers)
+        super(message: compose_message('invalid_version_header', message: message), status: 406, headers: headers)
+      end
+    end
+  end
+end

--- a/lib/grape/locale/en.yml
+++ b/lib/grape/locale/en.yml
@@ -45,4 +45,7 @@ en:
         invalid_accept_header:
           problem: 'Invalid accept header'
           resolution: '%{message}'
+        invalid_version_header:
+          problem: 'Invalid version header'
+          resolution: '%{message}'
 

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -47,6 +47,7 @@ module Grape
       end
 
       def rescuable?(klass)
+        return false if klass == Grape::Exceptions::InvalidVersionHeader
         options[:rescue_all] || (options[:rescue_handlers] || []).any? { |error, _handler| klass <= error } || (options[:base_only_rescue_handlers] || []).include?(klass)
       end
 

--- a/spec/grape/exceptions/invalid_accept_header_spec.rb
+++ b/spec/grape/exceptions/invalid_accept_header_spec.rb
@@ -54,13 +54,6 @@ describe Grape::Exceptions::InvalidAcceptHeader do
     end
 
     context 'that receives' do
-      context 'an invalid version in the request' do
-        before do
-          get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v77',
-                           'CONTENT_TYPE' => 'application/json'
-        end
-        it_should_behave_like 'a rescued request'
-      end
       context 'an invalid vendor in the request' do
         before do
           get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.invalidvendor-v99',
@@ -128,13 +121,6 @@ describe Grape::Exceptions::InvalidAcceptHeader do
     end
 
     context 'that receives' do
-      context 'an invalid version in the request' do
-        before do
-          get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v77',
-                           'CONTENT_TYPE' => 'application/json'
-        end
-        it_should_behave_like 'a rescued request'
-      end
       context 'an invalid vendor in the request' do
         before do
           get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.invalidvendor-v99',


### PR DESCRIPTION
A suggested fix for https://github.com/ruby-grape/grape/issues/968

There are two failing specs which show that unfortunately there is no way to `rescue_from` an invalid version, since it's possibly valid and needs to propogate. This was also the case before the regression was introduced.