### PR TITLE
Fix bug at array index context in errors 

### DIFF
--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -175,5 +175,6 @@ require 'grape/validations/validators/values'
 require 'grape/validations/params_scope'
 require 'grape/validations/validators/all_or_none'
 require 'grape/validations/types'
+require 'grape/validations/validate_service'
 
 require 'grape/version'

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -200,9 +200,12 @@ module Grape
       # @param params [Hash] initial hash of parameters
       # @return hash of parameters with index information relevant for the current scope
       # example:
-      # params: [{"name"=>"Job", "parents"=>[{"name"=>"Joy"}, {"name"=>"Bob"}], "_param_index": {"children_index": 0}}, {"name"=>"Jim", "parents"=>[{}], "_param_index": {"children_index": 1}}]
+      # params: [{"name"=>"Job", "parents"=>[{"name"=>"Joy"}, {"name"=>"Bob"}], "_param_index": {"children_index": 0}},
+      #   {"name"=>"Jim", "parents"=>[{}], "_param_index": {"children_index": 1}}]
       # element: parents
-      # result: [{"name"=>"Joy", "_param_index": {children[parents]: 0, "children": 0}}, {"name"=>"Bob", "_param_index": {children[parents]: 1, "children": 0}}, { "_param_index": {children[parents]: 0, "children": 1}}]
+      # result: [{"name"=>"Joy", "_param_index": {children[parents]: 0, "children": 0}},
+      #   {"name"=>"Bob", "_param_index": {children[parents]: 1, "children": 0}},
+      #   { "_param_index": {children[parents]: 0, "children": 1}}]
       def params_with_index(params)
         params = @parent.params_with_index(params) if @parent
         if @element
@@ -223,7 +226,7 @@ module Grape
         param_index ||= {}
         param_index[@parent.full_name(@element)] = index if index && @parent
         if item.is_a?(Array)
-          item.map.with_index{|e, i| e.merge!('_param_index' => param_index.merge(@parent.full_name(@element) =>i)) if e.respond_to?(:merge!) }
+          item.map.with_index { |e, i| e.merge!('_param_index' => param_index.merge(@parent.full_name(@element) => i)) if e.respond_to?(:merge!) }
         else
           item.merge!('_param_index' => param_index) if item.respond_to?(:merge!)
         end

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -107,7 +107,7 @@ module Grape
        Namespace.joined_space(namespace_stackable(:namespace)),
        (namespace_stackable(:mount_path) || []).join('/'),
        options[:path].join('/')
-       ].join(' ')
+      ].join(' ')
     end
 
     def routes
@@ -137,7 +137,7 @@ module Grape
             route_set.add_route(self, {
                                   path_info: route.route_compiled,
                                   request_method: method
-            }, route_info: route)
+                                }, route_info: route)
           end
         end
       end

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -340,7 +340,7 @@ module Grape
         @params = validate_service.params
       else
         fail Grape::Exceptions::ValidationErrors, errors: validate_service.errors, headers: header
-      end      
+      end
     end
 
     def run_filters(filters, type = :other)

--- a/lib/grape/util/strict_hash_configuration.rb
+++ b/lib/grape/util/strict_hash_configuration.rb
@@ -98,7 +98,7 @@ module Grape
           new_config_class = config_class(*args)
 
           class_mod.send(:define_method, :config_class) do
-            @config_context ||= new_config_class
+            @config_class ||= new_config_class
           end
         end
       end

--- a/lib/grape/validations.rb
+++ b/lib/grape/validations.rb
@@ -14,5 +14,9 @@ module Grape
     def self.register_validator(short_name, klass)
       validators[short_name] = klass
     end
+
+    def self.validate_service(validators, params)
+      ValidateService.new(validators, params)
+    end
   end
 end

--- a/lib/grape/validations/attributes_iterator.rb
+++ b/lib/grape/validations/attributes_iterator.rb
@@ -8,7 +8,7 @@ module Grape
       def initialize(validator, scope, params)
         @scope = scope
         @attrs = validator.attrs
