### PR TITLE
[documentation] Add appsignal to monitoring products

### DIFF
--- a/README.md
+++ b/README.md
@@ -3236,6 +3236,7 @@ Grape integrates with following third-party tools:
 * **New Relic** - [built-in support](https://docs.newrelic.com/docs/agents/ruby-agent/frameworks/grape-instrumentation) from v3.10.0 of the official [newrelic_rpm](https://github.com/newrelic/rpm) gem, also [newrelic-grape](https://github.com/xinminlabs/newrelic-grape) gem
 * **Librato Metrics** - [grape-librato](https://github.com/seanmoon/grape-librato) gem
 * **[Skylight](https://www.skylight.io/)** - [skylight](https://github.com/skylightio/skylight-ruby) gem, [documentation](https://docs.skylight.io/grape/)
+* **[AppSignal](https://www.appsignal.com)** - [appsignal-ruby](https://github.com/appsignal/appsignal-ruby) gem, [documentation](http://docs.appsignal.com/getting-started/supported-frameworks.html#grape)
 
 ## Contributing to Grape
 


### PR DESCRIPTION
Adds [AppSignal](https://appsignal.com) to list of monitoring products that support Grape.

Picks up on Grape instrumentation and works out of the box if you mount Grape on Rails, only a few rackup additions if not.

[Relevant documentation](http://docs.appsignal.com/getting-started/supported-frameworks.html#grape)