### PR TITLE
Fix logic for `include_parent_namespaces` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#1380](https://github.com/ruby-grape/grape/pull/1380): Fix `allow_blank: false` for `Time` attributes with valid values causes `NoMethodError` - [@ipkes](https://github.com/ipkes).
 * [#1384](https://github.com/ruby-grape/grape/pull/1384): Fix parameter validation with an empty optional nested `Array` - [@ipkes](https://github.com/ipkes).
 * [#1414](https://github.com/ruby-grape/grape/pull/1414): Fix multiple version definitions for path versioning - [@304](https://github.com/304).
+* [#1415](https://github.com/ruby-grape/grape/pull/1415): Fix `declared(params, include_parent_namespaces: false)` - [@304](https://github.com/304).
 
 0.16.2 (4/12/2016)
 ==================

--- a/README.md
+++ b/README.md
@@ -554,6 +554,52 @@ The returned hash is a `Hashie::Mash` instance, allowing you to access parameter
 The `#declared` method is not available to `before` filters, as those are evaluated prior
 to parameter coercion.
 
+### Include parent namespaces
+
+By default `declared(params)` includes parameters that were defined in all parent namespaces. If you want to return only parameters from your current namespace, you can set `include_parent_namespaces` option to `false`.
+
+````ruby
+format :json
+
+namespace :parent do
+  params do
+    requires :parent_name, type: String
+  end
+
+  namespace ':parent_name' do
+    params do
+      requires :child_name, type: String
+    end
+    get ':child_name' do
+      {
+        'without_parent_namespaces' => declared(params, include_parent_namespaces: false),
+        'with_parent_namespaces' => declared(params, include_parent_namespaces: true),
+      }
+    end
+  end
+end
+````
+
+**Request**
+
+````bash
+curl -X GET -H "Content-Type: application/json" localhost:9292/parent/foo/bar
+````
+
+**Response**
+
+````json
+{
+  "without_parent_namespaces": {
+    "child_name": "bar"
+  },
+  "with_parent_namespaces": {
+    "parent_name": "foo",
+    "child_name": "bar"
+  },
+}
+````
+
 ### Include missing
 
 By default `declared(params)` includes parameters that have `nil` values. If you want to return only the parameters that are not `nil`, you can use the `include_missing` option. By default, `include_missing` is set to `true`. Consider the following API:

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -29,7 +29,10 @@ module Grape
         def declared(params, options = {}, declared_params = nil)
           options = options.reverse_merge(include_missing: true, include_parent_namespaces: true)
 
-          declared_params ||= (!options[:include_parent_namespaces] ? route_setting(:declared_params) : (route_setting(:saved_declared_params) || [])).flatten(1) || []
+          all_declared_params = route_setting(:declared_params)
+          current_namespace_declared_params = route_setting(:saved_declared_params).last
+
+          declared_params ||= options[:include_parent_namespaces] ? all_declared_params : current_namespace_declared_params
 
           raise ArgumentError, 'Tried to filter for declared parameters but none exist.' unless declared_params
 

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -464,65 +464,70 @@ describe Grape::Endpoint do
   end
 
   describe '#declared; call from child namespace' do
-    context 'include_parent_namespaces: true' do
-      before do
-        subject.format :json
-        subject.namespace :something do
+    before do
+      subject.format :json
+      subject.namespace :parent do
+        params do
+          requires :parent_name, type: String
+        end
+
+        namespace ':parent_name' do
           params do
-            requires :id, type: Integer
+            requires :child_name, type: String
+            requires :child_age, type: Integer
           end
-          resource ':id' do
+
+          namespace ':child_name' do
             params do
-              requires :foo
-              optional :bar
+              requires :grandchild_name, type: String
             end
-            get do
+
+            get ':grandchild_name' do
               {
-                params: params,
-                declared_params: declared(params)
+                'params' => params,
+                'without_parent_namespaces' => declared(params, include_parent_namespaces: false),
+                'with_parent_namespaces' => declared(params, include_parent_namespaces: true)
               }
             end
           end
         end
       end
 
-      it 'should include params defined in the parent namespace' do
-        get '/something/123', foo: 'test', extra: 'hello'
-        expect(last_response.status).to eq 200
-        json = JSON.parse(last_response.body, symbolize_names: true)
-        expect(json[:params][:id]).to eq 123
-        expect(json[:declared_params].keys).to match_array [:foo, :bar, :id]
+      get '/parent/foo/bar/baz', child_age: 5, extra: 'hello'
+    end
+
+    let(:parsed_response) { JSON.parse(last_response.body, symbolize_names: true) }
+
+    it { expect(last_response.status).to eq 200 }
+
+    context 'with include_parent_namespaces: false' do
+      it 'returns declared parameters only from current namespace' do
+        expect(parsed_response[:without_parent_namespaces]).to eq(
+          grandchild_name: 'baz'
+        )
       end
     end
 
-    context 'include_parent_namespaces: false' do
-      before do
-        subject.format :json
-        subject.namespace :something do
-          params do
-            requires :id, type: Integer
-          end
-          resource ':id' do
-            params do
-              requires :happy
-              optional :days
-            end
-            get '/test' do
-              {
-                params: params,
-                declared_params: declared(params, include_parent_namespaces: false)
-              }
-            end
-          end
-        end
+    context 'with include_parent_namespaces: true' do
+      it 'returns declared parameters from every parent namespace' do
+        expect(parsed_response[:with_parent_namespaces]).to eq(
+          parent_name: 'foo',
+          child_name: 'bar',
+          grandchild_name: 'baz',
+          child_age: 5
+        )
       end
+    end
 
-      it 'does not include params defined in the parent namespace' do
-        get '/something/123/test', happy: 'test', extra: 'hello'
-        expect(last_response.status).to eq 200
-        json = JSON.parse(last_response.body, symbolize_names: true)
-        expect(json[:params][:id]).to eq 123
-        expect(json[:declared_params].keys).to match_array [:happy, :days]
+    context 'without declaration' do
+      it 'returns all requested parameters' do
+        expect(parsed_response[:params]).to eq(
+          parent_name: 'foo',
+          child_name: 'bar',
+          grandchild_name: 'baz',
+          child_age: 5,
+          extra: 'hello'
+        )
       end
     end
   end


### PR DESCRIPTION
Based on PR #1408.

* Add specs to test different combinations of namespaces
* Add documentation for the `include_parent_namespaces` option