### PR TITLE
Updating activerecord without rails section on README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ### 1.0.3 (Next)
 
-#### Features
+#### Fixes
 
-* Your contribution here.
+* Changed ActiveRecord Without Rails section of the README.md to use another approach to ConnectionManagement. [@thiagoramos23](https://github.com/thiagoramos23)
 
 #### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Fixes
 
+* Your contribution here.
 * [#1747](https://github.com/ruby-grape/grape/pull/1747): Updating activerecord without rails section on README.md - [@thiagoramos23](https://github.com/thiagoramos23).
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Fixes
 
-* [#1747](https://github.com/ruby-grape/grape/pull/1747): Updating activerecord without rails section on README.md [@thiagoramos23](https://github.com/thiagoramos23)
+* [#1747](https://github.com/ruby-grape/grape/pull/1747): Updating activerecord without rails section on README.md - [@thiagoramos23](https://github.com/thiagoramos23).
 
 #### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Fixes
 
-* [#1747] Updating activerecord without rails section on README.md [@thiagoramos23](https://github.com/thiagoramos23)
+* [#1747](https://github.com/ruby-grape/grape/pull/1747): Updating activerecord without rails section on README.md [@thiagoramos23](https://github.com/thiagoramos23)
 
 #### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Fixes
 
-* Changed ActiveRecord Without Rails section of the README.md to use another approach to ConnectionManagement. [@thiagoramos23](https://github.com/thiagoramos23)
+*[#1747] Updating activerecord without rails section on README.md [@thiagoramos23](https://github.com/thiagoramos23)
 
 #### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Fixes
 
-*[#1747] Updating activerecord without rails section on README.md [@thiagoramos23](https://github.com/thiagoramos23)
+* [#1747] Updating activerecord without rails section on README.md [@thiagoramos23](https://github.com/thiagoramos23)
 
 #### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@
 #### Fixes
 
 * [#1740](https://github.com/ruby-grape/grape/pull/1740): Fix dependent parameter validation using `given` when parameter is a `Hash` - [@jvortmann](https://github.com/jvortmann).
-
-* Your contribution here.
 * [#1737](https://github.com/ruby-grape/grape/pull/1737): Fix translating error when passing symbols as params in custom validations - [@mlzhuyi](https://github.com/mlzhuyi).
 
 ### 1.0.2 (1/10/2018)

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ In the old days you could use ActiveRecord's `ConnectionManagement` middleware i
 `config.ru` before mounting Grape.
 
 But this class was removed on ActiveRecord 5. So, if you want to use ActiveRecord you will need to handle
-connections by your self.
+connections by yourself.
 
 The easyest way to achieve this is by creating the class yourself as a rack midleware and call it in your
 config.ru file, e.g.:

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Grape will also automatically respond to HEAD and OPTIONS for all GET, and just 
 If you want to use ActiveRecord within Grape, you will need to make sure that ActiveRecord's connection pool
 is handled correctly.
 
-In the old days we could use ActiveRecord's `ConnectionManagement` middleware in your
+In the old days you could use ActiveRecord's `ConnectionManagement` middleware in your
 `config.ru` before mounting Grape.
 
 But this class was removed on ActiveRecord 5. So, if you want to use ActiveRecord you will need to handle


### PR DESCRIPTION
The class `ActiveRecord::ConnectionAdapters::ConnectionManagement` no longer exists in ActiveRecord 5. 

We need to handle the connection management from now on.

Updated the documentation following a solution that worked at my company.

Solution is here: [Replacing ActiveRecord ConnectionManagement](https://stackoverflow.com/questions/41400202/replacing-activerecordconnectionadaptersconnectionmanagement-in-activerecord)