### PR TITLE
Workaround for #1350, lock grape-entity at 0.5.0.

### DIFF
--- a/grape.gemspec
+++ b/grape.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'virtus', '>= 1.0.0'
   s.add_runtime_dependency 'builder'
 
-  s.add_development_dependency 'grape-entity', '>= 0.4.4'
+  s.add_development_dependency 'grape-entity', '0.5.0'
   s.add_development_dependency 'rake', '~> 10'
   s.add_development_dependency 'maruku'
   s.add_development_dependency 'yard'


### PR DESCRIPTION
#1350