### PR TITLE
Add extra specs for Boolean type field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#1635](https://github.com/ruby-grape/grape/pull/1635): Instrument validators with ActiveSupport::Notifications - [@ktimothy](https://github.com/ktimothy).
 * [#1646](https://github.com/ruby-grape/grape/pull/1646): Add ability to include an array of modules as helpers - [@pablonahuelgomez](https://github.com/pablonahuelgomez).
 * [#1623](https://github.com/ruby-grape/grape/pull/1623): Removed `multi_json` and `multi_xml` dependencies - [@dblock](https://github.com/dblock).
+* [#1650](https://github.com/ruby-grape/grape/pull/1650): Add extra specs for Boolean type field - [@tiarly](https://github.com/tiarly).
 * Your contribution here.
 
 #### Fixes

--- a/spec/grape/validations/validators/coerce_spec.rb
+++ b/spec/grape/validations/validators/coerce_spec.rb
@@ -280,6 +280,43 @@ describe Grape::Validations::CoerceValidator do
         expect(last_response.body).to eq('TrueClass')
       end
 
+      it 'Boolean' do
+        subject.params do
+          optional :boolean, type: Boolean, default: true
+        end
+        subject.get '/boolean' do
+          params[:boolean].class
+        end
+
+        get '/boolean'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('TrueClass')
+
+        get '/boolean', boolean: true
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('TrueClass')
+
+        get '/boolean', boolean: false
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('FalseClass')
+
+        get '/boolean', boolean: 'true'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('TrueClass')
+
+        get '/boolean', boolean: 'false'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('FalseClass')
+
+        get '/boolean', boolean: 123
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('boolean is invalid')
+
+        get '/boolean', boolean: '123'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('boolean is invalid')
+      end
+
       it 'Rack::Multipart::UploadedFile' do
         subject.params do
           requires :file, type: Rack::Multipart::UploadedFile


### PR DESCRIPTION
This is commit adds additional specs to make sure Boolean type
is indeed working as expected.

https://github.com/ruby-grape/grape/issues/1551