### PR TITLE
Redirect as plain text with message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 #### Fixes
 
+* [#1194](https://github.com/ruby-grape/grape/pull/1194): Redirect as plain text with message - [@tylerdooling](https://github.com/tylerdooling).
 * [#1185](https://github.com/ruby-grape/grape/pull/1185): Use formatters for custom vendored content types - [@tylerdooling](https://github.com/tylerdooling).
 * [#1156](https://github.com/ruby-grape/grape/pull/1156): Fixed `no implicit conversion of Symbol into Integer` with nested `values` validation - [@quickpay](https://github.com/quickpay).
 * [#1153](https://github.com/ruby-grape/grape/pull/1153): Fixes boolean declaration in an external file - [@towanda](https://github.com/towanda).

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -23,6 +23,15 @@ be bypassed when processing responses for status codes defined [by rack](https:/
 
 See [#1190](https://github.com/ruby-grape/grape/pull/1190) for more information.
 
+#### Redirects respond as plain text with message
+
+`#redirect` now uses `text/plain` regardless of whether that format has
+been enabled. This prevents formatters from attempting to serialize the
+message body and allows for a descriptive message body to be provided - and
+optionally overridden - that better fulfills the theme of the HTTP spec.
+
+See [#1194](https://github.com/ruby-grape/grape/pull/1194) for more information.
+
 ### Upgrading to >= 0.12.0
 
 #### Changes in middleware

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -91,19 +91,25 @@ module Grape
       # @param url [String] The url to be redirect.
       # @param options [Hash] The options used when redirect.
       #                       :permanent, default false.
+      #                       :body, default a short message including the URL.
       def redirect(url, options = {})
-        merged_options = options.reverse_merge(permanent: false)
-        if merged_options[:permanent]
+        permanent = options.fetch(:permanent, false)
+        body_message = options.fetch(:body, nil)
+        if permanent
           status 301
+          body_message ||= "This resource has been moved permanently to #{url}."
         else
           if env[Grape::Http::Headers::HTTP_VERSION] == 'HTTP/1.1' && request.request_method.to_s.upcase != Grape::Http::Headers::GET
             status 303
+            body_message ||= "An alternate resource is located at #{url}."
           else
             status 302
+            body_message ||= "This resource has been moved temporarily to #{url}."
           end
         end
         header 'Location', url
-        body ''
+        content_type 'text/plain'
+        body body_message
       end
 
       # Set or retrieve the HTTP status code.

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -752,7 +752,7 @@ describe Grape::Endpoint do
       get '/hey'
       expect(last_response.status).to eq 302
       expect(last_response.headers['Location']).to eq '/ha'
-      expect(last_response.body).to eq ''
+      expect(last_response.body).to eq 'This resource has been moved temporarily to /ha.'
     end
 
     it 'has status code 303 if it is not get request and it is http 1.1' do
@@ -762,6 +762,7 @@ describe Grape::Endpoint do
       post '/hey', {}, 'HTTP_VERSION' => 'HTTP/1.1'
       expect(last_response.status).to eq 303
       expect(last_response.headers['Location']).to eq '/ha'
+      expect(last_response.body).to eq 'An alternate resource is located at /ha.'
     end
 
     it 'support permanent redirect' do
@@ -771,7 +772,15 @@ describe Grape::Endpoint do
       get '/hey'
       expect(last_response.status).to eq 301
       expect(last_response.headers['Location']).to eq '/ha'
-      expect(last_response.body).to eq ''
+      expect(last_response.body).to eq 'This resource has been moved permanently to /ha.'
+    end
+
+    it 'allows for an optional redirect body override' do
+      subject.get('/hey') do
+        redirect '/ha', body: 'test body'
+      end
+      get '/hey'
+      expect(last_response.body).to eq 'test body'
     end
   end
 


### PR DESCRIPTION
## Summary
This change forces redirect to use a content type of `text/plain` to both bypass any serialization attempts by the formatters and more closely meet the spec defined for [redirection](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3).

## Backstory
Original issue #1157.  Related issues #1162, #1159

The original issue here was concerned with the XML formatter attempting to serialize an empty body when an redirect was invoked. The situation can happen when an API is limited to XML only, or when XML is supported and requested.

## The spec
[The HTTP spec for redirection](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3) states:
> Unless the request method was HEAD, the entity of the response SHOULD contain a short hypertext note with a hyperlink to the new URI(s).

I interpret this as indicating that a message body is preferred when responding with a redirect for statuses `301, 302, 303`.

## Proposal
In #1162 I brought up a couple of ideas to address this problem:
- set the body of a redirect to an object that supports all default serializations - `#to_json`, `#to_xml`, `#to_s` - and allow the client to negotiate the content type
- default redirect to use `text/plain` and allow the user to override when invoked

As I though about it over the weekend a third option seemed to make sense - really a derivation of the second above - where we just simple force the content type to `text/plain` and add a nicely formed message that fulfills the theme of the spec.

This is relatively safe in that it doesn't limit the framework from supporting optional extensions for redirects in the future. The biggest gain I think is that it removes complication for 99% of the users out there as it will 'just work' as I believe they'll expect it to even if they choose to limit or customize content types.

Hopefully this will work or at least spark a solution. Please let me know if you all have better ideas.