### PR TITLE
Don't call builder on every request.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ Lint/NestedMethodDefinition:
 
 # Offense count: 37
 Metrics/AbcSize:
-  Max: 46
+  Max: 51
 
 # Offense count: 1
 Metrics/BlockNesting:
@@ -36,7 +36,7 @@ Metrics/LineLength:
 # Offense count: 42
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 35
+  Max: 36
 
 # Offense count: 8
 # Configuration parameters: CountComments.


### PR DESCRIPTION
Hello!

This is an attempt to fix a most wrong thing in Grape: middleware stack is initializing *on every request* and even more Grape `dup` them when they're called.

I don't know should it be merged or not. It might break someone's code even when specs are green.