### PR TITLE
ValidationErrors initialize check args[:errors] is present

### DIFF
--- a/lib/grape/exceptions/validation.rb
+++ b/lib/grape/exceptions/validation.rb
@@ -7,7 +7,7 @@ module Grape
       attr_accessor :message_key
 
       def initialize(args = {})
-        fail 'Params are missing:' unless args.key? :params
+        fail 'Params are missing: params' unless args.key? :params
         @params = args[:params]
         @message_key = args[:message_key]
         args[:message] = translate_message(args[:message_key]) if args.key? :message_key

--- a/lib/grape/exceptions/validation_errors.rb
+++ b/lib/grape/exceptions/validation_errors.rb
@@ -8,6 +8,7 @@ module Grape
       attr_reader :errors
 
       def initialize(args = {})
+        fail 'Params are missing: errors' unless args.key? :errors
         @errors = {}
         args[:errors].each do |validation_error|
           @errors[validation_error.params] ||= []


### PR DESCRIPTION
ValidationErrors will throw NoMethodError (undefined method `each' for nil:NilClass) when I manually throw a ValidationErrors exception without params.
This argument appears to be necessary, so it should detect the presence or absence of this key. Or give it a default value.
And the fail word should let us know which key is missing.