### PR TITLE
Avoid coercion of a value if it is valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Features
 
-* Your contribution here.
+* [#1686](https://github.com/ruby-grape/grape/pull/1686): Avoid coercion of a value if it is valid - [@timothysu](https://github.com/timothysu).
 
 #### Fixes
 

--- a/lib/grape/validations/types/custom_type_coercer.rb
+++ b/lib/grape/validations/types/custom_type_coercer.rb
@@ -137,7 +137,7 @@ module Grape
             # passed, or if the type also implements a parse() method.
             type
           elsif type.is_a?(Enumerable)
-            ->(value) { value.all? { |item| item.is_a? type[0] } }
+            ->(value) { value.respond_to?(:all?) && value.all? { |item| item.is_a? type[0] } }
           else
             # By default, do a simple type check
             ->(value) { value.is_a? type }

--- a/lib/grape/validations/validators/coerce.rb
+++ b/lib/grape/validations/validators/coerce.rb
@@ -16,7 +16,7 @@ module Grape
 
       def validate_param!(attr_name, params)
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:coerce) unless params.is_a? Hash
-        return if valid_type?(params[attr_name]) && !custom_type_coercer?
+        return if valid_type?(params[attr_name]) && !coerce_with?
         new_value = coerce_value(params[attr_name])
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:coerce) unless valid_type?(new_value)
         params[attr_name] = new_value
@@ -65,8 +65,9 @@ module Grape
         @option[:type].is_a?(Hash) ? @option[:type][:value] : @option[:type]
       end
 
-      def custom_type_coercer?
-        converter.coercer.class.name.demodulize == 'CustomTypeCoercer'
+      def coerce_with?
+        # JSON types cannot have coerce_with
+        converter.coercer.respond_to?(:method) && !converter.is_a?(Grape::Validations::Types::Json)
       end
     end
   end

--- a/lib/grape/validations/validators/coerce.rb
+++ b/lib/grape/validations/validators/coerce.rb
@@ -16,11 +16,10 @@ module Grape
 
       def validate_param!(attr_name, params)
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:coerce) unless params.is_a? Hash
-        unless valid_type?(params[attr_name])
-          new_value = coerce_value(params[attr_name])
-          raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:coerce) unless valid_type?(new_value)
-          params[attr_name] = new_value
-        end
+        return if valid_type?(params[attr_name]) && !converter.coercer.respond_to?(:method)
+        new_value = coerce_value(params[attr_name])
+        raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:coerce) unless valid_type?(new_value)
+        params[attr_name] = new_value
       end
 
       private

--- a/lib/grape/validations/validators/coerce.rb
+++ b/lib/grape/validations/validators/coerce.rb
@@ -16,7 +16,7 @@ module Grape
 
       def validate_param!(attr_name, params)
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:coerce) unless params.is_a? Hash
-        return if valid_type?(params[attr_name]) && !coerce_with?
+        return unless requires_coercion?(params[attr_name])
         new_value = coerce_value(params[attr_name])
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:coerce) unless valid_type?(new_value)
         params[attr_name] = new_value
@@ -65,9 +65,9 @@ module Grape
         @option[:type].is_a?(Hash) ? @option[:type][:value] : @option[:type]
       end
 
-      def coerce_with?
-        # JSON types cannot have coerce_with
-        converter.coercer.respond_to?(:method) && !converter.is_a?(Grape::Validations::Types::Json)
+      def requires_coercion?(value)
+        # JSON types do not require coercion if value is valid
+        !valid_type?(value) || converter.coercer.respond_to?(:method) && !converter.is_a?(Grape::Validations::Types::Json)
       end
     end
   end

--- a/lib/grape/validations/validators/coerce.rb
+++ b/lib/grape/validations/validators/coerce.rb
@@ -16,9 +16,11 @@ module Grape
 
       def validate_param!(attr_name, params)
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:coerce) unless params.is_a? Hash
-        new_value = coerce_value(params[attr_name])
-        raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:coerce) unless valid_type?(new_value)
-        params[attr_name] = new_value
+        unless valid_type?(params[attr_name])
+          new_value = coerce_value(params[attr_name])
+          raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:coerce) unless valid_type?(new_value)
+          params[attr_name] = new_value
+        end
       end
 
       private

--- a/lib/grape/validations/validators/coerce.rb
+++ b/lib/grape/validations/validators/coerce.rb
@@ -16,7 +16,7 @@ module Grape
 
       def validate_param!(attr_name, params)
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:coerce) unless params.is_a? Hash
-        return if valid_type?(params[attr_name]) && !converter.coercer.class.name.demodulize == 'CustomTypeCoercer'
+        return if valid_type?(params[attr_name]) && !custom_type_coercer?
         new_value = coerce_value(params[attr_name])
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:coerce) unless valid_type?(new_value)
         params[attr_name] = new_value
