### PR TITLE
Add ability to include an array of modules as helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#1594](https://github.com/ruby-grape/grape/pull/1594): Replace `Hashie::Mash` parameters with `ActiveSupport::HashWithIndifferentAccess` - [@james2m](https://github.com/james2m), [@dblock](https://github.com/dblock).
 * [#1622](https://github.com/ruby-grape/grape/pull/1622): Add `except_values` validator to replace `except` option of `values` validator - [@jlfaber](https://github.com/jlfaber).
 * [#1635](https://github.com/ruby-grape/grape/pull/1635): Instrument validators with ActiveSupport::Notifications - [@ktimothy](https://github.com/ktimothy).
+* [#1646](https://github.com/ruby-grape/grape/pull/1646): Add ability to include an array of modules as helpers - [@pablonahuelgomez](https://github.com/pablonahuelgomez).
 * Your contribution here.
 
 #### Fixes

--- a/spec/grape/dsl/helpers_spec.rb
+++ b/spec/grape/dsl/helpers_spec.rb
@@ -6,8 +6,12 @@ module Grape
       class Dummy
         include Grape::DSL::Helpers
 
-        def self.mod
-          namespace_stackable(:helpers).first
+        def self.mods
+          namespace_stackable(:helpers)
+        end
+
+        def self.first_mod
+          mods.first
         end
       end
     end
@@ -36,23 +40,38 @@ module Grape
           expect(subject).to receive(:namespace_stackable).with(:helpers).and_call_original
           subject.helpers(&proc)
 
-          expect(subject.mod.instance_methods).to include(:test)
+          expect(subject.first_mod.instance_methods).to include(:test)
         end
 
         it 'uses provided modules' do
           mod = Module.new
 
-          expect(subject).to receive(:namespace_stackable).with(:helpers, kind_of(Grape::DSL::Helpers::BaseHelper)).and_call_original
+          expect(subject).to receive(:namespace_stackable).with(:helpers, kind_of(Grape::DSL::Helpers::BaseHelper)).and_call_original.exactly(2).times
           expect(subject).to receive(:namespace_stackable).with(:helpers).and_call_original
           subject.helpers(mod, &proc)
 
-          expect(subject.mod).to eq mod
+          expect(subject.first_mod).to eq mod
+        end
+
+        it 'uses many provided modules' do
+          mod  = Module.new
+          mod2 = Module.new
+          mod3 = Module.new
+
+          expect(subject).to receive(:namespace_stackable).with(:helpers, kind_of(Grape::DSL::Helpers::BaseHelper)).and_call_original.exactly(4).times
+          expect(subject).to receive(:namespace_stackable).with(:helpers).and_call_original.exactly(3).times
+
+          subject.helpers(mod, mod2, mod3, &proc)
+
+          expect(subject.mods).to include(mod)
+          expect(subject.mods).to include(mod2)
+          expect(subject.mods).to include(mod3)
         end
 
         context 'with an external file' do
           it 'sets Boolean as a Virtus::Attribute::Boolean' do
             subject.helpers BooleanParam
-            expect(subject.mod::Boolean).to eq Virtus::Attribute::Boolean
+            expect(subject.first_mod::Boolean).to eq Virtus::Attribute::Boolean
           end
         end
       end


### PR DESCRIPTION
Changing helpers DSL to allow the inclusion of many modules.
This attempts to bring a better readability, since it seems to be
more intuitive to send a list of modules when the message in
question is called `helpers`.

Want to move from a syntax like:

```ruby
helpers MyHelper
helpers MyOtherHelper
```
To a syntax like:
```ruby
helpers MyHelper, MyOtherHelper
```