### PR TITLE
Fixed regexp that match unintended string in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,7 +684,7 @@ You can define validations and coercion options for your parameters using a `par
 ```ruby
 params do
   requires :id, type: Integer
-  optional :text, type: String, regexp: /^[a-z]+$/
+  optional :text, type: String, regexp: /\A[a-z]+\z/
   group :media do
     requires :url
   end
@@ -1152,7 +1152,7 @@ end
 ```ruby
 class AlphaNumeric < Grape::Validations::Base
   def validate_param!(attr_name, params)
-    unless params[attr_name] =~ /^[[:alnum:]]+$/
+    unless params[attr_name] =~ /\A[[:alnum:]]+\z/
       fail Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: 'must consist of alpha-numeric characters'
     end
   end


### PR DESCRIPTION
1. In ruby, regexp default mode is multiline mode.
2. [[:alnum:]] don't match only ascii character. it match also multibyte character.

for example.

about 1.
```ruby
$ irb
2.2.1 :001 > "aaaa\nbbbb\nccc" =~ /^b+$/
 => 5
2.2.1 :002 > "aaaa\nbbbb\nccc" =~ /\Ab+\z/
 => nil
```

about 2.
```ruby
$ irb
2.2.1 :001 > "あ" =~ /\A[[:alnum:]]+\z/
 => 0
2.2.1 :002 > "A" =~ /\A[[:alnum:]]+\z/
 => 0
```

I think that it may become vulnerability.
so, it is better to quit as a sample.