### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -960,7 +960,7 @@ params do
 end
 post '/' do
   params[:avatar][:filename] # => 'avatar.png'
-  params[:avatar][:avatar] # => 'image/png'
+  params[:avatar][:type] # => 'image/png'
   params[:avatar][:tempfile] # => #<File>
 end
 ```


### PR DESCRIPTION
':avatar' => ':type' in Multipart File Parameters section.