### PR TITLE
Silence warnings "instance var not initialized"

### DIFF
--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -145,7 +145,7 @@ module Grape
         when Integer
           @status = status
         when nil
-          return @status if @status
+          return @status if defined? @status
           case request.request_method.to_s.upcase
           when Grape::Http::Headers::POST
             201
@@ -200,7 +200,7 @@ module Grape
         elsif value == false
           @body = ''
           status 204
-        else
+        elsif defined? @body
           @body
         end
       end
@@ -234,7 +234,7 @@ module Grape
         elsif !value.is_a?(NilClass)
           warn '[DEPRECATION] Argument as FileStreamer-like object is deprecated. Use path to file instead.'
           @file = Grape::ServeFile::FileResponse.new(value)
-        else
+        elsif defined? @file
           @file
         end
       end
@@ -296,7 +296,7 @@ module Grape
         representation = { root => representation } if root
         if key
           representation = (@body || {}).merge(key => representation)
-        elsif entity_class.present? && @body
+        elsif entity_class.present? && defined? @body
           raise ArgumentError, "Representation of type #{representation.class} cannot be merged." unless representation.respond_to?(:merge)
           representation = @body.merge(representation)
         end


### PR DESCRIPTION
Add `defined?` checks for instance variables.

I will need feedback to get rid of more warnings, I am not aware of every warning triggered yet.
If someone has warnings too, let me know and I'll update the PR.

Reference to #1582