### PR TITLE
Failing test to expose a declared params bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * [#1559](https://github.com/ruby-grape/grape/pull/1559): You can once again pass `nil` to optional attributes with `values` validation set - [@ghiculescu](https://github.com/ghiculescu).
 * [#1562](https://github.com/ruby-grape/grape/pull/1562): Fix rainbow gem installation failure above ruby 2.3.3 on travis-ci - [@brucehsu](https://github.com/brucehsu).
 * [#1561](https://github.com/ruby-grape/grape/pull/1561): Fix performance issue introduced by duplicated calls in StackableValue#[] - [@brucehsu](https://github.com/brucehsu).
+* [#1564](https://github.com/ruby-grape/grape/pull/1564): Fix declared params bug with nested namespaces - [@bmarini](https://github.com/bmarini).
+* Your contribution here.
 
 ### 0.19.1 (1/9/2017)
 

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -29,8 +29,11 @@ module Grape
         def declared(params, options = {}, declared_params = nil)
           options = options.reverse_merge(include_missing: true, include_parent_namespaces: true)
 
-          all_declared_params = route_setting(:declared_params)
-          current_namespace_declared_params = route_setting(:saved_declared_params).last
+          # Declared params including parent namespaces
+          all_declared_params = route_setting(:saved_declared_params).flatten | Array(route_setting(:declared_params))
+
+          # Declared params at current namespace
+          current_namespace_declared_params = route_setting(:saved_declared_params).last & Array(route_setting(:declared_params))
 
           declared_params ||= options[:include_parent_namespaces] ? all_declared_params : current_namespace_declared_params
 

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -588,7 +588,8 @@ describe Grape::Endpoint do
       subject.format :json
       subject.resource :users do
         route_param :id, type: Integer, desc: 'ID desc' do
-          # Adding this causes issues loading declared params below
+          # Adding this causes route_setting(:declared_params) to be nil for the
+          # get block in namespace 'foo' below
           get do
           end
 
@@ -596,7 +597,8 @@ describe Grape::Endpoint do
             get do
               {
                 params: params,
-                declared_params: declared(params)
+                declared_params: declared(params),
+                declared_params_no_parent: declared(params, include_parent_namespaces: false)
               }
             end
           end
@@ -605,10 +607,12 @@ describe Grape::Endpoint do
     end
 
     it 'can access parent route_param' do
-      get '/users/123/foo'
+      get '/users/123/foo', bar: 'bar'
       expect(last_response.status).to eq 200
       json = JSON.parse(last_response.body, symbolize_names: true)
+
       expect(json[:declared_params][:id]).to eq 123
+      expect(json[:declared_params_no_parent][:id]).to eq nil
     end
   end
 

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -583,6 +583,35 @@ describe Grape::Endpoint do
     end
   end
 
+  describe '#declared; mixed nesting' do
+    before do
+      subject.format :json
+      subject.resource :users do
+        route_param :id, type: Integer, desc: 'ID desc' do
+          # Adding this causes issues loading declared params below
+          get do
+          end
+
+          namespace 'foo' do
+            get do
+              {
+                params: params,
+                declared_params: declared(params)
+              }
+            end
+          end
+        end
+      end
+    end
+
+    it 'can access parent route_param' do
+      get '/users/123/foo'
+      expect(last_response.status).to eq 200
+      json = JSON.parse(last_response.body, symbolize_names: true)
+      expect(json[:declared_params][:id]).to eq 123
+    end
+  end
+
   describe '#declared; with multiple route_param' do
     before do
       mounted = Class.new(Grape::API)


### PR DESCRIPTION
I'm working on enforcing declared params usage in my codebase, and in doing so I started running into issues where I thought a declared param should be available via a parent scope, but for some reason wasn't.

This is one of those cases. It works as expected if I remove the route defined just above the namespace 'foo'.