### PR TITLE
Removing Router from autoload, API already loads it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#1740](https://github.com/ruby-grape/grape/pull/1740): Fix dependent parameter validation using `given` when parameter is a `Hash` - [@jvortmann](https://github.com/jvortmann).
 * [#1737](https://github.com/ruby-grape/grape/pull/1737): Fix translating error when passing symbols as params in custom validations - [@mlzhuyi](https://github.com/mlzhuyi).
 * [#1749](https://github.com/ruby-grape/grape/pull/1749): Allow rescue from non-`StandardError` exceptions - [@dm1try](https://github.com/dm1try).
+* [#1750](https://github.com/ruby-grape/grape/pull/1750): Fix a circular dependency warning due to router being loaded by API - [@salasrod](https://github.com/salasrod).
 * Your contribution here.
 
 ### 1.0.2 (1/10/2018)

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -30,7 +30,6 @@ module Grape
   eager_autoload do
     autoload :API
     autoload :Endpoint
-    autoload :Router
 
     autoload :Namespace
 


### PR DESCRIPTION
Fix #1663 

Routes are already being eagerly loaded by `grape/lib/grape/api.rb:1`.