### PR TITLE
Improve docs related to the `Accept-Version Header`

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,8 @@ Using this versioning strategy, clients should pass the desired version in the H
 By default, the first matching version is used when no `Accept-Version` header is
 supplied. This behavior is similar to routing in Rails. To circumvent this default behavior,
 one could use the `:strict` option. When this option is set to `true`, a `406 Not Acceptable` error
-is returned when no correct `Accept` header is supplied.
+is returned when no correct `Accept` header is supplied and the `:cascade` option is set to `false`.
+Otherwise a `404 Not Found` error is returned by Rack if no other route matches.
 
 ### Param
 


### PR DESCRIPTION
This is related to issue #1413 

It's not clear by reading the docs that when using the `Accept-Version header` a `406` will only be returned IF `:cascade` is set to `false`.This PR aims to make that behavior more visible in the docs.