### PR TITLE
Rescue StandardError from explicit values validator procs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 * [#1652](https://github.com/ruby-grape/grape/pull/1652): Fix missing backtrace that was not being bubbled up to the `error_formatter` - [@dcsg](https://github.com/dcsg).
 * [#1661](https://github.com/ruby-grape/grape/pull/1661): Handle deeply-nested dependencies correctly - [@rnubel](https://github.com/rnubel), [@jnardone](https://github.com/jnardone).
-* [#1679](https://github.com/ruby-grape/grape/pull/1679): Treat StandardError from explicit values validator proc as false[@jlfaber](https://github.com/jlfaber).
+* [#1679](https://github.com/ruby-grape/grape/pull/1679): Treat StandardError from explicit values validator proc as false - [@jlfaber](https://github.com/jlfaber).
 
 ### 1.0.0 (7/3/2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * [#1652](https://github.com/ruby-grape/grape/pull/1652): Fix missing backtrace that was not being bubbled up to the `error_formatter` - [@dcsg](https://github.com/dcsg).
 * [#1661](https://github.com/ruby-grape/grape/pull/1661): Handle deeply-nested dependencies correctly - [@rnubel](https://github.com/rnubel), [@jnardone](https://github.com/jnardone).
+* [#1678](https://github.com/ruby-grape/grape/pull/1678): Treat StandardError from explicit values validator proc as false[@jlfaber](https://github.com/jlfaber).
 
 ### 1.0.0 (7/3/2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 * [#1652](https://github.com/ruby-grape/grape/pull/1652): Fix missing backtrace that was not being bubbled up to the `error_formatter` - [@dcsg](https://github.com/dcsg).
 * [#1661](https://github.com/ruby-grape/grape/pull/1661): Handle deeply-nested dependencies correctly - [@rnubel](https://github.com/rnubel), [@jnardone](https://github.com/jnardone).
-* [#1678](https://github.com/ruby-grape/grape/pull/1678): Treat StandardError from explicit values validator proc as false[@jlfaber](https://github.com/jlfaber).
+* [#1679](https://github.com/ruby-grape/grape/pull/1679): Treat StandardError from explicit values validator proc as false[@jlfaber](https://github.com/jlfaber).
 
 ### 1.0.0 (7/3/2017)
 

--- a/README.md
+++ b/README.md
@@ -1179,7 +1179,8 @@ end
 
 Alternatively, a Proc with arity one (i.e. taking one argument) can be used to explicitly validate
 each parameter value.  In that case, the Proc is expected to return a truthy value if the parameter
-value is valid.
+value is valid. The parameter will be considered invalid if the Proc returns a falsy value or if it
+raises a StandardError.
 
 ```ruby
 params do

--- a/lib/grape/validations/validators/values.rb
+++ b/lib/grape/validations/validators/values.rb
@@ -32,7 +32,7 @@ module Grape
           unless check_excepts(param_array)
 
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:values) \
-          unless check_values(param_array)
+          unless check_values(param_array, attr_name)
 
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:values) \
           if @proc && !param_array.all? { |param| @proc.call(param) }
@@ -40,12 +40,13 @@ module Grape
 
       private
 
-      def check_values(param_array)
+      def check_values(param_array, attr_name)
         values = @values.is_a?(Proc) && @values.arity.zero? ? @values.call : @values
         return true if values.nil?
         begin
           return param_array.all? { |param| values.call(param) } if values.is_a? Proc
-        rescue StandardError => _e
+        rescue StandardError => e
+          warn "Error '#{e}' raised while validating attribute '#{attr_name}'"
           return false
         end
         param_array.all? { |param| values.include?(param) }

--- a/lib/grape/validations/validators/values.rb
+++ b/lib/grape/validations/validators/values.rb
@@ -43,7 +43,11 @@ module Grape
       def check_values(param_array)
         values = @values.is_a?(Proc) && @values.arity.zero? ? @values.call : @values
         return true if values.nil?
-        return param_array.all? { |param| values.call(param) } if values.is_a? Proc
+        begin
+          return param_array.all? { |param| values.call(param) } if values.is_a? Proc
+        rescue => _e
+          return false
+        end
         param_array.all? { |param| values.include?(param) }
       end
 

--- a/lib/grape/validations/validators/values.rb
+++ b/lib/grape/validations/validators/values.rb
@@ -45,7 +45,7 @@ module Grape
         return true if values.nil?
         begin
           return param_array.all? { |param| values.call(param) } if values.is_a? Proc
-        rescue => _e
+        rescue StandardError => _e
           return false
         end
         param_array.all? { |param| values.include?(param) }

--- a/spec/grape/validations/validators/values_spec.rb
+++ b/spec/grape/validations/validators/values_spec.rb
@@ -111,6 +111,13 @@ describe Grape::Validations::ValuesValidator do
         end
 
         params do
+          requires :number, type: Integer, values: ->(v) { v > 0 }
+        end
+        get '/lambda_int_val' do
+          { number: params[:number] }
+        end
+
+        params do
           requires :type, values: -> { [] }
         end
         get '/empty_lambda'
@@ -355,6 +362,24 @@ describe Grape::Validations::ValuesValidator do
     get('/lambda', type: 'invalid-type')
     expect(last_response.status).to eq 400
     expect(last_response.body).to eq({ error: 'type does not have a valid value' }.to_json)
+  end
+
+  it 'does not allow non-numeric string value for int value using lambda' do
+    get('/lambda_int_val', number: 'foo')
+    expect(last_response.status).to eq 400
+    expect(last_response.body).to eq({ error: 'number is invalid, number does not have a valid value' }.to_json)
+  end
+
+  it 'does not allow nil for int value using lambda' do
+    get('/lambda_int_val', number: nil)
+    expect(last_response.status).to eq 400
+    expect(last_response.body).to eq({ error: 'number does not have a valid value' }.to_json)
+  end
+
+  it 'allows numeric string for int value using lambda' do
+    get('/lambda_int_val', number: '3')
+    expect(last_response.status).to eq 200
+    expect(last_response.body).to eq({ number: 3 }.to_json)
   end
 
   it 'allows value using lambda' do


### PR DESCRIPTION
Example:
```ruby
params do
  requires :number, type: Integer, values: ->(v) { v.even? && v < 25 }
end
```
Right now, sending a non-numeric string or a nil value for `number` will result in a stack trace because neither String nor NilClass have an `even?` method. One could address this with an additional type check in the proc, but that would result in a lot of extra code that doesn't really contribute to the overall clarity of the declaration.

Instead, we should rescue any StandardError raised from an arity-one values validator proc and treat it as a false result.