### PR TITLE
clarify possibility to combine rescuing all and custom exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1816,6 +1816,18 @@ end
 
 In this case ```UserDefinedError``` must be inherited from ```StandardError```.
 
+Notice that you could combine these two approaches (rescuing custom errors takes precedence). For example, it's useful for handling all exceptions except Grape validation errors.
+
+```ruby
+class Twitter::API < Grape::API
+  rescue_from Grape::Exceptions::ValidationErrors do |e|
+    error!(e, 400)
+  end
+
+  rescue_from :all
+end
+```
+
 The error format will match the request format. See "Content-Types" below.
 
 Custom error formatters for existing and additional types can be defined with a proc.
@@ -1863,7 +1875,7 @@ class Twitter::API < Grape::API
 end
 ```
 
-You can also rescue specific exceptions with a code block and handle the Rack response at the lowest level.
+You can also rescue all exceptions with a code block and handle the Rack response at the lowest level.
 
 ```ruby
 class Twitter::API < Grape::API


### PR DESCRIPTION
As for me, with current version of Readme it isn't obvious that you could combine `rescue_from :all` and `rescue_from CustomError`. But at the moment it's probably the only way to properly handle validation errors and giving fallback for other exceptions. I am not alone with this issue: @johnsinco has created #938 and part of the source for this PR was kindly provided by @dblock in #939.

By the way, what do you think about having something like this?
```ruby
rescue_from :all, except: [Grape::Exceptions::Validation, Grape::Exceptions::ValidationErrors]
# or
rescue_from :all, except: :validation_errors
```
Maybe this approach would be useful to utilize both default way to handle validation errors and all other errors (without need to manually handle them).