### PR TITLE
Fix array indicies in error messages.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -17,7 +17,7 @@ Metrics/BlockNesting:
 # Offense count: 7
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 264
+  Max: 266
 
 # Offense count: 24
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 #### Features
 
+* [#1463](https://github.com/ruby-grape/grape/pull/1463): Fix array indicies in error messages - [@ffloyd](https://github.com/ffloyd).
 * [#1393](https://github.com/ruby-grape/grape/pull/1393): Middleware can be inserted before or after default Grape middleware - [@ridiculous](https://github.com/ridiculous).
 * [#1390](https://github.com/ruby-grape/grape/pull/1390): Allows inserting middleware at arbitrary points in the middleware stack - [@Rosa](https://github.com/Rosa).
 * [#1366](https://github.com/ruby-grape/grape/pull/1366): Stores `message_key` on `Grape::Exceptions::Validation` - [@mkou](https://github.com/mkou).

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -58,6 +58,7 @@ module Grape
     extend ActiveSupport::Autoload
     autoload :Base
     autoload :Validation
+    autoload :ValidationArrayErrors
     autoload :ValidationErrors
     autoload :MissingVendorOption
     autoload :MissingMimeType

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -191,7 +191,8 @@ module Grape
         params = @parent.params(params) if @parent
         if @element
           params = if params.is_a?(Array)
-                     params.flat_map { |el| el[@element] || {} }
+                     # used for calculating parent array indices for error messages
+                     params.map { |el| el[@element] || {} }
                    elsif params.is_a?(Hash)
                      params[@element] || {}
                    else

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -335,6 +335,8 @@ module Grape
           validator.validate(request)
         rescue Grape::Exceptions::Validation => e
           validation_errors << e
+        rescue Grape::Exceptions::ValidationArrayErrors => e
+          validation_errors += e.errors
         end
       end
 

--- a/lib/grape/exceptions/validation_array_errors.rb
+++ b/lib/grape/exceptions/validation_array_errors.rb
@@ -1,0 +1,11 @@
+module Grape
+  module Exceptions
+    class ValidationArrayErrors < Base
+      attr_reader :errors
+
+      def initialize(errors)
+        @errors = errors
+      end
+    end
+  end
+end

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -2,6 +2,7 @@ module Grape
   module Validations
     class ParamsScope
       attr_accessor :element, :parent, :index
+      attr_reader :type
 
       include Grape::DSL::Parameters
 
@@ -57,7 +58,7 @@ module Grape
         case
         when nested?
           # Find our containing element's name, and append ours.
-          "#{@parent.full_name(@element)}#{parent_index}[#{name}]"
+          "#{@parent.full_name(@element)}#{array_index}[#{name}]"
         when lateral?
           # Find the name of the element as if it was at the
           # same nesting level as our parent.
@@ -68,8 +69,8 @@ module Grape
         end
       end
 
-      def parent_index
-        "[#{@parent.index}]" if @parent.present? && @parent.index.present?
+      def array_index
+        "[#{@index}]" if @index.present?
       end
 
       # @return [Boolean] whether or not this scope is the root-level scope

--- a/lib/grape/validations/types/build_coercer.rb
+++ b/lib/grape/validations/types/build_coercer.rb
@@ -26,7 +26,15 @@ module Grape
         converter_options = {
           nullify_blank: true
         }
-        conversion_type = type
+        conversion_type = if method == JSON
+                            Object
+                            # because we want just parsed JSON content:
+                            # if type is Array and data is `"{}"`
+                            # result will be [] because Virtus converts hashes
+                            # to arrays
+                          else
+                            type
+                          end
 
         # Use a special coercer for multiply-typed parameters.
         if Types.multiple?(type)

--- a/spec/grape/validations/validators/coerce_spec.rb
+++ b/spec/grape/validations/validators/coerce_spec.rb
@@ -400,7 +400,7 @@ describe Grape::Validations::CoerceValidator do
 
         get '/ints', ints: '{"i":1,"j":"2"}'
         expect(last_response.status).to eq(400)
-        expect(last_response.body).to eq('ints[0][i] is missing, ints[0][i] is invalid, ints[0][j] is missing')
+        expect(last_response.body).to eq('ints is invalid')
 
         get '/ints', ints: '[{"i":"1","j":"2"}]'
         expect(last_response.status).to eq(200)


### PR DESCRIPTION
Error messages for arrays was totally broken. It always returns index 0 and detect errors only for first entry in Array. You may cherry-pick to master first commit from this branch and run specs to see the problem.

Moreover, i have no idea how previous implementation of indicies may work correctly with current ParamsScope implementation (#1218).

Also i've found bug in coercion - look for TODO comment inside diff. Specs aren't green because of this bug.