### PR TITLE
Make helpers available in subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Your contribution here.
 * [#1652](https://github.com/ruby-grape/grape/pull/1652): Add the original exception to the error_formatter the original exception - [@dcsg](https://github.com/dcsg).
+* [#1662](https://github.com/ruby-grape/grape/pull/1662): Make helpers available in subclasses - [@pablonahuelgomez](https://github.com/pablonahuelgomez).
 
 #### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Your contribution here.
 * [#1652](https://github.com/ruby-grape/grape/pull/1652): Add the original exception to the error_formatter the original exception - [@dcsg](https://github.com/dcsg).
-* [#1662](https://github.com/ruby-grape/grape/pull/1662): Make helpers available in subclasses - [@pablonahuelgomez](https://github.com/pablonahuelgomez).
+* [#1665](https://github.com/ruby-grape/grape/pull/1665): Make helpers available in subclasses - [@pablonahuelgomez](https://github.com/pablonahuelgomez).
 
 #### Fixes
 

--- a/lib/grape/dsl/settings.rb
+++ b/lib/grape/dsl/settings.rb
@@ -2,7 +2,7 @@ require 'active_support/concern'
 
 module Grape
   module DSL
-    # Keeps track of settings (impemented as key-value pairs, grouped by
+    # Keeps track of settings (implemented as key-value pairs, grouped by
     # types), in two contexts: top-level settings which apply globally no
     # matter where they're defined, and inheritable settings which apply only
     # in the current scope and scopes nested under it.
@@ -13,7 +13,7 @@ module Grape
 
       # Fetch our top-level settings, which apply to all endpoints in the API.
       def top_level_setting
-        @top_level_setting ||= Grape::Util::InheritableSetting.new
+        @top_level_setting ||= obtain_top_level_setting
       end
 
       # Fetch our current inheritable settings, which are inherited by
@@ -161,6 +161,18 @@ module Grape
         reset_validations!
 
         result
+      end
+
+      private
+
+      # Obtains the current class :inheritable_setting. If available, it returns the superclass's :inheritable_setting.
+      # Otherwise, a clean :inheritable_setting is returned.
+      def obtain_top_level_setting
+        if defined?(superclass) && superclass.respond_to?(:inheritable_setting) && superclass != Grape::API
+          superclass.inheritable_setting
+        else
+          Grape::Util::InheritableSetting.new
+        end
       end
     end
   end

--- a/lib/grape/dsl/settings.rb
+++ b/lib/grape/dsl/settings.rb
@@ -13,7 +13,7 @@ module Grape
 
       # Fetch our top-level settings, which apply to all endpoints in the API.
       def top_level_setting
-        @top_level_setting ||= obtain_top_level_setting
+        @top_level_setting ||= build_top_level_setting
       end
 
       # Fetch our current inheritable settings, which are inherited by
@@ -165,9 +165,9 @@ module Grape
 
       private
 
-      # Obtains the current class :inheritable_setting. If available, it returns the superclass's :inheritable_setting.
+      # Builds the current class :inheritable_setting. If available, it returns the superclass's :inheritable_setting.
       # Otherwise, a clean :inheritable_setting is returned.
-      def obtain_top_level_setting
+      def build_top_level_setting
         if defined?(superclass) && superclass.respond_to?(:inheritable_setting) && superclass != Grape::API
           superclass.inheritable_setting
         else

--- a/spec/grape/api/inherited_helpers_spec.rb
+++ b/spec/grape/api/inherited_helpers_spec.rb
@@ -1,0 +1,114 @@
+require 'spec_helper'
+
+describe Grape::API::Helpers do
+  let(:user) { 'Miguel Caneo' }
+  let(:id)   { '42' }
+
+  module InheritedHelpersSpec
+    class SuperClass < Grape::API
+      helpers do
+        params(:superclass_params) { requires :id, type: String }
+
+        def current_user
+          params[:user]
+        end
+      end
+    end
+
+    class OverriddenSubClass < SuperClass
+      params { use :superclass_params }
+
+      helpers do
+        def current_user
+          "#{params[:user]} with id"
+        end
+      end
+
+      get 'resource' do
+        "#{current_user}: #{params['id']}"
+      end
+    end
+
+    class SubClass < SuperClass
+      params { use :superclass_params }
+
+      get 'resource' do
+        "#{current_user}: #{params['id']}"
+      end
+    end
+
+    class Example < SubClass
+      params { use :superclass_params }
+
+      get 'resource' do
+        "#{current_user}: #{params['id']}"
+      end
+    end
+  end
+
+  context 'non overriding subclass' do
+    subject { InheritedHelpersSpec::SubClass }
+
+    def app
+      subject
+    end
+
+    context 'given expected params' do
+      it 'inherits helpers from a superclass' do
+        get '/resource', id: id, user: user
+        expect(last_response.body).to eq("#{user}: #{id}")
+      end
+    end
+
+    context 'with lack of expected params' do
+      it 'returns missing error' do
+        get '/resource'
+        expect(last_response.body).to eq('id is missing')
+      end
+    end
+  end
+
+  context 'overriding subclass' do
+    subject { InheritedHelpersSpec::OverriddenSubClass }
+
+    def app
+      subject
+    end
+
+    context 'given expected params' do
+      it 'overrides helpers from a superclass' do
+        get '/resource', id: id, user: user
+        expect(last_response.body).to eq("#{user} with id: #{id}")
+      end
+    end
+
+    context 'with lack of expected params' do
+      it 'returns missing error' do
+        get '/resource'
+        expect(last_response.body).to eq('id is missing')
+      end
+    end
+  end
+
+  context 'example subclass' do
+    subject { InheritedHelpersSpec::Example }
+
+    def app
+      subject
+    end
+
+    context 'given expected params' do
+      it 'inherits helpers from a superclass' do
+        get '/resource', id: id, user: user
+        expect(last_response.body).to eq("#{user}: #{id}")
+      end
+    end
+
+    context 'with lack of expected params' do
+      it 'returns missing error' do
+        get '/resource'
+        expect(last_response.body).to eq('id is missing')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Updating settings code to define `:top_level_setting` with parent's
`:inheritable_setting` when available. This will emulate inheritance,
with its expected capabilities (sharing and overriding).

This fixes #1617 