### PR TITLE
Avoid duplicated calls in StackableValue#[]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 * [#1559](https://github.com/ruby-grape/grape/pull/1559): You can once again pass `nil` to optional attributes with `values` validation set - [@ghiculescu](https://github.com/ghiculescu).
 * [#1562](https://github.com/ruby-grape/grape/pull/1562): Fix rainbow gem installation failure above ruby 2.3.3 on travis-ci - [@brucehsu](https://github.com/brucehsu).
+* [#1561](https://github.com/ruby-grape/grape/pull/1561): Fix performance issue introduced by duplicated calls in StackableValue#[] - [@brucehsu](https://github.com/brucehsu).
 
 ### 0.19.1 (1/9/2017)
 

--- a/lib/grape/util/stackable_values.rb
+++ b/lib/grape/util/stackable_values.rb
@@ -15,8 +15,8 @@ module Grape
         return @frozen_values[name] if @frozen_values.key? name
 
         value = []
-        value.concat(@inherited_values[name]) if @inherited_values[name]
-        value.concat(@new_values[name]) if @new_values[name]
+        value.concat(@inherited_values[name] || [])
+        value.concat(@new_values[name] || [])
         value
       end
 


### PR DESCRIPTION
Fixing the performance issue mentioned in issue #1560 by eliminating duplicated calls of `StackableValue#[]` in one-liner conditionals.