### PR TITLE
Add #middleware_spec hook method to Middleware.use

### DIFF
--- a/lib/grape/dsl/middleware.rb
+++ b/lib/grape/dsl/middleware.rb
@@ -12,10 +12,13 @@ module Grape
         # to the current namespace and any children, but
         # not parents.
         #
-        # @param middleware_class [Class] The class of the middleware you'd like
-        #   to inject.
-        def use(middleware_class, *args, &block)
-          arr = [:use, middleware_class, *args]
+        # @param [Class] klass The class of the middleware you'd like to inject.
+        def use(klass, *args, &block)
+          arr = if klass.respond_to?(:middleware_spec)
+                  klass.middleware_spec.push(*args)
+                else
+                  [:use, klass, *args]
+                end
           arr << block if block_given?
 
           namespace_stackable(:middleware, arr)

--- a/spec/grape/dsl/middleware_spec.rb
+++ b/spec/grape/dsl/middleware_spec.rb
@@ -20,6 +20,21 @@ module Grape
 
           subject.use foo_middleware, :arg1, &proc
         end
+
+        context 'when the given class responds to +middleware_spec+' do
+          let(:foo_middleware) do
+            Class.new do
+              def self.middleware_spec
+                [:insert_after, Object, self]
+              end
+            end
+          end
+
+          it 'stores the return value of +middleware_spec+ with the given args and proc' do
+            expect(subject).to receive(:namespace_stackable).with(:middleware, [:insert_after, Object, foo_middleware, :arg1, proc])
+            subject.use foo_middleware, :arg1, &proc
+          end
+        end
       end
 
       describe '.insert_before' do


### PR DESCRIPTION
@dblock @namusyaka What do you think about this? The benefit is it provides a way for middleware to position themselves when added with `use`
