### PR TITLE
Fix exception being thrown when dependent parameter is a Hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 #### Fixes
 
+* [#1740](https://github.com/ruby-grape/grape/pull/1740): Fix dependent parameter validation using `given` when parameter is a `Hash` - [@jvortmann](https://github.com/jvortmann).
+
 * Your contribution here.
 
 ### 1.0.2 (1/10/2018)

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -201,7 +201,7 @@ module Grape
       # @yield a parameter definition DSL
       def given(*attrs, &block)
         attrs.each do |attr|
-          proxy_attr = attr.is_a?(Hash) ? attr.keys[0] : attr
+          proxy_attr = first_hash_key_or_param(attr)
           raise Grape::Exceptions::UnknownParameter.new(proxy_attr) unless declared_param?(proxy_attr)
         end
         new_lateral_scope(dependent_on: attrs, &block)
@@ -213,7 +213,9 @@ module Grape
       def declared_param?(param)
         # @declared_params also includes hashes of options and such, but those
         # won't be flattened out.
-        @declared_params.flatten.include?(param)
+        @declared_params.flatten.any? do |declared_param|
+          first_hash_key_or_param(declared_param) == param
+        end
       end
 
       alias group requires
@@ -237,6 +239,12 @@ module Grape
         params = @parent.params(params) if @parent
         params = map_params(params, @element) if @element
         params
+      end
+
+      private
+
+      def first_hash_key_or_param(parameter)
+        parameter.is_a?(Hash) ? parameter.keys.first : parameter
       end
     end
   end

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -466,6 +466,19 @@ describe Grape::Validations::ParamsScope do
       end.to raise_error(Grape::Exceptions::UnknownParameter)
     end
 
+    it 'does not raise an error if the dependent parameter is a Hash' do
+      expect do
+        subject.params do
+          optional :a, type: Hash do
+            requires :b
+          end
+          given :a do
+            requires :c
+          end
+        end
+      end.to_not raise_error
+    end
+
     it 'does not validate nested requires when given is false' do
       subject.params do
         requires :a, type: String, allow_blank: false, values: %w[x y z]


### PR DESCRIPTION
When using `given` and the paramter type is a Hash,
a Grape::Exceptions::UnknownParameter is thrown. This is a wrong behavior
due to the fact that the method `declared_param?(param)` do not deal
properly with params that are hashes (even after flattening the
declared params).

This commit fixes this by checking if the param is a Hash and thus
returning its first key. This approach was already used in other part of
the code, so it was extracted and reused on `declared_params?(param)`.