### PR TITLE
Use extract_options!

### DIFF
--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -31,7 +31,7 @@ module Grape
       #     end
       def use(*names)
         named_params = Grape::DSL::Configuration.stacked_hash_to_hash(@api.namespace_stackable(:named_params)) || {}
-        options = names.last.is_a?(Hash) ? names.pop : {}
+        options = names.extract_options!
         names.each do |name|
           params_block = named_params.fetch(name) do
             fail "Params :#{name} not found!"
@@ -86,7 +86,7 @@ module Grape
       def requires(*attrs, &block)
         orig_attrs = attrs.clone
 
-        opts = attrs.last.is_a?(Hash) ? attrs.pop.clone : {}
+        opts = attrs.extract_options!.clone
         opts[:presence] = true
 
         if opts[:using]
@@ -105,7 +105,7 @@ module Grape
       def optional(*attrs, &block)
         orig_attrs = attrs.clone
 
-        opts = attrs.last.is_a?(Hash) ? attrs.pop.clone : {}
+        opts = attrs.extract_options!.clone
         type = opts[:type]
 
         # check type for optional parameter group

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -104,7 +104,7 @@ module Grape
             handler = block
           end
 
-          options = args.last.is_a?(Hash) ? args.pop : {}
+          options = args.extract_options!
           handler ||= proc { options[:with] } if options.key?(:with)
 
           if args.include?(:all)

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -28,8 +28,7 @@ module Grape
         #
         def version(*args, &block)
           if args.any?
-            options = args.pop if args.last.is_a? Hash
-            options ||= {}
+            options = args.extract_options!
             options = { using: :path }.merge(options)
 
             fail Grape::Exceptions::MissingVendorOption.new if options[:using] == :header && !options.key?(:vendor)


### PR DESCRIPTION
This one, on the contrary to #1122, #1124, utilizes ActiveSupport feature.
`extract_options!` is harmless and not heavy, also `Grape` already uses it in some place.

It should not impact performance since the fixed methods  are `DSL` methods (they're called just once). Here we better have clarity.