### PR TITLE
[Bug] Fix validations nested under a `given`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#1691](https://github.com/ruby-grape/grape/pull/1691): Fix validations nested under `given` - [@rnubel](https://github.com/rnubel).
 * Your contribution here.
 
 ### 1.0.1 (9/8/2017)

--- a/lib/grape/validations/validators/all_or_none.rb
+++ b/lib/grape/validations/validators/all_or_none.rb
@@ -4,7 +4,7 @@ module Grape
     class AllOrNoneOfValidator < MultipleParamsBase
       def validate!(params)
         super
-        if scope_requires_params && only_subset_present
+        if scope_requires_params && only_subset_present(params)
           raise Grape::Exceptions::Validation, params: all_keys, message: message(:all_or_none)
         end
         params
@@ -12,8 +12,12 @@ module Grape
 
       private
 
-      def only_subset_present
-        scoped_params.any? { |resource_params| !keys_in_common(resource_params).empty? && keys_in_common(resource_params).length < attrs.length }
+      def only_subset_present(params)
+        scoped_params.any? do |resource_params|
+          next unless scope_should_validate?(resource_params, params)
+
+          !keys_in_common(resource_params).empty? && keys_in_common(resource_params).length < attrs.length
+        end
       end
     end
   end

--- a/lib/grape/validations/validators/at_least_one_of.rb
+++ b/lib/grape/validations/validators/at_least_one_of.rb
@@ -4,7 +4,7 @@ module Grape
     class AtLeastOneOfValidator < MultipleParamsBase
       def validate!(params)
         super
-        if scope_requires_params && no_exclusive_params_are_present
+        if scope_requires_params && no_exclusive_params_are_present(params)
           raise Grape::Exceptions::Validation, params: all_keys, message: message(:at_least_one)
         end
         params
@@ -12,8 +12,12 @@ module Grape
 
       private
 
-      def no_exclusive_params_are_present
-        scoped_params.any? { |resource_params| keys_in_common(resource_params).empty? }
+      def no_exclusive_params_are_present(params)
+        scoped_params.any? do |resource_params|
+          next unless scope_should_validate?(resource_params, params)
+
+          keys_in_common(resource_params).empty?
+        end
       end
     end
   end

--- a/lib/grape/validations/validators/default.rb
+++ b/lib/grape/validations/validators/default.rb
@@ -20,6 +20,8 @@ module Grape
       def validate!(params)
         attrs = AttributesIterator.new(self, @scope, params)
         attrs.each do |resource_params, attr_name|
+          next unless @scope.meets_dependency?(resource_params, params)
+
           if resource_params.is_a?(Hash) && resource_params[attr_name].nil?
             validate_param!(attr_name, resource_params)
           end

--- a/lib/grape/validations/validators/exactly_one_of.rb
+++ b/lib/grape/validations/validators/exactly_one_of.rb
@@ -4,7 +4,7 @@ module Grape
     class ExactlyOneOfValidator < MutualExclusionValidator
       def validate!(params)
         super
-        if scope_requires_params && none_of_restricted_params_is_present
+        if scope_requires_params && none_of_restricted_params_is_present(params)
           raise Grape::Exceptions::Validation, params: all_keys, message: message(:exactly_one)
         end
         params
@@ -21,8 +21,12 @@ module Grape
 
       private
 
-      def none_of_restricted_params_is_present
-        scoped_params.any? { |resource_params| keys_in_common(resource_params).empty? }
+      def none_of_restricted_params_is_present(params)
+        scoped_params.any? do |resource_params|
+          next unless scope_should_validate?(resource_params, params)
+
+          keys_in_common(resource_params).empty?
+        end
       end
     end
   end

--- a/lib/grape/validations/validators/multiple_params_base.rb
+++ b/lib/grape/validations/validators/multiple_params_base.rb
@@ -10,6 +10,10 @@ module Grape
 
       private
 
+      def scope_should_validate?(scoped_params, params)
+        @scope.meets_dependency?(scoped_params, params)
+      end
+
       def scope_requires_params
         @scope.required? || scoped_params.any?(&:any?)
       end

--- a/lib/grape/validations/validators/mutual_exclusion.rb
+++ b/lib/grape/validations/validators/mutual_exclusion.rb
@@ -6,7 +6,7 @@ module Grape
 
       def validate!(params)
         super
-        if two_or_more_exclusive_params_are_present
+        if two_or_more_exclusive_params_are_present(params)
           raise Grape::Exceptions::Validation, params: processing_keys_in_common, message: message(:mutual_exclusion)
         end
         params
@@ -14,8 +14,10 @@ module Grape
 
       private
 
-      def two_or_more_exclusive_params_are_present
+      def two_or_more_exclusive_params_are_present(params)
         scoped_params.any? do |resource_params|
+          next unless scope_should_validate?(resource_params, params)
+
           @processing_keys_in_common = keys_in_common(resource_params)
           @processing_keys_in_common.length > 1
         end


### PR DESCRIPTION
Addresses #1681.

Multi-param and default validators, all of which implemented their own `validate!` method, were not respecting the `given` dependency as expected. This change copies the check into all those validators.

The bug was likely introduced by #1625, which required that the dependency check be moved out of the scope itself and into the validators. Rolling back that change would require fundamentally re-architecting how array parameters are validated (possibly with a new kind of scope?).