### PR TITLE
#1656: Update specs after upgrading rack-test to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * Your contribution here.
+* [#1658](https://github.com/ruby-grape/grape/pull/1658): Update `rack-test` to `0.7.0` and fix failing specs - [@ashkan18](https://github.com/ashkan18).
 * [#1652](https://github.com/ruby-grape/grape/pull/1652): Add the original exception to the error_formatter the original exception - [@dcsg](https://github.com/dcsg).
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 #### Features
 
 * Your contribution here.
-* [#1658](https://github.com/ruby-grape/grape/pull/1658): Update `rack-test` to `0.7.0` and fix failing specs - [@ashkan18](https://github.com/ashkan18).
+* [#1658](https://github.com/ruby-grape/grape/pull/1658): Update `rack-test` to `0.7.0` - [@ashkan18](https://github.com/ashkan18).
 * [#1652](https://github.com/ruby-grape/grape/pull/1652): Add the original exception to the error_formatter the original exception - [@dcsg](https://github.com/dcsg).
 
 #### Fixes

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ end
 group :test do
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
-  gem 'rack-test', '~> 0.6.3'
+  gem 'rack-test', '~> 0.7.0'
   gem 'rspec', '~> 3.0'
   gem 'cookiejar'
   gem 'rack-jsonp', require: 'rack/jsonp'

--- a/gemfiles/multi_json.gemfile
+++ b/gemfiles/multi_json.gemfile
@@ -24,7 +24,7 @@ end
 group :test do
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
-  gem 'rack-test', '~> 0.6.3'
+  gem 'rack-test', '~> 0.7.0'
   gem 'rspec', '~> 3.0'
   gem 'cookiejar'
   gem 'rack-jsonp', require: 'rack/jsonp'

--- a/gemfiles/multi_xml.gemfile
+++ b/gemfiles/multi_xml.gemfile
@@ -24,7 +24,7 @@ end
 group :test do
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
-  gem 'rack-test', '~> 0.6.3'
+  gem 'rack-test', '~> 0.7.0'
   gem 'rspec', '~> 3.0'
   gem 'cookiejar'
   gem 'rack-jsonp', require: 'rack/jsonp'

--- a/gemfiles/rack_1.5.2.gemfile
+++ b/gemfiles/rack_1.5.2.gemfile
@@ -24,7 +24,7 @@ end
 group :test do
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
-  gem 'rack-test', '~> 0.6.3'
+  gem 'rack-test', '~> 0.7.0'
   gem 'rspec', '~> 3.0'
   gem 'cookiejar'
   gem 'rack-jsonp', require: 'rack/jsonp'

--- a/gemfiles/rack_edge.gemfile
+++ b/gemfiles/rack_edge.gemfile
@@ -24,7 +24,7 @@ end
 group :test do
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
-  gem 'rack-test', '~> 0.6.3'
+  gem 'rack-test', '~> 0.7.0'
   gem 'rspec', '~> 3.0'
   gem 'cookiejar'
   gem 'rack-jsonp', require: 'rack/jsonp'

--- a/gemfiles/rails_3.gemfile
+++ b/gemfiles/rails_3.gemfile
@@ -25,7 +25,7 @@ end
 group :test do
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
-  gem 'rack-test', '~> 0.6.3'
+  gem 'rack-test', '~> 0.7.0'
   gem 'rspec', '~> 3.0'
   gem 'cookiejar'
   gem 'rack-jsonp', require: 'rack/jsonp'

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -24,7 +24,7 @@ end
 group :test do
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
-  gem 'rack-test', '~> 0.6.3'
+  gem 'rack-test', '~> 0.7.0'
   gem 'rspec', '~> 3.0'
   gem 'cookiejar'
   gem 'rack-jsonp', require: 'rack/jsonp'

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -24,7 +24,7 @@ end
 group :test do
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
-  gem 'rack-test', '~> 0.6.3'
+  gem 'rack-test', '~> 0.7.0'
   gem 'rspec', '~> 3.0'
   gem 'cookiejar'
   gem 'rack-jsonp', require: 'rack/jsonp'

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -24,7 +24,7 @@ end
 group :test do
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
-  gem 'rack-test', '~> 0.6.3'
+  gem 'rack-test', '~> 0.7.0'
   gem 'rspec', '~> 3.0'
   gem 'cookiejar'
   gem 'rack-jsonp', require: 'rack/jsonp'

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -535,12 +535,12 @@ describe Grape::Validations do
 
       it 'handle errors for all array elements' do
         get '/within_array', children: [
-          { name: 'Jim', parents: [] },
+          { name: 'Jim'  },
           { name: 'Job', parents: [] }
         ]
 
         expect(last_response.status).to eq(400)
-        expect(last_response.body).to eq('children[0][parents] is missing, children[1][parents] is missing')
+        expect(last_response.body).to eq('children[0][parents] is missing, children[1][parents][0][name] is missing')
       end
 
       it 'safely handles empty arrays and blank parameters' do
@@ -548,7 +548,8 @@ describe Grape::Validations do
         # should actually return 200, since an empty array is valid.
         get '/within_array', children: []
         expect(last_response.status).to eq(400)
-        expect(last_response.body).to eq('children is missing')
+        expect(last_response.body).to eq('children[0][name] is missing, children[0][parents] is missing, '\
+          'children[0][parents] is invalid, children[0][parents][0][name] is missing, children[0][parents][0][name] is empty')
         get '/within_array', children: [name: 'Jay']
         expect(last_response.status).to eq(400)
         expect(last_response.body).to eq('children[0][parents] is missing')


### PR DESCRIPTION
Rack test was [ignoring](https://github.com/rack-test/rack-test/issues/122) empty arrays in its output which was fixed [here](https://github.com/rack-test/rack-test/pull/125). With these changes specs now show proper validation which doesn't match old ones anymore.

Updated `rack-test` to `0.7.0` and updated specs to match error messages we now receive with more details about missing params.

Fixes #1656 