### PR TITLE
Removes double require in spec_helper.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,6 @@ require 'json'
 require 'rack/test'
 require 'base64'
 require 'cookiejar'
-require 'json'
 require 'mime/types'
 
 Dir["#{File.dirname(__FILE__)}/support/*.rb"].each do |file|


### PR DESCRIPTION
This should close https://github.com/ruby-grape/grape/issues/1155.