### PR TITLE
Fix include_missing for aliased parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#1737](https://github.com/ruby-grape/grape/pull/1737): Fix translating error when passing symbols as params in custom validations - [@mlzhuyi](https://github.com/mlzhuyi).
 * [#1749](https://github.com/ruby-grape/grape/pull/1749): Allow rescue from non-`StandardError` exceptions - [@dm1try](https://github.com/dm1try).
 * [#1750](https://github.com/ruby-grape/grape/pull/1750): Fix a circular dependency warning due to router being loaded by API - [@salasrod](https://github.com/salasrod).
+* [#1752](https://github.com/ruby-grape/grape/pull/1752): Fix `include_missing` behavior for aliased parameters - [@jonasoberschweiber](https://github.com/jonasoberschweiber).
 * Your contribution here.
 
 ### 1.0.2 (1/10/2018)

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -64,7 +64,7 @@ module Grape
               has_alias = route_setting(:aliased_params) && route_setting(:aliased_params).find { |current| current[declared_param] }
               param_alias = has_alias[declared_param] if has_alias
 
-              next unless options[:include_missing] || passed_params.key?(declared_param) || param_alias
+              next unless options[:include_missing] || passed_params.key?(declared_param) || (param_alias && passed_params.key?(param_alias))
 
               if param_alias
                 memo[optioned_param_key(param_alias, options)] = passed_params[param_alias]

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -464,7 +464,20 @@ describe Grape::Endpoint do
 
     it 'does not include missing attributes if that option is passed' do
       subject.get '/declared' do
-        error! 400, 'expected nil' if declared(params, include_missing: false)[:second]
+        error! 'expected nil', 400 if declared(params, include_missing: false).key?(:second)
+        ''
+      end
+
+      get '/declared?first=one&other=two'
+      expect(last_response.status).to eq(200)
+    end
+
+    it 'does not include aliased missing attributes if that option is passed' do
+      subject.params do
+        optional :aliased_original, as: :aliased
+      end
+      subject.get '/declared' do
+        error! 'expected nil', 400 if declared(params, include_missing: false).key?(:aliased)
         ''
       end
 


### PR DESCRIPTION
`include_missing` currently includes aliased parameters even if they're not specified. The existing test for `include_missing` was also broken, it passed regardless of the value of `include_missing`.