### PR TITLE
Fix built-in parsers and formatters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * [#1325](https://github.com/ruby-grape/grape/pull/1325): Params: Fix coerce_with helper with Array types - [@ngonzalez](https://github.com/ngonzalez).
 * [#1326](https://github.com/ruby-grape/grape/pull/1326): Fix wrong behavior for OPTIONS and HEAD requests with catch-all - [@ekampp](https://github.com/ekampp), [@namusyaka](https://github.com/namusyaka).
+* [#1330](https://github.com/ruby-grape/grape/pull/1330): Fix built-in parsers and formatters - [@namusyaka](https://github.com/namusyaka).
 
 0.15.0 (3/8/2016)
 =================

--- a/lib/grape/error_formatter.rb
+++ b/lib/grape/error_formatter.rb
@@ -1,8 +1,11 @@
+require 'grape/util/registrable'
+
 module Grape
   module ErrorFormatter
+    extend Registrable
     class << self
       def builtin_formatters
-        {
+        @builtin_formatters ||= {
           serializable_hash: Grape::ErrorFormatter::Json,
           json: Grape::ErrorFormatter::Json,
           jsonapi: Grape::ErrorFormatter::Json,
@@ -12,7 +15,7 @@ module Grape
       end
 
       def formatters(options)
-        builtin_formatters.merge(options[:error_formatters] || {})
+        builtin_formatters.merge(default_elements).merge(options[:error_formatters] || {})
       end
 
       def formatter_for(api_format, options = {})

--- a/lib/grape/formatter.rb
+++ b/lib/grape/formatter.rb
@@ -1,8 +1,12 @@
+require 'grape/util/registrable'
+
 module Grape
   module Formatter
+    extend Registrable
+
     class << self
       def builtin_formmaters
-        {
+        @builtin_formatters ||= {
           json: Grape::Formatter::Json,
           jsonapi: Grape::Formatter::Json,
           serializable_hash: Grape::Formatter::SerializableHash,
@@ -12,7 +16,7 @@ module Grape
       end
 
       def formatters(options)
-        builtin_formmaters.merge(options[:formatters] || {})
+        builtin_formmaters.merge(default_elements).merge(options[:formatters] || {})
       end
 
       def formatter_for(api_format, options = {})

--- a/lib/grape/parser.rb
+++ b/lib/grape/parser.rb
@@ -1,8 +1,12 @@
+require 'grape/util/registrable'
+
 module Grape
   module Parser
+    extend Registrable
+
     class << self
       def builtin_parsers
-        {
+        @builtin_parsers ||= {
           json: Grape::Parser::Json,
           jsonapi: Grape::Parser::Json,
           xml: Grape::Parser::Xml
@@ -10,7 +14,7 @@ module Grape
       end
 
       def parsers(options)
-        builtin_parsers.merge(options[:parsers] || {})
+        builtin_parsers.merge(default_elements).merge(options[:parsers] || {})
       end
 
       def parser_for(api_format, options = {})

--- a/lib/grape/util/registrable.rb
+++ b/lib/grape/util/registrable.rb
@@ -1,0 +1,11 @@
+module Grape
+  module Registrable
+    def default_elements
+      @default_elements ||= {}
+    end
+
+    def register(format, element)
+      default_elements[format] = element unless default_elements[format]
+    end
+  end
+end


### PR DESCRIPTION
ref 93e699829f7b4a2fe152370eccdf9b2712f4329f #1329 
I'd like to use grape-msgpack without tricky hacking. Currently, our implementation does not support inheritable interface, so I fixed a few points.

Thoughts?