### PR TITLE
add back message key in order to have error_codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Your contribution here.
 
 #### Features
-* [#1366](https://github.com/ruby-grape/grape/pull/1366): Store back `message_key` on `Grape::Exceptions::Validation` - [@mkou](https://github.com/mkou).
+* [#1366](https://github.com/ruby-grape/grape/pull/1366): Store `message_key` on `Grape::Exceptions::Validation` - [@mkou](https://github.com/mkou).
 
 0.16.2 (4/12/2016)
 ==================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 * Your contribution here.
 
+#### Features
+* [#1366](https://github.com/ruby-grape/grape/pull/1366): Store back `message_key` on `Grape::Exceptions::Validation` - [@mkou](https://github.com/mkou).
+
 0.16.2 (4/12/2016)
 ==================
 

--- a/lib/grape/exceptions/validation.rb
+++ b/lib/grape/exceptions/validation.rb
@@ -9,8 +9,10 @@ module Grape
       def initialize(args = {})
         fail 'Params are missing:' unless args.key? :params
         @params = args[:params]
-        @message_key = args[:message] if args.key?(:message) && args[:message].is_a?(Symbol)
-        args[:message] = translate_message(args[:message]) if args.key? :message
+        if args.key?(:message)
+          @message_key = args[:message] if args[:message].is_a?(Symbol)
+          args[:message] = translate_message(args[:message])
+        end
         super
       end
 

--- a/lib/grape/exceptions/validation.rb
+++ b/lib/grape/exceptions/validation.rb
@@ -9,6 +9,7 @@ module Grape
       def initialize(args = {})
         fail 'Params are missing:' unless args.key? :params
         @params = args[:params]
+        @message_key = args[:message] if args.key?(:message) && args[:message].is_a?(Symbol)
         args[:message] = translate_message(args[:message]) if args.key? :message
         super
       end

--- a/spec/grape/exceptions/validation_spec.rb
+++ b/spec/grape/exceptions/validation_spec.rb
@@ -4,4 +4,14 @@ describe Grape::Exceptions::Validation do
   it 'fails when params are missing' do
     expect { Grape::Exceptions::Validation.new(message: 'presence') }.to raise_error(RuntimeError, 'Params are missing:')
   end
+  context 'when message is a symbol' do
+    it 'stores message_key' do
+      expect(Grape::Exceptions::Validation.new(params: ['id'], message: :presence).message_key).to eq(:presence)
+    end
+  end
+  context 'when message is a String' do
+    it 'does not store the message_key' do
+      expect(Grape::Exceptions::Validation.new(params: ['id'], message: 'presence').message_key).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
In my situation, in the exception validations, I need message keys as well as the translations in order to pass error codes