### PR TITLE
Add test_with option to values validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * [#1555](https://github.com/ruby-grape/grape/pull/1555): Added code coverage w/Coveralls - [@dblock](https://github.com/dblock).
+* [#1568](https://github.com/ruby-grape/grape/pull/1568): Add `proc` option to `values` validator to allow custom checks - [@jlfaber](https://github.com/jlfaber).
 * Your contribution here.
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -1152,6 +1152,20 @@ params do
 end
 ```
 
+Finally, for even greater control, an explicit validation Proc may be supplied using ```proc```.
+It will be called with a single argument (the input value), and should return
+a truthy value if the value passes validation. If the input is an array, the Proc will be called
+multiple times, once for each element in the array.
+
+```ruby
+params do
+  requires :number, type: Integer, values: { proc: ->(v) { v.even? && v < 25 }, message: 'is odd or greater than 25' }
+end
+```
+
+While ```proc``` is convenient for single cases, consider using [Custom Validators](#custom-validators) in cases where a validation is used more than once.
+
+
 #### `regexp`
 
 Parameters can be restricted to match a specific regular expression with the `:regexp` option. If the value

--- a/lib/grape/validations/validators/values.rb
+++ b/lib/grape/validations/validators/values.rb
@@ -5,6 +5,8 @@ module Grape
         if options.is_a?(Hash)
           @excepts = options[:except]
           @values = options[:value]
+          @proc = options[:proc]
+          raise ArgumentError, 'proc must be a Proc' if @proc && !@proc.is_a?(Proc)
         else
           @values = options
         end
@@ -24,6 +26,9 @@ module Grape
 
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:values) \
           if !values.nil? && !param_array.all? { |param| values.include?(param) }
+
+        raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:values) \
+          if @proc && !param_array.all? { |param| @proc.call(param) }
       end
 
       private


### PR DESCRIPTION
This PR adds a new option `test_with` to the `values` validator.  If present, it must be a Proc that accepts a single argument (the param value) and returns a truthy value if the argument is valid.

I don't think this has been explicitly asked for, and one could certainly do the same thing using a custom validator.  But this seemed a little more convenient for simple validations that aren't already handled by the existing built-ins.

This could be an acceptable workaround/solution for #1535 which requests the ability to specify a maximum parameter value.