### PR TITLE
Bugfix: Correctly handle `given` in Array params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Fixes
 
 * [#1615](https://github.com/ruby-grape/grape/pull/1615): Fix default and type validator when values is a Hash with no value attribute - [@jlfaber](https://github.com/jlfaber).
+* [#1625](https://github.com/ruby-grape/grape/pull/1625): Handle `given` correctly when nested in Array params - [@rnubel](https://github.com/rnubel), [@avellable](https://github.com/avellable).
 * Your contribution here.
 
 ### 0.19.2 (4/12/2017)

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -47,17 +47,17 @@ module Grape
       end
 
       def meets_dependency?(params)
-        if @dependent_on
-          params = params.with_indifferent_access
+        return true unless @dependent_on
 
-          @dependent_on.each do |dependency|
-            if dependency.is_a?(Hash)
-              dependency_key = dependency.keys[0]
-              proc = dependency.values[0]
-              return false unless proc.call(params.try(:[], dependency_key))
-            elsif params.respond_to?(:key?) && params.try(:[], dependency).blank?
-              return false
-            end
+        params = params.with_indifferent_access
+
+        @dependent_on.each do |dependency|
+          if dependency.is_a?(Hash)
+            dependency_key = dependency.keys[0]
+            proc = dependency.values[0]
+            return false unless proc.call(params.try(:[], dependency_key))
+          elsif params.respond_to?(:key?) && params.try(:[], dependency).blank?
+            return false
           end
         end
 

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -42,37 +42,45 @@ module Grape
         return false if @optional && (params(parameters).blank? ||
                                        any_element_blank?(parameters))
 
-        @dependent_on.each do |dependency|
-          if dependency.is_a?(Hash)
-            dependency_key = dependency.keys[0]
-            proc = dependency.values[0]
-            return false unless proc.call(params(parameters).try(:[], dependency_key))
-          elsif params(parameters).try(:[], dependency).blank?
-            return false
-          end
-        end if @dependent_on
-
         return true if parent.nil?
         parent.should_validate?(parameters)
       end
 
+      def meets_dependency?(params)
+        if @dependent_on
+          params = params.with_indifferent_access
+
+          @dependent_on.each do |dependency|
+            if dependency.is_a?(Hash)
+              dependency_key = dependency.keys[0]
+              proc = dependency.values[0]
+              return false unless proc.call(params.try(:[], dependency_key))
+            elsif params.respond_to?(:key?) && params.try(:[], dependency).blank?
+              return false
+            end
+          end
+        end
+
+        true
+      end
+
       # @return [String] the proper attribute name, with nesting considered.
-      def full_name(name)
+      def full_name(name, index: nil)
         if nested?
           # Find our containing element's name, and append ours.
-          "#{@parent.full_name(@element)}#{array_index}[#{name}]"
+          [@parent.full_name(@element), [@index || index, name].map(&method(:brackets))].compact.join
         elsif lateral?
-          # Find the name of the element as if it was at the
-          # same nesting level as our parent.
-          @parent.full_name(name)
+          # Find the name of the element as if it was at the same nesting level
+          # as our parent. We need to forward our index upward to achieve this.
+          @parent.full_name(name, index: @index)
         else
           # We must be the root scope, so no prefix needed.
           name.to_s
         end
       end
 
-      def array_index
-        "[#{@index}]" if @index.present?
+      def brackets(val)
+        "[#{val}]" if val
       end
 
       # @return [Boolean] whether or not this scope is the root-level scope
@@ -187,7 +195,7 @@ module Grape
           element:      nil,
           parent:       self,
           options:      @optional,
-          type:         Hash,
+          type:         type == Array ? Array : Hash,
           dependent_on: options[:dependent_on],
           &block
         )

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -41,6 +41,7 @@ module Grape
         array_errors = []
         attributes.each do |resource_params, attr_name|
           next unless @required || (resource_params.respond_to?(:key?) && resource_params.key?(attr_name))
+          next unless @scope.meets_dependency?(resource_params)
 
           begin
             validate_param!(attr_name, resource_params)


### PR DESCRIPTION
Addresses #1600 and #1602.

Array parameters are handled as a parameter that opens a scope with `type: Array`; `given` opens up a new scope, but was always setting the type to Hash. This patch fixes that, as well as correctly labeling the error messages associated with array fields.