### PR TITLE
Fix wrong transformation of empty Array in declared params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Fixes
 
+* [#1710](https://github.com/ruby-grape/grape/pull/1710): Fix wrong transformation of empty Array in declared params - [@pablonahuelgomez](https://github.com/pablonahuelgomez).
 * Your contribution here.
 
 ### 1.0.1 (9/8/2017)

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -295,6 +295,9 @@ describe Grape::Endpoint do
             end
           end
         end
+        optional :nested_arr, type: Array do
+          optional :eighth
+        end
       end
     end
 
@@ -366,7 +369,7 @@ describe Grape::Endpoint do
       end
       get '/declared?first=present'
       expect(last_response.status).to eq(200)
-      expect(JSON.parse(last_response.body).keys.size).to eq(4)
+      expect(JSON.parse(last_response.body).keys.size).to eq(5)
     end
 
     it 'has a optional param with default value all the time' do
@@ -408,8 +411,8 @@ describe Grape::Endpoint do
       expect(JSON.parse(last_response.body)['nested'].size).to eq 2
     end
 
-    context 'sets nested hash when the param is missing' do
-      it 'to be array when include_missing is true' do
+    context 'sets nested objects when the param is missing' do
+      it 'to be a hash when include_missing is true' do
         subject.get '/declared' do
           declared(params, include_missing: true)
         end
@@ -417,6 +420,16 @@ describe Grape::Endpoint do
         get '/declared?first=present'
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)['nested']).to be_a(Hash)
+      end
+
+      it 'to be an array when include_missing is true' do
+        subject.get '/declared' do
+          declared(params, include_missing: true)
+        end
+
+        get '/declared?first=present'
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)['nested_arr']).to be_a(Array)
       end
 
       it 'to be nil when include_missing is false' do

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -339,6 +339,18 @@ describe Grape::Validations::ParamsScope do
       get '/optional_type_array'
     end
 
+    it 'handles missing optional Array type' do
+      subject.params do
+        optional :a, type: Array do
+          requires :b
+        end
+      end
+      subject.get('/test') { declared(params).to_json }
+      get '/test'
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq('{"a":[]}')
+    end
+
     it 'errors with an unsupported type' do
       expect do
         subject.params do


### PR DESCRIPTION
Updating `PostBeforeFilter` module to handle empty given arrays as expected:
returning an empty array instead of an empty hash.

Specs have been taken from #1678 and from [this commit](https://github.com/ruby-grape/grape/commit/696db42c1e6ab6627b18e525a7011900d4740c5d).