### PR TITLE
add possibility to automatically load user-defined validators(a.k.a custom)

### DIFF
--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -173,6 +173,7 @@ require 'grape/validations/validators/presence'
 require 'grape/validations/validators/regexp'
 require 'grape/validations/validators/values'
 require 'grape/validations/params_scope'
+require 'grape/validations/autoload'
 require 'grape/validations/validators/all_or_none'
 require 'grape/validations/types'
 

--- a/lib/grape/validations/autoload.rb
+++ b/lib/grape/validations/autoload.rb
@@ -1,0 +1,52 @@
+module Grape
+  module Validations
+    class Autoload
+      DEFAULT_PATH = %w(api validators)
+
+      def initialize(api)
+        @api = api
+        @loaded_validators = []
+      end
+
+      def try_load(name)
+        return nil unless defined?(::ActiveSupport::Dependencies)
+
+        name = name.to_s
+        inner_path   = File.join(@api.to_s.deconstantize.underscore, 'validators', name).to_s
+        default_path = File.join(DEFAULT_PATH, name).to_s
+
+        found_path = [inner_path, default_path].find do |path|
+          begin
+            require_dependency(path)
+            mark_as_loaded(name)
+            update_before_remove_const_callback(path)
+
+            true
+          rescue LoadError
+            nil
+          end
+        end
+        (found_path && found_path.classify.constantize) || nil
+      end
+
+      private
+
+      def mark_as_loaded(name)
+        @loaded_validators << name
+      end
+
+      def update_before_remove_const_callback(path)
+        parent_const = path.classify.split('::').first.constantize
+
+        # see ActiveSupport::Dependencies.remove_unloadable_constants!
+        parent_const.class.class_eval %{
+          def before_remove_const
+            #{@loaded_validators}.each do |validator_name|
+              Grape::Validations.validators.delete(validator_name)
+            end
+          end
+        }
+      end
+    end
+  end
+end

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -271,7 +271,7 @@ module Grape
       end
 
       def validate(type, options, attrs, doc_attrs)
-        validator_class = Validations.validators[type.to_s]
+        validator_class = Validations.validators[type.to_s] || custom_validator_autoload.try_load(type)
 
         if validator_class
           value = validator_class.new(attrs, options, doc_attrs[:required], self)
@@ -291,6 +291,10 @@ module Grape
         end
         return unless value_types.any? { |v| !v.is_a?(coerce_type) }
         fail Grape::Exceptions::IncompatibleOptionValues.new(:type, coerce_type, :values, values)
+      end
+
+      def custom_validator_autoload
+        @custom_validator_autoload ||= Autoload.new(@api)
       end
     end
   end

--- a/spec/grape/integration/custom_validators_autoload/api/validators/custom.rb
+++ b/spec/grape/integration/custom_validators_autoload/api/validators/custom.rb
@@ -1,0 +1,9 @@
+module Api
+  module Validators
+    class Custom < Grape::Validations::Base
+      def validate_param!(attr_name, params)
+        params[attr_name] = 'custom_validated'
+      end
+    end
+  end
+end

--- a/spec/grape/integration/custom_validators_autoload_spec.rb
+++ b/spec/grape/integration/custom_validators_autoload_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe 'custom validators autoloading based on ActiveSupport::Dependencies' do
+  before(:all) do
+    require 'active_support/dependencies'
+  end
+
+  subject { Class.new(Grape::API) }
+
+  def app
+    subject
+  end
+
+  shared_examples 'raise an exception for an unknown validator' do |validator_name|
+    it 'raises Grape::Exceptions::UnknownValidator' do
+      expect {
+        subject.params do
+          requires :param, validator_name => true
+        end
+      }.to raise_error(Grape::Exceptions::UnknownValidator)
+    end
+  end
+
+  context 'autoload paths are defined' do
+    before do
+      ActiveSupport::Dependencies.autoload_paths << File.expand_path('spec/grape/integration/custom_validators_autoload/')
+    end
+
+    it 'load and applies the custom validator if it exists in autoload paths' do
+      subject.params do
+        requires :param, custom: true
+      end
+      subject.get do
+        params[:param]
+      end
+
+      get '/', param: 'some_param'
+      expect(last_response.body).to eq 'custom_validated'
+    end
+
+    it_behaves_like 'raise an exception for an unknown validator', :not_custom
+  end
+
+  context 'autoload paths are empty' do
+    before do
+      ActiveSupport::Dependencies.autoload_paths = []
+    end
+
+    it_behaves_like 'raise an exception for an unknown validator', :some_validator
+  end
+end

