### PR TITLE
Avoid failing even if given path does not match with prefix

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,6 @@ Style/MultilineIfModifier:
 
 Style/RaiseArgs:
   Enabled: false
+
+Lint/UnneededDisable:
+  Enabled: false

--- a/Appraisals
+++ b/Appraisals
@@ -14,3 +14,7 @@ end
 appraise 'rack-1.5.2' do
   gem 'rack', '1.5.2'
 end
+
+appraise 'rails-edge' do
+  gem 'arel', github: 'rails/arel'
+end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Fixes
 
+* [#1548](https://github.com/ruby-grape/grape/pull/1548): Avoid failing even if given path does not match with prefix - [@thomas-peyric](https://github.com/thomas-peyric), [@namusyaka](https://github.com/namusyaka).
 * Your contribution here.
 
 ### 0.19.0 (12/18/2016)

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -2,12 +2,12 @@
 
 source 'https://rubygems.org'
 
-gem 'rails', github: 'rails/rails'
+gem 'arel', github: 'rails/arel'
 
 group :development, :test do
   gem 'bundler'
   gem 'rake'
-  gem 'rubocop', '~> 0.45.0'
+  gem 'rubocop', '~> 0.45'
 end
 
 group :development do

--- a/lib/grape/middleware/versioner/path.rb
+++ b/lib/grape/middleware/versioner/path.rb
@@ -26,7 +26,7 @@ module Grape
         def before
           path = env[Grape::Http::Headers::PATH_INFO].dup
 
-          if prefix && path.index(prefix) == 0
+          if prefix && path.index(prefix) == 0 # rubocop:disable all
             path.sub!(prefix, '')
             path = Grape::Router.normalize_path(path)
           end

--- a/lib/grape/middleware/versioner/path.rb
+++ b/lib/grape/middleware/versioner/path.rb
@@ -26,7 +26,7 @@ module Grape
         def before
           path = env[Grape::Http::Headers::PATH_INFO].dup
 
-          if prefix && path.index(prefix).zero?
+          if prefix && path.index(prefix) == 0
             path.sub!(prefix, '')
             path = Grape::Router.normalize_path(path)
           end

--- a/spec/grape/middleware/versioner/path_spec.rb
+++ b/spec/grape/middleware/versioner/path_spec.rb
@@ -41,4 +41,11 @@ describe Grape::Middleware::Versioner::Path do
       end
     end
   end
+
+  context 'with prefix, but requested version is not matched' do
+    let(:options) { { prefix: '/v1', pattern: /v./i } }
+    it 'recognizes potential version' do
+      expect(subject.call('PATH_INFO' => '/v3/foo').last).to eq('v3')
+    end
+  end
 end


### PR DESCRIPTION
I partially reverted changes and disabled rubocop in the line. Also, I added a spec for this case.

Rubocop seems to have a bug about NumericPredicate.
@dblock @thomas-peyric Thoughts?