### PR TITLE
Fix router bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * [#1357](https://github.com/ruby-grape/grape/pull/1357): Don't include fixed named captures as route params - [@namusyaka](https://github.com/namusyaka).
 * [#1359](https://github.com/ruby-grape/grape/pull/1359): Return 404 even if version is using as header - [@namusyaka](https://github.com/namusyaka).
+* [#1359](https://github.com/ruby-grape/grape/pull/1359): Avoid evaluating the same route twice - [@namusyaka](https://github.com/namusyaka), [@dblock](https://github.com/dblock).
 
 0.16.1 (4/3/2016)
 =================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Fixes
 
 * [#1357](https://github.com/ruby-grape/grape/pull/1357): Don't include fixed named captures as route params - [@namusyaka](https://github.com/namusyaka).
+* [#1359](https://github.com/ruby-grape/grape/pull/1359): Return 404 even if version is using as header - [@namusyaka](https://github.com/namusyaka).
 
 0.16.1 (4/3/2016)
 =================

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -124,6 +124,8 @@ module Grape
     def method_not_allowed(env, methods, endpoint)
       current = endpoint.dup
       current.instance_eval do
+        namespace_inheritable_to_nil(:version)
+        @lazy_initialized = false
         run_filters befores, :before
         @method_not_allowed = true
         @block = proc do

--- a/spec/grape/integration/version_header_spec.rb
+++ b/spec/grape/integration/version_header_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+describe Grape::API::Helpers do
+  module PatchHelpersSpec
+    class PatchPublic < Grape::API
+      format :json
+      version 'public-v1', using: :header, vendor: 'grape'
+
+      get do
+        { ok: 'public' }
+      end
+    end
+
+    module AuthMethods
+      def authenticate!
+      end
+    end
+
+    class PatchPrivate < Grape::API
+      format :json
+      version 'private-v1', using: :header, vendor: 'grape'
+
+      helpers AuthMethods
+
+      before do
+        authenticate!
+      end
+
+      get do
+        { ok: 'private' }
+      end
+    end
+
+    class Main < Grape::API
+      mount PatchPublic
+      mount PatchPrivate
+    end
+  end
+
+  def app
+    PatchHelpersSpec::Main
+  end
+
+  context 'default' do
+    it 'public' do
+      get '/', {}, 'HTTP_ACCEPT' => 'application/vnd.grape-public-v1+json'
+      expect(last_response.status).to eq 200
+      expect(last_response.body).to eq({ ok: 'public' }.to_json)
+    end
+
+    it 'private' do
+      get '/', {}, 'HTTP_ACCEPT' => 'application/vnd.grape-private-v1+json'
+      expect(last_response.status).to eq 200
+      expect(last_response.body).to eq({ ok: 'private' }.to_json)
+    end
+
+    it 'default' do
+      get '/'
+      expect(last_response.status).to eq 200
+      expect(last_response.body).to eq({ ok: 'public' }.to_json)
+    end
+  end
+
+  context 'patch' do
+    it 'public' do
+      patch '/', {}, 'HTTP_ACCEPT' => 'application/vnd.grape-public-v1+json'
+      expect(last_response.status).to eq 405
+    end
+
+    it 'private' do
+      patch '/', {}, 'HTTP_ACCEPT' => 'application/vnd.grape-private-v1+json'
+      expect(last_response.status).to eq 405
+    end
+
+    it 'default' do
+      patch '/'
+      expect(last_response.status).to eq 405
+    end
+  end
+end


### PR DESCRIPTION
ref #1355 #1356 
The `PATCH` bug is caused by calling `Grape::Middleware::Versioner::Header`.
Now, grape router calls it because you can not eject route except first route of all routes having same paths.
But maybe it has no problem essentially.
So I think this problem can be solved by not call the middleware.

/cc @dblock 