@@ -63,6 +63,10 @@ module Grape
       # @return [Class]
       def type
         @option[:type].is_a?(Hash) ? @option[:type][:value] : @option[:type]
+      end
+
+      def custom_type_coercer?
+        converter.coercer.class.name.demodulize == 'CustomTypeCoercer'
       end
     end
   end

--- a/lib/grape/validations/validators/coerce.rb
+++ b/lib/grape/validations/validators/coerce.rb
@@ -16,7 +16,7 @@ module Grape
 
       def validate_param!(attr_name, params)
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:coerce) unless params.is_a? Hash
-        return if valid_type?(params[attr_name]) && !converter.coercer.respond_to?(:method) && converter.coercer.method
+        return if valid_type?(params[attr_name]) && !converter.coercer.class.name.demodulize == 'CustomTypeCoercer'
         new_value = coerce_value(params[attr_name])
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:coerce) unless valid_type?(new_value)
         params[attr_name] = new_value

--- a/lib/grape/validations/validators/coerce.rb
+++ b/lib/grape/validations/validators/coerce.rb
@@ -16,7 +16,7 @@ module Grape
 
       def validate_param!(attr_name, params)
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:coerce) unless params.is_a? Hash
-        return if valid_type?(params[attr_name]) && !converter.coercer.respond_to?(:method)
+        return if valid_type?(params[attr_name]) && !converter.coercer.respond_to?(:method) && converter.coercer.method
         new_value = coerce_value(params[attr_name])
         raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:coerce) unless valid_type?(new_value)
         params[attr_name] = new_value

--- a/spec/grape/validations/validators/coerce_spec.rb
+++ b/spec/grape/validations/validators/coerce_spec.rb
@@ -477,7 +477,7 @@ describe Grape::Validations::CoerceValidator do
     end
 
     context 'first-class JSON' do
-      it 'parses objects and arrays' do
+      it 'parses objects, hashes, and arrays' do
         subject.params do
           requires :splines, type: JSON do
             requires :x, type: Integer, values: [1, 2, 3]
@@ -499,7 +499,15 @@ describe Grape::Validations::CoerceValidator do
         expect(last_response.status).to eq(200)
         expect(last_response.body).to eq('woof')
 
+        get '/', splines: { x: 1, ints: [1, 2, 3], obj: { y: 'woof' } }
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('woof')
+
         get '/', splines: '[{"x":2,"ints":[]},{"x":3,"ints":[4],"obj":{"y":"quack"}}]'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('arrays work')
+
+        get '/', splines: [{ x: 2, ints: [] }, { x: 3, ints: [4], obj: { y: 'quack' } }]
         expect(last_response.status).to eq(200)
         expect(last_response.body).to eq('arrays work')
 
@@ -507,7 +515,15 @@ describe Grape::Validations::CoerceValidator do
         expect(last_response.status).to eq(400)
         expect(last_response.body).to eq('splines[x] does not have a valid value')
 
+        get '/', splines: { x: 4, ints: [2] }
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('splines[x] does not have a valid value')
+
         get '/', splines: '[{"x":1,"ints":[]},{"x":4,"ints":[]}]'
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('splines[x] does not have a valid value')
+
+        get '/', splines: [{ x: 1, ints: [] }, { x: 4, ints: [] }]
         expect(last_response.status).to eq(400)
         expect(last_response.body).to eq('splines[x] does not have a valid value')
       end

--- a/spec/grape/validations/validators/coerce_spec.rb
+++ b/spec/grape/validations/validators/coerce_spec.rb
@@ -419,6 +419,23 @@ describe Grape::Validations::CoerceValidator do
         expect(JSON.parse(last_response.body)).to eq([0, 0, 0, 0])
       end
 
+      it 'parses parameters even if type is valid' do
+        subject.params do
+          requires :values, type: Array, coerce_with: ->(array) { array.map { |val| val.to_i + 1 } }
+        end
+        subject.get '/ints' do
+          params[:values]
+        end
+
+        get '/ints', values: [1, 2, 3, 4]
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)).to eq([2, 3, 4, 5])
+
+        get '/ints', values: %w(a b c d)
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)).to eq([1, 1, 1, 1])
+      end
+
       it 'uses parse where available' do
         subject.params do
           requires :ints, type: Array, coerce_with: JSON do


### PR DESCRIPTION
This PR aims to simplify the logic (and expensiveness) of coercion by not coercing the param if it is already a valid value unless a custom coercer is provided, which resolves issues we're run into around JSON until further work can be done to improve the experience.  Relates to #1685