### PR TITLE
Fix infinite loop when mounting endpoint with same superclass

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -34,7 +34,7 @@ Metrics/AbcSize:
 # Offense count: 282
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
-  Max: 3117
+  Max: 3125
 
 # Offense count: 9
 # Configuration parameters: CountComments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#1724](https://github.com/ruby-grape/grape/pull/1724): Optional nested array validation - [@ericproulx](https://github.com/ericproulx).
 * [#1725](https://github.com/ruby-grape/grape/pull/1725): Fix `rescue_from :all` documentation - [@Jelkster](https://github.com/Jelkster).
 * [#1726](https://github.com/ruby-grape/grape/pull/1726): Improved startup performance during API method generation - [@jkowens](https://github.com/jkowens).
+* [#1727](https://github.com/ruby-grape/grape/pull/1727): Fix infinite loop when mounting endpoint with same superclass - [@jkowens](https://github.com/jkowens).
 * Your contribution here.
 
 ### 1.0.1 (9/8/2017)

--- a/lib/grape/dsl/settings.rb
+++ b/lib/grape/dsl/settings.rb
@@ -165,13 +165,13 @@ module Grape
 
       private
 
-      # Builds the current class :inheritable_setting. If available, it returns the superclass's :inheritable_setting.
-      # Otherwise, a clean :inheritable_setting is returned.
+      # Builds the current class :inheritable_setting. If available, it inherits from
+      # the superclass's :inheritable_setting.
       def build_top_level_setting
-        if defined?(superclass) && superclass.respond_to?(:inheritable_setting) && superclass != Grape::API
-          superclass.inheritable_setting
-        else
-          Grape::Util::InheritableSetting.new
+        Grape::Util::InheritableSetting.new.tap do |setting|
+          if defined?(superclass) && superclass.respond_to?(:inheritable_setting) && superclass != Grape::API
+            setting.inherit_from superclass.inheritable_setting
+          end
         end
       end
     end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3129,6 +3129,16 @@ XML
         get '/two/v1/world'
         expect(last_response.status).to eq 200
       end
+
+      context 'when mounting class extends a subclass of Grape::API' do
+        it 'mounts APIs with the same superclass' do
+          base_api = Class.new(Grape::API)
+          a = Class.new(base_api)
+          b = Class.new(base_api)
+
+          expect { a.mount b }.to_not raise_error
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Parent and child classes were pointing to the same inheritable setting creating an infinite loop when retrieving values. Fixes #1683 
  
This was a regression introduced with commit https://github.com/ruby-grape/grape/commit/2c4d5740234da6b96c668e35de4384d0a5d1a8a6.