### PR TITLE
Declaring an endpoint in the namespace affects its state

### DIFF
--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -1303,4 +1303,50 @@ describe Grape::Endpoint do
       )
     end
   end
+
+  context 'bug' do
+    context 'endpoint is first in a namespace with params' do
+      it do
+        subject.instance_exec do
+          params do
+            optional :parent
+          end
+          namespace :namespace do
+            # get
+
+            resource :resource do
+              get do
+                declared(params).keys.join(',')
+              end
+            end
+          end
+        end
+
+        get 'namespace/resource', parent: 'parent'
+        expect(last_response.body).to eq('parent')
+      end
+    end
+
+    context 'endpoint is second in a namespace with params' do
+      it do
+        subject.instance_exec do
+          params do
+            optional :parent
+          end
+          namespace :namespace do
+            get
+
+            resource :resource do
+              get do
+                declared(params).keys.join(',')
+              end
+            end
+          end
+        end
+
+        get 'namespace/resource', parent: 'parent'
+        expect(last_response.body).to eq('parent')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Please, see the 2 specs I have added. First one has no other endpoints in the namespace, while the second one has another endpoint defined before the one we are testing. The first spec succeeds in building `declared(params)`, while the second one tells that there are none declared.
I would be glad to locate the issue in the source code, but it was too hard, so I gave up.