### PR TITLE
First-class JSON parameter type #1135

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Your contribution here.
 
+* [#1163](https://github.com/ruby-grape/grape/pull/1163): First-class `JSON` parameter type - [@dslh](https://github.com/dslh).
 * [#1161](https://github.com/ruby-grape/grape/pull/1161): Custom parameter coercion using `coerce_with` - [@dslh](https://github.com/dslh).
 * [#1134](https://github.com/ruby-grape/grape/pull/1134): Adds a code of conduct - [@towanda](https://github.com/towanda).
 

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -49,21 +49,25 @@ module Grape
       #   the :using hash. The last key can be a hash, which specifies
       #   options for the parameters
       # @option attrs :type [Class] the type to coerce this parameter to before
-      #   passing it to the endpoint. See Grape::ParameterTypes for supported
-      #   types, or use a class that defines `::parse` as a custom type
+      #   passing it to the endpoint. See {Grape::ParameterTypes} for a list of
+      #   types that are supported automatically. Custom classes may be used
+      #   where they define a class-level `::parse` method, or in conjunction
+      #   with the `:coerce_with` parameter. `JSON` may be supplied to denote
+      #   `JSON`-formatted objects or arrays of objects. `Array[JSON]` accepts
+      #   the same values as `JSON` but will wrap single objects in an `Array`.
       # @option attrs :desc [String] description to document this parameter
       # @option attrs :default [Object] default value, if parameter is optional
       # @option attrs :values [Array] permissable values for this field. If any
       #   other value is given, it will be handled as a validation error
       # @option attrs :using [Hash[Symbol => Hash]] a hash defining keys and
-      #   options, like that returned by Grape::Entity#documentation. The value
+      #   options, like that returned by {Grape::Entity#documentation}. The value
       #   of each key is an options hash accepting the same parameters
       # @option attrs :except [Array[Symbol]] a list of keys to exclude from
       #   the :using Hash. The meaning of this depends on if :all or :none was
       #   passed; :all + :except will make the :except fields optional, whereas
       #   :none + :except will make the :except fields required
       # @option attrs :coerce_with [#parse, #call] method to be used when coercing
-      #   the parameter to the type named by +attrs[:type]. Any class or object
+      #   the parameter to the type named by `attrs[:type]`. Any class or object
       #   that defines `::parse` or `::call` may be used.
       #
       # @example

--- a/lib/grape/locale/en.yml
+++ b/lib/grape/locale/en.yml
@@ -35,7 +35,7 @@ en:
         exactly_one: 'are missing, exactly one parameter must be provided'
         all_or_none: 'provide all or none of parameters'
         missing_group_type: 'group type is required'
-        unsupported_group_type: 'group type must be Array or Hash'
+        unsupported_group_type: 'group type must be Array, Hash, JSON or Array[JSON]'
         invalid_message_body:
           problem: "message body does not match declared format"
           resolution:


### PR DESCRIPTION
Addresses issue #1135. Allows `type: JSON` and `type: Array[JSON]`
as options for `Grape::DSL::Parameters::requires` and `::optional`,
allowing convenient handling of parameters supplied as JSON-encoded
strings.

See README.md#first-class-json-types for usage.