### PR TITLE
Fix incredibly minimal typo on namespace.rb documentation

### DIFF
--- a/lib/grape/namespace.rb
+++ b/lib/grape/namespace.rb
@@ -1,6 +1,6 @@
 module Grape
   # A container for endpoints or other namespaces, which allows for both
-  # logical grouping of endpoints as well as sharing commonconfiguration.
+  # logical grouping of endpoints as well as sharing common configuration.
   # May also be referred to as group, segment, or resource.
   class Namespace
     attr_reader :space, :options


### PR DESCRIPTION
Fix incredibly minimal typo on `namespace.rb` documentation.