### PR TITLE
Don't use URI.escape as it has been obsoluted

### DIFF
--- a/README.md
+++ b/README.md
@@ -1909,7 +1909,7 @@ class Twitter::API < Grape::API
     filename = params[:file][:filename]
     content_type MIME::Types.type_for(filename)[0].to_s
     env['api.format'] = :binary # there's no formatter for :binary, data will be returned "as is"
-    header 'Content-Disposition', "attachment; filename*=UTF-8''#{URI.escape(filename)}"
+    header 'Content-Disposition', "attachment; filename*=UTF-8''#{CGI.escape(filename)}"
     params[:file][:tempfile].read
   end
 end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -896,7 +896,7 @@ describe Grape::API do
           filename = params[:file][:filename]
           content_type MIME::Types.type_for(filename)[0].to_s
           env['api.format'] = :binary # there's no formatter for :binary, data will be returned "as is"
-          header 'Content-Disposition', "attachment; filename*=UTF-8''#{URI.escape(filename)}"
+          header 'Content-Disposition', "attachment; filename*=UTF-8''#{CGI.escape(filename)}"
           params[:file][:tempfile].read
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ require 'rack/test'
 require 'base64'
 require 'cookiejar'
 require 'mime/types'
+require 'cgi'
 
 Dir["#{File.dirname(__FILE__)}/support/*.rb"].each do |file|
   require file


### PR DESCRIPTION
I guess we can use `CGI.escape` instead of `URI.escape`.
Ref: https://github.com/ruby/ruby/commit/238b979f1789f95262a267d8df6239806f2859cc
