### PR TITLE
Makes #declared unavailable to before filters

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,7 +22,7 @@ Metrics/BlockNesting:
 # Offense count: 5
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 249
+  Max: 250
 
 # Offense count: 23
 Metrics/CyclomaticComplexity:
@@ -41,7 +41,7 @@ Metrics/MethodLength:
 # Offense count: 8
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 271
+  Max: 272
 
 # Offense count: 17
 Metrics/PerceivedComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 #### Fixes
 
+* [#1142](https://github.com/ruby-grape/grape/pull/1114): Makes #declared unavailable to before filters - [@jrforrest](https://github.com/jrforrest)
 * [#1114](https://github.com/ruby-grape/grape/pull/1114): Fix regression which broke identical endpoints with different versions - [@suan](https://github.com/suan).
 * [#1109](https://github.com/ruby-grape/grape/pull/1109): Memoize Virtus attribute and fix memory leak - [@marshall-lee](https://github.com/marshall-lee).
 * [#1101](https://github.com/intridea/grape/pull/1101): Fix: Incorrect media-type `Accept` header now correctly returns 406 with `strict: true` - [@elliotlarson](https://github.com/elliotlarson).

--- a/README.md
+++ b/README.md
@@ -534,6 +534,10 @@ The returned hash is a `Hashie::Mash` instance, allowing you to access parameter
   declared(params).user == declared(params)["user"]
 ```
 
+
+The `#declared` method is not available to `before` filters, as those are evaluated prior
+to parameter coercion.
+
 ### Include missing
 
 By default `declared(params)` includes parameters that have `nil` values. If you want to return only the parameters that are not `nil`, you can use the `include_missing` option. By default, `include_missing` is set to `true`. Consider the following API:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,12 @@ Upgrading Grape
 
 ### Upgrading to >= 0.13.1
 
+#### Changes to availability of DSL methods in filters
+
+The `#declared` method of the route DSL is no longer available in the `before` filter.  Using `declared` in a `before` filter will now raise `Grape::DSL::InsideRoute::MethodNotYetAvailable`.
+
+See [#1074](https://github.com/ruby-grape/grape/issues/1074) for discussion of the issue.
+
 #### Changes to header versioning and invalid header version handling
 
 Identical endpoints with different versions now work correctly. A regression introduced in Grape 0.11.0 caused all but the first-mounted version for such an endpoint to wrongly throw an `InvalidAcceptHeader`. As a side effect, requests with a correct vendor but invalid version can no longer be rescued from a `rescue_from` block.

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -317,6 +317,7 @@ module Grape
           instance_eval(&filter)
         end
       end
+      extend DSL::InsideRoute.post_filter_methods(type)
     end
 
     def befores

--- a/spec/grape/dsl/inside_route_spec.rb
+++ b/spec/grape/dsl/inside_route_spec.rb
@@ -343,8 +343,9 @@ module Grape
       describe '#declared' do
         # see endpoint_spec.rb#declared for spec coverage
 
-        it 'returns an empty hash' do
-          expect(subject.declared({})).to eq({})
+        it 'is not available by default' do
+          expect { subject.declared({}) }.to raise_error(
+            Grape::DSL::InsideRoute::MethodNotYetAvailable)
         end
       end
     end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -239,6 +239,16 @@ describe Grape::Endpoint do
       end
     end
 
+    it 'does not work in a before filter' do
+      subject.before do
+        declared(params)
+      end
+      subject.get('/declared') { declared(params) }
+
+      expect { get('/declared') }.to raise_error(
+        Grape::DSL::InsideRoute::MethodNotYetAvailable)
+    end
+
     it 'has as many keys as there are declared params' do
       inner_params = nil
       subject.get '/declared' do


### PR DESCRIPTION
In response to issue #1074

This adds a mechanism by which Grape::DSL::InsideRoute methods may be
overriden after certain filters are run.

The first problem case of a filter being utilized before it should that
necessitated this enhancement is the `#declared` method, which was
returning un-coerced params in `before` filters.

There may be other problem cases, which may be rectified using this same
mechanism.