### PR TITLE
Coerce collections of parseable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#1686](https://github.com/ruby-grape/grape/pull/1686): Avoid coercion of a value if it is valid - [@timothysu](https://github.com/timothysu).
 * [#1688](https://github.com/ruby-grape/grape/pull/1688): Removes yard docs - [@ramkumar-kr](https://github.com/ramkumar-kr).
 * [#1702](https://github.com/ruby-grape/grape/pull/1702): Added danger-toc, verify correct TOC in README - [@dblock](https://github.com/dblock).
+* [#1711](https://github.com/ruby-grape/grape/pull/1711): Automatically coerce arrays and sets of types that implement a `parse` method - [@dslh](https://github.com/dslh).
 
 #### Fixes
 

--- a/README.md
+++ b/README.md
@@ -909,6 +909,8 @@ end
 
 params do
   requires :color, type: Color, default: Color.new('blue')
+  requires :more_colors, type: Array[Color] # Collections work
+  optional :unique_colors, type: Set[Color] # Duplicates discarded
 end
 
 get '/stuff' do
@@ -940,6 +942,26 @@ It will parse a string and return an Array of Integers, matching the `Array[Inte
 ```ruby
 params do
   requires :values, type: Array[Integer], coerce_with: ->(val) { val.split(/\s+/).map(&:to_i) }
+end
+```
+
+Grape will assert that coerced values match the given `type`, and will reject the request
+if they do not. To override this behaviour, custom types may implement a `parsed?` method
+that should accept a single argument and return `true` if the value passes type validation.
+
+```ruby
+class SecureUri
+  def self.parse(value)
+    URI.parse value
+  end
+
+  def self.parsed?(value)
+    value.is_a? URI::HTTPS
+  end
+end
+
+params do
+  requires :secure_uri, type: SecureUri
 end
 ```
 

--- a/lib/grape/validations/types.rb
+++ b/lib/grape/validations/types.rb
@@ -1,5 +1,6 @@
 require_relative 'types/build_coercer'
 require_relative 'types/custom_type_coercer'
+require_relative 'types/custom_type_collection_coercer'
 require_relative 'types/multiple_type_coercer'
 require_relative 'types/variant_collection_coercer'
 require_relative 'types/json'
@@ -143,7 +144,8 @@ module Grape
       end
 
       # A valid custom type must implement a class-level `parse` method, taking
-      #   one String argument and returning the parsed value in its correct type.
+      # one String argument and returning the parsed value in its correct type.
+      #
       # @param type [Class] type to check
       # @return [Boolean] whether or not the type can be used as a custom type
       def self.custom?(type)
@@ -154,6 +156,17 @@ module Grape
           !special?(type) &&
           type.respond_to?(:parse) &&
           type.method(:parse).arity == 1
+      end
+
+      # Is the declared type an +Array+ or +Set+ of a {#custom?} type?
+      #
+      # @param type [Array<Class>,Class] type to check
+      # @return [Boolean] true if +type+ is a collection of a type that implements
+      #   its own +#parse+ method.
+      def self.collection_of_custom?(type)
+        (type.is_a?(Array) || type.is_a?(Set)) &&
+          type.length == 1 &&
+          custom?(type.first)
       end
     end
   end

--- a/lib/grape/validations/types/build_coercer.rb
+++ b/lib/grape/validations/types/build_coercer.rb
@@ -51,6 +51,14 @@ module Grape
         elsif method || Types.custom?(type)
           converter_options[:coercer] = Types::CustomTypeCoercer.new(type, method)
 
+        # Special coercer for collections of types that implement a parse method.
+        # CustomTypeCoercer (above) already handles such types when an explicit coercion
+        # method is supplied.
+        elsif Types.collection_of_custom?(type)
+          converter_options[:coercer] = Types::CustomTypeCollectionCoercer.new(
+            type.first, type.is_a?(Set)
+          )
+
         # Grape swaps in its own Virtus::Attribute implementations
         # for certain special types that merit first-class support
         # (but not if a custom coercion method has been supplied).

--- a/lib/grape/validations/types/custom_type_collection_coercer.rb
+++ b/lib/grape/validations/types/custom_type_collection_coercer.rb
@@ -1,0 +1,71 @@
+module Grape
+  module Validations
+    module Types
+      # Instances of this class may be passed to
+      # +Virtus::Attribute.build+ as the +:coercer+
+      # option, to handle collections of types that
+      # provide their own parsing (and optionally,
+      # type-checking) functionality.
+      #
+      # See {CustomTypeCoercer} for details on types
+      # that will be supported by this by this coercer.
+      # This coercer works in the same way as +CustomTypeCoercer+
+      # except that it expects to receive an array of strings to
+      # coerce and will return an array (or optionally, a set)
+      # of coerced values.
+      #
+      # +CustomTypeCoercer+ is already capable of providing type
+      # checking for arrays where an independent coercion method
+      # is supplied. As such, +CustomTypeCollectionCoercer+ does
+      # not allow for such a method to be supplied independently
+      # of the type.
+      class CustomTypeCollectionCoercer < CustomTypeCoercer
+        # A new coercer for collections of the given type.
+        #
+        # @param type [Class,#parse]
+        #   type to which items in the array should be coerced.
+        #   Must implement a +parse+ method which accepts a string,
+        #   and for the purposes of type-checking it may either be
+        #   a class, or it may implement a +coerced?+, +parsed?+ or
+        #   +call+ method (in that order of precedence) which
+        #   accepts a single argument and returns true if the given
+        #   array item has been coerced correctly.
+        # @param set [Boolean]
+        #   when true, a +Set+ will be returned by {#call} instead
+        #   of an +Array+ and duplicate items will be discarded.
+        def initialize(type, set = false)
+          super(type)
+          @set = set
+        end
+
+        # This method is called from somewhere within
+        # +Virtus::Attribute::coerce+ in order to coerce
+        # the given value.
+        #
+        # @param value [Array<String>] an array of values to be coerced
+        # @return [Array,Set] the coerced result. May be an +Array+ or a
+        #   +Set+ depending on the setting given to the constructor
+        def call(value)
+          coerced = value.map { |item| super(item) }
+
+          @set ? Set.new(coerced) : coerced
+        end
+
+        # This method is called from somewhere within
+        # +Virtus::Attribute::value_coerced?+ in order to assert
+        # that the all of the values in the array have been coerced
+        # successfully.
+        #
+        # @param primitive [Axiom::Types::Type] primitive type for
+        #   the coercion as deteced by axiom-types' inference system.
+        # @param value [Enumerable] a coerced result returned from {#call}
+        # @return [true,false] whether or not all of the coerced values in
+        #   the collection satisfy type requirements.
+        def success?(primitive, value)
+          value.is_a?(@set ? Set : Array) &&
+            value.all? { |item| super(primitive, item) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi @dblock and @javmorin!

This implements support for "`type: Array[type that responds to .parse]`", as discussed in #1700. `CustomTypeCoercer` is leveraged, so the type may also implement `coerced?` or `parsed?` to implement custom type-checking (or also `call`, which I admit seems a bit weird in this instance).

Supporting `type: Array[Virtus::Attribute subclass]` should also be possible but I think it needs some different plumbing to make it work. From the discussion it wasn't clear to me that there's anyone who is specifically looking for it, or if this PR would make it redundant. Let me know if there's any interest and I can take a look at it.

Supports `Set` declarations as well as `Array`. `Hash` didn't make much sense to me in this context but if anyone has a usage example in mind I could take a look.

A couple more tests could be appropriate, I'll also get the readme and changelog filled in when I can, but now seemed like a good time to get get some feedback. Is there anything that could be changed or added?