### PR TITLE
Added a sample spec and example in README.md for admin only fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1198,6 +1198,35 @@ params do
 end
 ```
 
+You can also create custom validation that use request to validate the attribute. For example if you want to have parameters that are available to only admins, you can do the following.
+
+```ruby
+class Admin < Grape::Validations::Base
+  def validate(request)
+    # return if the param we are checking was not in request
+    # @attrs is a list containing the attribute we are currently validating
+    # in our sample case this method once will get called with 
+    # @attrs being [:admin_field] and once with @attrs being [:admin_false_field]
+    return unless request.params.key? @attrs.first
+    # check if admin flag is set to true
+    return unless @option
+    # check if user is admin or not
+    # as an example get a token from request and check if it's admin or not
+    fail Grape::Exceptions::Validation, params: @attrs, message: 'Can not set admin-only field.' unless request.headers['X-Access-Token'] == 'admin'
+  end
+end
+```
+
+And use it in your endpoint definition as:
+
+```ruby
+params do
+  optional :admin_field, type: String, admin: true
+  optional :non_admin_field, type: String
+  optional :admin_false_field, type: String, admin: false
+end
+```
+
 ### Validation Errors
 
 Validation and coercion errors are collected and an exception of type `Grape::Exceptions::ValidationErrors` is raised. If the exception goes uncaught it will respond with a status of 400 and an error message. The validation errors are grouped by parameter name and can be accessed via `Grape::Exceptions::ValidationErrors#errors`.

--- a/spec/grape/api/custom_validations_spec.rb
+++ b/spec/grape/api/custom_validations_spec.rb
@@ -113,4 +113,71 @@ describe Grape::Validations do
       expect(last_response.body).to eq 'text is missing'
     end
   end
+
+  context 'using a custom request/param validator' do
+    before do
+      module CustomValidationsSpec
+        class Admin < Grape::Validations::Base
+          def validate(request)
+            # return if the param we are checking was not in request
+            # @attrs is a list containing the attribute we are currently validating
+            return unless request.params.key? @attrs.first
+            # check if admin flag is set to true
+            return unless @option
+            # check if user is admin or not
+            # as an example get a token from request and check if it's admin or not
+            fail Grape::Exceptions::Validation, params: @attrs, message: 'Can not set Admin only field.' unless request.headers['X-Access-Token'] == 'admin'
+          end
+        end
+      end
+    end
+    subject do
+      Class.new(Grape::API) do
+        params do
+          optional :admin_field, type: String, admin: true
+          optional :non_admin_field, type: String
+          optional :admin_false_field, type: String, admin: false
+        end
+        get do
+          'bacon'
+        end
+      end
+    end
+
+    def app
+      subject
+    end
+
+    it 'fail when non-admin user sets an admin field' do
+      get '/', admin_field: 'tester', non_admin_field: 'toaster'
+      expect(last_response.status).to eq 400
+      expect(last_response.body).to include 'Can not set Admin only field.'
+    end
+
+    it 'does not fail when we send non-admin fields only' do
+      get '/', non_admin_field: 'toaster'
+      expect(last_response.status).to eq 200
+      expect(last_response.body).to eq 'bacon'
+    end
+
+    it 'does not fail when we send non-admin and admin=false fields only' do
+      get '/', non_admin_field: 'toaster', admin_false_field: 'test'
+      expect(last_response.status).to eq 200
+      expect(last_response.body).to eq 'bacon'
+    end
+
+    it 'does not fail when we send admin fields and we are admin' do
+      header 'X-Access-Token', 'admin'
+      get '/', admin_field: 'tester', non_admin_field: 'toaster', admin_false_field: 'test'
+      expect(last_response.status).to eq 200
+      expect(last_response.body).to eq 'bacon'
+    end
+
+    it 'fails when we send admin fields and we are not admin' do
+      header 'X-Access-Token', 'user'
+      get '/', admin_field: 'tester', non_admin_field: 'toaster', admin_false_field: 'test'
+      expect(last_response.status).to eq 400
+      expect(last_response.body).to include 'Can not set Admin only field.'
+    end
+  end
 end


### PR DESCRIPTION
# Problem
Wanted to be able to have custom validation based on request and parameter. As an example wanted to be able to have _Admin Only_ fields that are only available to endpoint if user is admin.

# Solution
With new `validate(request)` method added for custom validation (https://github.com/ruby-grape/grape/pull/1242) we can now support these kinds of attributes. I only added a new sample in spec and also a sample in README.md.