### PR TITLE
Add text content type to redirects

### DIFF
--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -103,6 +103,7 @@ module Grape
           end
         end
         header 'Location', url
+        content_type 'text/plain'
         body ''
       end
 


### PR DESCRIPTION
The redirect helper returned an empty response, which confused the XML and JSON helpers (e.g. when rendering in a browser).

This sets the content type explicitly, which solves that problem. :)