### PR TITLE
Place generated OPTIONS ahead of user defined routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#1216](https://github.com/ruby-grape/grape/pull/1142): Fix JSON error response when calling `error!` with non-Strings - [@jrforrest](https://github.com/jrforrest).
 * [#1225](https://github.com/ruby-grape/grape/pull/1225): Fix `given` with nested params not returning correct declared params - [@JanStevens](https://github.com/JanStevens).
 * [#1249](https://github.com/ruby-grape/grape/pull/1249): Don't fail even if invalid type value is passed to default validator - [@namusyaka](https://github.com/namusyaka).
+* [#1263](https://github.com/ruby-grape/grape/pull/1263): Fix `route :any, '*path'` breaking generated OPTIONS, Not Allowed routes - [@arempe93](https://github.com/arempe93)
 
 0.14.0 (12/07/2015)
 ===================

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -32,6 +32,10 @@ end
 
 See [#1147](https://github.com/ruby-grape/grape/issues/1147) and [#1240](https://github.com/ruby-grape/grape/issues/1240) for discussion of the issues.
 
+#### Changes to generated OPTIONS and Not Allowed routes
+
+Using `route :any, '*path'` no longer blocks generated OPTIONS and Not Allowed methods from other routes. Use `do_not_route_options!` to prevent OPTIONS routes from being created.
+
 ### Upgrading to >= 0.14.0
 
 #### Changes to availability of DSL methods in filters


### PR DESCRIPTION
Fix for #1260 

This change places the generated OPTIONS routes ahead of user defined routes, so that 404 handling does not interfere.

I also noticed a problem when doing this, declaring a route with `:any` as the http verb would declare an OPTIONS route and a 405 Not Allowed route for ALL methods. It would just be below the user defined route in the stack, and therefore never called. This, however, interfered with my change so I fixed it to map to all methods properly in `Grape::API#add_head_not_allowed_methods_and_options_methods`