### PR TITLE
Fix #1348: global functions called during mount.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.16.2 (Next)
 ============
 
+* [#1348](https://github.com/ruby-grape/grape/pull/1348): Fix global functions polluting Grape::API scope - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 0.16.1 (4/3/2016)

--- a/lib/grape/router/route.rb
+++ b/lib/grape/router/route.rb
@@ -8,20 +8,6 @@ module Grape
     class Route
       ROUTE_ATTRIBUTE_REGEXP = /route_([_a-zA-Z]\w*)/.freeze
       SOURCE_LOCATION_REGEXP = /^(.*?):(\d+?)(?::in `.+?')?$/.freeze
-      TRANSLATION_ATTRIBUTES = [
-        :prefix,
-        :version,
-        :namespace,
-        :settings,
-        :format,
-        :description,
-        :http_codes,
-        :headers,
-        :entity,
-        :details,
-        :requirements,
-        :request_method
-      ].freeze
 
       attr_accessor :pattern, :translator, :app, :index, :regexp
 
@@ -29,13 +15,6 @@ module Grape
 
       extend Forwardable
       def_delegators :pattern, :path, :origin
-
-      def self.translate(*attributes)
-        AttributeTranslator.register(*attributes)
-        def_delegators :@translator, *attributes
-      end
-
-      translate(*TRANSLATION_ATTRIBUTES)
 
       def method_missing(method_id, *arguments)
         match = ROUTE_ATTRIBUTE_REGEXP.match(method_id.to_s)
@@ -45,6 +24,25 @@ module Grape
           @options[method_name]
         else
           super
+        end
+      end
+
+      [
+        :prefix,
+        :version,
+        :settings,
+        :format,
+        :description,
+        :http_codes,
+        :headers,
+        :entity,
+        :details,
+        :requirements,
+        :request_method,
+        :namespace
+      ].each do |method_name|
+        define_method method_name do
+          attributes.public_send method_name
         end
       end
 

--- a/spec/grape/integration/global_namespace_function_spec.rb
+++ b/spec/grape/integration/global_namespace_function_spec.rb
@@ -1,0 +1,29 @@
+# see https://github.com/ruby-grape/grape/issues/1348
+
+require 'spec_helper'
+
+def namespace
+  fail
+end
+
+describe Grape::API do
+  subject do
+    Class.new(Grape::API) do
+      format :json
+      get do
+        { ok: true }
+      end
+    end
+  end
+
+  def app
+    subject
+  end
+
+  context 'with a global namespace function' do
+    it 'works' do
+      get '/'
+      expect(last_response.status).to eq 200
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/ruby-grape/grape/issues/1348.

A globally defined `def namespace` in Ruby 2.3.0 pollutes OStruct instance methods. This is described in https://bugs.ruby-lang.org/issues/12136 and https://bugs.ruby-lang.org/issues/12251. One way to reproduce this is to `include Rake::DSL` in the global scope, which defines a global `namespace` method.

This PR gets rid of the OStruct. We cannot use a `Hash` here because we want to respond to methods like `.index` which are natively defined on a `Hash`, so we need a dummy structure that responds to anything. Because it behaves like a Hash though we don't need to register parameters or such, cc: @namusyaka in case I missed anything.

