### PR TITLE
Save message_key in Grape::Exceptions::Validation

### DIFF
--- a/lib/grape/exceptions/validation.rb
+++ b/lib/grape/exceptions/validation.rb
@@ -4,10 +4,12 @@ module Grape
   module Exceptions
     class Validation < Grape::Exceptions::Base
       attr_accessor :params
+      attr_reader :message_key
 
       def initialize(args = {})
         fail 'Params are missing:' unless args.key? :params
         @params = args[:params]
+        @message_key = args[:message_key]
         args[:message] = translate_message(args[:message_key]) if args.key? :message_key
         super
       end


### PR DESCRIPTION
This way you can make better API errors, that have a stable message_key, alongside a translated message.