### PR TITLE
Initial work adding Danger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,6 @@ gemfile:
   - gemfiles/rack_1.5.2.gemfile
 
 bundler_args: --without development
+
+before_script:
+  - bundle exec danger

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,28 @@
+# Sometimes it's a README fix, or something like that - which isn't relevant for
+# including in a project's CHANGELOG for example
+declared_trivial = github.pr_title.include? "#trivial"
+
+# Has any changes happened inside the lib dir?
+has_app_changes = !git.modified_files.grep(/lib/).empty?
+if git.modified_files.include?("CHANGELOG.md") == false && !declared_trivial
+  fail("No CHANGELOG changes made in CHANGELOG.md when there are library changes.", sticky: false)
+    pr_number = github.pr_json["number"] 
+    markdown <<-MARKDOWN
+Here's an example of your CHANGELOG entry:
+
+```markdown
+* [##{pr_number}](https://github.com/ruby-grape/grape/pull/#{pr_number}): #{github.pr_title} [@#{github.pr_author}](https://github.com/#{github.pr_author}).
+```
+MARKDOWN
+end
+
+# Don't let testing shortcuts get into master by accident, 
+# ensuring that we don't get green builds based on a subset of tests
+(git.modified_files + git.added_files - %w(Dangerfile)).each do |file|
+  next unless File.file?(file)
+  contents = File.read(file)
+  if file.start_with?('spec')
+    fail("`xit` or `fit` left in tests (#{file})") if contents =~ /^\w*[xf]it/
+    fail("`fdescribe` left in tests (#{file})") if contents =~ /^\w*fdescribe/
+  end
+end

--- a/Gemfile
+++ b/Gemfile
@@ -28,4 +28,5 @@ group :test do
   gem 'cookiejar'
   gem 'rack-contrib'
   gem 'mime-types', '< 3.0'
+  gem 'danger', '~> 2.0'
 end

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -24,6 +24,8 @@ require 'thread'
 
 require 'virtus'
 
+# I will remove this comment in an amended commit once Danger is set up.
+
 I18n.load_path << File.expand_path('../grape/locale/en.yml', __FILE__)
 
 module Grape


### PR DESCRIPTION
**Pre-requisite**

This requires the CI ENV var `DANGER_GITHUB_API_TOKEN` to be set up, so someone has to [follow this guide](http://danger.systems/guides/getting_started.html) from "Creating a GitHub Account for Danger to use". 

I'd recommend making a new GitHub account for GrapeCI - see our [DangerCI one](https://github.com/DangerCI?tab=activity), don't give it access to any of the repos. 

Then re-build this PR. I've not made any README changes, so it should show a message about me adding one.