### PR TITLE
Fix Rainbow gem installation failure above Ruby 2.3.3 on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,6 @@ matrix:
     - rvm: rbx-2
 
 bundler_args: --without development
+
+before_install: gem update --system
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 #### Fixes
 
 * [#1559](https://github.com/ruby-grape/grape/pull/1559): You can once again pass `nil` to optional attributes with `values` validation set - [@ghiculescu](https://github.com/ghiculescu).
-* Your contribution here.
+* [#1562](https://github.com/ruby-grape/grape/pull/1562): Fix rainbow gem installation failure above ruby 2.3.3 on travis-ci - [@brucehsu](https://github.com/brucehsu).
 
 ### 0.19.1 (1/9/2017)
 


### PR DESCRIPTION
Reference: https://github.com/sickill/rainbow/issues/48