### PR TITLE
Allow to use regexp validator with arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Next Release
 ============
 
 * Your contribution here.
+* [#1503](https://github.com/ruby-grape/grape/pull/1503): Allow to use regexp validator with arrays - [@akoltun](https://github.com/akoltun).
 
 0.18.0 (10/7/2016)
 ==================

--- a/lib/grape/validations/validators/regexp.rb
+++ b/lib/grape/validations/validators/regexp.rb
@@ -2,7 +2,7 @@ module Grape
   module Validations
     class RegexpValidator < Base
       def validate_param!(attr_name, params)
-        return unless params.respond_to?(:has_key?) && params.has_key?(attr_name)
+        return unless params.respond_to?(:key?) && params.key?(attr_name)
         return if Array.wrap(params[attr_name]).all? { |param| param.nil? || (param.to_s =~ (options_key?(:value) ? @option[:value] : @option)) }
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:regexp)
       end

--- a/lib/grape/validations/validators/regexp.rb
+++ b/lib/grape/validations/validators/regexp.rb
@@ -2,7 +2,7 @@ module Grape
   module Validations
     class RegexpValidator < Base
       def validate_param!(attr_name, params)
-        return unless params.key?(attr_name) && !params[attr_name].nil? && !(params[attr_name].to_s =~ (options_key?(:value) ? @option[:value] : @option))
+        return if Array.wrap(params[attr_name]).all? { |param| param.nil? || (param.to_s =~ (options_key?(:value) ? @option[:value] : @option)) }
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:regexp)
       end
     end

--- a/lib/grape/validations/validators/regexp.rb
+++ b/lib/grape/validations/validators/regexp.rb
@@ -2,6 +2,7 @@ module Grape
   module Validations
     class RegexpValidator < Base
       def validate_param!(attr_name, params)
+        return unless params.respond_to?(:has_key?) && params.has_key?(attr_name)
         return if Array.wrap(params[attr_name]).all? { |param| param.nil? || (param.to_s =~ (options_key?(:value) ? @option[:value] : @option)) }
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:regexp)
       end

--- a/spec/grape/validations/validators/regexp_spec.rb
+++ b/spec/grape/validations/validators/regexp_spec.rb
@@ -31,6 +31,14 @@ describe Grape::Validations::RegexpValidator do
         end
         get 'regexp_with_array' do
         end
+
+        params do
+          requires :people, type: Hash do
+            requires :names, type: Array[String], regexp: /^[a-z]+$/
+          end
+        end
+        get 'nested_regexp_with_array' do
+        end
       end
     end
   end
@@ -146,6 +154,14 @@ describe Grape::Validations::RegexpValidator do
     it 'accepts nil instead of array' do
       get '/regexp_with_array', names: nil
       expect(last_response.status).to eq(200)
+    end
+  end
+
+  context 'nested regexp with array' do
+    it 'refuses inapppopriate' do
+      get '/nested_regexp_with_array', people: 'invalid name'
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq('{"error":"people is invalid, people[names] is missing, people[names] is invalid"}')
     end
   end
 end

--- a/spec/grape/validations/validators/regexp_spec.rb
+++ b/spec/grape/validations/validators/regexp_spec.rb
@@ -12,12 +12,24 @@ describe Grape::Validations::RegexpValidator do
           end
           get do
           end
+
+          params do
+            requires :names, type: { value: Array[String], message: 'can\'t be nil' }, regexp: { value: /^[a-z]+$/, message: 'format is invalid' }
+          end
+          get 'regexp_with_array' do
+          end
         end
 
         params do
           requires :name, regexp: /^[a-z]+$/
         end
         get do
+        end
+
+        params do
+          requires :names, type: Array[String], regexp: /^[a-z]+$/
+        end
+        get 'regexp_with_array' do
         end
       end
     end
@@ -51,6 +63,36 @@ describe Grape::Validations::RegexpValidator do
       get '/custom_message', name: 'bob'
       expect(last_response.status).to eq(200)
     end
+
+    context 'regexp with array' do
+      it 'refuses inapppopriate items' do
+        get '/custom_message/regexp_with_array', names: ['invalid name', 'abc']
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('{"error":"names format is invalid"}')
+      end
+
+      it 'refuses empty items' do
+        get '/custom_message/regexp_with_array', names: ['', 'abc']
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('{"error":"names format is invalid"}')
+      end
+
+      it 'refuses nil items' do
+        get '/custom_message/regexp_with_array', names: [nil, 'abc']
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('{"error":"names can\'t be nil"}')
+      end
+
+      it 'accepts valid items' do
+        get '/custom_message/regexp_with_array', names: ['bob']
+        expect(last_response.status).to eq(200)
+      end
+
+      it 'accepts nil instead of array' do
+        get '/custom_message/regexp_with_array', names: nil
+        expect(last_response.status).to eq(200)
+      end
+    end
   end
 
   context 'invalid input' do
@@ -75,5 +117,35 @@ describe Grape::Validations::RegexpValidator do
   it 'accepts valid input' do
     get '/', name: 'bob'
     expect(last_response.status).to eq(200)
+  end
+
+  context 'regexp with array' do
+    it 'refuses inapppopriate items' do
+      get '/regexp_with_array', names: ['invalid name', 'abc']
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq('{"error":"names is invalid"}')
+    end
+
+    it 'refuses empty items' do
+      get '/regexp_with_array', names: ['', 'abc']
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq('{"error":"names is invalid"}')
+    end
+
+    it 'refuses nil items' do
+      get '/regexp_with_array', names: [nil, 'abc']
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq('{"error":"names is invalid"}')
+    end
+
+    it 'accepts valid items' do
+      get '/regexp_with_array', names: ['bob']
+      expect(last_response.status).to eq(200)
+    end
+
+    it 'accepts nil instead of array' do
+      get '/regexp_with_array', names: nil
+      expect(last_response.status).to eq(200)
+    end
   end
 end


### PR DESCRIPTION
Ex. this will work

```
params do
  requires :names, type: Array[String], regexp: /^[a-z]+$/
end
```
