### PR TITLE
Bugfix: values without value breaks type and default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#1590](https://github.com/ruby-grape/grape/pull/1590): Fix default and type validator when values is a Hash with no value attribute - [@jlfaber](https://github.com/jlfaber).
 * Your contribution here.
 
 ### 0.19.2 (4/12/2017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Fixes
 
-* [#1590](https://github.com/ruby-grape/grape/pull/1590): Fix default and type validator when values is a Hash with no value attribute - [@jlfaber](https://github.com/jlfaber).
+* [#1615](https://github.com/ruby-grape/grape/pull/1615): Fix default and type validator when values is a Hash with no value attribute - [@jlfaber](https://github.com/jlfaber).
 * Your contribution here.
 
 ### 0.19.2 (4/12/2017)

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -232,17 +232,20 @@ module Grape
         default = validations[:default]
         doc_attrs[:default] = default if validations.key?(:default)
 
-        values = validations[:values]
-        if values.is_a? Hash
-          excepts = values[:except]
-          values = values[:value]
-          values = nil if values.is_a? Proc
+        if (values_hash = validations[:values]).is_a? Hash
+          values = values_hash[:value]
+          excepts = values_hash[:except]
+        else
+          values = validations[:values]
         end
-
         doc_attrs[:values] = values if values
 
+        # NB. values and excepts should be nil, Proc, Array, or Range.
+        # Specifically, values should NOT be a Hash
+
         # use values or excepts to guess coerce type when stated type is Array
-        coerce_type = guess_coerce_type(coerce_type, values || excepts)
+        coerce_type = guess_coerce_type(coerce_type, values)
+        coerce_type = guess_coerce_type(coerce_type, excepts)
 
         # default value should be present in values array, if both exist and are not procs
         check_incompatible_option_values(values, default)
@@ -380,10 +383,6 @@ module Grape
       def validate_value_coercion(coerce_type, values)
         return unless coerce_type && values
         return if values.is_a?(Proc)
-        if values.is_a?(Hash)
-          return if values[:value] && values[:value].is_a?(Proc)
-          return if values[:except] && values[:except].is_a?(Proc)
-        end
         coerce_type = coerce_type.first if coerce_type.is_a?(Array)
         value_types = values.is_a?(Range) ? [values.begin, values.end] : values
         if coerce_type == Virtus::Attribute::Boolean

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -232,16 +232,25 @@ module Grape
         default = validations[:default]
         doc_attrs[:default] = default if validations.key?(:default)
 
-        values = options_key?(:values, :value, validations) ? validations[:values][:value] : validations[:values]
+        values = validations[:values]
+        if values.is_a? Hash
+          excepts = values[:except]
+          values = values[:value]
+          values = nil if values.is_a? Proc
+        end
+
         doc_attrs[:values] = values if values
 
-        coerce_type = guess_coerce_type(coerce_type, values)
+        # use values or excepts to guess coerce type when stated type is Array
+        coerce_type = guess_coerce_type(coerce_type, values || excepts)
 
         # default value should be present in values array, if both exist and are not procs
         check_incompatible_option_values(values, default)
 
         # type should be compatible with values array, if both exist
         validate_value_coercion(coerce_type, values)
+        # type should be compatible with excepts array, if both exist
+        validate_value_coercion(coerce_type, excepts)
 
         doc_attrs[:documentation] = validations.delete(:documentation) if validations.key?(:documentation)
 


### PR DESCRIPTION
The checking of `type` and `default` validators in `params_scope.rb` is broken in cases where `values` is a Hash containing only the `except` attribute (and no `value` attribute).  For example both of the following are broken:
```
params do
  requires :foo, type: String, values: { except: ['bar', 'baz'] }
  requires :foo2, values: { except: ['bar2', 'baz2'] }, default: 'bing'
end
```
