### PR TITLE
support Array with index

### DIFF
--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -129,6 +129,7 @@ module Grape
     autoload :InheritableSetting
     autoload :StrictHashConfiguration
     autoload :FileResponse
+    autoload :HashParameter
   end
 
   module DSL

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -188,6 +188,7 @@ module Grape
       # @api private
       def params(params)
         params = @parent.params(params) if @parent
+
         if @element
           if params.is_a?(Array)
             params = params.flat_map { |el| el[@element] || {} }
@@ -197,7 +198,34 @@ module Grape
             params = {}
           end
         end
+
+        if params.is_a?(Hash) && deem_hash_array?(params)
+          params = params.values
+        end
+
         params
+      end
+
+      def deem_hash_array?(hash)
+        unless hash.present?
+          return false
+        end
+
+        hash.keys.each do |key|
+          unless integer_string?(key)
+            return false
+          end
+        end
+        true
+      end
+
+      def integer_string?(str)
+        Integer(str)
+        true
+      rescue ArgumentError
+        false
+      rescue TypeError
+        false
       end
     end
   end

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -8,6 +8,8 @@ module Grape
     module Parameters
       extend ActiveSupport::Concern
 
+      include Grape::Util::HashParameter
+
       # Include reusable params rules among current.
       # You can define reusable params with helpers method.
       #
@@ -204,28 +206,6 @@ module Grape
         end
 
         params
-      end
-
-      def deem_hash_array?(hash)
-        unless hash.present?
-          return false
-        end
-
-        hash.keys.each do |key|
-          unless integer_string?(key)
-            return false
-          end
-        end
-        true
-      end
-
-      def integer_string?(str)
-        Integer(str)
-        true
-      rescue ArgumentError
-        false
-      rescue TypeError
-        false
       end
     end
   end

--- a/lib/grape/util/hash_parameter.rb
+++ b/lib/grape/util/hash_parameter.rb
@@ -1,0 +1,29 @@
+require 'active_support/concern'
+module Grape
+  module Util
+    module HashParameter
+      extend ActiveSupport::Concern
+
+      def deem_hash_array?(hash)
+        unless hash.present?
+          return false
+        end
+
+        hash.keys.each do |key|
+          unless integer_string?(key)
+            return false
+          end
+        end
+        true
+      end
+
+      def integer_string?(str)
+        Integer(str)
+        true
+      rescue ArgumentError, TypeError
+        false
+      end
+    end
+  end
+end
+

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -39,6 +39,26 @@ module Grape
         short_name = convert_to_short_name(klass)
         Validations.register_validator(short_name, klass)
       end
+
+      def deem_hash_array?(hash)
+        unless hash.present?
+          return false
+        end
+
+        hash.keys.each do |key|
+          unless integer_string?(key)
+            return false
+          end
+        end
+        true
+      end
+
+      def integer_string?(str)
+        Integer(str)
+        true
+      rescue ArgumentError
+        false
+      end
     end
   end
 end

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -3,6 +3,8 @@ module Grape
     class Base
       attr_reader :attrs
 
+      include Grape::Util::HashParameter
+
       # Creates a new Validator from options specified
       # by a +requires+ or +optional+ directive during
       # parameter definition.
@@ -40,25 +42,6 @@ module Grape
         Validations.register_validator(short_name, klass)
       end
 
-      def deem_hash_array?(hash)
-        unless hash.present?
-          return false
-        end
-
-        hash.keys.each do |key|
-          unless integer_string?(key)
-            return false
-          end
-        end
-        true
-      end
-
-      def integer_string?(str)
-        Integer(str)
-        true
-      rescue ArgumentError
-        false
-      end
     end
   end
 end

--- a/lib/grape/validations/validators/coerce.rb
+++ b/lib/grape/validations/validators/coerce.rb
@@ -29,20 +29,6 @@ module Grape
         true
       end
 
-      def deem_hash_array?(hash)
-        hash.keys.each do |key|
-          return false unless integer_string?(key)
-        end
-        true
-      end
-
-      def integer_string?(str)
-        Integer(str)
-        true
-      rescue ArgumentError
-        false
-      end
-
       def coerce_value(val)
         # Don't coerce things other than nil to Arrays or Hashes
         unless (@option[:method] && !val.nil?) || type.is_a?(Virtus::Attribute)

--- a/lib/grape/validations/validators/coerce.rb
+++ b/lib/grape/validations/validators/coerce.rb
@@ -23,8 +23,24 @@ module Grape
 
         # Allow nil, to ignore when a parameter is absent
         return true if val.nil?
+        unless !type.is_a?(Types::VariantCollectionCoercer) && type == Array && val.is_a?(Hash) && deem_hash_array?(val)
+          return converter.value_coerced? val
+        end
+        true
+      end
 
-        converter.value_coerced? val
+      def deem_hash_array?(hash)
+        hash.keys.each do |key|
+          return false unless integer_string?(key)
+        end
+        true
+      end
+
+      def integer_string?(str)
+        Integer(str)
+        true
+      rescue ArgumentError
+        false
       end
 
       def coerce_value(val)

--- a/spec/grape/validations/validators/default_spec.rb
+++ b/spec/grape/validations/validators/default_spec.rb
@@ -99,6 +99,18 @@ describe Grape::Validations::DefaultValidator do
     expect(last_response.body).to eq({ array: [{ name: 'name', with_default: 'default' }, { name: 'name2', with_default: 'bar2' }] }.to_json)
   end
 
+  it 'sets default values for grouped arrays with index' do
+    get('/array?array[0][name]=name&array[1][name]=name2&array[0][with_default]=bar1')
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq(
+      { array:
+        {
+          :'0' => { name: 'name', with_default: 'bar1' },
+          :'1' => { name: 'name2', with_default: 'default' }
+        }
+      }.to_json)
+  end
+
   context 'optional group with defaults' do
     subject do
       Class.new(Grape::API) do


### PR DESCRIPTION
This change will enable to use array with index.

```ruby
params do
  requires :abc, type: Array do
    requires :name
  end
end
```

```html
<input type="text" name="abc[0][name]]"> 
<input type="text" name="abc[1][name]">
```

