### PR TITLE
Ditch each_with_object

### DIFF
--- a/benchmark/simple.rb
+++ b/benchmark/simple.rb
@@ -1,6 +1,6 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'grape'
-require 'benchmark'
+require 'benchmark/ips'
 
 class API < Grape::API
   prefix :api
@@ -20,12 +20,8 @@ env = Rack::MockRequest.env_for('/api/v1', options)
   env["HTTP_HEADER#{i}"] = '123'
 end
 
-iters = 5000
-
-Benchmark.bm do |bm|
-  bm.report('simple') do
-    iters.times do
-      API.call env
-    end
+Benchmark.ips do |ips|
+  ips.report('simple') do
+    API.call env
   end
 end

--- a/grape.gemspec
+++ b/grape.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack-contrib'
   s.add_development_dependency 'mime-types'
   s.add_development_dependency 'appraisal'
+  s.add_development_dependency 'benchmark-ips'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/grape/formatter/serializable_hash.rb
+++ b/lib/grape/formatter/serializable_hash.rb
@@ -21,9 +21,11 @@ module Grape
           elsif object.is_a?(Array) && !object.map { |o| o.respond_to? :serializable_hash }.include?(false)
             object.map(&:serializable_hash)
           elsif object.is_a?(Hash)
-            object.each_with_object({}) do |(k, v), h|
+            h = {}
+            object.each_pair do |k, v|
               h[k] = serialize(v)
             end
+            h
           else
             object
           end

--- a/lib/grape/middleware/base.rb
+++ b/lib/grape/middleware/base.rb
@@ -55,9 +55,11 @@ module Grape
       end
 
       def mime_types
-        content_types.each_with_object({}) do |(k, v), types_without_params|
+        types_without_params = {}
+        content_types.each_pair do |k, v|
           types_without_params[v.split(';').first] = k
         end
+        types_without_params
       end
     end
   end

--- a/lib/grape/request.rb
+++ b/lib/grape/request.rb
@@ -2,27 +2,39 @@ module Grape
   class Request < Rack::Request
     HTTP_PREFIX = 'HTTP_'.freeze
 
+    alias_method :rack_params, :params
+
     def params
-      @params ||= begin
-        params = Hashie::Mash.new(super)
-        if env[Grape::Env::RACK_ROUTING_ARGS]
-          args = env[Grape::Env::RACK_ROUTING_ARGS].dup
-          # preserve version from query string parameters
-          args.delete(:version)
-          args.delete(:route_info)
-          params.deep_merge!(args)
-        end
-        params
-      end
+      @params ||= build_params
     end
 
     def headers
-      @headers ||= env.each_with_object({}) do |(k, v), h|
+      @headers ||= build_headers
+    end
+
+    private
+
+    def build_params
+      params = Hashie::Mash.new(rack_params)
+      if env[Grape::Env::RACK_ROUTING_ARGS]
+        args = env[Grape::Env::RACK_ROUTING_ARGS].dup
+        # preserve version from query string parameters
+        args.delete(:version)
+        args.delete(:route_info)
+        params.deep_merge!(args)
+      end
+      params
+    end
+
+    def build_headers
+      headers = {}
+      env.each_pair do |k, v|
         next unless k.to_s.start_with? HTTP_PREFIX
 
         k = k[5..-1].split('_').each(&:capitalize!).join('-')
-        h[k] = v
+        headers[k] = v
       end
+      headers
     end
   end
 end

--- a/lib/grape/util/strict_hash_configuration.rb
+++ b/lib/grape/util/strict_hash_configuration.rb
@@ -64,7 +64,8 @@ module Grape
           end
 
           define_method 'to_hash' do
-            merge_hash = setting_name.keys.each_with_object({}) { |k, hash| hash[k] = send("#{k}_context").to_hash }
+            merge_hash = {}
+            setting_name.each_key { |k| merge_hash[k] = send("#{k}_context").to_hash }
 
             @settings.to_hash.merge(
               merge_hash


### PR DESCRIPTION
Remove `each_with_object` where it's slow.
    
Remember https://github.com/ruby-grape/grape/pull/1128?
Unfortunately, calling `each_with_object` on `Hash` is not a good idea (`inject` has the same problem btw). It allocates an array for each `(k,v)` pair which is not good.
    
More details here: https://github.com/rails/rails/commit/960de47f0eef79d234eb3cfc47fabb470fef1529
@tenderlove exellently covered it all.
