### PR TITLE
Suppress `warning: method redefined`

### DIFF
--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -7,7 +7,7 @@ module Grape
       include Grape::DSL::Configuration
 
       module ClassMethods
-        attr_reader :endpoints, :routes
+        attr_reader :endpoints
 
         # Specify an API version.
         #

--- a/lib/grape/dsl/settings.rb
+++ b/lib/grape/dsl/settings.rb
@@ -9,7 +9,7 @@ module Grape
     module Settings
       extend ActiveSupport::Concern
 
-      attr_accessor :inheritable_setting, :top_level_setting
+      attr_writer :inheritable_setting, :top_level_setting
 
       # Fetch our top-level settings, which apply to all endpoints in the API.
       def top_level_setting


### PR DESCRIPTION
This PR suppresses the following warning at lib/grape/dsl.

```
RUBYOPT=-w bundle exec rake

/Users/numata/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/grape-0.19.2/lib/grape/dsl/settings.rb:15: warning: method redefined; discarding old top_level_setting

/Users/numata/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/grape-0.19.2/lib/grape/dsl/settings.rb:21: warning: method redefined; discarding old inheritable_setting

/Users/numata/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/grape-0.19.2/lib/grape/dsl/routing.rb:182: warning: method redefined; discarding old routes
```