### PR TITLE
Fix build warnings

### DIFF
--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1289,7 +1289,7 @@ describe Grape::API do
       subject.get '/exception' do
         fail 'rain!'
       end
-      expect { get '/exception' }.to raise_error
+      expect { get '/exception' }.to raise_error(RuntimeError, 'rain!')
     end
 
     it 'rescues all errors if rescue_from :all is called' do
@@ -1322,7 +1322,7 @@ describe Grape::API do
       get '/rescued'
       expect(last_response.status).to eql 500
 
-      expect { get '/unrescued' }.to raise_error
+      expect { get '/unrescued' }.to raise_error(RuntimeError, 'beefcake')
     end
 
     context 'CustomError subclass of Grape::Exceptions::Base' do

--- a/spec/grape/middleware/exception_spec.rb
+++ b/spec/grape/middleware/exception_spec.rb
@@ -59,7 +59,7 @@ describe Grape::Middleware::Error do
       use Grape::Middleware::Error
       run ExceptionSpec::ExceptionApp
     end
-    expect { get '/' }.to raise_error
+    expect { get '/' }.to raise_error(RuntimeError, 'rain!')
   end
 
   context 'with rescue_all set to true' do

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -66,7 +66,7 @@ describe Grape::Middleware::Formatter do
 
       expect do
         catch(:error) { subject.call('PATH_INFO' => '/somewhere.xml', 'HTTP_ACCEPT' => 'application/json') }
-      end.to raise_error
+      end.to raise_error(StandardError)
     end
   end
 

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -366,7 +366,7 @@ describe Grape::Validations do
       end
 
       it "doesn't throw a missing param when param is present" do
-        get '/required', items: [key: 'hello', key: 'world']
+        get '/required', items: [key: 'hello']
         expect(last_response.status).to eq(200)
         expect(last_response.body).to eq('required works')
       end


### PR DESCRIPTION
Fix hash duplicated keys and raise_error specs avoiding warnings during the build.