### PR TITLE
Fix ValuesValidator: do not allow none if none allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Fixes
 
+* [#1566](https://github.com/ruby-grape/grape/pull/1566): Fix ValuesValidator: do not allow none if none allowed - [@faucct](https://github.com/faucct).
 * [#1559](https://github.com/ruby-grape/grape/pull/1559): You can once again pass `nil` to optional attributes with `values` validation set - [@ghiculescu](https://github.com/ghiculescu).
 * [#1562](https://github.com/ruby-grape/grape/pull/1562): Fix rainbow gem installation failure above ruby 2.3.3 on travis-ci - [@brucehsu](https://github.com/brucehsu).
 * [#1561](https://github.com/ruby-grape/grape/pull/1561): Fix performance issue introduced by duplicated calls in StackableValue#[] - [@brucehsu](https://github.com/brucehsu).

--- a/lib/grape/validations/validators/values.rb
+++ b/lib/grape/validations/validators/values.rb
@@ -3,9 +3,9 @@ module Grape
     class ValuesValidator < Base
       def initialize(attrs, options, required, scope, opts = {})
         @excepts = (options_key?(:except, options) ? options[:except] : [])
-        @values = (options_key?(:value, options) ? options[:value] : [])
+        @values = options_key?(:value, options) && options[:value]
 
-        @values = options if @excepts == [] && @values == []
+        @values = options if @excepts == [] && !@values
         super
       end
 
@@ -21,7 +21,7 @@ module Grape
           raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: except_message
         end
 
-        return if (values.is_a?(Array) && values.empty?) || param_array.all? { |param| values.include?(param) }
+        return if !values || param_array.all? { |param| values.include?(param) }
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:values)
       end
 

--- a/spec/grape/validations/validators/values_spec.rb
+++ b/spec/grape/validations/validators/values_spec.rb
@@ -91,6 +91,11 @@ describe Grape::Validations::ValuesValidator do
         end
 
         params do
+          requires :type, values: -> { [] }
+        end
+        get '/empty_lambda'
+
+        params do
           optional :type, values: ValuesModel.values, default: -> { ValuesModel.values.sample }
         end
         get '/default_lambda' do
@@ -284,6 +289,12 @@ describe Grape::Validations::ValuesValidator do
 
   it 'does not allow an invalid value for a parameter using lambda' do
     get('/lambda', type: 'invalid-type')
+    expect(last_response.status).to eq 400
+    expect(last_response.body).to eq({ error: 'type does not have a valid value' }.to_json)
+  end
+
+  it 'validates against an empty array in a proc' do
+    get('/empty_lambda', type: 'any')
     expect(last_response.status).to eq 400
     expect(last_response.body).to eq({ error: 'type does not have a valid value' }.to_json)
   end


### PR DESCRIPTION
Hello, I have noticed that this behaviour has changed at some point and brought it back since there are no specs on that.