### PR TITLE
Use formatters for custom vendored content types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 #### Fixes
 
+* [#1185](https://github.com/ruby-grape/grape/pull/1185): Use formatters for custom vendored content types - [@tylerdooling](https://github.com/tylerdooling).
 * [#1156](https://github.com/ruby-grape/grape/pull/1156): Fixed `no implicit conversion of Symbol into Integer` with nested `values` validation - [@quickpay](https://github.com/quickpay).
 * [#1153](https://github.com/ruby-grape/grape/pull/1153): Fixes boolean declaration in an external file - [@towanda](https://github.com/towanda).
 * [#1142](https://github.com/ruby-grape/grape/pull/1142): Makes #declared unavailable to before filters - [@jrforrest](https://github.com/jrforrest).

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -167,7 +167,7 @@ module Grape
 
         accept.scan(accept_into_mime_and_quality)
           .sort_by { |_, quality_preference| -quality_preference.to_f }
-          .map { |mime, _| mime.sub(vendor_prefix_pattern, '') }
+          .flat_map { |mime, _| [mime, mime.sub(vendor_prefix_pattern, '')] }
       end
     end
   end

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -132,6 +132,18 @@ describe Grape::Middleware::Formatter do
       expect(subject.env['api.format']).to eq(:xml)
     end
 
+    context 'with custom vendored content types' do
+      before do
+        subject.options[:content_types] = {}
+        subject.options[:content_types][:custom] = 'application/vnd.test+json'
+      end
+
+      it 'it uses the custom type' do
+        subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/vnd.test+json')
+        expect(subject.env['api.format']).to eq(:custom)
+      end
+    end
+
     it 'parses headers with symbols as hash keys' do
       subject.call('PATH_INFO' => '/info', 'http_accept' => 'application/xml', system_time: '091293')
       expect(subject.env[:system_time]).to eq('091293')
@@ -156,6 +168,16 @@ describe Grape::Middleware::Formatter do
       subject.options[:content_types][:custom] = 'application/x-custom'
       _, headers, = subject.call('PATH_INFO' => '/info.custom')
       expect(headers['Content-type']).to eq('application/x-custom')
+    end
+    it 'is set for vendored with registered type' do
+      subject.options[:content_types] = {}
+      subject.options[:content_types][:custom] = 'application/vnd.test+json'
+      _, headers, = subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/vnd.test+json')
+      expect(headers['Content-type']).to eq('application/vnd.test+json')
+    end
+    it 'is set to closest generic for custom vendored/versioned without registered type' do
+      _, headers, = subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/vnd.test+json')
+      expect(headers['Content-type']).to eq('application/json')
     end
   end
 


### PR DESCRIPTION
## Summary
When using custom vendored content types the specified formatters were not being used because only the generalized type was being made available to match.

`Grape::Middleware::Formatter#mime_array` - when provided with accept header `application/vnd.mycompany.upcase+txt` - has previously returned 
``` ruby
[ 'application/txt']
```
and now returns 
``` ruby
['application/vnd.mycompany.upcase+txt',  'application/txt']
``` 
This allows `Grape::Middleware::Formatter#format_from_header` to match the custom type and proceed to use the custom formatter.

### Example
```ruby
class Hello < Grape::API
  content_type :upcase, 'application/vnd.mycompany.upcase+txt'
  formatter :upcase, ->(obj, env){ obj.upcase }
  content_type :dashed, 'application/vnd.mycompany.dashed+txt'
  formatter :dashed, ->(obj, env){ obj.tr(' ', '-') }

  get :test do
    'hello world'
  end
end
```

```bash
# Before
$ curl localhost:9292/test -H 'Accept: application/vnd.mycompany.upcase+txt'
# status 406

$ curl localhost:9292/test -H 'Accept: application/vnd.mycompany.dashed+txt'
# status 406

# After
$ curl localhost:9292/test -H 'Accept: application/vnd.mycompany.upcase+txt'
# Content-Type: application/vnd.mycompany.upcase+txt
# HELLO WORLD

$ curl localhost:9292/test -H 'Accept: application/vnd.mycompany.dashed+txt'
# Content-Type: application/vnd.mycompany.dashed+txt
# hello-world
```