### PR TITLE
do not raise an IncompatibleOptionValues For a couple of potentially valid use cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#1237](https://github.com/ruby-grape/grape/pull/1237): Allow multiple parameters in `given`, which behaves as if the scopes were nested in the inputted order - [@ochagata](https://github.com/ochagata).
 * [#1238](https://github.com/ruby-grape/grape/pull/1238): Call `after` of middleware on error - [@namusyaka](https://github.com/namusyaka).
 * [#1243](https://github.com/ruby-grape/grape/pull/1243): Add `header` support for middleware - [@namusyaka](https://github.com/namusyaka).
+* [#1252](https://github.com/ruby-grape/grape/pull/1252): Allow default to be a subset or equal to allowed values without raising IncompatibleOptionValues - [@jeradphelps](https://github.com/jeradphelps).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -316,7 +316,7 @@ module Grape
       def check_incompatible_option_values(values, default)
         return unless values && default
         return if values.is_a?(Proc) || default.is_a?(Proc)
-        return if values.include?(default)
+        return if values.include?(default) || (Array(default) - Array(values)).empty?
         fail Grape::Exceptions::IncompatibleOptionValues.new(:default, default, :values, values)
       end
 

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -174,6 +174,24 @@ describe Grape::Validations::ParamsScope do
       end
     end
 
+    context 'when the default is an array' do
+      context 'and is the entire range of allowed values' do
+        it 'does not raise an exception' do
+          expect do
+            subject.params { optional :numbers, type: Array[Integer], values: 0..2, default: 0..2 }
+          end.to_not raise_error
+        end
+      end
+
+      context 'and is a subset of allowed values' do
+        it 'does not raise an exception' do
+          expect do
+            subject.params { optional :numbers, type: Array[Integer], values: [0, 1, 2], default: [1, 0] }
+          end.to_not raise_error
+        end
+      end
+    end
+
     context 'when both range endpoints are #kind_of? the type' do
       it 'accepts values in the range' do
         subject.params do


### PR DESCRIPTION
I believe the following two params blocks should be valid:

~~~
# The default is the entire range of allowed values
params { optional :numbers, type: Array[Integer], values: 0..2, default: 0..2 }
~~~

~~~
# The default is a subset of the entire range of allowed values
subject.params { optional :numbers, type: Array[Integer], values: [0, 1, 2], default: [1, 0] }
~~~

The current implementation doesn't account for these use cases and raises `Grape::Exceptions::IncompatibleOptionValues`.  This PR will allow the two cases above.