### PR TITLE
Avoid noise when code runs with Ruby warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Next Release
 * [#1517](https://github.com/ruby-grape/grape/pull/1517), [#1089](https://github.com/ruby-grape/grape/pull/1089): Fix: priority of ANY routes - [@namusyaka](https://github.com/namusyaka), [@wagenet](https://github.com/wagenet).
 * [#1512](https://github.com/ruby-grape/grape/pull/1512): Fix: deeply nested parameters are included within `#declared(params)` - [@krbs](https://github.com/krbs).
 * [#1510](https://github.com/ruby-grape/grape/pull/1510): Fix: inconsistent validation for multiple parameters - [@dgasper](https://github.com/dgasper).
+* [#1526](https://github.com/ruby-grape/grape/pull/1526): Reduce warnings caused by instance variables not initialized - [@cpetschnig](https://github.com/cpetschnig).
 
 0.18.0 (10/7/2016)
 ==================

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -95,6 +95,8 @@ module Grape
       @options[:route_options] ||= {}
 
       @lazy_initialize_lock = Mutex.new
+      @lazy_initialized = nil
+      @block = nil
 
       return unless block_given?
 

--- a/lib/grape/middleware/base.rb
+++ b/lib/grape/middleware/base.rb
@@ -13,6 +13,7 @@ module Grape
       def initialize(app, **options)
         @app = app
         @options = default_options.merge(**options)
+        @app_response = nil
       end
 
       def default_options

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -29,6 +29,7 @@ module Grape
         @group        = opts[:group] || {}
         @dependent_on = opts[:dependent_on]
         @declared_params = []
+        @index = nil
 
         instance_eval(&block) if block_given?
 

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1202,7 +1202,7 @@ XML
         def initialize(app, *args)
           @args = args
           @app = app
-          @block = true if block_given?
+          @block = block_given? ? true : nil
         end
 
         def call(env)

--- a/spec/grape/middleware/versioner/path_spec.rb
+++ b/spec/grape/middleware/versioner/path_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe Grape::Middleware::Versioner::Path do
   let(:app) { ->(env) { [200, env, env['api.version']] } }
-  subject { Grape::Middleware::Versioner::Path.new(app, @options || {}) }
+  let(:options) { {} }
+  subject { Grape::Middleware::Versioner::Path.new(app, options) }
 
   it 'sets the API version based on the first path' do
     expect(subject.call('PATH_INFO' => '/v1/awesome').last).to eq('v1')
@@ -17,7 +18,7 @@ describe Grape::Middleware::Versioner::Path do
   end
 
   context 'with a pattern' do
-    before { @options = { pattern: /v./i } }
+    let(:options) { { pattern: /v./i } }
     it 'sets the version if it matches' do
       expect(subject.call('PATH_INFO' => '/v1/awesome').last).to eq('v1')
     end
@@ -29,7 +30,7 @@ describe Grape::Middleware::Versioner::Path do
 
   [%w(v1 v2), [:v1, :v2], [:v1, 'v2'], ['v1', :v2]].each do |versions|
     context "with specified versions as #{versions}" do
-      before { @options = { versions: versions } }
+      let(:options) { { versions: versions } }
 
       it 'throws an error if a non-allowed version is specified' do
         expect(catch(:error) { subject.call('PATH_INFO' => '/v3/awesome') }[:status]).to eq(404)


### PR DESCRIPTION
New versions of RSpec have warnings turned on by default:

    # This setting enables warnings. It's recommended, but in some cases may
    # be too noisy due to issues in dependencies.
    config.warnings = true

I believe these warnings are helpful in general to write better code. However, Grape and Grape Entity are very noisy. I get about 20 lines of warnings for one single test where Grape is involved.

I hope you agree. Many of my changes could also be solved differently for sure. I am happy to discuss and change those cases. I also changed the specs for less warnings and turned them on in the test suite.