### PR TITLE
[Bugfix] Handle deeply-nested dependent params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 #### Fixes
 
 * [#1652](https://github.com/ruby-grape/grape/pull/1652): Fix missing backtrace that was not being bubbled up to the `error_formatter` - [@dcsg](https://github.com/dcsg).
+* [#1661](https://github.com/ruby-grape/grape/pull/1661): Handle deeply-nested dependencies correctly - [@rnubel](https://github.com/rnubel), [@jnardone](https://github.com/jnardone).
 
 ### 1.0.0 (7/3/2017)
 

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -46,7 +46,11 @@ module Grape
         parent.should_validate?(parameters)
       end
 
-      def meets_dependency?(params)
+      def meets_dependency?(params, request_params)
+        if @parent.present? && !@parent.meets_dependency?(@parent.params(request_params), request_params)
+          return false
+        end
+
         return true unless @dependent_on
 
         params = params.with_indifferent_access

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -39,7 +39,7 @@ module Grape
         array_errors = []
         attributes.each do |resource_params, attr_name|
           next unless @required || (resource_params.respond_to?(:key?) && resource_params.key?(attr_name))
-          next unless @scope.meets_dependency?(resource_params)
+          next unless @scope.meets_dependency?(resource_params, params)
 
           begin
             validate_param!(attr_name, resource_params)

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -418,6 +418,32 @@ describe Grape::Validations::ParamsScope do
       end.to raise_error(Grape::Exceptions::UnknownParameter)
     end
 
+    it 'does not validate nested requires when given is false' do
+      subject.params do
+        requires :a, type: String, allow_blank: false, values: %w(x y)
+        given a: ->(val) { val == 'x' } do
+          requires :inner1, type: Hash, allow_blank: false do
+            requires :foo, type: Integer, allow_blank: false
+          end
+        end
+        given a: ->(val) { val == 'y' } do
+          requires :inner2, type: Hash, allow_blank: false do
+            requires :bar, type: Integer, allow_blank: false
+          end
+        end
+      end
+      subject.get('/varying') { declared(params).to_json }
+
+      # this fails with inner2[bar] is missing, inner2[bar] is empty
+      # but shouldn't because criteria not met
+      get '/varying', a: 'x', inner1: { foo: 1 }
+      expect(last_response.status).to eq(200)
+
+      # this will fail similarly if tested first, but with inner1
+      get '/varying', a: 'y', inner2: { bar: 2 }
+      expect(last_response.status).to eq(200)
+    end
+
     it 'includes the parameter within #declared(params)' do
       get '/test', a: true, b: true
 


### PR DESCRIPTION
Addresses https://github.com/ruby-grape/grape/issues/1659. The core issue was that param validations are a flat list, and the tree structure was only enforced by the recursion in `should_validate?`. When I moved the dependency check into the actual validator, the structure was no longer respected past one level deep. To resolve, I've added a similar recursive check into `ParamsScope#meets_dependency?`. I also added a few more test cases onto @jnardone's repro to test out the behavior works with arrays and nested arrays.