### PR TITLE
allow dashes, periods, and other RFC6838-compliant characters in header vendor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Your contribution here.
 
+* [#1170](https://github.com/ruby-grape/grape/pull/1170): Allow dashes and periods in header vendor - [@suan](https://github.com/suan).
 * [#1167](https://github.com/ruby-grape/grape/pull/1167): Convenience wrapper `type: File` for validating multipart file parameters - [@dslh](https://github.com/dslh).
 * [#1167](https://github.com/ruby-grape/grape/pull/1167): Refactor and extend coercion and type validation system - [@dslh](https://github.com/dslh).
 * [#1163](https://github.com/ruby-grape/grape/pull/1163): First-class `JSON` parameter type - [@dslh](https://github.com/dslh).

--- a/README.md
+++ b/README.md
@@ -332,6 +332,17 @@ Using this versioning strategy, clients should pass the desired version in the U
 version 'v1', using: :header, vendor: 'twitter'
 ```
 
+Currently, Grape only supports versioned media types in the following format:
+
+```
+vnd.vendor-and-or-resource-v1234+format
+```
+
+Basically all tokens between the final `-` and the `+` will be interpreted as the version.
+Grape also only supports alphanumerics, periods, and dashes in the vendor/resource/version parts
+of the media type, even though [the appropriate RFC](http://tools.ietf.org/html/rfc6838#section-4.2)
+technically allows far more characters.
+
 Using this versioning strategy, clients should pass the desired version in the HTTP `Accept` head.
 
     curl -H Accept:application/vnd.twitter-v1+json http://localhost:9292/statuses/public_timeline

--- a/spec/grape/middleware/versioner/header_spec.rb
+++ b/spec/grape/middleware/versioner/header_spec.rb
@@ -252,7 +252,7 @@ describe Grape::Middleware::Versioner::Header do
     end
   end
 
-  context 'when there are multiple versions specified with rescue_from :all' do
+  context 'when there are multiple versions with complex vendor specified with rescue_from :all' do
     subject {
       Class.new(Grape::API) do
         rescue_from :all
@@ -261,7 +261,11 @@ describe Grape::Middleware::Versioner::Header do
 
     let(:v1_app) {
       Class.new(Grape::API) do
-        version 'v1', using: :header, vendor: 'test'
+        version 'v1', using: :header, vendor: 'test.a-cool-resource'
+        content_type :v1_test, 'application/vnd.test.a-cool-resource-v1+json'
+        formatter :v1_test, ->(object, _) { object }
+        format :v1_test
+
         resources :users do
           get :hello do
             'one'
@@ -272,7 +276,11 @@ describe Grape::Middleware::Versioner::Header do
 
     let(:v2_app) {
       Class.new(Grape::API) do
-        version 'v2', using: :header, vendor: 'test'
+        version 'v2', using: :header, vendor: 'test.a-cool-resource'
+        content_type :v2_test, 'application/vnd.test.a-cool-resource-v2+json'
+        formatter :v2_test, ->(object, _) { object }
+        format :v2_test
+
         resources :users do
           get :hello do
             'two'
@@ -289,13 +297,13 @@ describe Grape::Middleware::Versioner::Header do
 
     context 'with header versioned endpoints and a rescue_all block defined' do
       it 'responds correctly to a v1 request' do
-        versioned_get '/users/hello', 'v1', using: :header, vendor: 'test'
+        versioned_get '/users/hello', 'v1', using: :header, vendor: 'test.a-cool-resource'
         expect(last_response.body).to eq('one')
         expect(last_response.body).not_to include('API vendor or version not found')
       end
 
       it 'responds correctly to a v2 request' do
-        versioned_get '/users/hello', 'v2', using: :header, vendor: 'test'
+        versioned_get '/users/hello', 'v2', using: :header, vendor: 'test.a-cool-resource'
         expect(last_response.body).to eq('two')
         expect(last_response.body).not_to include('API vendor or version not found')
       end


### PR DESCRIPTION
The current accept header parsing logic treats everything after the first `-` as the version, whereas it's not uncommon to have dashes in more complex vendor/resource media type definitions (an IANA-registered example is `application/vnd.ms-office.activeX+xml`)

This change correctly handles dashes in the vendor part, while still assuming what's after the last dash is the version.

The current logic also doesn't allow underscores, ampersands, etc, which are allowed media type characters per [RFC 6838](http://tools.ietf.org/html/rfc6838#section-4.2). This change makes Grape itself handle these characters correctly, however for them to actually work is contingent on https://github.com/mjackson/rack-accept/pull/17 which unfortunately has been open for more than 6 months (I'll ping maintainer again, but any weight you can throw around there would also be appreciated :smile:)

_P/S: It should be noted that the current header versioning logic is very limited and doesn't support formats such as `application/vnd.github.v3+json` (as what [github uses now](https://developer.github.com/v3/media/#request-specific-version)) I'll try to add a caveat in the README while I add the CHANGELOG entry for this_