### PR TITLE
Bypass formatting for statuses with no entity-body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Your contribution here.
 
+* [#1190](https://github.com/ruby-grape/grape/putt/1190): Bypass formatting for statuses with no entity-body - [@tylerdooling](https://github.com/tylerdooling).
 * [#1188](https://github.com/ruby-grape/grape/putt/1188): Allow parameters with more than one type - [@dslh](https://github.com/dslh).
 * [#1179](https://github.com/ruby-grape/grape/pull/1179): Allow all RFC6838 valid characters in header vendor - [@suan](https://github.com/suan).
 * [#1170](https://github.com/ruby-grape/grape/pull/1170): Allow dashes and periods in header vendor - [@suan](https://github.com/suan).

--- a/README.md
+++ b/README.md
@@ -1976,6 +1976,11 @@ Built-in formatters are the following.
 * `:serializable_hash`: use object's `serializable_hash` when available, otherwise fallback to `:json`
 * `:binary`: data will be returned "as is"
 
+Response statuses that indicate no content as defined by [Rack](https://github.com/rack)
+[here](https://github.com/rack/rack/blob/master/lib/rack/utils.rb#L567)
+will bypass serialization and the body entity - though there should be none -
+will not be modified.
+
 ### JSONP
 
 Grape supports JSONP via [Rack::JSONP](https://github.com/rack/rack-contrib), part of the

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -15,6 +15,14 @@ Identical endpoints with different versions now work correctly. A regression int
 
 See [#1114](https://github.com/ruby-grape/grape/pull/1114) for more information.
 
+#### Bypasses formatters when status code indicates no content
+
+To be consistent with rack and it's handling of standard responses
+associated with no content, both default and custom formatters will now
+be bypassed when processing responses for status codes defined [by rack](https://github.com/rack/rack/blob/master/lib/rack/utils.rb#L567)
+
+See [#1190](https://github.com/ruby-grape/grape/pull/1190) for more information.
+
 ### Upgrading to >= 0.12.0
 
 #### Changes in middleware

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -20,6 +20,7 @@ module Grape
 
       def after
         status, headers, bodies = *@app_response
+        return @app_response if Rack::Utils::STATUS_WITH_NO_ENTITY_BODY.include?(status)
 
         if bodies.is_a?(Grape::Util::FileResponse)
           headers = ensure_content_type(headers)

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -20,37 +20,37 @@ module Grape
 
       def after
         status, headers, bodies = *@app_response
-        return @app_response if Rack::Utils::STATUS_WITH_NO_ENTITY_BODY.include?(status)
 
-        if bodies.is_a?(Grape::Util::FileResponse)
-          headers = ensure_content_type(headers)
-
-          response =
-            Rack::Response.new([], status, headers) do |resp|
-              resp.body = bodies.file
-            end
+        if Rack::Utils::STATUS_WITH_NO_ENTITY_BODY.include?(status)
+          @app_response
         else
-          # Allow content-type to be explicitly overwritten
-          api_format = mime_types[headers[Grape::Http::Headers::CONTENT_TYPE]] || env[Grape::Env::API_FORMAT]
-          formatter = Grape::Formatter::Base.formatter_for(api_format, options)
-
-          begin
-            bodymap = bodies.collect do |body|
-              formatter.call(body, env)
-            end
-
-            headers = ensure_content_type(headers)
-
-            response = Rack::Response.new(bodymap, status, headers)
-          rescue Grape::Exceptions::InvalidFormatter => e
-            throw :error, status: 500, message: e.message
-          end
+          build_formatted_response(status, headers, bodies)
         end
-
-        response
       end
 
       private
+
+      def build_formatted_response(status, headers, bodies)
+        headers = ensure_content_type(headers)
+
+        if bodies.is_a?(Grape::Util::FileResponse)
+          Rack::Response.new([], status, headers) do |resp|
+            resp.body = bodies.file
+          end
+        else
+          # Allow content-type to be explicitly overwritten
+          formatter = fetch_formatter(headers, options)
+          bodymap = bodies.collect { |body| formatter.call(body, env) }
+          Rack::Response.new(bodymap, status, headers)
+        end
+      rescue Grape::Exceptions::InvalidFormatter => e
+        throw :error, status: 500, message: e.message
+      end
+
+      def fetch_formatter(headers, options)
+        api_format = mime_types[headers[Grape::Http::Headers::CONTENT_TYPE]] || env[Grape::Env::API_FORMAT]
+        Grape::Formatter::Base.formatter_for(api_format, options)
+      end
 
       # Set the content type header for the API format if it is not already present.
       #

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -537,16 +537,38 @@ describe Grape::API do
       expect(last_response.headers['Content-Type']).to eql 'text/plain'
     end
 
-    it 'adds an OPTIONS route that returns a 204, an Allow header and a X-Custom-Header' do
-      subject.before { header 'X-Custom-Header', 'foo' }
-      subject.get 'example' do
-        'example'
+    describe 'adds an OPTIONS route that' do
+      before do
+        subject.before { header 'X-Custom-Header', 'foo' }
+        subject.get 'example' do
+          'example'
+        end
+        options '/example'
       end
-      options '/example'
-      expect(last_response.status).to eql 204
-      expect(last_response.body).to eql ''
-      expect(last_response.headers['Allow']).to eql 'OPTIONS, GET, HEAD'
-      expect(last_response.headers['X-Custom-Header']).to eql 'foo'
+
+      it 'returns a 204' do
+        expect(last_response.status).to eql 204
+      end
+
+      it 'has an empty body' do
+        expect(last_response.body).to be_blank
+      end
+
+      it 'has an Allow header' do
+        expect(last_response.headers['Allow']).to eql 'OPTIONS, GET, HEAD'
+      end
+
+      it 'has a X-Custom-Header' do
+        expect(last_response.headers['X-Custom-Header']).to eql 'foo'
+      end
+
+      it 'has no Content-Type' do
+        expect(last_response.content_type).to be_nil
+      end
+
+      it 'has no Content-Length' do
+        expect(last_response.content_length).to be_nil
+      end
     end
 
     it 'allows HEAD on a GET request' do

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -201,6 +201,18 @@ describe Grape::Middleware::Formatter do
     end
   end
 
+  context 'no content responses' do
+    let(:no_content_response) { ->(status) { [status, {}, ['']] } }
+
+    Rack::Utils::STATUS_WITH_NO_ENTITY_BODY.each do |status|
+      it "does not modify a #{status} response" do
+        expected_response = no_content_response[status]
+        allow(app).to receive(:call).and_return(expected_response)
+        expect(subject.call({})).to eq(expected_response)
+      end
+    end
+  end
+
   context 'input' do
     %w(POST PATCH PUT DELETE).each do |method|
       ['application/json', 'application/json; charset=utf-8'].each do |content_type|


### PR DESCRIPTION
## tl;dr;
Allow the formatter middleware to bypass serialization of response bodies when the status indicates there is no content.

## Background
#1162 describes a scenario where `OPTIONS` requests and redirects can raise exceptions when content types are limited to those that don't consider `''` as valid or are not prepared to handle it.  The specific example given involved content types being limited (or set by default) to XML. `''` is not consider to be valid XML and as such results in an error when serialization is attempted. 

A resolution was proposed to handle this in the formatters by checking the request method.  It seems - and was suggested - that this opens up the scope of concern for the formatters too much and I agree. Additionally, it places a burden on all custom formatters to account for responses intended to have no content - like the OPTIONS request in question.

## Process
I initially referenced the RFC to determine the best course of action, and found this:
> A 200 response SHOULD include any header fields that indicate optional features implemented by the server and applicable to that resource (e.g., Allow), possibly including extensions not defined by this specification. The response body, if any, SHOULD also include information about the communication options. The format for such a body is not defined by this specification, but might be defined by future extensions to HTTP. Content negotiation MAY be used to select the appropriate response format. If no response body is included, the response MUST include a Content-Length field with a field-value of "0".

This indicates that while the specification for a response body is not defined in the RFC, it is most certainly allowed given that the status code is `200` and should ideally be accounted for. This led me to begin ensuring that `OPTIONS` requests could be serialized appropriately by the formatter middleware, which led to ideas involving a special representation of no content that could be checked conditioned there.

When thinking through this and beginning to write some tests, I found that I was unable to get the content type to persist in the response.  This led me to [Rack](https://github.com/rack/rack) where I found [this](https://github.com/rack/rack/blob/master/lib/rack/response.rb#L63):

```ruby
 if [204, 205, 304].include?(status.to_i)
   header.delete CONTENT_TYPE
   header.delete CONTENT_LENGTH
   close
   [status.to_i, header, []]
 else
   [status.to_i, header, BodyProxy.new(self){}]
 end
```
After some additional digging I found that `Rack::Lint` takes it a step further and does not consider a response to be valid if it has content information and it's status code is included in `Rack::Utils::STATUS_WITH_NO_ENTITY_BODY`.
- https://github.com/rack/rack/blob/master/lib/rack/lint.rb#L659
- https://github.com/rack/rack/blob/master/lib/rack/lint.rb#L673

## Proposal
Using these observations, my proposal here is to condition the formatter middleware to look for response statuses that indicate a content body in not appropriate and make the decision to bypass serialization.

This allows for both `OPTIONS` routes that return a `200` with a serialized body based on normal content negotiation, and for the default `OPTIONS` route that is auto-generated by the framework which returns a `204` and no content and does add additional concerns to each default and custom formatter.

Additionally, I believe this addresses the second issue in #1162 involving a similar issue with redirects.