### PR TITLE
allow undefined route options

### DIFF
--- a/lib/grape/util/strict_hash_configuration.rb
+++ b/lib/grape/util/strict_hash_configuration.rb
@@ -26,6 +26,10 @@ module Grape
         def to_hash
           @settings.to_hash
         end
+
+        def method_missing(setting_name, value)
+          @settings[setting_name] = value
+        end
       end
 
       def self.config_class(*args)


### PR DESCRIPTION
I would like to be allowed to add arbitrary options into a route description like this:

```
desc 'get an object' do
  option awesome_value
end
```

and then have that option be available in `route.options`

after a little looking into it, using `method_missing` like this works, but i wonder if there is a solution that would be preferred over this.

Any thoughts?