### PR TITLE
Removes redundant nil? check.

### DIFF
--- a/lib/grape/dsl/configuration.rb
+++ b/lib/grape/dsl/configuration.rb
@@ -97,7 +97,7 @@ module Grape
 
       # Merge multiple layers of settings into one hash.
       def stacked_hash_to_hash(settings)
-        return nil if settings.nil? || settings.blank?
+        return nil if settings.blank?
         settings.each_with_object({}) { |value, result| result.deep_merge!(value) }
       end
 

--- a/lib/grape/util/content_types.rb
+++ b/lib/grape/util/content_types.rb
@@ -10,7 +10,7 @@ module Grape
     }
 
     def self.content_types_for_settings(settings)
-      return nil if settings.nil? || settings.blank?
+      return nil if settings.blank?
 
       settings.each_with_object({}) { |value, result| result.merge!(value) }
     end


### PR DESCRIPTION
If we are calling ```.blank?```, calling ```.nil?``` first is redundant.