### PR TITLE
Lock rack-test that passes array parameters differently.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ end
 group :test do
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
-  gem 'rack-test'
+  gem 'rack-test', '~> 0.6.3'
   gem 'rspec', '~> 3.0'
   gem 'cookiejar'
   gem 'rack-jsonp', require: 'rack/jsonp'

--- a/gemfiles/multi_json.gemfile
+++ b/gemfiles/multi_json.gemfile
@@ -24,7 +24,7 @@ end
 group :test do
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
-  gem 'rack-test'
+  gem 'rack-test', '~> 0.6.3'
   gem 'rspec', '~> 3.0'
   gem 'cookiejar'
   gem 'rack-jsonp', require: 'rack/jsonp'

--- a/gemfiles/multi_xml.gemfile
+++ b/gemfiles/multi_xml.gemfile
@@ -24,7 +24,7 @@ end
 group :test do
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
-  gem 'rack-test'
+  gem 'rack-test', '~> 0.6.3'
   gem 'rspec', '~> 3.0'
   gem 'cookiejar'
   gem 'rack-jsonp', require: 'rack/jsonp'

--- a/gemfiles/rack_1.5.2.gemfile
+++ b/gemfiles/rack_1.5.2.gemfile
@@ -24,7 +24,7 @@ end
 group :test do
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
-  gem 'rack-test'
+  gem 'rack-test', '~> 0.6.3'
   gem 'rspec', '~> 3.0'
   gem 'cookiejar'
   gem 'rack-jsonp', require: 'rack/jsonp'

--- a/gemfiles/rack_edge.gemfile
+++ b/gemfiles/rack_edge.gemfile
@@ -24,7 +24,7 @@ end
 group :test do
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
-  gem 'rack-test'
+  gem 'rack-test', '~> 0.6.3'
   gem 'rspec', '~> 3.0'
   gem 'cookiejar'
   gem 'rack-jsonp', require: 'rack/jsonp'

--- a/gemfiles/rails_3.gemfile
+++ b/gemfiles/rails_3.gemfile
@@ -25,7 +25,7 @@ end
 group :test do
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
-  gem 'rack-test'
+  gem 'rack-test', '~> 0.6.3'
   gem 'rspec', '~> 3.0'
   gem 'cookiejar'
   gem 'rack-jsonp', require: 'rack/jsonp'

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -24,7 +24,7 @@ end
 group :test do
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
-  gem 'rack-test'
+  gem 'rack-test', '~> 0.6.3'
   gem 'rspec', '~> 3.0'
   gem 'cookiejar'
   gem 'rack-jsonp', require: 'rack/jsonp'

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -24,7 +24,7 @@ end
 group :test do
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
-  gem 'rack-test'
+  gem 'rack-test', '~> 0.6.3'
   gem 'rspec', '~> 3.0'
   gem 'cookiejar'
   gem 'rack-jsonp', require: 'rack/jsonp'

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -24,7 +24,7 @@ end
 group :test do
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
-  gem 'rack-test'
+  gem 'rack-test', '~> 0.6.3'
   gem 'rspec', '~> 3.0'
   gem 'cookiejar'
   gem 'rack-jsonp', require: 'rack/jsonp'


### PR DESCRIPTION
Build started failing because rack-test was upgraded from 0.6.3 to 0.7.0, which now [supports sending empty arrays](https://github.com/rack-test/rack-test/pull/125). For now just fixing it.