### PR TITLE
implemented except in values validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ==================
 
 * [#1480](https://github.com/ruby-grape/grape/pull/1480): Use the ruby-grape-danger gem for PR linting - [@dblock](https://github.com/dblock).
+* [#1486](https://github.com/ruby-grape/grape/pull/1486): implemented except in values validator - [@jonmchan](https://github.com/jonmchan).
 * Your contribution here.
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ==================
 
 * [#1480](https://github.com/ruby-grape/grape/pull/1480): Use the ruby-grape-danger gem for PR linting - [@dblock](https://github.com/dblock).
-* [#1486](https://github.com/ruby-grape/grape/pull/1486): implemented except in values validator - [@jonmchan](https://github.com/jonmchan).
+* [#1486](https://github.com/ruby-grape/grape/pull/1486): Implemented except in values validator - [@jonmchan](https://github.com/jonmchan).
 * Your contribution here.
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -1065,6 +1065,26 @@ params do
 end
 ```
 
+The values validator can also validate that the value is explicitly not within a specific
+set of values by passing ```except```. ```except``` accepts the same types of parameters as
+values (Procs, ranges, etc.).
+
+```ruby
+params do
+  requires :browsers, values: { except: [ 'ie6', 'ie7', 'ie8' ] }
+end
+```
+
+Values and except can be combined to define a range of accepted values while not allowing
+certain values within the set. Custom error messages can be defined for both when the parameter 
+passed falls within the ```except``` list or when it falls entirely outside the ```value``` list. 
+
+```ruby
+params do
+  requires :number, type: Integer, values: { value: 1..20 except: [4,13], except_message: 'includes unsafe numbers', message: 'is outside the range of numbers allowed' }
+end
+```
+
 #### `regexp`
 
 Parameters can be restricted to match a specific regular expression with the `:regexp` option. If the value

--- a/lib/grape/locale/en.yml
+++ b/lib/grape/locale/en.yml
@@ -8,6 +8,7 @@ en:
         regexp: 'is invalid'
         blank: 'is empty'
         values: 'does not have a valid value'
+        except: 'has a value not allowed'
         missing_vendor_option:
           problem: 'missing :vendor option.'
           summary: 'when version using header, you must specify :vendor option. '

--- a/lib/grape/validations/validators/values.rb
+++ b/lib/grape/validations/validators/values.rb
@@ -2,7 +2,10 @@ module Grape
   module Validations
     class ValuesValidator < Base
       def initialize(attrs, options, required, scope)
-        @values = (options_key?(:value, options) ? options[:value] : options)
+        @excepts = (options_key?(:except, options) ? options[:except] : [])
+        @values = (options_key?(:value, options) ? options[:value] : [])
+
+        @values = options if @excepts == [] && @values == []
         super
       end
 
@@ -11,12 +14,23 @@ module Grape
         return unless params[attr_name] || required_for_root_scope?
 
         values = @values.is_a?(Proc) ? @values.call : @values
+        excepts = @excepts.is_a?(Proc) ? @excepts.call : @excepts
         param_array = params[attr_name].nil? ? [nil] : Array.wrap(params[attr_name])
-        return if param_array.all? { |param| values.include?(param) }
+
+        if param_array.all? { |param| excepts.include?(param) }
+          raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: except_message
+        end
+
+        return if (values.is_a?(Array) && values.empty?) || param_array.all? { |param| values.include?(param) }
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:values)
       end
 
       private
+
+      def except_message
+        options = instance_variable_get(:@option)
+        options_key?(:except_message) ? options[:except_message] : message(:except)
+      end
 
       def required_for_root_scope?
         @required && @scope.root?


### PR DESCRIPTION
This implements the feature requested in #1485 .

Some notes:

* This PR allows for except to be used exclusively allowing all other values except what is defined in except as well as with values, defining a range and then marking a subset of the range as invalid.
* This PR allows for custom except message outside of the regular validation fail message, but falls back to the regular validation fail message if no ```except_message``` is defined.
* There was slight difficulty maintaining compatibility with allowing values to be passed in to ```values:``` without the ```value:``` key. Please ensure that line 5-8 of values.rb https://github.com/ruby-grape/grape/compare/master...jonmchan:feature/except?expand=1#diff-45b62b4ed0aed7ceff346c347f76570eR8 do not cause any incompatibility issues.
* Side effect of this implementation is that ```values: []``` accepts all passed parameters. Previous implementation, ```values: []``` would reject every value. I figure nobody would be trying to create a parameter that would allow no value so I did not bother to maintain this functionality.