### PR TITLE
Fix `do_not_route_options!` handling: do not respond to OPTIONS if disabled!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#1109](https://github.com/ruby-grape/grape/pull/1109): Memoize Virtus attribute and fix memory leak - [@marshall-lee](https://github.com/marshall-lee).
 * [#1101](https://github.com/intridea/grape/pull/1101): Fix: Incorrect media-type `Accept` header now correctly returns 406 with `strict: true` - [@elliotlarson](https://github.com/elliotlarson).
 * [#1108](https://github.com/ruby-grape/grape/pull/1039): Raise a warning when `desc` is called with options hash and block - [@rngtng](https://github.com/rngtng).
+* [#1119](https://github.com/ruby-grape/grape/pull/1119): Fix `do_not_route_options!` handling: do not respond to OPTIONS if disabled! - [@jf](https://github.com/jf).
 
 0.13.0 (8/10/2015)
 ==================

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -160,15 +160,15 @@ module Grape
             unless self.class.namespace_inheritable(:do_not_route_head)
               allowed_methods |= [Grape::Http::Headers::HEAD] if allowed_methods.include?(Grape::Http::Headers::GET)
             end
+            allowed_methods |= [Grape::Http::Headers::OPTIONS] unless self.class.namespace_inheritable(:do_not_route_options)
 
-            allow_header = ([Grape::Http::Headers::OPTIONS] | allowed_methods).join(', ')
+            allow_header = allowed_methods.join(', ')
+
             unless self.class.namespace_inheritable(:do_not_route_options)
-              unless allowed_methods.include?(Grape::Http::Headers::OPTIONS)
-                self.class.options(path, {}) do
-                  header 'Allow', allow_header
-                  status 204
-                  ''
-                end
+              self.class.options(path, {}) do
+                header 'Allow', allow_header
+                status 204
+                ''
               end
             end
 

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -523,7 +523,7 @@ describe Grape::API do
         'example'
       end
       put '/example'
-      expect(last_response.headers['Allow']).to eql 'OPTIONS, GET, POST, HEAD'
+      expect(last_response.headers['Allow']).to eql 'GET, POST, HEAD, OPTIONS'
     end
 
     specify '405 responses includes an Content-Type header' do
@@ -545,7 +545,7 @@ describe Grape::API do
       options '/example'
       expect(last_response.status).to eql 204
       expect(last_response.body).to eql ''
-      expect(last_response.headers['Allow']).to eql 'OPTIONS, GET, HEAD'
+      expect(last_response.headers['Allow']).to eql 'GET, HEAD, OPTIONS'
       expect(last_response.headers['X-Custom-Header']).to eql 'foo'
     end
 
@@ -581,7 +581,7 @@ describe Grape::API do
       options '/example'
       expect(last_response.status).to eql 204
       expect(last_response.body).to eql ''
-      expect(last_response.headers['Allow']).to eql 'OPTIONS, GET'
+      expect(last_response.headers['Allow']).to eql 'GET, OPTIONS'
     end
     it 'does not allow HEAD on a GET request' do
       head '/example'


### PR DESCRIPTION
FYI: so apparently this wasn't caught by `spec/grape/dsl/routing_spec.rb`. Not too sure how to fix that.