### PR TITLE
Create a test that shows bug #1403

### DIFF
--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -652,6 +652,18 @@ describe Grape::Endpoint do
       expect(last_response.body).to eq('{"error":"The requested content-type \'application/xml\' is not supported."}')
     end
 
+    it 'responds with a 406 for an unsupported content-type for a post request' do
+      subject.format :json
+      # subject.content_type :json, "application/json"
+      subject.post '/request_body' do
+        params[:user]
+      end
+      post '/request_body', 'user=ciao', 'CONTENT_TYPE' => 'application/x-www-form-urlencoded'
+      expect(last_request.content_type).to eq('application/x-www-form-urlencoded')
+      expect(last_response.status).to eq(406)
+      expect(last_response.body).to eq('{"error":"The requested content-type \'application/xml\' is not supported."}')
+    end
+
     context 'content type with params' do
       before do
         subject.format :json


### PR DESCRIPTION
I have created an example that shows that even if it is setted `format :json`, if I send a post request with content_type: application/x-www-form-urlencoded it does return `201`