### PR TITLE
Fix Allow header including OPTIONS when do_not_route_options! set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#1225](https://github.com/ruby-grape/grape/pull/1225): Fix `given` with nested params not returning correct declared params - [@JanStevens](https://github.com/JanStevens).
 * [#1249](https://github.com/ruby-grape/grape/pull/1249): Don't fail even if invalid type value is passed to default validator - [@namusyaka](https://github.com/namusyaka).
 * [#1263](https://github.com/ruby-grape/grape/pull/1263): Fix `route :any, '*path'` breaking generated `OPTIONS`, Method Not Allowed routes - [@arempe93](https://github.com/arempe93).
+* [#1266](https://github.com/ruby-grape/grape/pull/1266): Fix `Allow` header including `OPTIONS` when `do_not_route_options!` is active - [@arempe93](https://github.com/arempe93).
 
 0.14.0 (12/07/2015)
 ===================

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -165,7 +165,7 @@ module Grape
               allowed_methods |= [Grape::Http::Headers::HEAD] if allowed_methods.include?(Grape::Http::Headers::GET)
             end
 
-            allow_header = ([Grape::Http::Headers::OPTIONS] | allowed_methods).join(', ')
+            allow_header = (self.class.namespace_inheritable(:do_not_route_options) ? allowed_methods : [Grape::Http::Headers::OPTIONS] | allowed_methods).join(', ')
 
             unless self.class.namespace_inheritable(:do_not_route_options)
               generate_options_method(path, allow_header) unless allowed_methods.include?(Grape::Http::Headers::OPTIONS)

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -673,9 +673,16 @@ describe Grape::API do
         'example'
       end
     end
-    it 'options does not exist' do
+
+    it 'does not create an OPTIONS route' do
       options '/example'
       expect(last_response.status).to eql 405
+    end
+
+    it 'does not include OPTIONS in Allow header' do
+      options '/example'
+      expect(last_response.status).to eql 405
+      expect(last_response.headers['Allow']).to eql 'GET, HEAD'
     end
   end
 


### PR DESCRIPTION
I believe this may be a fix for the intention of #1119, or maybe just its own small bug