### PR TITLE
Fix using JSON and Array[JSON] as groups when parameter is optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#1270](https://github.com/ruby-grape/grape/pull/1270): Fix `param` versioning with a custom parameter - [@wshatch](https://github.com/wshatch).
 * [#1282](https://github.com/ruby-grape/grape/pull/1282): Fix specs circular dependency - [@304](https://github.com/304).
 * [#1283](https://github.com/ruby-grape/grape/pull/1283): Fix 500 error for xml format when method is not allowed - [@304](https://github.com/304).
+* [#1197](https://github.com/ruby-grape/grape/pull/1290): Fix using JSON and Array[JSON] as groups when parameter is optional - [@lukeivers](https://github.com/lukeivers).
 
 0.14.0 (12/07/2015)
 ===================

--- a/README.md
+++ b/README.md
@@ -2629,9 +2629,8 @@ For example, you can write a middleware to log application exception.
 ```ruby
 class LoggingError < Grape::Middleware::Base
   def after
-    if @api_response[0] == 500
-      env['rack.logger'].error("Raised error on #{env['PATH_INFO']}")
-    end
+    return unless @app_response && @app_response[0] == 500
+    env['rack.logger'].error("Raised error on #{env['PATH_INFO']}")
   end
 end
 ```

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -17,20 +17,26 @@ end
 
 #### Changes to behavior of `after` method of middleware on error
 
-The `after` method of the middleware is now called on error.
-The following code would work correctly.
+The `after` method of the middleware is now also called on error. The following code would work correctly.
 
 ```ruby
 class ErrorMiddleware < Grape::Middleware::Base
   def after
-    if @api_response[0] == 500
-      env['rack.logger'].debug("Raised error on #{env['PATH_INFO']}")
-    end
+    return unless @app_response && @app_response[0] == 500
+    env['rack.logger'].debug("Raised error on #{env['PATH_INFO']}")
   end
 end
 ```
 
 See [#1147](https://github.com/ruby-grape/grape/issues/1147) and [#1240](https://github.com/ruby-grape/grape/issues/1240) for discussion of the issues.
+
+A warning will be logged if an exception is raised in an `after` callback, which points you to middleware that was not called in the previous version and is called now.
+
+```
+caught error of type NoMethodError in after callback inside Api::Middleware::SomeMiddleware : undefined method `headers' for nil:NilClass
+```
+
+See [#1285](https://github.com/ruby-grape/grape/pull/1285) for more information.
 
 #### Changes to generated OPTIONS and Method Not Allowed routes
 

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -122,7 +122,7 @@ module Grape
         # check type for optional parameter group
         if attrs && block_given?
           fail Grape::Exceptions::MissingGroupTypeError.new if type.nil?
-          fail Grape::Exceptions::UnsupportedGroupTypeError.new unless [Array, Hash].include?(type)
+          fail Grape::Exceptions::UnsupportedGroupTypeError.new unless Grape::Validations::Types.group?(type)
         end
 
         if opts[:using]

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -147,7 +147,7 @@ module Grape
         type = attrs[1] ? attrs[1][:type] : nil
         if attrs.first && !optional
           fail Grape::Exceptions::MissingGroupTypeError.new if type.nil?
-          fail Grape::Exceptions::UnsupportedGroupTypeError.new unless [Array, Hash, JSON, Array[JSON]].include?(type)
+          fail Grape::Exceptions::UnsupportedGroupTypeError.new unless Grape::Validations::Types.group?(type)
         end
 
         opts = attrs[1] || { type: Array }

--- a/lib/grape/validations/types.rb
+++ b/lib/grape/validations/types.rb
@@ -63,6 +63,13 @@ module Grape
         Rack::Multipart::UploadedFile => File
       }
 
+      GROUPS = [
+        Array,
+        Hash,
+        JSON,
+        Array[JSON]
+      ]
+
       # Is the given class a primitive type as recognized by Grape?
       #
       # @param type [Class] type to check
@@ -124,6 +131,15 @@ module Grape
       # @return [Boolean] +true+ if special routines are available
       def self.special?(type)
         SPECIAL.key? type
+      end
+
+      # Is the declared type a supported group type?
+      # Currently supported group types are Array, Hash, JSON, and Array[JSON]
+      #
+      # @param type [Array<Class>,Class] type to check
+      # @return [Boolean] +true+ if the type is a supported group type
+      def self.group?(type)
+        GROUPS.include? type
       end
 
       # A valid custom type must implement a class-level `parse` method, taking

--- a/spec/grape/validations/validators/coerce_spec.rb
+++ b/spec/grape/validations/validators/coerce_spec.rb
@@ -368,6 +368,41 @@ describe Grape::Validations::CoerceValidator do
         expect(last_response.body).to eq('splines[x] does not have a valid value')
       end
 
+      it 'works when declared optional' do
+        subject.params do
+          optional :splines, type: JSON do
+            requires :x, type: Integer, values: [1, 2, 3]
+            optional :ints, type: Array[Integer]
+            optional :obj, type: Hash do
+              optional :y
+            end
+          end
+        end
+        subject.get '/' do
+          if params[:splines].is_a? Hash
+            params[:splines][:obj][:y]
+          else
+            'arrays work' if params[:splines].any? { |s| s.key? :obj }
+          end
+        end
+
+        get '/', splines: '{"x":1,"ints":[1,2,3],"obj":{"y":"woof"}}'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('woof')
+
+        get '/', splines: '[{"x":2,"ints":[]},{"x":3,"ints":[4],"obj":{"y":"quack"}}]'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('arrays work')
+
+        get '/', splines: '{"x":4,"ints":[2]}'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('splines[x] does not have a valid value')
+
+        get '/', splines: '[{"x":1,"ints":[]},{"x":4,"ints":[]}]'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('splines[x] does not have a valid value')
+      end
+
       it 'accepts Array[JSON] shorthand' do
         subject.params do
           requires :splines, type: Array[JSON] do


### PR DESCRIPTION
In response to issue #1197

Uses suggested fix from that issue, including an abstraction to add GROUPS to Grape::Validations::Types

Includes an addition to the spec to ensure that it works the same when declared optional as when declared required.