### PR TITLE
`rescue_from :all` documentation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#1710](https://github.com/ruby-grape/grape/pull/1710): Fix wrong transformation of empty Array in declared params - [@pablonahuelgomez](https://github.com/pablonahuelgomez).
 * [#1722](https://github.com/ruby-grape/grape/pull/1722): Fix catch-all hiding multiple versions of an endpoint after the first definition - [@zherr](https://github.com/zherr).
 * [#1724](https://github.com/ruby-grape/grape/pull/1724): Optional nested array validation - [@ericproulx](https://github.com/ericproulx).
+* [#1725](https://github.com/ruby-grape/grape/pull/1725): Fix `rescue_from :all` documentation - [@Jelkster](https://github.com/Jelkster).
 * Your contribution here.
 
 ### 1.0.1 (9/8/2017)

--- a/README.md
+++ b/README.md
@@ -2177,8 +2177,8 @@ class Twitter::API < Grape::API
     error!("ArgumentError: #{e.message}")
   end
 
-  rescue_from NotImplementedError do |e|
-    error!("NotImplementedError: #{e.message}")
+  rescue_from NoMethodError do |e|
+    error!("NoMethodError: #{e.message}")
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -2071,7 +2071,7 @@ literally accepts every request.
 
 ## Exception Handling
 
-Grape can be told to rescue all exceptions and return them in the API format.
+Grape can be told to rescue all `StandardError` exceptions and return them in the API format.
 
 ```ruby
 class Twitter::API < Grape::API


### PR DESCRIPTION
Addresses `rescue_from :all` documentation aspect of https://github.com/ruby-grape/grape/issues/1713