### PR TITLE
Skip running param validators inside inactive given blocks (#1433)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 #### Fixes
 
+* [#1498](https://github.com/ruby-grape/grape/pull/1498): Skip validations in inactive given blocks - [@jlfaber](https://github.com/jlfaber).
 * [#1479](https://github.com/ruby-grape/grape/pull/1479): Support inserting middleware before/after anonymous classes in the middleware stack - [@rosa](https://github.com/rosa).
 * [#1488](https://github.com/ruby-grape/grape/pull/1488): Ensure calling before filters when receiving OPTIONS request - [@namusyaka](https://github.com/namusyaka), [@jlfaber](https://github.com/jlfaber).
 * [#1493](https://github.com/ruby-grape/grape/pull/1493): Coercion and lambda fails params validation - [@jonmchan](https://github.com/jonmchan).

--- a/lib/grape/validations/validators/allow_blank.rb
+++ b/lib/grape/validations/validators/allow_blank.rb
@@ -7,19 +7,6 @@ module Grape
         value = params[attr_name]
         value = value.strip if value.respond_to?(:strip)
 
-        key_exists = params.key?(attr_name)
-
-        should_validate = if @scope.root?
-                            # root scope. validate if it's a required param. if it's optional, validate only if key exists in hash
-                            @required || key_exists
-                          else # nested scope
-                            (@required && params.present?) ||
-                              # optional param but key inside scoping element exists
-                              (!@required && params.key?(attr_name))
-                          end
-
-        return unless should_validate
-
         return if false == value || value.present?
 
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:blank)

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -24,6 +24,7 @@ module Grape
       # @raise [Grape::Exceptions::Validation] if validation failed
       # @return [void]
       def validate(request)
+        return unless @scope.should_validate?(request.params)
         validate!(request.params)
       end
 

--- a/lib/grape/validations/validators/default.rb
+++ b/lib/grape/validations/validators/default.rb
@@ -18,8 +18,6 @@ module Grape
       end
 
       def validate!(params)
-        return unless @scope.should_validate?(params)
-
         attrs = AttributesIterator.new(self, @scope, params)
         attrs.each do |resource_params, attr_name|
           if resource_params.is_a?(Hash) && resource_params[attr_name].nil?

--- a/lib/grape/validations/validators/presence.rb
+++ b/lib/grape/validations/validators/presence.rb
@@ -1,11 +1,6 @@
 module Grape
   module Validations
     class PresenceValidator < Base
-      def validate!(params)
-        return unless @scope.should_validate?(params)
-        super
-      end
-
       def validate_param!(attr_name, params)
         return if params.respond_to?(:key?) && params.key?(attr_name)
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:presence)

--- a/spec/grape/validations/validators/allow_blank_spec.rb
+++ b/spec/grape/validations/validators/allow_blank_spec.rb
@@ -9,7 +9,12 @@ describe Grape::Validations::AllowBlankValidator do
         params do
           requires :name, allow_blank: false
         end
-        get
+        get '/disallow_blank'
+
+        params do
+          optional :name, type: String, allow_blank: false
+        end
+        get '/opt_disallow_string_blank'
 
         params do
           optional :name, allow_blank: false
@@ -247,7 +252,7 @@ describe Grape::Validations::AllowBlankValidator do
 
   context 'invalid input' do
     it 'refuses empty string' do
-      get '/', name: ''
+      get '/disallow_blank', name: ''
       expect(last_response.status).to eq(400)
 
       get '/disallow_datetime_blank', val: ''
@@ -255,18 +260,23 @@ describe Grape::Validations::AllowBlankValidator do
     end
 
     it 'refuses only whitespaces' do
-      get '/', name: '   '
+      get '/disallow_blank', name: '   '
       expect(last_response.status).to eq(400)
 
-      get '/', name: "  \n "
+      get '/disallow_blank', name: "  \n "
       expect(last_response.status).to eq(400)
 
-      get '/', name: "\n"
+      get '/disallow_blank', name: "\n"
       expect(last_response.status).to eq(400)
     end
 
     it 'refuses nil' do
-      get '/', name: nil
+      get '/disallow_blank', name: nil
+      expect(last_response.status).to eq(400)
+    end
+
+    it 'refuses missing' do
+      get '/disallow_blank'
       expect(last_response.status).to eq(400)
     end
   end
@@ -432,8 +442,13 @@ describe Grape::Validations::AllowBlankValidator do
   end
 
   context 'valid input' do
+    it 'allows missing optional strings' do
+      get 'opt_disallow_string_blank'
+      expect(last_response.status).to eq(200)
+    end
+
     it 'accepts valid input' do
-      get '/', name: 'bob'
+      get '/disallow_blank', name: 'bob'
       expect(last_response.status).to eq(200)
     end
 


### PR DESCRIPTION
This should address both the primary issue identified in #1433, which was related to the ```type``` coercer, and related issues with ```allow_blank```.  In both cases, these validators were being run even when their scopes indicated they should not (since the associated ```given``` criterion had not been met).