### PR TITLE
Modify the priority of :any routes, fixes #1089

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Next Release
 #### Fixes
 
 * [#1505](https://github.com/ruby-grape/grape/pull/1505): Run `before` and `after` callbacks, but skip the rest when handling OPTIONS - [@jlfaber](https://github.com/jlfaber).
+* [#1517](https://github.com/ruby-grape/grape/pull/1517), [#1089](https://github.com/ruby-grape/grape/pull/1089): Fix: priority of ANY routes - [@namusyaka](https://github.com/namusyaka), [@wagenet](https://github.com/wagenet).
 
 0.18.0 (10/7/2016)
 ==================

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,22 @@ Upgrading Grape
 
 ### Upgrading to >= 0.18.1
 
+#### Modify the priority of :any routes
+
+Conventional, the :any routes had been searched after matching first route and 405 routes.
+This version adds the :any routes processing before 405 processing, so the behavior of following code will be changed. 
+
+```ruby
+post :example do
+  'example'
+end
+route :any, '*path' do
+  error! :not_found, 404
+end
+
+get '/example' #=> before: 405, currently: 404
+```
+
 #### Removed param processing from built-in OPTIONS handler
 
 When a request is made to the built-in `OPTIONS` handler, only the `before` and `after`

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -161,7 +161,7 @@ module Grape
           route_settings[:endpoint] = route.app
 
           # using the :any shorthand produces [nil] for route methods, substitute all manually
-          route_settings[:methods] = %w(GET PUT POST DELETE PATCH HEAD OPTIONS) if route_settings[:methods].include?('ANY')
+          route_settings[:methods] = %w(GET PUT POST DELETE PATCH HEAD OPTIONS) if route_settings[:methods].include?('*')
         end
       end
 

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -99,6 +99,7 @@ module Grape
               method: :any,
               path: path,
               app: app,
+              route_options: { anchor: false },
               forward_match: !app.respond_to?(:inheritable_setting),
               for: self
             )
@@ -118,6 +119,7 @@ module Grape
         #     end
         #   end
         def route(methods, paths = ['/'], route_options = {}, &block)
+          methods = '*' if methods == :any
           endpoint_options = {
             method: methods,
             path: paths,

--- a/lib/grape/http/headers.rb
+++ b/lib/grape/http/headers.rb
@@ -16,6 +16,8 @@ module Grape
       HEAD    = 'HEAD'.freeze
       OPTIONS = 'OPTIONS'.freeze
 
+      SUPPORTED_METHODS = [GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS].freeze
+
       HTTP_ACCEPT_VERSION    = 'HTTP_ACCEPT_VERSION'.freeze
       X_CASCADE              = 'X-Cascade'.freeze
       HTTP_TRANSFER_ENCODING = 'HTTP_TRANSFER_ENCODING'.freeze

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -69,48 +69,54 @@ module Grape
 
     def identity(env)
       route = nil
-      response = transaction(env) do |input, method, routing_args|
+      response = transaction(env) do |input, method|
         route = match?(input, method)
-        if route
-          env[Grape::Env::GRAPE_ROUTING_ARGS] = make_routing_args(routing_args, route, input)
-          route.exec(env)
-        end
+        process_route(route, env) if route
       end
       [response, route]
     end
 
     def rotation(env, exact_route = nil)
       response = nil
-      input, method, routing_args = *extract_required_args(env)
+      input, method = *extract_input_and_method(env)
       map[method].each do |route|
         next if exact_route == route
         next unless route.match?(input)
-        env[Grape::Env::GRAPE_ROUTING_ARGS] = make_routing_args(routing_args, route, input)
-        response = route.exec(env)
+        response = process_route(route, env)
         break unless cascade?(response)
       end
       response
     end
 
     def transaction(env)
-      input, method, routing_args = *extract_required_args(env)
-      response = yield(input, method, routing_args)
+      input, method = *extract_input_and_method(env)
+      response = yield(input, method)
 
       return response if response && !(cascade = cascade?(response))
-
       neighbor = greedy_match?(input)
 
-      if neighbor && method == 'OPTIONS'
-        return (!cascade && neighbor) ? call_with_allow_headers(env, neighbor.allow_header, neighbor.endpoint) : nil
-      end
+      # If neighbor exists and request method is OPTIONS,
+      # return response by using #call_with_allow_headers.
+      return call_with_allow_headers(
+        env,
+        neighbor.allow_header,
+        neighbor.endpoint
+      ) if neighbor && method == 'OPTIONS' && !cascade
 
-      if route = match?(input, '*')
-        env[Grape::Env::GRAPE_ROUTING_ARGS] = make_routing_args(routing_args, route, input)
-        response = route.exec(env)
+      route = match?(input, '*')
+      if route
+        response = process_route(route, env)
         return response if response && !(cascade = cascade?(response))
       end
 
       (!cascade && neighbor) ? call_with_allow_headers(env, neighbor.allow_header, neighbor.endpoint) : nil
+    end
+
+    def process_route(route, env)
+      input, = *extract_input_and_method(env)
+      routing_args = env[Grape::Env::GRAPE_ROUTING_ARGS]
+      env[Grape::Env::GRAPE_ROUTING_ARGS] = make_routing_args(routing_args, route, input)
+      route.exec(env)
     end
 
     def make_routing_args(default_args, route, input)
@@ -118,11 +124,10 @@ module Grape
       args.merge(route.params(input))
     end
 
-    def extract_required_args(env)
+    def extract_input_and_method(env)
       input = string_for(env[Grape::Http::Headers::PATH_INFO])
       method = env[Grape::Http::Headers::REQUEST_METHOD]
-      routing_args = env[Grape::Env::GRAPE_ROUTING_ARGS]
-      [input, method, routing_args]
+      [input, method]
     end
 
     def with_optimization

--- a/lib/grape/router/pattern.rb
+++ b/lib/grape/router/pattern.rb
@@ -35,7 +35,13 @@ module Grape
       end
 
       def build_path(pattern, anchor: false, suffix: nil, **_options)
-        pattern << '*path' unless anchor || pattern.end_with?('*path')
+        unless anchor || pattern.end_with?('*path')
+          pattern << ?/ unless pattern.end_with?(?/)
+          pattern << '*path'
+        end
+        pattern = pattern.split(?/).tap { |parts|
+          parts[parts.length - 1] = ?? + parts.last
+        }.join(?/) if pattern.end_with?('*path')
         pattern + suffix.to_s
       end
 

--- a/lib/grape/router/pattern.rb
+++ b/lib/grape/router/pattern.rb
@@ -36,12 +36,12 @@ module Grape
 
       def build_path(pattern, anchor: false, suffix: nil, **_options)
         unless anchor || pattern.end_with?('*path')
-          pattern << ?/ unless pattern.end_with?(?/)
+          pattern << '/' unless pattern.end_with?('/')
           pattern << '*path'
         end
-        pattern = pattern.split(?/).tap { |parts|
-          parts[parts.length - 1] = ?? + parts.last
-        }.join(?/) if pattern.end_with?('*path')
+        pattern = pattern.split('/').tap do |parts|
+          parts[parts.length - 1] = '?' + parts.last
+        end.join('/') if pattern.end_with?('*path')
         pattern + suffix.to_s
       end
 

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -508,6 +508,37 @@ describe Grape::API do
       end
     end
 
+    it 'allows for catch-all in a namespace' do
+      subject.namespace :nested do
+        get do
+          'root'
+        end
+
+        get 'something' do
+          'something'
+        end
+
+        route :any, '*path' do
+          'catch-all'
+        end
+      end
+
+      send('get', 'nested')
+      expect(last_response.body).to eql 'root'
+
+      send('get', 'nested/something')
+      expect(last_response.body).to eql 'something'
+
+      send('get', 'nested/missing')
+      expect(last_response.body).to eql 'catch-all'
+
+      send('post', 'nested')
+      expect(last_response.body).to eql 'catch-all'
+
+      send('post', 'nested/something')
+      expect(last_response.body).to eql 'catch-all'
+    end
+
     verbs = %w(post get head delete put options patch)
     verbs.each do |verb|
       it "allows and properly constrain a #{verb.upcase} method" do

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -786,9 +786,6 @@ XML
         subject.post :example do
           'example'
         end
-        subject.route :any, '*path' do
-          error! :not_found, 404
-        end
         get '/example'
       end
 


### PR DESCRIPTION
ref #1089 

Conventional, the :any routes had been searched after matching first route and 405 routes.
This PR fixes the issue by adding the :any routes processing before 405 processing.