### PR TITLE
Updates `invalid_versioner_option` translation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 #### 0.19.1 (Next)
 
+* [#1536](https://github.com/ruby-grape/grape/pull/1536): Updates `invalid_versioner_option` translation - [@Lavode](https://github.com/Lavode).
 * Your contribution here.
 
 ### 0.19.0 (12/18/2016)

--- a/lib/grape/locale/en.yml
+++ b/lib/grape/locale/en.yml
@@ -26,7 +26,7 @@ en:
         invalid_formatter: 'cannot convert %{klass} to %{to_format}'
         invalid_versioner_option:
           problem: 'Unknown :using for versioner: %{strategy}'
-          resolution: 'available strategy for :using is :path, :header, :param'
+          resolution: 'available strategy for :using is :path, :header, :accept_version_header, :param'
         unknown_validator: 'unknown validator: %{validator_type}'
         unknown_options: 'unknown options: %{options}'
         unknown_parameter: 'unknown parameter: %{param}'


### PR DESCRIPTION
Adds `:accept_version_header` as valid setting.