### PR TITLE
Removing dependence on git in gemspec

### DIFF
--- a/grape.gemspec
+++ b/grape.gemspec
@@ -36,8 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'benchmark-ips'
   s.add_development_dependency 'rubocop', '0.35.1'
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
+  s.files         = Dir['**/*'].keep_if { |file| File.file?(file) }
+  s.test_files    = Dir['spec/**/*']
   s.require_paths = ['lib']
 end


### PR DESCRIPTION
This is a PR to fix #1214 