### PR TITLE
Fix filters being called multiple times, consistent intialization for…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 #### Fixes
 
+* [#1465](https://github.com/ruby-grape/grape/pull/1465): Fix 'before' being called twice when using not allowed method - [@jsteinberg](https://github.com/jsteinberg).
 * [#1446](https://github.com/ruby-grape/grape/pull/1446): Fix for `env` inside `before` when using not allowed method - [@leifg](https://github.com/leifg).
 * [#1438](https://github.com/ruby-grape/grape/pull/1439): Try to dup non-frozen default params with each use - [@jlfaber](https://github.com/jlfaber).
 * [#1430](https://github.com/ruby-grape/grape/pull/1430): Fix for `declared(params)` inside `route_param` - [@Arkanain](https://github.com/Arkanain).

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -248,9 +248,12 @@ module Grape
 
         run_filters befores, :before
 
+        allowed_methods = env[Grape::Env::GRAPE_METHOD_NOT_ALLOWED]
+        raise Grape::Exceptions::MethodNotAllowed, header.merge('Allow' => allowed_methods) if allowed_methods
+
         run_filters before_validations, :before_validation
 
-        run_validators validations, request unless env[Grape::Env::GRAPE_METHOD_NOT_ALLOWED]
+        run_validators validations, request
 
         run_filters after_validations, :after_validation
 

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -133,24 +133,8 @@ module Grape
     end
 
     def method_not_allowed(env, methods, endpoint)
-      env[Grape::Env::GRAPE_METHOD_NOT_ALLOWED] = true
-      current = endpoint.dup
-      current.instance_eval do
-        @env = env
-        @header = {}
-
-        @request = Grape::Request.new(env)
-        @params = @request.params
-        @headers = @request.headers
-
-        @lazy_initialized = false
-        lazy_initialize!
-        run_filters befores, :before
-        @block = proc do
-          raise Grape::Exceptions::MethodNotAllowed, header.merge('Allow' => methods)
-        end
-      end
-      current.call(env)
+      env[Grape::Env::GRAPE_METHOD_NOT_ALLOWED] = methods
+      endpoint.call(env)
     end
 
     def cascade?(response)


### PR DESCRIPTION
… method_not_found errors

I also think this is a more consistent fix to this: https://github.com/ruby-grape/grape/pull/1446