### PR TITLE
allow_blank for Time types 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Fixes
 
 * [#1365](https://github.com/ruby-grape/grape/pull/1365): Fix finding exception handler in error middleware - [@ktimothy](https://github.com/ktimothy).
+* [#1380](https://github.com/ruby-grape/grape/pull/1380): `allow_blank: false` for `Time` attribute with valid value causes an error [@ipkes](https://github.com/ipkes).
 
 0.16.2 (4/12/2016)
 ==================

--- a/lib/grape/validations/validators/allow_blank.rb
+++ b/lib/grape/validations/validators/allow_blank.rb
@@ -20,7 +20,7 @@ module Grape
 
         return unless should_validate
 
-        return if value == false || value.present?
+        return if false == value || value.present?
 
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:blank)
       end

--- a/spec/grape/validations/validators/allow_blank_spec.rb
+++ b/spec/grape/validations/validators/allow_blank_spec.rb
@@ -488,6 +488,11 @@ describe Grape::Validations::AllowBlankValidator do
       get '/disallow_boolean_blank', val: false
       expect(last_response.status).to eq(200)
     end
+
+    it 'accepts value when time allow_blank' do
+      get '/disallow_datetime_blank', val: Time.now
+      expect(last_response.status).to eq(200)
+    end
   end
 
   context 'in an optional group' do


### PR DESCRIPTION
Based on [this](https://github.com/ruby-grape/grape/issues/723#issuecomment-214208198)
Valid value for `Time` attribute causes an error when attribute marked `allow_blank: false`