### PR TITLE
Fixed edge case regarding Hash with inner param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 #### Fixes
 
+* [#1156](https://github.com/ruby-grape/grape/pull/1156): Fixed `no implicit conversion of Symbol into Integer` with nested `values` validation - [@quickpay](https://github.com/quickpay).
 * [#1153](https://github.com/ruby-grape/grape/pull/1153): Fixes boolean declaration in an external file - [@towanda](https://github.com/towanda).
 * [#1142](https://github.com/ruby-grape/grape/pull/1142): Makes #declared unavailable to before filters - [@jrforrest](https://github.com/jrforrest).
 * [#1114](https://github.com/ruby-grape/grape/pull/1114): Fix regression which broke identical endpoints with different versions - [@suan](https://github.com/suan).

--- a/lib/grape/validations/validators/values.rb
+++ b/lib/grape/validations/validators/values.rb
@@ -7,6 +7,7 @@ module Grape
       end
 
       def validate_param!(attr_name, params)
+        return unless params.is_a?(Hash)
         return unless params[attr_name] || required_for_root_scope?
 
         values = @values.is_a?(Proc) ? @values.call : @values

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -318,6 +318,35 @@ describe Grape::Validations do
       end
     end
 
+    context 'hash with a required param with validation' do
+      before do
+        subject.params do
+          requires :items, type: Hash do
+            requires :key, type: String, values: %w(a b)
+          end
+        end
+        subject.get '/required' do
+          'required works'
+        end
+      end
+
+      it 'errors when param is not a Hash' do
+        get '/required', items: 'not a hash'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('items is invalid, items[key] is missing, items[key] is invalid')
+
+        get '/required', items: [{ key: 'hash in array' }]
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('items is invalid, items[key] does not have a valid value')
+      end
+
+      it 'works when all params match' do
+        get '/required', items: { key: 'a' }
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('required works')
+      end
+    end
+
     context 'group' do
       before do
         subject.params do


### PR DESCRIPTION
This fixes an edge case where the API would blow up with a `"no implicit conversion of Symbol into Integer"`.

To trigger the error, make a param nested inside a `Hash` param and add `values` validations to the param. Then send something that is not a hash to the outer param. (see spec)
