### PR TITLE
Replace merge by merge!

### DIFF
--- a/lib/grape/cookies.rb
+++ b/lib/grape/cookies.rb
@@ -32,7 +32,7 @@ module Grape
     end
 
     def delete(name, opts = {})
-      options = opts.merge(value: 'deleted', expires: Time.at(0))
+      options = opts.merge!(value: 'deleted', expires: Time.at(0))
       self.[]=(name, options)
     end
   end

--- a/lib/grape/dsl/desc.rb
+++ b/lib/grape/dsl/desc.rb
@@ -51,7 +51,7 @@ module Grape
           end
           options = config_class.settings
         else
-          options = options.merge(description: description)
+          options = options.merge!(description: description)
         end
 
         namespace_setting :description, options

--- a/lib/grape/dsl/desc.rb
+++ b/lib/grape/dsl/desc.rb
@@ -51,7 +51,7 @@ module Grape
           end
           options = config_class.settings
         else
-          options = options.merge!(description: description)
+          options[:description] = description
         end
 
         namespace_setting :description, options

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -308,7 +308,7 @@ module Grape
       def entity_representation_for(entity_class, object, options)
         embeds = { env: env }
         embeds[:version] = env[Grape::Env::API_VERSION] if env[Grape::Env::API_VERSION]
-        entity_class.represent(object, embeds.merge(options))
+        entity_class.represent(object, embeds.merge!(options))
       end
     end
   end

--- a/lib/grape/error_formatter.rb
+++ b/lib/grape/error_formatter.rb
@@ -14,7 +14,7 @@ module Grape
       end
 
       def formatters(options)
-        builtin_formatters.merge(default_elements).merge(options[:error_formatters] || {})
+        builtin_formatters.merge!(default_elements).merge(options[:error_formatters] || {})
       end
 
       def formatter_for(api_format, options = {})

--- a/lib/grape/error_formatter/json.rb
+++ b/lib/grape/error_formatter/json.rb
@@ -8,7 +8,7 @@ module Grape
           result = wrap_message(present(message, env))
 
           if (options[:rescue_options] || {})[:backtrace] && backtrace && !backtrace.empty?
-            result.merge!(backtrace: backtrace)
+            result[:backtrace] = backtrace
           end
           MultiJson.dump(result)
         end

--- a/lib/grape/error_formatter/json.rb
+++ b/lib/grape/error_formatter/json.rb
@@ -8,7 +8,7 @@ module Grape
           result = wrap_message(present(message, env))
 
           if (options[:rescue_options] || {})[:backtrace] && backtrace && !backtrace.empty?
-            result = result.merge(backtrace: backtrace)
+            result.merge!(backtrace: backtrace)
           end
           MultiJson.dump(result)
         end

--- a/lib/grape/error_formatter/xml.rb
+++ b/lib/grape/error_formatter/xml.rb
@@ -9,7 +9,7 @@ module Grape
 
           result = message.is_a?(Hash) ? message : { message: message }
           if (options[:rescue_options] || {})[:backtrace] && backtrace && !backtrace.empty?
-            result.merge!(backtrace: backtrace)
+            result[:backtrace] = backtrace
           end
           result.respond_to?(:to_xml) ? result.to_xml(root: :error) : result.to_s
         end

--- a/lib/grape/error_formatter/xml.rb
+++ b/lib/grape/error_formatter/xml.rb
@@ -9,7 +9,7 @@ module Grape
 
           result = message.is_a?(Hash) ? message : { message: message }
           if (options[:rescue_options] || {})[:backtrace] && backtrace && !backtrace.empty?
-            result = result.merge(backtrace: backtrace)
+            result.merge!(backtrace: backtrace)
           end
           result.respond_to?(:to_xml) ? result.to_xml(root: :error) : result.to_s
         end

--- a/lib/grape/exceptions/base.rb
+++ b/lib/grape/exceptions/base.rb
@@ -72,7 +72,7 @@ module Grape
 
       def translate(key, options = {})
         message = ::I18n.translate(key, options)
-        message.present? ? message : ::I18n.translate(key, options.merge(locale: FALLBACK_LOCALE))
+        message.present? ? message : ::I18n.translate(key, options.merge!(locale: FALLBACK_LOCALE))
       end
     end
   end

--- a/lib/grape/formatter.rb
+++ b/lib/grape/formatter.rb
@@ -14,7 +14,7 @@ module Grape
       end
 
       def formatters(options)
-        builtin_formmaters.merge(default_elements).merge(options[:formatters] || {})
+        builtin_formmaters.merge!(default_elements).merge(options[:formatters] || {})
       end
 
       def formatter_for(api_format, options = {})

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -61,7 +61,7 @@ module Grape
         if headers[Grape::Http::Headers::CONTENT_TYPE]
           headers
         else
-          headers.merge(Grape::Http::Headers::CONTENT_TYPE => content_type_for(env[Grape::Env::API_FORMAT]))
+          headers.merge!(Grape::Http::Headers::CONTENT_TYPE => content_type_for(env[Grape::Env::API_FORMAT]))
         end
       end
 

--- a/lib/grape/parser.rb
+++ b/lib/grape/parser.rb
@@ -12,7 +12,7 @@ module Grape
       end
 
       def parsers(options)
-        builtin_parsers.merge(default_elements).merge(options[:parsers] || {})
+        builtin_parsers.merge!(default_elements).merge(options[:parsers] || {})
       end
 
       def parser_for(api_format, options = {})

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -44,7 +44,7 @@ module Grape
 
     def associate_routes(pattern, options = {})
       regexp = /(?<_#{@neutral_map.length}>)#{pattern.to_regexp}/
-      @neutral_map << Any.new(pattern, options.merge(regexp: regexp, index: @neutral_map.length))
+      @neutral_map << Any.new(pattern, options.merge!(regexp: regexp, index: @neutral_map.length))
     end
 
     def call(env)
@@ -100,7 +100,7 @@ module Grape
 
     def make_routing_args(default_args, route, input)
       args = default_args || { route_info: route }
-      args.merge(route.params(input))
+      args.merge!(route.params(input))
     end
 
     def extract_required_args(env)

--- a/lib/grape/router/pattern.rb
+++ b/lib/grape/router/pattern.rb
@@ -40,7 +40,7 @@ module Grape
       end
 
       def extract_capture(options = {})
-        requirements = {}.merge(options[:requirements])
+        requirements = {}.merge!(options[:requirements])
         supported_capture.each_with_object(requirements) do |field, capture|
           option = Array(options[field])
           capture[field] = option.map(&:to_s) if option.present?


### PR DESCRIPTION
As described [here](https://github.com/JuanitoFatas/fast-ruby#hashmerge-vs-hashmerge-code), `merge!` is 24x faster than `merge`.