### PR TITLE
should be able to pass `nil` to an optional array values param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 #### Fixes
 
-* Your contribution here.
+* [#1559](https://github.com/ruby-grape/grape/pull/1559): You can once again pass `nil` to optional attributes with `values` validation set - [@ghiculescu](https://github.com/ghiculescu).
 
 ### 0.19.1 (1/9/2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 #### Fixes
 
 * [#1559](https://github.com/ruby-grape/grape/pull/1559): You can once again pass `nil` to optional attributes with `values` validation set - [@ghiculescu](https://github.com/ghiculescu).
+* Your contribution here.
 
 ### 0.19.1 (1/9/2017)
 

--- a/lib/grape/validations/validators/values.rb
+++ b/lib/grape/validations/validators/values.rb
@@ -17,7 +17,7 @@ module Grape
         excepts = @excepts.is_a?(Proc) ? @excepts.call : @excepts
         param_array = params[attr_name].nil? ? [nil] : Array.wrap(params[attr_name])
 
-        if param_array.all? { |param| excepts.include?(param) }
+        if !param_array.empty? && param_array.all? { |param| excepts.include?(param) }
           raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: except_message
         end
 

--- a/spec/grape/validations/validators/values_spec.rb
+++ b/spec/grape/validations/validators/values_spec.rb
@@ -159,6 +159,11 @@ describe Grape::Validations::ValuesValidator do
         get '/mixed/value/except' do
           { type: params[:type] }
         end
+
+        params do
+          optional :optional, type: Array[String], values: %w(a b c)
+        end
+        put '/optional_with_array_of_string_values'
       end
     end
   end
@@ -240,6 +245,11 @@ describe Grape::Validations::ValuesValidator do
 
     it 'allows for a required param in child scope' do
       get('/optional_with_required_values')
+      expect(last_response.status).to eq 200
+    end
+
+    it 'allows for an optional param with a list of values' do
+      put('/optional_with_array_of_string_values', optional: nil)
       expect(last_response.status).to eq 200
     end
   end


### PR DESCRIPTION
this bug was introduced in https://github.com/ruby-grape/grape/commit/3540ea25a6cc82a700a572b2c8f483b66302d7e6#diff-45b62b4ed0aed7ceff346c347f76570e

previously, you were able to pass `nil` to an endpoint for an attribute that was marked as optional and had a set array of values. after the above change, this was no longer possible.