### PR TITLE
Add Danger

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,7 @@
 AllCops:
+  Include:
+    - Dangerfile
+
   Exclude:
     - vendor/**/*
     - bin/**/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,6 @@ gemfile:
   - gemfiles/rack_1.5.2.gemfile
 
 bundler_args: --without development
+
+before_script:
+  - bundle exec danger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * [#1366](https://github.com/ruby-grape/grape/pull/1366): Store `message_key` on `Grape::Exceptions::Validation` - [@mkou](https://github.com/mkou).
 * [#1398](https://github.com/ruby-grape/grape/pull/1398): Added `rescue_from :grape_exceptions` - allow Grape to use the built-in `Grape::Exception` handing and use `rescue :all` behavior for everything else - [@mmclead](https://github.com/mmclead).
 * [#1443](https://github.com/ruby-grape/grape/pull/1443): Extended `given` to receive a `Proc` - [@glaucocustodio](https://github.com/glaucocustodio).
+* [#1455](https://github.com/ruby-grape/grape/pull/1455): Adds some automated PR rules around CHANGELOGs and ensuring the `fit` and `fdescribe` don't end up in the test suite. - [@orta](https://github.com/orta).
+
 * Your contribution here.
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@
 
 * [#1440](https://github.com/ruby-grape/grape/pull/1441): Supports only Ruby 2.2.2 and later - [@jlfaber](https://github.com/jlfaber).
 * [#1393](https://github.com/ruby-grape/grape/pull/1393): Middleware can be inserted before or after default Grape middleware - [@ridiculous](https://github.com/ridiculous).
-* [#1390](https://github.com/ruby-grape/grape/pull/1390): Allow inserting middleware at arbitrary points in the middleware stack - [@Rosa](https://github.com/Rosa).
-* [#1366](https://github.com/ruby-grape/grape/pull/1366): Store `message_key` on `Grape::Exceptions::Validation` - [@mkou](https://github.com/mkou).
-* [#1398](https://github.com/ruby-grape/grape/pull/1398): Added `rescue_from :grape_exceptions` - allow Grape to use the built-in `Grape::Exception` handing and use `rescue :all` behavior for everything else - [@mmclead](https://github.com/mmclead).
-* [#1443](https://github.com/ruby-grape/grape/pull/1443): Extended `given` to receive a `Proc` - [@glaucocustodio](https://github.com/glaucocustodio).
-* [#1455](https://github.com/ruby-grape/grape/pull/1455): Adds an automated PR linter [@orta](https://github.com/orta).
+* [#1390](https://github.com/ruby-grape/grape/pull/1390): Allows inserting middleware at arbitrary points in the middleware stack - [@Rosa](https://github.com/Rosa).
+* [#1366](https://github.com/ruby-grape/grape/pull/1366): Stores `message_key` on `Grape::Exceptions::Validation` - [@mkou](https://github.com/mkou).
+* [#1398](https://github.com/ruby-grape/grape/pull/1398): Adds `rescue_from :grape_exceptions` - allow Grape to use the built-in `Grape::Exception` handing and use `rescue :all` behavior for everything else - [@mmclead](https://github.com/mmclead).
+* [#1443](https://github.com/ruby-grape/grape/pull/1443): Extends `given` to receive a `Proc` - [@glaucocustodio](https://github.com/glaucocustodio).
+* [#1455](https://github.com/ruby-grape/grape/pull/1455): Adds an automated PR linter - [@orta](https://github.com/orta).
 
 * Your contribution here.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * [#1366](https://github.com/ruby-grape/grape/pull/1366): Store `message_key` on `Grape::Exceptions::Validation` - [@mkou](https://github.com/mkou).
 * [#1398](https://github.com/ruby-grape/grape/pull/1398): Added `rescue_from :grape_exceptions` - allow Grape to use the built-in `Grape::Exception` handing and use `rescue :all` behavior for everything else - [@mmclead](https://github.com/mmclead).
 * [#1443](https://github.com/ruby-grape/grape/pull/1443): Extended `given` to receive a `Proc` - [@glaucocustodio](https://github.com/glaucocustodio).
-* [#1455](https://github.com/ruby-grape/grape/pull/1455): Adds some automated PR rules around CHANGELOGs and ensuring the `fit` and `fdescribe` don't end up in the test suite. - [@orta](https://github.com/orta).
+* [#1455](https://github.com/ruby-grape/grape/pull/1455): Adds an automated PR linter [@orta](https://github.com/orta).
 
 * Your contribution here.
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,28 @@
+# Sometimes it's a README fix, or something like that - which isn't relevant for
+# including in a project's CHANGELOG for example
+declared_trivial = github.pr_title.include? "#trivial"
+
+# Has any changes happened inside the lib dir?
+has_app_changes = !git.modified_files.grep(/lib/).empty?
+if git.modified_files.include?("CHANGELOG.md") == false && !declared_trivial
+  fail("No CHANGELOG changes made in CHANGELOG.md when there are library changes.", sticky: false)
+    pr_number = github.pr_json["number"] 
+    markdown <<-MARKDOWN
+Here's an example of your CHANGELOG entry:
+
+```markdown
+* [##{pr_number}](https://github.com/ruby-grape/grape/pull/#{pr_number}): #{github.pr_title} [@#{github.pr_author}](https://github.com/#{github.pr_author}).
+```
+MARKDOWN
+end
+
+# Don't let testing shortcuts get into master by accident, 
+# ensuring that we don't get green builds based on a subset of tests
+(git.modified_files + git.added_files - %w(Dangerfile)).each do |file|
+  next unless File.file?(file)
+  contents = File.read(file)
+  if file.start_with?('spec')
+    fail("`xit` or `fit` left in tests (#{file})") if contents =~ /^\w*[xf]it/
+    fail("`fdescribe` left in tests (#{file})") if contents =~ /^\w*fdescribe/
+  end
+end

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,13 +1,14 @@
 # Sometimes it's a README fix, or something like that - which isn't relevant for
 # including in a project's CHANGELOG for example
-declared_trivial = github.pr_title.include? "#trivial"
+declared_trivial = github.pr_title.include? '#trivial'
 
 # Has any changes happened inside the lib dir?
 has_app_changes = !git.modified_files.grep(/lib/).empty?
-if git.modified_files.include?("CHANGELOG.md") == false && !declared_trivial
-  fail("No CHANGELOG changes made in CHANGELOG.md when there are library changes.", sticky: false)
-    pr_number = github.pr_json["number"] 
-    markdown <<-MARKDOWN
+
+if git.modified_files.include?('CHANGELOG.md') == false && !declared_trivial && has_app_changes
+  raise('No CHANGELOG changes made in CHANGELOG.md when there are library changes.', sticky: false)
+  pr_number = github.pr_json['number']
+  markdown <<-MARKDOWN
 Here's an example of your CHANGELOG entry:
 
 ```markdown
@@ -16,13 +17,13 @@ Here's an example of your CHANGELOG entry:
 MARKDOWN
 end
 
-# Don't let testing shortcuts get into master by accident, 
+# Don't let testing shortcuts get into master by accident,
 # ensuring that we don't get green builds based on a subset of tests
 (git.modified_files + git.added_files - %w(Dangerfile)).each do |file|
   next unless File.file?(file)
   contents = File.read(file)
   if file.start_with?('spec')
-    fail("`xit` or `fit` left in tests (#{file})") if contents =~ /^\w*[xf]it/
-    fail("`fdescribe` left in tests (#{file})") if contents =~ /^\w*fdescribe/
+    raise("`xit` or `fit` left in tests (#{file})") if contents =~ /^\w*[xf]it/
+    raise("`fdescribe` left in tests (#{file})") if contents =~ /^\w*fdescribe/
   end
 end

--- a/Dangerfile
+++ b/Dangerfile
@@ -11,7 +11,7 @@ if git.modified_files.include?("CHANGELOG.md") == false && !declared_trivial
 Here's an example of your CHANGELOG entry:
 
 ```markdown
-* [##{pr_number}](https://github.com/ruby-grape/grape/pull/#{pr_number}): #{github.pr_title} [@#{github.pr_author}](https://github.com/#{github.pr_author}).
+* [##{pr_number}](https://github.com/ruby-grape/grape/pull/#{pr_number}): #{github.pr_title} - [@#{github.pr_author}](https://github.com/#{github.pr_author}).
 ```
 MARKDOWN
 end

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,12 +1,7 @@
-# Sometimes it's a README fix, or something like that - which isn't relevant for
-# including in a project's CHANGELOG for example
-declared_trivial = github.pr_title.include? '#trivial'
-
 # Has any changes happened inside the lib dir?
 has_app_changes = !git.modified_files.grep(/lib/).empty?
 
 if git.modified_files.include?('CHANGELOG.md') == false && !declared_trivial && has_app_changes
-  raise('No CHANGELOG changes made in CHANGELOG.md when there are library changes.', sticky: false)
   pr_number = github.pr_json['number']
   markdown <<-MARKDOWN
 Here's an example of your CHANGELOG entry:
@@ -14,11 +9,12 @@ Here's an example of your CHANGELOG entry:
 ```markdown
 * [##{pr_number}](https://github.com/ruby-grape/grape/pull/#{pr_number}): #{github.pr_title} - [@#{github.pr_author}](https://github.com/#{github.pr_author}).
 ```
+  fail('No CHANGELOG changes made in CHANGELOG.md when there are library changes.', sticky: false)
 MARKDOWN
 end
 
 # Don't let testing shortcuts get into master by accident,
-# ensuring that we don't get green builds based on a subset of tests
+# ensuring that we don't get green builds based on a subset of tests.
 (git.modified_files + git.added_files - %w(Dangerfile)).each do |file|
   next unless File.file?(file)
   contents = File.read(file)

--- a/Gemfile
+++ b/Gemfile
@@ -28,4 +28,5 @@ group :test do
   gem 'cookiejar'
   gem 'rack-contrib'
   gem 'mime-types', '< 3.0'
+  gem 'danger', '~> 2.0'
 end

--- a/gemfiles/rack_1.5.2.gemfile
+++ b/gemfiles/rack_1.5.2.gemfile
@@ -28,6 +28,7 @@ group :test do
   gem 'cookiejar'
   gem 'rack-contrib'
   gem 'mime-types', '< 3.0'
+  gem 'danger', '~> 2.0'
 end
 
 gemspec path: '../'

--- a/gemfiles/rails_3.gemfile
+++ b/gemfiles/rails_3.gemfile
@@ -29,6 +29,7 @@ group :test do
   gem 'cookiejar'
   gem 'rack-contrib'
   gem 'mime-types', '< 3.0'
+  gem 'danger', '~> 2.0'
 end
 
 gemspec path: '../'

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -28,6 +28,7 @@ group :test do
   gem 'cookiejar'
   gem 'rack-contrib'
   gem 'mime-types', '< 3.0'
+  gem 'danger', '~> 2.0'
 end
 
 gemspec path: '../'

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -24,6 +24,8 @@ require 'thread'
 
 require 'virtus'
 
+# I will remove this comment in an amended commit once Danger is set up.
+
 I18n.load_path << File.expand_path('../grape/locale/en.yml', __FILE__)
 
 module Grape

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -24,8 +24,6 @@ require 'thread'
 
 require 'virtus'
 
-# I will remove this comment in an amended commit once Danger is set up.
-
 I18n.load_path << File.expand_path('../grape/locale/en.yml', __FILE__)
 
 module Grape


### PR DESCRIPTION
Sorry ~250 watchers, I got hit by https://github.com/isaacs/github/issues/361

**Pre-requisite**

This requires the CI ENV var `DANGER_GITHUB_API_TOKEN` to be set up, so someone has to [follow this guide](http://danger.systems/guides/getting_started.html) from "Creating a GitHub Account for Danger to use". 

I'd recommend making a new GitHub account for GrapeCI - see our [DangerCI one](https://github.com/DangerCI?tab=activity), don't give it access to any of the repos. 

Then re-build this PR. I've not made any README changes, so it should show a message about me adding one.