### PR TITLE
fix OPTIONS endpoint with the xml formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#1109](https://github.com/ruby-grape/grape/pull/1109): Memoize Virtus attribute and fix memory leak - [@marshall-lee](https://github.com/marshall-lee).
 * [#1101](https://github.com/intridea/grape/pull/1101): Fix: Incorrect media-type `Accept` header now correctly returns 406 with `strict: true` - [@elliotlarson](https://github.com/elliotlarson).
 * [#1108](https://github.com/ruby-grape/grape/pull/1039): Raise a warning when `desc` is called with options hash and block - [@rngtng](https://github.com/rngtng).
+* [#1159](https://github.com/ruby-grape/grape/pull/1159): Fix OPTIONS body when the XML formatter is enabled - [@urkle](https://github.com/urkle)
 
 0.13.0 (8/10/2015)
 ==================

--- a/lib/grape/formatter/xml.rb
+++ b/lib/grape/formatter/xml.rb
@@ -2,8 +2,9 @@ module Grape
   module Formatter
     module Xml
       class << self
-        def call(object, _env)
+        def call(object, env)
           return object.to_xml if object.respond_to?(:to_xml)
+          return object if env['REQUEST_METHOD'] == 'OPTIONS' && object == ''
           fail Grape::Exceptions::InvalidFormatter.new(object.class, 'xml')
         end
       end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -2810,6 +2810,14 @@ describe Grape::API do
 </error>
 XML
       end
+      it 'OPTIONS request' do
+        subject.get '/example' do
+          'example'
+        end
+        options '/example'
+        expect(last_response.status).to eq(204)
+        expect(last_response.body).to eq ''
+      end
       it 'hash' do
         subject.get '/example' do
           {


### PR DESCRIPTION
- OPTIONS should return no body, thus we need to skip the error handling for that method.