### PR TITLE
Custom parameter coercion using `coerce_with` #1135

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Your contribution here.
 
+* [#1161](https://github.com/ruby-grape/grape/pull/1161): Custom parameter coercion using `coerce_with` - [@dslh](https://github.com/dslh).
 * [#1134](https://github.com/ruby-grape/grape/pull/1134): Adds a code of conduct - [@towanda](https://github.com/towanda).
 
 #### Fixes

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -62,6 +62,9 @@ module Grape
       #   the :using Hash. The meaning of this depends on if :all or :none was
       #   passed; :all + :except will make the :except fields optional, whereas
       #   :none + :except will make the :except fields required
+      # @option attrs :coerce_with [#parse, #call] method to be used when coercing
+      #   the parameter to the type named by +attrs[:type]. Any class or object
+      #   that defines `::parse` or `::call` may be used.
       #
       # @example
       #

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -180,6 +180,11 @@ module Grape
         # special case (type = coerce)
         validations[:coerce] = validations.delete(:type) if validations.key?(:type)
 
+        # type must be supplied for coerce_with
+        if validations.key?(:coerce_with) && !validations.key?(:coerce)
+          fail ArgumentError, 'must supply type for coerce_with'
+        end
+
         coerce_type = validations[:coerce]
 
         doc_attrs[:type] = coerce_type.to_s if coerce_type
@@ -216,7 +221,12 @@ module Grape
         # whatever coercion so that we are working with correctly
         # type casted values
         if validations.key? :coerce
-          validate('coerce', validations[:coerce], attrs, doc_attrs)
+          coerce_options = {
+            type: validations[:coerce],
+            method: validations[:coerce_with]
+          }
+          validate('coerce', coerce_options, attrs, doc_attrs)
+          validations.delete(:coerce_with)
           validations.delete(:coerce)
         end
 

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -3,6 +3,13 @@ module Grape
     class Base
       attr_reader :attrs
 
+      # Creates a new Validator from options specified
+      # by a +requires+ or +optional+ directive during
+      # parameter definition.
+      # @param attrs [Array] names of attributes to which the Validator applies
+      # @param options [Object] implementation-dependent Validator options
+      # @param required [Boolean] attribute(s) are required or optional
+      # @param scope [ParamsScope] parent scope for this Validator
       def initialize(attrs, options, required, scope)
         @attrs = Array(attrs)
         @option = options


### PR DESCRIPTION
Addresses issue #1135. Adds `coerce_using` option to
`Grape::DSL::Parameters::requires` and `::optional`,
allowing implementors arbitrary coercion uncoupled
from the parameter type.

See README.md#custom-types-and-coercions for usage.