### PR TITLE
Allow custom coercion failure messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#1390](https://github.com/ruby-grape/grape/pull/1390): Allow inserting middleware at arbitrary points in the middleware stack - [@Rosa](https://github.com/Rosa).
 * [#1366](https://github.com/ruby-grape/grape/pull/1366): Store `message_key` on `Grape::Exceptions::Validation` - [@mkou](https://github.com/mkou).
 * [#1398](https://github.com/ruby-grape/grape/pull/1398): Added `rescue_from :grape_exceptions` - allow Grape to use the built-in `Grape::Exception` handing and use `rescue :all` behavior for everything else - [@mmclead](https://github.com/mmclead).
+* [#1203](https://github.com/ruby-grape/grape/pull/1203): Allow custom coercion failure messages - [@zuk](https://github.com/zuk).
 * Your contribution here.
  
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -803,7 +803,9 @@ Aside from the default set of supported types listed above, any class can be
 used as a type so long as an explicit coercion method is supplied. If the type
 implements a class-level `parse` method, Grape will use it automatically.
 This method must take one string argument and return an instance of the correct
-type, or raise an exception to indicate the value was invalid. E.g.,
+type. An exception raised inside the `parse` method will be reported as a validation
+failure with a generic error message. To report a custom error message, return an
+`InvalidValue` initialized with the custom message. E.g.,
 
 ```ruby
 class Color
@@ -813,8 +815,11 @@ class Color
   end
 
   def self.parse(value)
-    fail 'Invalid color' unless %w(blue red green).include?(value)
-    new(value)
+    if  %w(blue red green).include?(value)
+      new(value)
+    else
+      Grape::Validations::Types::InvalidValue.new "is not a valid color"
+    end
   end
 end
 

--- a/lib/grape/validations/types.rb
+++ b/lib/grape/validations/types.rb
@@ -24,7 +24,12 @@ module Grape
     module Types
       # Instances of this class may be used as tokens to denote that
       # a parameter value could not be coerced.
-      class InvalidValue; end
+      class InvalidValue
+        attr_reader :message
+        def initialize(message = nil)
+          @message = message
+        end
+      end
 
       # Types representing a single value, which are coerced through Virtus
       # or special logic in Grape.

--- a/lib/grape/validations/validators/coerce.rb
+++ b/lib/grape/validations/validators/coerce.rb
@@ -13,8 +13,16 @@ module Grape
       def validate_param!(attr_name, params)
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:coerce) unless params.is_a? Hash
         new_value = coerce_value(params[attr_name])
-        raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:coerce) unless valid_type?(new_value)
-        params[attr_name] = new_value
+        if valid_type?(new_value)
+          params[attr_name] = new_value
+        else
+          bad_value = new_value
+          if bad_value.is_a?(Types::InvalidValue) && !bad_value.message.nil?
+            fail Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: bad_value.message.to_s
+          else
+            fail Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message_key: :coerce
+          end
+        end
       end
 
       private


### PR DESCRIPTION
Currently if something goes wrong inside a custom param type's `.parse` method, the only feedback in the resulting validation failure response is a generic `"____ is invalid"` message. This pull request allows custom coercion failure messages by having the `.parse` method return an `InvalidValue` initialized with the failure message.

For example:

``` ruby
class Color
  attr_reader :value
  def initialize(color)
    @value = color
  end

  def self.parse(value)
    if  %w(blue red green).include?(value)
      new(value)
    else
      Grape::Validations::Types::InvalidValue.new "is not a valid color"
    end
  end
end

# ...

params do
  requires :color, type: Color, default: Color.new('blue')
end

get '/stuff' do
  # params[:color] is already a Color.
  params[:color].value
end
```
