### PR TITLE
Fix Given with nested params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 =============
 
 * [#1216](https://github.com/ruby-grape/grape/pull/1142): Fix JSON error response when calling `error!` with non-Strings - [@jrforrest](https://github.com/jrforrest).
+* [#1225](https://github.com/ruby-grape/grape/pull/1225): Fix `given` with nested params not returning correct declared params - [@JanStevens](https://github.com/JanStevens).
 * Your contribution here.
 
 0.14.0 (12/07/2015)

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -90,7 +90,11 @@ module Grape
       # Adds a parameter declaration to our list of validations.
       # @param attrs [Array] (see Grape::DSL::Parameters#requires)
       def push_declared_params(attrs)
-        @declared_params.concat attrs
+        if lateral?
+          @parent.push_declared_params(attrs)
+        else
+          @declared_params.concat attrs
+        end
       end
 
       private
@@ -145,7 +149,14 @@ module Grape
         end
 
         opts = attrs[1] || { type: Array }
-        self.class.new(api: @api, element: attrs.first, parent: self, optional: optional, type: opts[:type], &block)
+
+        self.class.new(
+          api:      @api,
+          element:  attrs.first,
+          parent:   self,
+          optional: optional,
+          type:     opts[:type],
+          &block)
       end
 
       # Returns a new parameter scope, not nested under any current-level param


### PR DESCRIPTION
When a lateral scope is defined push the declared params on the parent and not itself,

Fixes #1219 

I added extra test case. Another issue is still not fixed, described in the following spec:

```ruby
    it 'includes level 2 nested parameter within #declared(params)' do
      subject.params do
        requires :bar, type: Hash do
          optional :a

          optional :c, type: Hash do
            given :a do
              requires :b
            end
          end
        end
      end
      subject.get('/nested') { declared(params).to_json }
      get '/nested', bar: { a: true, c: { b: 'yes' } }
      expect(JSON.parse(last_response.body)).to eq('bar' => { 'a' => "true", 'b' => 'yes' })
    end
```

For this the validation of the given DSL should be moved somewhere else. Right now `given` only works for parameters defined in the same block. I highly doubt that somebody would need this level of complexity for defining depending params.