### PR TITLE
Enable to use custom helpers in error middleware, closes #438 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [#1216](https://github.com/ruby-grape/grape/pull/1142): Fix JSON error response when calling `error!` with non-Strings - [@jrforrest](https://github.com/jrforrest).
 * [#1225](https://github.com/ruby-grape/grape/pull/1225): Fix `given` with nested params not returning correct declared params - [@JanStevens](https://github.com/JanStevens).
 * [#1227](https://github.com/ruby-grape/grape/pull/1227): Store `message_key` on Grape::Exceptions::Validation - [@stjhimy](https://github.com/sthimy).
+* [#1232](https://github.com/ruby-grape/grape/pull/1232): Enable to use custom helpers in error middleware - [@namusyaka](https://github.com/namusyaka).
 * Your contribution here.
 
 0.14.0 (12/07/2015)

--- a/README.md
+++ b/README.md
@@ -1738,6 +1738,23 @@ rescue_from RuntimeError, rescue_subclasses: false do |e|
 end
 ```
 
+In addition, you can use your helpers in a code block.
+
+```ruby
+class Twitter::API < Grape::API
+  format :json
+  helpers do
+    def server_error!
+      error!({ error: 'Server error.' }, 500, { 'Content-Type' => 'text/error' })
+    end
+  end
+
+  rescue_from :all do |e|
+    server_error!
+  end
+end
+```
+
 The `rescue_from` block must return a `Rack::Response` object, call `error!` or re-raise an exception.
 
 #### Unrescuable Exceptions

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -22,6 +22,8 @@ module Grape
       def call!(env)
         @env = env
 
+        inject_helpers!
+
         begin
           error_response(catch(:error) do
             return @app.call(@env)
@@ -57,6 +59,19 @@ module Grape
         else
           instance_exec(e, &handler)
         end
+      end
+
+      def inject_helpers!
+        return if helpers_available?
+        endpoint = @env['api.endpoint']
+        self.class.instance_eval do
+          include endpoint.send(:helpers)
+        end if endpoint.is_a?(Grape::Endpoint)
+        @helpers = true
+      end
+
+      def helpers_available?
+        @helpers
       end
 
       def error!(message, status = options[:default_status], headers = {}, backtrace = [])

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1292,6 +1292,20 @@ describe Grape::API do
       expect { get '/exception' }.to raise_error(RuntimeError, 'rain!')
     end
 
+    it 'uses custom helpers defined by using #helpers method' do
+      subject.helpers do
+        def custom_error!(name)
+          error! "hello #{name}"
+        end
+      end
+      subject.rescue_from(ArgumentError) { custom_error! :bob }
+      subject.get '/custom_error' do
+        fail ArgumentError
+      end
+      get '/custom_error'
+      expect(last_response.body).to eq 'hello bob'
+    end
+
     it 'rescues all errors if rescue_from :all is called' do
       subject.rescue_from :all
       subject.get '/exception' do


### PR DESCRIPTION
Hello, everyone.
I'd love to use custom helpers in the Error middleware.
This change might be able to close #438 issue.
Could you review this?

Thanks.