### PR TITLE
Refactor #generate_api_method to improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#1722](https://github.com/ruby-grape/grape/pull/1722): Fix catch-all hiding multiple versions of an endpoint after the first definition - [@zherr](https://github.com/zherr).
 * [#1724](https://github.com/ruby-grape/grape/pull/1724): Optional nested array validation - [@ericproulx](https://github.com/ericproulx).
 * [#1725](https://github.com/ruby-grape/grape/pull/1725): Fix `rescue_from :all` documentation - [@Jelkster](https://github.com/Jelkster).
+* [#1726](https://github.com/ruby-grape/grape/pull/1726): Improved startup performance during API method generation - [@jkowens](https://github.com/jkowens).
 * Your contribution here.
 
 ### 1.0.1 (9/8/2017)

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -44,7 +44,7 @@ module Grape
       # @return [Proc]
       # @raise [NameError] an instance method with the same name already exists
       def generate_api_method(method_name, &block)
-        if instance_methods.include?(method_name.to_sym) || instance_methods.include?(method_name.to_s)
+        if method_defined?(method_name)
           raise NameError.new("method #{method_name.inspect} already exists and cannot be used as an unbound method name")
         end
 


### PR DESCRIPTION
This is an attempt to resolve #1672.

Benchmark script:

```
require 'grape'
require 'benchmark/ips'

Benchmark.ips do |ips|
  ips.report('class_load') do
    class API < Grape::API
      prefix :api
      version 'v1', using: :path
      get '/' do
        'hello'
      end
    end
  end
end
```

Before:

```
Warming up --------------------------------------
          class_load   590.000  i/100ms
Calculating -------------------------------------
          class_load      5.589k (±10.3%) i/s -     27.730k in   5.029428s
```

After:

```
Warming up --------------------------------------
          class_load   860.000  i/100ms
Calculating -------------------------------------
          class_load      8.761k (±13.6%) i/s -     43.000k in   5.035511s
```