### PR TITLE
Allow inserting middleware at arbitrary points in the middleware stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 #### Features
 
+* [#1390](https://github.com/ruby-grape/grape/pull/1390): Allow inserting middleware at arbitrary points in the middleware stack - [@Rosa](https://github.com/Rosa).
 * [#1366](https://github.com/ruby-grape/grape/pull/1366): Store `message_key` on `Grape::Exceptions::Validation` - [@mkou](https://github.com/mkou).
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -2807,7 +2807,27 @@ Your middleware can overwrite application response as follows, except error case
 ```ruby
 class Overwriter < Grape::Middleware::Base
   def after
-    [200, { 'Content-Type' => 'text/plain' }, ['Overwrited.']]
+    [200, { 'Content-Type' => 'text/plain' }, ['Overwritten.']]
+  end
+end
+```
+
+You can add your custom middleware with `use`, that push the middleware onto the stack, and you can also control where the middleware is inserted using `insert`, `insert_before` and `insert_after`.
+
+```ruby
+class CustomOverwriter < Grape::Middleware::Base
+  def after
+    [200, { 'Content-Type' => 'text/plain' }, [@options[:message]]]
+  end
+end
+
+
+class API < Grape::API
+  use Overwriter
+  insert_before Overwriter, CustomOverwriter, message: 'Overwritten again.'
+  insert 0, CustomOverwriter, message: 'Overwrites all other middleware.'
+
+  get '/' do
   end
 end
 ```

--- a/lib/grape/dsl/middleware.rb
+++ b/lib/grape/dsl/middleware.rb
@@ -15,7 +15,21 @@ module Grape
         # @param middleware_class [Class] The class of the middleware you'd like
         #   to inject.
         def use(middleware_class, *args, &block)
-          arr = [middleware_class, *args]
+          arr = [:use, middleware_class, *args]
+          arr << block if block_given?
+
+          namespace_stackable(:middleware, arr)
+        end
+
+        def insert_before(*args, &block)
+          arr = [:insert_before, *args]
+          arr << block if block_given?
+
+          namespace_stackable(:middleware, arr)
+        end
+
+        def insert_after(*args, &block)
+          arr = [:insert_after, *args]
           arr << block if block_given?
 
           namespace_stackable(:middleware, arr)

--- a/lib/grape/middleware/stack.rb
+++ b/lib/grape/middleware/stack.rb
@@ -1,0 +1,97 @@
+module Grape
+  module Middleware
+    # Class to handle the stack of middlewares based on ActionDispatch::MiddlewareStack
+    # It allows to insert and insert after
+    class Stack
+      class Middleware
+        attr_reader :args, :block, :klass
+
+        def initialize(klass, *args, &block)
+          @klass = klass
+          @args = args
+          @block = block
+        end
+
+        def name
+          klass.name
+        end
+
+        def ==(other)
+          case other
+          when Middleware
+            klass == other.klass
+          when Class
+            klass == other
+          end
+        end
+
+        def inspect
+          klass.to_s
+        end
+      end
+
+      include Enumerable
+
+      attr_accessor :middlewares
+
+      def initialize
+        @middlewares = []
+      end
+
+      def each
+        @middlewares.each { |x| yield x }
+      end
+
+      def size
+        middlewares.size
+      end
+
+      def last
+        middlewares.last
+      end
+
+      def [](i)
+        middlewares[i]
+      end
+
+      def insert(index, *args, &block)
+        index = assert_index(index, :before)
+        middleware = self.class::Middleware.new(*args, &block)
+        middlewares.insert(index, middleware)
+      end
+
+      alias insert_before insert
+
+      def insert_after(index, *args, &block)
+        index = assert_index(index, :after)
+        insert(index + 1, *args, &block)
+      end
+
+      def use(*args, &block)
+        middleware = self.class::Middleware.new(*args, &block)
+        middlewares.push(middleware)
+      end
+
+      def merge_with(other)
+        other.each do |operation, *args|
+          block = args.pop if args.last.is_a?(Proc)
+          block ? send(operation, *args, &block) : send(operation, *args)
+        end
+      end
+
+      def build(builder)
+        middlewares.each do |m|
+          m.block ? builder.use(m.klass, *m.args, &m.block) : builder.use(m.klass, *m.args)
+        end
+      end
+
+      protected
+
+      def assert_index(index, where)
+        i = index.is_a?(Integer) ? index : middlewares.index(index)
+        raise "No such middleware to insert #{where}: #{index.inspect}" unless i
+        i
+      end
+    end
+  end
+end

--- a/lib/grape/util/stackable_values.rb
+++ b/lib/grape/util/stackable_values.rb
@@ -3,16 +3,16 @@ module Grape
     class StackableValues
       attr_accessor :inherited_values
       attr_reader :new_values
-      attr_reader :froozen_values
+      attr_reader :frozen_values
 
       def initialize(inherited_values = {})
         @inherited_values = inherited_values
         @new_values = {}
-        @froozen_values = {}
+        @frozen_values = {}
       end
 
       def [](name)
-        return @froozen_values[name] if @froozen_values.key? name
+        return @frozen_values[name] if @frozen_values.key? name
 
         value = []
         value.concat(@inherited_values[name]) if @inherited_values[name]
@@ -21,7 +21,7 @@ module Grape
       end
 
       def []=(name, value)
-        raise if @froozen_values.key? name
+        raise if @frozen_values.key? name
         @new_values[name] ||= []
         @new_values[name].push value
       end
@@ -43,7 +43,7 @@ module Grape
       end
 
       def freeze_value(key)
-        @froozen_values[key] = self[key].freeze
+        @frozen_values[key] = self[key].freeze
       end
 
       def initialize_copy(other)

--- a/spec/grape/dsl/middleware_spec.rb
+++ b/spec/grape/dsl/middleware_spec.rb
@@ -7,23 +7,43 @@ module Grape
         include Grape::DSL::Middleware
       end
     end
+
     describe Middleware do
       subject { Class.new(MiddlewareSpec::Dummy) }
       let(:proc) { ->() {} }
+      let(:foo_middleware) { Class.new }
+      let(:bar_middleware) { Class.new }
 
       describe '.use' do
-        it 'adds a middleware' do
-          expect(subject).to receive(:namespace_stackable).with(:middleware, [:my_middleware, :arg1, proc])
+        it 'adds a middleware with the right operation' do
+          expect(subject).to receive(:namespace_stackable).with(:middleware, [:use, foo_middleware, :arg1, proc])
 
-          subject.use :my_middleware, :arg1, &proc
+          subject.use foo_middleware, :arg1, &proc
+        end
+      end
+
+      describe '.insert_before' do
+        it 'adds a middleware with the right operation' do
+          expect(subject).to receive(:namespace_stackable).with(:middleware, [:insert_before, foo_middleware, :arg1, proc])
+
+          subject.insert_before foo_middleware, :arg1, &proc
+        end
+      end
+
+      describe '.insert_after' do
+        it 'adds a middleware with the right operation' do
+          expect(subject).to receive(:namespace_stackable).with(:middleware, [:insert_after, foo_middleware, :arg1, proc])
+
+          subject.insert_after foo_middleware, :arg1, &proc
         end
       end
 
       describe '.middleware' do
         it 'returns the middleware stack' do
-          subject.use :my_middleware, :arg1, &proc
+          subject.use foo_middleware, :arg1, &proc
+          subject.insert_before bar_middleware, :arg1, :arg2
 
-          expect(subject.middleware).to eq [[:my_middleware, :arg1, proc]]
+          expect(subject.middleware).to eq [[:use, foo_middleware, :arg1, proc], [:insert_before, bar_middleware, :arg1, :arg2]]
         end
       end
     end

--- a/spec/grape/middleware/stack_spec.rb
+++ b/spec/grape/middleware/stack_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+describe Grape::Middleware::Stack do
+  module StackSpec
+    class FooMiddleware; end
+    class BarMiddleware; end
+    class BlockMiddleware
+      attr_reader :block
+      def initialize(&block)
+        @block = block
+      end
+    end
+  end
+
+  subject { Grape::Middleware::Stack.new }
+
+  before do
+    subject.use StackSpec::FooMiddleware
+  end
+
+  describe '#use' do
+    it 'pushes a middleware class onto the stack' do
+      expect { subject.use StackSpec::BarMiddleware }
+        .to change { subject.size }.by(1)
+      expect(subject.last).to eq(StackSpec::BarMiddleware)
+    end
+
+    it 'pushes a middleware class with arguments onto the stack' do
+      expect { subject.use StackSpec::BarMiddleware, false, my_arg: 42 }
+        .to change { subject.size }.by(1)
+      expect(subject.last).to eq(StackSpec::BarMiddleware)
+      expect(subject.last.args).to eq([false, { my_arg: 42 }])
+    end
+
+    it 'pushes a middleware class with block arguments onto the stack' do
+      proc = ->() {}
+      expect { subject.use StackSpec::BlockMiddleware, &proc }
+        .to change { subject.size }.by(1)
+      expect(subject.last).to eq(StackSpec::BlockMiddleware)
+      expect(subject.last.args).to eq([])
+      expect(subject.last.block).to eq(proc)
+    end
+  end
+
+  describe '#insert' do
+    it 'inserts a middleware class at the integer index' do
+      expect { subject.insert 0, StackSpec::BarMiddleware }
+        .to change { subject.size }.by(1)
+      expect(subject[0]).to eq(StackSpec::BarMiddleware)
+      expect(subject[1]).to eq(StackSpec::FooMiddleware)
+    end
+  end
+
+  describe '#insert_before' do
+    it 'inserts a middleware before another middleware class' do
+      expect { subject.insert_before StackSpec::FooMiddleware, StackSpec::BarMiddleware }
+        .to change { subject.size }.by(1)
+      expect(subject[0]).to eq(StackSpec::BarMiddleware)
+      expect(subject[1]).to eq(StackSpec::FooMiddleware)
+    end
+
+    it 'raises an error on an invalid index' do
+      expect { subject.insert_before StackSpec::BlockMiddleware, StackSpec::BarMiddleware }
+        .to raise_error(RuntimeError, 'No such middleware to insert before: StackSpec::BlockMiddleware')
+    end
+  end
+
+  describe '#insert_after' do
+    it 'inserts a middleware after another middleware class' do
+      expect { subject.insert_after StackSpec::FooMiddleware, StackSpec::BarMiddleware }
+        .to change { subject.size }.by(1)
+      expect(subject[1]).to eq(StackSpec::BarMiddleware)
+      expect(subject[0]).to eq(StackSpec::FooMiddleware)
+    end
+
+    it 'raises an error on an invalid index' do
+      expect { subject.insert_after StackSpec::BlockMiddleware, StackSpec::BarMiddleware }
+        .to raise_error(RuntimeError, 'No such middleware to insert after: StackSpec::BlockMiddleware')
+    end
+  end
+
+  describe '#merge_with' do
+    let(:proc) { ->() {} }
+    let(:other) { [[:use, StackSpec::BarMiddleware], [:insert_before, StackSpec::BarMiddleware, StackSpec::BlockMiddleware, proc]] }
+
+    it 'applies a collection of operations and middlewares' do
+      expect { subject.merge_with(other) }
+        .to change { subject.size }.by(2)
+      expect(subject[0]).to eq(StackSpec::FooMiddleware)
+      expect(subject[1]).to eq(StackSpec::BlockMiddleware)
+      expect(subject[2]).to eq(StackSpec::BarMiddleware)
+    end
+  end
+end


### PR DESCRIPTION
This pull request is inspired by #794. I was using Grape and found myself needing this feature, so I have built a possible way of supporting `insert`, `insert_after` and `insert_before` in a similar way as Rails does.

Adding a new middleware can now be done through `use`, `insert`, `insert_after` and `insert_before`, and the operation chosen to do so is stacked together with the middleware class, args, and blocks. The stack is built using the operations in `Grape::Endpoint#build_stack` using a new class `Grape::Middleware::Stack`, based on `ActionDispatch::MiddlewareStack` with some simplifications (for example, only classes are supported for middleware, no symbols or strings, which is being deprecated in `ActionDispatch` in any case).

The commit message offers more details on the implementation itself. If anyone has a better idea of how this feature could be implemented I'd be glad to modify my changes to follow a different approach.

This is my first PR in the Grape project and I have tried to follow the same style when adding new tests for the feature and updating the `README`, but I'd be more than happy to adapt those according to feedback 😃 




