### PR TITLE
adding option to allow grape to handle Grape::Exception when rescue all is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 * Your contribution here.
 
+* [#1398](https://github.com/ruby-grape/grape/pull/1398): Added rescue_from :grape_exceptions option to allow Grape to use the built in Grape::Exception handing and use rescue :all behavior for everything else - [@mmclead](https://github.com/mmclead).
+
 #### Features
 
 * [#1393](https://github.com/ruby-grape/grape/pull/1393): Middleware can be inserted before or after default Grape middleware - [@ridiculous](https://github.com/ridiculous).

--- a/README.md
+++ b/README.md
@@ -1853,6 +1853,17 @@ class Twitter::API < Grape::API
 end
 ```
 
+Grape can also rescue from all exceptions and still use the built-in exception handing.
+This will give the same behavior as `rescue_from :all` with the addition that Grape will use the exception handling defined by all Exception classes that inherit Grape::Exceptions::Base.
+
+The intent of this setting is to provide a simple way to cover the most common exceptions and return any unexpected exceptions in the API format.
+
+```ruby
+class Twitter::API < Grape::API
+  rescue_from :grape_exceptions
+end
+```
+
 You can also rescue specific exceptions.
 
 ```ruby

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -110,9 +110,13 @@ module Grape
           end
           handler ||= extract_with(options)
 
-          if args.include?(:all)
+          case
+          when args.include?(:all)
             namespace_inheritable(:rescue_all, true)
             namespace_inheritable :all_rescue_handler, handler
+          when args.include?(:grape_exceptions)
+            namespace_inheritable(:rescue_all, true)
+            namespace_inheritable(:rescue_grape_exceptions, true)
           else
             handler_type =
               case options[:rescue_subclasses]

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -254,6 +254,7 @@ module Grape
                 content_types: namespace_stackable_with_hash(:content_types),
                 default_status: namespace_inheritable(:default_error_status),
                 rescue_all: namespace_inheritable(:rescue_all),
+                rescue_grape_exceptions: namespace_inheritable(:rescue_grape_exceptions),
                 default_error_formatter: namespace_inheritable(:default_error_formatter),
                 error_formatters: namespace_stackable_with_hash(:error_formatters),
                 rescue_options: namespace_stackable_with_hash(:rescue_options) || {},

--- a/spec/grape/dsl/request_response_spec.rb
+++ b/spec/grape/dsl/request_response_spec.rb
@@ -143,6 +143,20 @@ module Grape
           end
         end
 
+        describe ':grape_exceptions' do
+          it 'sets rescue all to true' do
+            expect(subject).to receive(:namespace_inheritable).with(:rescue_all, true)
+            expect(subject).to receive(:namespace_inheritable).with(:rescue_grape_exceptions, true)
+            subject.rescue_from :grape_exceptions
+          end
+
+          it 'sets rescue_grape_exceptions to true' do
+            expect(subject).to receive(:namespace_inheritable).with(:rescue_all, true)
+            expect(subject).to receive(:namespace_inheritable).with(:rescue_grape_exceptions, true)
+            subject.rescue_from :grape_exceptions
+          end
+        end
+
         describe 'list of exceptions is passed' do
           it 'sets hash of exceptions as rescue handlers' do
             expect(subject).to receive(:namespace_reverse_stackable).with(:rescue_handlers, StandardError => nil)

--- a/spec/grape/exceptions/body_parse_errors_spec.rb
+++ b/spec/grape/exceptions/body_parse_errors_spec.rb
@@ -52,6 +52,43 @@ describe Grape::Exceptions::ValidationErrors do
     end
   end
 
+  context 'api with rescue_from :grape_exceptions handler' do
+    subject { Class.new(Grape::API) }
+    before do
+      subject.rescue_from :all do |_e|
+        rack_response 'message was processed', 400
+      end
+      subject.rescue_from :grape_exceptions
+
+      subject.params do
+        requires :beer
+      end
+      subject.post '/beer' do
+        'beer received'
+      end
+    end
+
+    def app
+      subject
+    end
+
+    context 'with content_type json' do
+      it 'returns body parsing error message' do
+        post '/beer', 'test', 'CONTENT_TYPE' => 'application/json'
+        expect(last_response.status).to eq 400
+        expect(last_response.body).to include 'message body does not match declared format'
+      end
+    end
+
+    context 'with content_type xml' do
+      it 'returns body parsing error message' do
+        post '/beer', 'test', 'CONTENT_TYPE' => 'application/xml'
+        expect(last_response.status).to eq 400
+        expect(last_response.body).to include 'message body does not match declared format'
+      end
+    end
+  end
+
   context 'api without a rescue handler' do
     subject { Class.new(Grape::API) }
     before do


### PR DESCRIPTION
This will allow Grape to use the built in Grape Exceptions defined in /lib/grape/exceptions when rescue :all is set.