--- a/spec/grape/validations/autoload_spec.rb
+++ b/spec/grape/validations/autoload_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+describe Grape::Validations::Autoload do
+  let(:fake_api) { stub_const('MyApp::Api::V2::Resourses', Class.new) }
+  let(:api_base_path) { 'my_app/api/v2' }
+
+  subject { described_class.new(fake_api) }
+
+  describe '#try_load' do
+    let(:validator_name) { :custom }
+    let(:validator_path_for_api) { "#{api_base_path}/validators/#{validator_name}" }
+    let(:common_validator_path) { "api/validators/#{validator_name}" }
+
+    context 'ActiveSupport::Dependencies is undefined' do
+      it { expect(subject.try_load(:some_validator)).to be_nil }
+    end
+
+    context 'ActiveSupport::Dependencies is defined' do
+      let!(:active_support_dependencies) { stub_const('::ActiveSupport::Dependencies', Class.new) }
+
+      context 'validator search paths' do
+        let!(:custom_validator_for_api) { stub_const('MyApp::Api::V2::Validators::Custom', Class.new) }
+        let!(:common_custom_validator) { stub_const('Api::Validators::Custom', Class.new) }
+
+        it 'requires the dependency using file path based on the api namespace' do
+          expect(subject).to receive(:require_dependency).with(validator_path_for_api)
+          subject.try_load(validator_name)
+        end
+
+        context 'the dependency based on the api namespace is not found' do
+          before do
+            allow(subject).to receive(:require_dependency).with(validator_path_for_api).and_raise(LoadError)
+          end
+
+          it 'requires the dependency from the default path "api/validators"' do
+            expect(subject).to receive(:require_dependency).with(common_validator_path)
+            subject.try_load(validator_name)
+          end
+        end
+      end
+
+      context 'the required dependency is not found' do
+        before do
+          allow(subject).to receive(:require_dependency).and_raise(LoadError)
+        end
+
+        it { expect(subject.try_load(:some_validator)).to be_nil }
+      end
+
+      context 'the required dependency is found' do
+        let!(:expected_validator_constant) { stub_const('MyApp::Api::V2::Validators::Custom', Class.new) }
+        let(:validator_name) { :custom }
+
+        before do
+          allow(subject).to receive(:require_dependency).with("my_app/api/v2/validators/#{validator_name}").and_return(true)
+        end
+
+        it 'returns the validator constant' do
+          expect(subject.try_load(validator_name)).to eq(expected_validator_constant)
+        end
+
+        context 'using the default path' do
+          let!(:expected_validator_constant) { stub_const('Api::Validators::MyValidator', Class.new) }
+          let(:validator_name) { :my_validator }
+
+          before do
+            allow(subject).to receive(:require_dependency).with("my_app/api/v2/validators/#{validator_name}").and_raise(LoadError)
+            allow(subject).to receive(:require_dependency).with("api/validators/#{validator_name}").and_return(true)
+          end
+
+          it 'returns the validator constant' do
+            expect(subject.try_load(validator_name)).to eq(expected_validator_constant)
+          end
+        end
+
+        it 'sets ActiveSupport::Dependencies "before_remove_const" callback to the parent constant' do
+          subject.try_load(validator_name)
+          expect(MyApp).to respond_to(:before_remove_const)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
the solution relies on ActiveSupport::Dependencies, so it works for Grape app mounted on Rails by default.

``` bash
 --app
   --controllers
     --api
       --validators
         custom.rb
```

``` ruby
params do
   requires :my_param, custom: true
end
```

on the dev enviroment the code of custom validator is refreshed as any other dependency

"proof-of-concept" that we discussed in #1178
