### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2299,7 +2299,9 @@ module API
       expose :text, documentation: { type: 'string', desc: 'Status update text.' }
       expose :ip, if: { type: :full }
       expose :user_type, :user_id, if: ->(status, options) { status.user.public? }
-      expose :digest { |status, options| Digest::MD5.hexdigest(status.txt) }
+      expose :digest do |status, options| 
+        Digest::MD5.hexdigest(status.txt)
+      end
       expose :replies, using: API::Status, as: :replies
     end
   end


### PR DESCRIPTION
When using something like `expose :updated_at {|instance, options| instance.updated_at.to_s}`, the following exception is raise:

```
SyntaxError:
/Users/x/app/api/entities/foo.rb:11: syntax error, unexpected '{', expecting keyword_end
expose :updated_at {|instance, options| instance.updated_at.to_s}
```
See: ruby-grape/grape-entity#12.
