### PR TITLE
Improve performance for StackableValues#[name] method

### DIFF
--- a/lib/grape/util/stackable_values.rb
+++ b/lib/grape/util/stackable_values.rb
@@ -13,9 +13,10 @@ module Grape
 
       def [](name)
         return @froozen_values[name] if @froozen_values.key? name
-        value = [@inherited_values[name], @new_values[name]]
-        value.compact!
-        value.flatten!(1)
+
+        value = []
+        value.concat(@inherited_values[name]) if @inherited_values[name]
+        value.concat(@new_values[name]) if @new_values[name]
         value
       end
 


### PR DESCRIPTION
I profiled our app that uses Grape and looks like the StackableValues#[name] ([this code](https://github.com/ruby-grape/grape/blob/master/lib/grape/util/stackable_values.rb#L14-L20)) takes most of the time. And it's good idea to improve its performance. So I tried to do this.

It gives some performance. Here my benchmarks:

```ruby
Benchmark.ips do |x|
  x.report(:old) do
    value = [@inherited_values[name], @new_values[name]]
    value.compact!
    value.flatten!(1)
    value
  end
  x.report(:new) do
    value = []
    value.concat(@inherited_values[name]) if @inherited_values[name]
    value.concat(@new_values[name]) if @new_values[name]
    value
  end
end
```

And the results:

```
Warming up --------------------------------------
                 old    61.139k i/100ms
                 new   173.740k i/100ms
Calculating -------------------------------------
                 old    846.468k (± 6.0%) i/s -      4.219M in   5.001411s
                 new      4.330M (± 7.6%) i/s -     21.544M in   5.005451s
```