### PR TITLE
Feature: add group attributes for parameter definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 Next Release
 ============
 
-* Your contribution here.
 * [#1503](https://github.com/ruby-grape/grape/pull/1503): Allow to use regexp validator with arrays - [@akoltun](https://github.com/akoltun).
+* [#1507](https://github.com/ruby-grape/grape/pull/1507): Add group attributes for parameter definitions - [@304](https://github.com/304).
+* Your contribution here.
 
 0.18.0 (10/7/2016)
 ==================

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
   - [Multiple Allowed Types](#multiple-allowed-types)
   - [Validation of Nested Parameters](#validation-of-nested-parameters)
   - [Dependent Parameters](#dependent-parameters)
+  - [Group Options](#group-options)
   - [Built-in Validators](#built-in-validators)
   - [Namespace Validation and Coercion](#namespace-validation-and-coercion)
   - [Custom Validators](#custom-validators)
@@ -1001,6 +1002,35 @@ params do
 end
 ```
 
+
+### Group Options
+
+Parameters options can be grouped. It can be useful if you want to extract
+common validation or types for several parameters. The example below presents a
+typical case when parameters share common options.
+
+```ruby
+params do
+  requires :first_name, type: String, regexp: /w+/, desc: 'First name'
+  requires :middle_name, type: String, regexp: /w+/, desc: 'Middle name'
+  requires :last_name, type: String, regexp: /w+/, desc: 'Last name'
+end
+```
+
+Grape allows you to present the same logic through the `with` method in your
+parameters block, like so:
+
+```ruby
+params do
+  with(type: String, regexp: /w+/) do
+    requires :first_name, desc: 'First name'
+    requires :middle_name, desc: 'Middle name'
+    requires :last_name, desc: 'Last name'
+  end
+end
+```
+
+
 ### Built-in Validators
 
 #### `allow_blank`
@@ -1076,8 +1106,8 @@ end
 ```
 
 Values and except can be combined to define a range of accepted values while not allowing
-certain values within the set. Custom error messages can be defined for both when the parameter 
-passed falls within the ```except``` list or when it falls entirely outside the ```value``` list. 
+certain values within the set. Custom error messages can be defined for both when the parameter
+passed falls within the ```except``` list or when it falls entirely outside the ```value``` list.
 
 ```ruby
 params do

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -99,6 +99,7 @@ module Grape
 
         opts = attrs.extract_options!.clone
         opts[:presence] = { value: true, message: opts[:message] }
+        opts = @group.merge(opts) if @group
 
         if opts[:using]
           require_required_and_optional_fields(attrs.first, opts)
@@ -118,6 +119,7 @@ module Grape
 
         opts = attrs.extract_options!.clone
         type = opts[:type]
+        opts = @group.merge(opts) if @group
 
         # check type for optional parameter group
         if attrs && block_given?
@@ -132,6 +134,13 @@ module Grape
 
           block_given? ? new_scope(orig_attrs, true, &block) : push_declared_params(attrs)
         end
+      end
+
+      # Define common settings for one or more parameters
+      # @param (see #requires)
+      # @option (see #requires)
+      def with(*attrs, &block)
+        new_group_scope(attrs.clone, &block)
       end
 
       # Disallow the given parameters to be present in the same request.

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -16,6 +16,7 @@ module Grape
       # @option opts :optional [Boolean] whether or not this scope needs to have
       #   any parameters set or not
       # @option opts :type [Class] a type meant to govern this scope (deprecated)
+      # @option opts :type [Hash] group options for this scope
       # @option opts :dependent_on [Symbol] if present, this scope should only
       #   validate if this param is present in the parent scope
       # @yield the instance context, open for parameter definitions
@@ -25,6 +26,7 @@ module Grape
         @api          = opts[:api]
         @optional     = opts[:optional] || false
         @type         = opts[:type]
+        @group        = opts[:group] || {}
         @dependent_on = opts[:dependent_on]
         @declared_params = []
 
@@ -186,6 +188,19 @@ module Grape
           options:      @optional,
           type:         Hash,
           dependent_on: options[:dependent_on],
+          &block)
+      end
+
+      # Returns a new parameter scope, subordinate to the current one and nested
+      # under the parameter corresponding to `attrs.first`.
+      # @param attrs [Array] the attributes passed to the `requires` or
+      #   `optional` invocation that opened this scope.
+      # @yield parameter scope
+      def new_group_scope(attrs, &block)
+        self.class.new(
+          api:          @api,
+          parent:       self,
+          group:        attrs.first,
           &block)
       end
 

--- a/spec/grape/dsl/parameters_spec.rb
+++ b/spec/grape/dsl/parameters_spec.rb
@@ -31,6 +31,11 @@ module Grape
           @validates
         end
 
+        def new_group_scope(args)
+          @group = args.clone.first
+          yield
+        end
+
         def extract_message_option(attrs)
           return nil unless attrs.is_a?(Array)
           opts = attrs.last.is_a?(Hash) ? attrs.pop : {}
@@ -86,6 +91,15 @@ module Grape
       describe '#optional' do
         it 'adds an optional parameter' do
           subject.optional :id, type: Integer, desc: 'Identity.'
+
+          expect(subject.validate_attributes_reader).to eq([[:id], { type: Integer, desc: 'Identity.' }])
+          expect(subject.push_declared_params_reader).to eq([[:id]])
+        end
+      end
+
+      describe '#with' do
+        it 'creates a scope with group attributes' do
+          subject.with(type: Integer) { subject.optional :id, desc: 'Identity.' }
 
           expect(subject.validate_attributes_reader).to eq([[:id], { type: Integer, desc: 'Identity.' }])
           expect(subject.push_declared_params_reader).to eq([[:id]])


### PR DESCRIPTION
It is a proposal with a working prototype for a group attributes feature. If it makes sense then I will continue working on this PR. Your feedback is welcome. 

I was looking into this issue (https://github.com/ruby-grape/grape/issues/1482) recently. I think the presented use case is common for complex APIs schemas. Currently, if I want to apply the same validator (or the same type) for a several endpoint attributes, then I have to define it for every parameter.

What if we introduce a way of defining common parameter settings? Something like [Rails conditional validations](http://guides.rubyonrails.org/active_record_validations.html#grouping-conditional-validations).

For example, this parameters definition:

```ruby
params do
  requires :first_name, type: String, allow_blank: false
  requires :last_name, type: String, allow_blank: false
end
```

can be replaced with
```ruby
params(with: { type: String, allow_blank: false }) do
  requires :first_name
  requires :last_name
end
```


It is also possible to extract group attributes into a class method and use it instead of default params in your code. It should provide the solution for the problem from #1482.
```ruby
class MyAPI < Grape::API do
  def self.not_blank_params(&block)
    params(with: { allow_blank: false }, &block)
  end

  not_blank_params do
    requires :first_name # This param won't accept blank lines 
    requires :last_name, allow_blank: true # This param *will* accept blank lines. 
  end
end
```

/cc @dblock