### PR TITLE
specs for declared(params) inside route_param bug.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 #### Fixes
 
+* [#1430](https://github.com/ruby-grape/grape/pull/1430): Fix for `declared(params)` inside `route_param` - [@Arkanain](https://github.com/Arkanain).
 * [#1405](https://github.com/ruby-grape/grape/pull/1405): Fix priority of `rescue_from` clauses applying - [@hedgesky](https://github.com/hedgesky).
 * [#1365](https://github.com/ruby-grape/grape/pull/1365): Fix finding exception handler in error middleware - [@ktimothy](https://github.com/ktimothy).
 * [#1380](https://github.com/ruby-grape/grape/pull/1380): Fix `allow_blank: false` for `Time` attributes with valid values causes `NoMethodError` - [@ipkes](https://github.com/ipkes).

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -190,7 +190,7 @@ module Grape
           @api.namespace_stackable(:declared_params, @declared_params)
 
           @api.route_setting(:declared_params, []) unless @api.route_setting(:declared_params)
-          @api.route_setting(:declared_params).concat @declared_params
+          @api.route_setting(:declared_params, @api.namespace_stackable(:declared_params).flatten)
         end
       end
 


### PR DESCRIPTION
I check some specs on my project and I find out that this functionality work little bit wrong with declared when we have several route_param in one namespace.
For example we have:

```ruby
class Artists
  namespace :artists do
    route_param :id, type: Integer do
      get do
        declared(params)
      end

      params do
        requires :filter, type: String
      end
      get :some_route do
        declared(params)
      end
    end
    route_param :artist_id, type: Integer do
      mount Compositions
    end
  end
end
```
`declared(params)` should return us next hash `{id: 1}`, but it return hash `{id: 1, artist_id: nil}`.
Also in first `route_param` in second endpoint(`get :some_route`) when we call `declared(params)` we have only `filter` params in returned hash `{filter: 'some_filter'}`

P.S.: I find out where we have problem! Problem is in options for route_param. where I use route_param :id without type: Integer everything is ok.