### PR TITLE
Expose bug with response codes

### DIFF
--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -115,6 +115,26 @@ describe Grape::Endpoint do
       expect(memoized_status).to eq(201)
       expect(last_response.body).to eq('Hello')
     end
+
+    it 'is set as default to 204 for delete with no content' do
+      subject.delete('/home') do
+      end
+
+      delete '/home'
+      expect(last_response.status).to eq(204)
+      expect(last_response.body).to eq('')
+    end
+
+    it 'is set as default to 200 for delete with content' do
+      subject.format :json
+      subject.delete('/home') do
+        {}
+      end
+
+      delete '/home'
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq('{}')
+    end
   end
 
   describe '#header' do


### PR DESCRIPTION
This is related to the 204 no content changes made #1532 and #1549 #1550 

Seems like the behavior should be as follows:

```
1. If status was not set: use that.
2. If status was not set:
    a) If body is formatted to an empty string, use 204 No Content
    b) If body is formatted to a non empty string, use a default status for method, (GET: 200, POST: 201, PATCH: 200, DELETE: 200). 
```
