### PR TITLE
Support more kindly for after method

### DIFF
--- a/lib/grape/middleware/base.rb
+++ b/lib/grape/middleware/base.rb
@@ -27,7 +27,7 @@ module Grape
         ensure
           after_response = after
         end
-        after_response || @app_response
+        response_valid?(after_response) ? after_response : @app_response
       end
 
       # @abstract
@@ -64,6 +64,17 @@ module Grape
           types_without_params[v.split(';').first] = k
         end
         types_without_params
+      end
+
+      def response_valid?(response)
+        if response.is_a?(Array)
+          status, headers, body = *response
+          (status >= 100 && status < 600) && (headers.is_a?(Hash)) && body.respond_to?(:each)
+        else
+          response.is_a?(Rack::Response)
+        end
+      rescue
+        false
       end
     end
   end

--- a/spec/grape/middleware/base_spec.rb
+++ b/spec/grape/middleware/base_spec.rb
@@ -40,11 +40,21 @@ describe Grape::Middleware::Base do
 
   context 'after callback' do
     before do
-      allow(subject).to receive(:after).and_return([200, {}, 'Hello from after callback'])
+      allow(subject).to receive(:after).and_return([200, {}, ['Hello from after callback']])
     end
 
     it 'overwrites application response' do
-      expect(subject.call!({}).last).to eq('Hello from after callback')
+      expect(subject.call!({}).last).to eq(['Hello from after callback'])
+    end
+  end
+
+  context 'after callback with invalid response' do
+    before do
+      allow(subject).to receive(:after).and_return('invalid response')
+    end
+
+    it 'does not overwrite application response' do
+      expect(subject.call!({}).last).to eq('Hi there.')
     end
   end
 


### PR DESCRIPTION
ref #1240

The current implementation is going to try to return `after_response` if `after_response` is not false.
I guess the behavior is not expected, and users will be confusing.
Thoughts?
