### PR TITLE
Presence validator ensures value is not nil

### DIFF
--- a/lib/grape/validations/validators/presence.rb
+++ b/lib/grape/validations/validators/presence.rb
@@ -7,7 +7,7 @@ module Grape
       end
 
       def validate_param!(attr_name, params)
-        return if params.respond_to?(:key?) && params.key?(attr_name)
+        return if params.respond_to?(:key?) && !params[attr_name].nil?
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:presence)
       end
     end

--- a/spec/grape/validations/validators/allow_blank_spec.rb
+++ b/spec/grape/validations/validators/allow_blank_spec.rb
@@ -123,7 +123,7 @@ describe Grape::Validations::AllowBlankValidator do
 
         resources :custom_message do
           params do
-            requires :name, allow_blank: { value: false, message: 'has no value' }
+            optional :name, allow_blank: { value: false, message: 'has no value' }
           end
           get
 

--- a/spec/grape/validations/validators/presence_spec.rb
+++ b/spec/grape/validations/validators/presence_spec.rb
@@ -127,6 +127,10 @@ describe Grape::Validations::PresenceValidator do
       expect(last_response.status).to eq(200)
       expect(last_response.body).to eq('Hello'.to_json)
     end
+    it 'rejects nil values' do
+      get '/', name: 'Bob', company: nil
+      expect(last_response.body).to eq({ error: 'company is missing' }.to_json)
+    end
   end
 
   context 'with nested parameters' do

--- a/spec/grape/validations/validators/regexp_spec.rb
+++ b/spec/grape/validations/validators/regexp_spec.rb
@@ -8,14 +8,14 @@ describe Grape::Validations::RegexpValidator do
 
         resources :custom_message do
           params do
-            requires :name, regexp: { value: /^[a-z]+$/, message: 'format is invalid' }
+            optional :name, regexp: { value: /^[a-z]+$/, message: 'format is invalid' }
           end
           get do
           end
         end
 
         params do
-          requires :name, regexp: /^[a-z]+$/
+          optional :name, regexp: /^[a-z]+$/
         end
         get do
         end

--- a/spec/grape/validations/validators/values_spec.rb
+++ b/spec/grape/validations/validators/values_spec.rb
@@ -38,7 +38,7 @@ describe Grape::Validations::ValuesValidator do
         end
 
         params do
-          requires :type, values: ValuesModel.values
+          optional :type, values: ValuesModel.values
         end
         get '/' do
           { type: params[:type] }
@@ -147,13 +147,7 @@ describe Grape::Validations::ValuesValidator do
     expect(last_response.body).to eq({ error: 'type does not have a valid value' }.to_json)
   end
 
-  context 'nil value for a parameter' do
-    it 'does not allow for root params scope' do
-      get('/', type: nil)
-      expect(last_response.status).to eq 400
-      expect(last_response.body).to eq({ error: 'type does not have a valid value' }.to_json)
-    end
-
+  context 'nil value for a parameter', focus: true do
     it 'allows for a required param in child scope' do
       get('/optional_with_required_values')
       expect(last_response.status).to eq 200


### PR DESCRIPTION
I was surprised today by a `NoMethodError` for `nil:NilClass` on a endpoint for a param declared using `requires`. I discovered it by submitting an empty form on a javascript app (still in prototyping, ie. no form validations) that requests my grape api. The app posts json to the api, and javascript replaced the unfilled fields with `null` and caused the above error.

I tracked this behavior to the presence validator, which currently only checks that the key is present in the request. I would say that it should reject `nil` values since using `requires`  (especially in conjunction with a `type` validator) seems like a promise to the programmer that the param will have a value in the endpoint.

I had to change some other specs that dealt with nil params. I tried to keep them focused on the behavior in question by changing the params to `optional`, but in one case I had to remove a spec. I feel it's redundant - but any feedback on that would be great.
