### PR TITLE
Param versioning will now correctly set parameter key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#1249](https://github.com/ruby-grape/grape/pull/1249): Don't fail even if invalid type value is passed to default validator - [@namusyaka](https://github.com/namusyaka).
 * [#1263](https://github.com/ruby-grape/grape/pull/1263): Fix `route :any, '*path'` breaking generated `OPTIONS`, Method Not Allowed routes - [@arempe93](https://github.com/arempe93).
 * [#1266](https://github.com/ruby-grape/grape/pull/1266): Fix `Allow` header including `OPTIONS` when `do_not_route_options!` is active - [@arempe93](https://github.com/arempe93).
+* [#1270](https://github.com/ruby-grape/grape/pull/1270): Fix `param` versioning with a custom parameter - [@wshatch](https://github.com/wshatch).
 
 0.14.0 (12/07/2015)
 ===================

--- a/lib/grape/middleware/versioner/param.rb
+++ b/lib/grape/middleware/versioner/param.rb
@@ -21,17 +21,28 @@ module Grape
       class Param < Base
         def default_options
           {
-            parameter: 'apiver'.freeze
+            version_options: {
+              parameter: 'apiver'.freeze
+            }
           }
         end
 
         def before
-          paramkey = options[:parameter]
           potential_version = Rack::Utils.parse_nested_query(env[Grape::Http::Headers::QUERY_STRING])[paramkey]
           return if potential_version.nil?
           throw :error, status: 404, message: '404 API Version Not Found', headers: { Grape::Http::Headers::X_CASCADE => 'pass' } if options[:versions] && !options[:versions].find { |v| v.to_s == potential_version }
           env[Grape::Env::API_VERSION] = potential_version
           env[Grape::Env::RACK_REQUEST_QUERY_HASH].delete(paramkey) if env.key? Grape::Env::RACK_REQUEST_QUERY_HASH
+        end
+
+        private
+
+        def paramkey
+          version_options[:parameter] || default_options[:version_options][:parameter]
+        end
+
+        def version_options
+          options[:version_options]
         end
       end
     end

--- a/spec/grape/middleware/versioner/param_spec.rb
+++ b/spec/grape/middleware/versioner/param_spec.rb
@@ -22,7 +22,7 @@ describe Grape::Middleware::Versioner::Param do
   end
 
   context 'with specified parameter name' do
-    before { @options = { parameter: 'v' } }
+    before { @options = { version_options: { parameter: 'v' } } }
     it 'sets the API version based on the custom parameter name' do
       env = Rack::MockRequest.env_for('/awesome', params: { 'v' => 'v1' })
       expect(subject.call(env)[1]['api.version']).to eq('v1')
@@ -52,5 +52,109 @@ describe Grape::Middleware::Versioner::Param do
     }
     env = Rack::MockRequest.env_for('/awesome', params: {})
     expect(subject.call(env).first).to eq(200)
+  end
+
+  context 'when there are multiple versions without a custom param' do
+    subject { Class.new(Grape::API) }
+
+    let(:v1_app) do
+      Class.new(Grape::API) do
+        version 'v1', using: :param
+        content_type :v1_test, 'application/vnd.test.a-cool_resource-v1+json'
+        formatter :v1_test, ->(object, _) { object }
+        format :v1_test
+
+        resources :users do
+          get :hello do
+            'one'
+          end
+        end
+      end
+    end
+
+    let(:v2_app) do
+      Class.new(Grape::API) do
+        version 'v2', using: :param
+        content_type :v2_test, 'application/vnd.test.a-cool_resource-v2+json'
+        formatter :v2_test, ->(object, _) { object }
+        format :v2_test
+
+        resources :users do
+          get :hello do
+            'two'
+          end
+        end
+      end
+    end
+
+    def app
+      subject.mount v2_app
+      subject.mount v1_app
+      subject
+    end
+
+    it 'responds correctly to a v1 request' do
+      versioned_get '/users/hello', 'v1', using: :param, parameter: :apiver
+      expect(last_response.body).to eq('one')
+      expect(last_response.body).not_to include('API vendor or version not found')
+    end
+
+    it 'responds correctly to a v2 request' do
+      versioned_get '/users/hello', 'v2', using: :param, parameter: :apiver
+      expect(last_response.body).to eq('two')
+      expect(last_response.body).not_to include('API vendor or version not found')
+    end
+  end
+
+  context 'when there are multiple versions with a custom param' do
+    subject { Class.new(Grape::API) }
+
+    let(:v1_app) do
+      Class.new(Grape::API) do
+        version 'v1', using: :param, parameter: 'v'
+        content_type :v1_test, 'application/vnd.test.a-cool_resource-v1+json'
+        formatter :v1_test, ->(object, _) { object }
+        format :v1_test
+
+        resources :users do
+          get :hello do
+            'one'
+          end
+        end
+      end
+    end
+
+    let(:v2_app) do
+      Class.new(Grape::API) do
+        version 'v2', using: :param, parameter: 'v'
+        content_type :v2_test, 'application/vnd.test.a-cool_resource-v2+json'
+        formatter :v2_test, ->(object, _) { object }
+        format :v2_test
+
+        resources :users do
+          get :hello do
+            'two'
+          end
+        end
+      end
+    end
+
+    def app
+      subject.mount v2_app
+      subject.mount v1_app
+      subject
+    end
+
+    it 'responds correctly to a v1 request' do
+      versioned_get '/users/hello', 'v1', using: :param, parameter: 'v'
+      expect(last_response.body).to eq('one')
+      expect(last_response.body).not_to include('API vendor or version not found')
+    end
+
+    it 'responds correctly to a v2 request' do
+      versioned_get '/users/hello', 'v2', using: :param, parameter: 'v'
+      expect(last_response.body).to eq('two')
+      expect(last_response.body).not_to include('API vendor or version not found')
+    end
   end
 end


### PR DESCRIPTION
Issue: https://github.com/ruby-grape/grape/issues/1270

Currently, we're looking for the parameter in ```@options``` instead of ```@options[:version_options]```. This should fix the issue. 