### PR TITLE
Allow multiple before_each block

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,7 +22,7 @@ Metrics/BlockNesting:
 # Offense count: 5
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 250
+  Max: 253
 
 # Offense count: 23
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Your contribution here.
 
+* [#1196](https://github.com/ruby-grape/grape/pull/1196): Allow multiple before each blocks- [@huynhquancam](https://github.com/huynhquancam).
 * [#1190](https://github.com/ruby-grape/grape/putt/1190): Bypass formatting for statuses with no entity-body - [@tylerdooling](https://github.com/tylerdooling).
 * [#1188](https://github.com/ruby-grape/grape/putt/1188): Allow parameters with more than one type - [@dslh](https://github.com/dslh).
 * [#1179](https://github.com/ruby-grape/grape/pull/1179): Allow all RFC6838 valid characters in header vendor - [@suan](https://github.com/suan).

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -13,14 +13,15 @@ module Grape
 
     class << self
       def before_each(new_setup = false, &block)
+        @before_each ||= []
         if new_setup == false
           if block_given?
-            @before_each = block
+            @before_each << block
           else
             return @before_each
           end
         else
-          @before_each = new_setup
+          @before_each = [new_setup]
         end
       end
 
@@ -226,7 +227,9 @@ module Grape
 
         cookies.read(@request)
 
-        self.class.before_each.call(self) if self.class.before_each
+        self.class.before_each.each do |blk|
+          blk.call(self) if blk.respond_to?(:call)
+        end if self.class.before_each.size > 0
 
         run_filters befores, :before
 


### PR DESCRIPTION
Hi forks,

Currently if I stub `first_method` and `second_method` in different before_each blocks, only the `second_method` got stubbed.

```ruby
describe "GET /users/me' do
  it 'returns user information" do
    Grape::Endpoint.before_each do |endpoint|
      allow(endpoint).to receive(:authenticate_user!).and_return(true)
    end

    Grape::Endpoint.before_each do |endpoint|
      allow(endpoint).to receive(:user).and_return(someone)
    end
   
    get '/users/me'
  end
end
```

Can Grape support this? I have added some code as well as tests.