-        @params = Array.wrap(scope.params(params))
+        @params = Array.wrap(scope.params_with_index(params))
       end
 
       def each

--- a/lib/grape/validations/attributes_iterator.rb
+++ b/lib/grape/validations/attributes_iterator.rb
@@ -13,10 +13,7 @@ module Grape
 
       def each
         @params.each do |resource_params|
-          @attrs.each_with_index do |attr_name, index|
-            if resource_params.is_a?(Hash) && resource_params[attr_name].is_a?(Array)
-              scope.index = index
-            end
+          @attrs.each do |attr_name|
             yield resource_params, attr_name
           end
         end

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -60,7 +60,7 @@ module Grape
       end
 
       def full_message(name, param_index = nil)
-        case 
+        case
         when nested?
           "#{@parent.full_message(@element, param_index)}#{locate(param_index)}[#{name}]"
         when lateral?
@@ -71,7 +71,7 @@ module Grape
       end
 
       def locate(param_index)
-        param_index && param_index["#{@parent.full_name(@element)}"] ? %Q([#{param_index["#{@parent.full_name(@element)}"]}]) : nil 
+        param_index && param_index["#{@parent.full_name(@element)}"] ? %([#{param_index["#{@parent.full_name(@element)}"]}]) : nil
       end
 
       # @return [Boolean] whether or not this scope is the root-level scope

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -35,7 +35,7 @@ module Grape
       # @return [Boolean] whether or not this entire scope needs to be
       #   validated
       def should_validate?(parameters)
-        return false if @optional && params_without_index(parameters).respond_to?(:all?) && params_without_index(parameters).all?(&:blank?)
+        return false if @optional && params(parameters).respond_to?(:all?) && params(parameters).all?(&:blank?)
         @dependent_on.each do |dependency|
           return false if params(parameters).try(:[], dependency).blank?
         end if @dependent_on

--- a/lib/grape/validations/validate_service.rb
+++ b/lib/grape/validations/validate_service.rb
@@ -1,7 +1,6 @@
 module Grape
   module Validations
     class ValidateService
-
       def initialize(validators, params)
         @validators = validators
         @params = params
@@ -31,6 +30,7 @@ module Grape
       end
 
       private
+
       def clean_params_index(params)
         case params
         when Array
@@ -38,7 +38,7 @@ module Grape
             clean_params_index(item)
           end
         when Hash
-          params.delete("_param_index")
+          params.delete('_param_index')
           params.each do |key, value|
             params[key] = clean_params_index(value)
           end

--- a/lib/grape/validations/validate_service.rb
+++ b/lib/grape/validations/validate_service.rb
@@ -1,0 +1,51 @@
+module Grape
+  module Validations
+    class ValidateService
+
+      def initialize(validators, params)
+        @validators = validators
+        @params = params
+      end
+
+      # api
+      def validate!
+        @errors = []
+        @validators.each do |validator|
+          begin
+            validator.validate!(params)
+          rescue Grape::Exceptions::Validation => e
+            @errors << e
+          end
+        end
+        @errors.empty?
+      end
+
+      # api
+      def params
+        clean_params_index(@params)
+      end
+
+      # api
+      def errors
+        @errors ||= []
+      end
+
+      private
+      def clean_params_index(params)
+        case params
+        when Array
+          params = params.map do |item|
+            clean_params_index(item)
+          end
+        when Hash
+          params.delete("_param_index")
+          params.each do |key, value|
+            params[key] = clean_params_index(value)
+          end
+        end
+
+        params
+      end
+    end
+  end
+end

--- a/lib/grape/validations/validators/allow_blank.rb
+++ b/lib/grape/validations/validators/allow_blank.rb
@@ -23,7 +23,7 @@ module Grape
 
         return if value == false || value.present?
 
-        fail Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message_key: :blank
+        fail Grape::Exceptions::Validation, params: [@scope.full_message(attr_name, param_index(params))], message_key: :blank
       end
     end
   end

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -26,6 +26,10 @@ module Grape
         end
       end
 
+      def param_index(params)
+        param_index = params.respond_to?(:key?) ? params['_param_index'] : nil
+      end
+
       def self.convert_to_short_name(klass)
         ret = klass.name.gsub(/::/, '/')
               .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -27,7 +27,7 @@ module Grape
       end
 
       def param_index(params)
-        param_index = params.respond_to?(:key?) ? params['_param_index'] : nil
+        params.respond_to?(:key?) ? params['_param_index'] : nil
       end
 
       def self.convert_to_short_name(klass)

--- a/lib/grape/validations/validators/coerce.rb
+++ b/lib/grape/validations/validators/coerce.rb
@@ -6,12 +6,12 @@ module Grape
   module Validations
     class CoerceValidator < Base
       def validate_param!(attr_name, params)
-        fail Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message_key: :coerce unless params.is_a? Hash
+        fail Grape::Exceptions::Validation, params: [@scope.full_message(attr_name, param_index(params))], message_key: :coerce unless params.is_a? Hash
         new_value = coerce_value(params[attr_name])
         if valid_type?(new_value)
           params[attr_name] = new_value
         else
-          fail Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message_key: :coerce
+          fail Grape::Exceptions::Validation, params: [@scope.full_message(attr_name, param_index(params))], message_key: :coerce
         end
       end
 

--- a/lib/grape/validations/validators/presence.rb
+++ b/lib/grape/validations/validators/presence.rb
@@ -8,7 +8,7 @@ module Grape
 
       def validate_param!(attr_name, params)
         return if params.respond_to?(:key?) && params.key?(attr_name)
-        fail Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message_key: :presence
+        fail Grape::Exceptions::Validation, params: [@scope.full_message(attr_name, param_index(params))], message_key: :presence
       end
     end
   end

--- a/lib/grape/validations/validators/regexp.rb
+++ b/lib/grape/validations/validators/regexp.rb
@@ -3,7 +3,7 @@ module Grape
     class RegexpValidator < Base
       def validate_param!(attr_name, params)
         return unless params.key?(attr_name) && !params[attr_name].nil? && !(params[attr_name].to_s =~ @option)
-        fail Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message_key: :regexp
+        fail Grape::Exceptions::Validation, params: [@scope.full_message(attr_name, param_index(params))], message_key: :regexp
       end
     end
   end

--- a/lib/grape/validations/validators/values.rb
+++ b/lib/grape/validations/validators/values.rb
@@ -13,7 +13,7 @@ module Grape
         values = @values.is_a?(Proc) ? @values.call : @values
         param_array = params[attr_name].nil? ? [nil] : Array.wrap(params[attr_name])
         return if param_array.all? { |param| values.include?(param) }
-        fail Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message_key: :values
+        fail Grape::Exceptions::Validation, params: [@scope.full_message(attr_name, param_index(params))], message_key: :values
       end
 
       private

--- a/spec/grape/validations/validators/coerce_spec.rb
+++ b/spec/grape/validations/validators/coerce_spec.rb
@@ -293,7 +293,7 @@ describe Grape::Validations::CoerceValidator do
 
         get '/ints', ints: '{"i":1,"j":"2"}'
         expect(last_response.status).to eq(400)
-        expect(last_response.body).to eq('ints[0][i] is missing, ints[0][i] is invalid, ints[0][j] is missing')
+        expect(last_response.body).to eq('ints[i] is missing, ints[i] is invalid, ints[j] is missing')
 
         get '/ints', ints: '[{"i":"1","j":"2"}]'
         expect(last_response.status).to eq(200)
@@ -365,7 +365,7 @@ describe Grape::Validations::CoerceValidator do
 
         get '/', splines: '[{"x":1,"ints":[]},{"x":4,"ints":[]}]'
         expect(last_response.status).to eq(400)
-        expect(last_response.body).to eq('splines[x] does not have a valid value')
+        expect(last_response.body).to eq('splines[1][x] does not have a valid value')
       end
 
       it 'accepts Array[JSON] shorthand' do
@@ -391,11 +391,11 @@ describe Grape::Validations::CoerceValidator do
 
         get '/', splines: '{"x":"4","y":"woof"}'
         expect(last_response.status).to eq(400)
-        expect(last_response.body).to eq('splines[x] does not have a valid value')
+        expect(last_response.body).to eq('splines[0][x] does not have a valid value')
 
         get '/', splines: '[{"x":"4","y":"woof"}]'
         expect(last_response.status).to eq(400)
-        expect(last_response.body).to eq('splines[x] does not have a valid value')
+        expect(last_response.body).to eq('splines[0][x] does not have a valid value')
       end
 
       it "doesn't make sense using coerce_with" do

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -649,11 +649,11 @@ describe Grape::Validations do
 
       it 'should prompt index in array when a parameter is not present' do
         put_with_json '/within_array', children: [
-          { name: 'Job', parents: [{ name: 'Joy' }, { name: 'Bob' }] },
-          { name: 'Jim', parents: [{}] }
+          { name: 'Job', parents: [{ name: 'Joy' }, {}] },
+          { name: 'Jim', parents: [{ name: 'Bob' }] }
         ]
         expect(last_response.status).to eq(400)
-        expect(last_response.body).to eq('children[0][parents][0][name] is missing')
+        expect(last_response.body).to eq('children[0][parents][1][name] is missing')
 
         put_with_json '/within_array', children: [
           { name: 'Job', parents: [{ name: 'Joy' }] },

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -647,6 +647,23 @@ describe Grape::Validations do
         expect(last_response.body).to eq('children[0][parents][0][name] is missing')
       end
 
+      it "should prompt index in array when a parameter is not present" do
+        put_with_json '/within_array', children: [
+          { name: 'Job', parents: [{ name: 'Joy' }, {name: 'Bob'}] },
+          { name: 'Jim', parents: [{}] }
+        ]
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('children[1][parents][0][name] is missing')
+
+
+        put_with_json '/within_array', children: [
+          { name: 'Job', parents: [{ name: 'Joy' }] },
+          { name: 'Jim', parents: [{}] }
+        ]
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('children[1][parents][0][name] is missing')
+      end
+
       it 'safely handles empty arrays and blank parameters' do
         put_with_json '/within_array', children: []
         expect(last_response.status).to eq(200)

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -647,14 +647,13 @@ describe Grape::Validations do
         expect(last_response.body).to eq('children[0][parents][0][name] is missing')
       end
 
-      it "should prompt index in array when a parameter is not present" do
+      it 'should prompt index in array when a parameter is not present' do
         put_with_json '/within_array', children: [
-          { name: 'Job', parents: [{ name: 'Joy' }, {name: 'Bob'}] },
+          { name: 'Job', parents: [{ name: 'Joy' }, { name: 'Bob' }] },
           { name: 'Jim', parents: [{}] }
         ]
         expect(last_response.status).to eq(400)
-        expect(last_response.body).to eq('children[1][parents][0][name] is missing')
-
+        expect(last_response.body).to eq('children[0][parents][0][name] is missing')
 
         put_with_json '/within_array', children: [
           { name: 'Job', parents: [{ name: 'Joy' }] },


### PR DESCRIPTION
```ruby 
subject.params do
    group :children, type: Array do
       requires :name
       group :parents, type: Array do
          requires :name
       end
    end
end
```

if params is:
```ruby
children: [
          { name: 'Job', parents: [{ name: 'Joy' }, {name: 'Bob'}] },
          { name: 'Jim', parents: [{}] }
]
```

expect raise 'children[1][parents][0][name] is missing'，got: "children[0][parents][0][name] is missing"