### PR TITLE
Removing references to `hashie-forbidden_attributes` from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,13 +322,6 @@ Modify `config/routes`:
 mount Twitter::API => '/'
 ```
 
-Additionally, if the version of your Rails is 4.0+ and the application uses the default model layer of ActiveRecord, you will want to use the [hashie-forbidden_attributes gem](https://github.com/Maxim-Filimonov/hashie-forbidden_attributes). This gem disables the security feature of `strong_params` at the model layer, allowing you the use of Grape's own params validation instead.
-
-```ruby
-# Gemfile
-gem 'hashie-forbidden_attributes'
-```
-
 See [below](#reloading-api-changes-in-development) for additional code that enables reloading of API changes in development.
 
 ### Modules


### PR DESCRIPTION
Hashie was [removed as dependency](https://github.com/ruby-grape/grape/commit/1bd1a21525e58768c2188a291488d0b3ba2832c5), so `hashie-forbidden_attributes` should not be installed anymore.