### PR TITLE
Support inserting middleware before/after anonymous classes in the middleware stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,17 @@
 
 * Your contribution here.
 
+#### Fixes
+
+* [#1479](https://github.com/ruby-grape/grape/pull/1479): Support inserting middleware before/after anonymous classes in the middleware stack - [@rosa](https://github.com/rosa).
+
 0.17.0 (7/29/2016)
 ==================
 
 #### Features
 
 * [#1393](https://github.com/ruby-grape/grape/pull/1393): Middleware can be inserted before or after default Grape middleware - [@ridiculous](https://github.com/ridiculous).
-* [#1390](https://github.com/ruby-grape/grape/pull/1390): Allow inserting middleware at arbitrary points in the middleware stack - [@Rosa](https://github.com/Rosa).
+* [#1390](https://github.com/ruby-grape/grape/pull/1390): Allow inserting middleware at arbitrary points in the middleware stack - [@rosa](https://github.com/rosa).
 * [#1366](https://github.com/ruby-grape/grape/pull/1366): Store `message_key` on `Grape::Exceptions::Validation` - [@mkou](https://github.com/mkou).
 * [#1398](https://github.com/ruby-grape/grape/pull/1398): Add `rescue_from :grape_exceptions` - allow Grape to use the built-in `Grape::Exception` handing and use `rescue :all` behavior for everything else - [@mmclead](https://github.com/mmclead).
 * [#1443](https://github.com/ruby-grape/grape/pull/1443): Extend `given` to receive a `Proc` - [@glaucocustodio](https://github.com/glaucocustodio).

--- a/lib/grape/middleware/stack.rb
+++ b/lib/grape/middleware/stack.rb
@@ -21,7 +21,7 @@ module Grape
           when Middleware
             klass == other.klass
           when Class
-            klass == other
+            klass == other || (name.nil? && klass.superclass == other)
           end
         end
 

--- a/spec/grape/middleware/stack_spec.rb
+++ b/spec/grape/middleware/stack_spec.rb
@@ -61,6 +61,16 @@ describe Grape::Middleware::Stack do
       expect(subject[1]).to eq(StackSpec::FooMiddleware)
     end
 
+    it 'inserts a middleware before an anonymous class given by its superclass' do
+      subject.use Class.new(StackSpec::BlockMiddleware)
+
+      expect { subject.insert_before StackSpec::BlockMiddleware, StackSpec::BarMiddleware }
+        .to change { subject.size }.by(1)
+
+      expect(subject[1]).to eq(StackSpec::BarMiddleware)
+      expect(subject[2]).to eq(StackSpec::BlockMiddleware)
+    end
+
     it 'raises an error on an invalid index' do
       expect { subject.insert_before StackSpec::BlockMiddleware, StackSpec::BarMiddleware }
         .to raise_error(RuntimeError, 'No such middleware to insert before: StackSpec::BlockMiddleware')
@@ -73,6 +83,16 @@ describe Grape::Middleware::Stack do
         .to change { subject.size }.by(1)
       expect(subject[1]).to eq(StackSpec::BarMiddleware)
       expect(subject[0]).to eq(StackSpec::FooMiddleware)
+    end
+
+    it 'inserts a middleware after an anonymous class given by its superclass' do
+      subject.use Class.new(StackSpec::BlockMiddleware)
+
+      expect { subject.insert_after StackSpec::BlockMiddleware, StackSpec::BarMiddleware }
+        .to change { subject.size }.by(1)
+
+      expect(subject[1]).to eq(StackSpec::BlockMiddleware)
+      expect(subject[2]).to eq(StackSpec::BarMiddleware)
     end
 
     it 'raises an error on an invalid index' do


### PR DESCRIPTION
I realised that [this commit](https://github.com/ruby-grape/grape/commit/7805dd0076f2b21e2f861665c2774ef1e112190d) broke usages of `insert_before`/`insert_after` with `Grape::Middleware::Error`. For example, this is how I use it:
```
insert_before Grape::Middleware::Error, Grape::Middleware::Logger
```

Since that commit, `Grape::Middleware::Error` is inserted in the middleware stack as `Class.new(Grape::Middleware::Error)`. Then, when we try to insert another middleware before or after it, we get:
```
RuntimeError:
       No such middleware to insert before: Grape::Middleware::Error
```

The reason is that we don't recognize the anoymous class that represents `Grape::Middleware::Error` in the stack. This pull-request allows considering the superclass for anonymous classes when comparing middleware within the stack. Feel free to suggest a different way to approach this problem, this was just my personal attempt to fix it in a simple way. 