### PR TITLE
Allow rescue from non-`StandardError` exceptions to use default error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#1749](https://github.com/ruby-grape/grape/pull/1749): Allow rescue from non-`StandardError` exceptions - [@dm1try](https://github.com/dm1try).
 * [#1750](https://github.com/ruby-grape/grape/pull/1750): Fix a circular dependency warning due to router being loaded by API - [@salasrod](https://github.com/salasrod).
 * [#1752](https://github.com/ruby-grape/grape/pull/1752): Fix `include_missing` behavior for aliased parameters - [@jonasoberschweiber](https://github.com/jonasoberschweiber).
+* [#1754](https://github.com/ruby-grape/grape/pull/1754): Allow rescue from non-`StandardError` exceptions to use default error handling - [@jelkster](https://github.com/jelkster).
 * Your contribution here.
 
 ### 1.0.2 (1/10/2018)

--- a/README.md
+++ b/README.md
@@ -2289,7 +2289,7 @@ Here `'inner'` will be result of handling occured `ArgumentError`.
 
 Any exception that is not subclass of `StandardError` should be rescued explicitly.
 Usually it is not a case for an application logic as such errors point to problems in Ruby runtime.
-This is following [standard recomendations for exceptions handling](https://ruby-doc.org/core/Exception.html).
+This is following [standard recommendations for exceptions handling](https://ruby-doc.org/core/Exception.html).
 
 ### Rails 3.x
 

--- a/spec/grape/middleware/exception_spec.rb
+++ b/spec/grape/middleware/exception_spec.rb
@@ -110,18 +110,35 @@ describe Grape::Middleware::Error do
   end
 
   context 'Non-StandardError exception with a provided rescue handler' do
-    subject do
-      Rack::Builder.app do
-        use Spec::Support::EndpointFaker
-        use Grape::Middleware::Error, rescue_handlers: { NotImplementedError => -> { [200, {}, 'rescued'] } }
-        run ExceptionSpec::OtherExceptionApp
+    context 'default error response' do
+      subject do
+        Rack::Builder.app do
+          use Spec::Support::EndpointFaker
+          use Grape::Middleware::Error, rescue_handlers: { NotImplementedError => nil }
+          run ExceptionSpec::OtherExceptionApp
+        end
+      end
+      it 'rescues the exception using the default handler' do
+        get '/'
+        expect(last_response.body).to eq('snow!')
       end
     end
-    it 'rescues the exception using the provided handler' do
-      get '/'
-      expect(last_response.body).to eq('rescued')
+
+    context 'custom error response' do
+      subject do
+        Rack::Builder.app do
+          use Spec::Support::EndpointFaker
+          use Grape::Middleware::Error, rescue_handlers: { NotImplementedError => -> { [200, {}, 'rescued'] } }
+          run ExceptionSpec::OtherExceptionApp
+        end
+      end
+      it 'rescues the exception using the provided handler' do
+        get '/'
+        expect(last_response.body).to eq('rescued')
+      end
     end
   end
+
   context do
     subject do
       Rack::Builder.app do


### PR DESCRIPTION
 This continues to address issues discussed in #1713 and #1745.

 @dm1try recently [added the ability to explicitly rescue non-StandardError exceptions](https://github.com/ruby-grape/grape/pull/1749) but I found that his solution required a block to be provided in order to handle exceptions or else it would raise an error due to no handler being found. This PR corrects that by re-using the existing `find_handler` and `rescuable?` logic, with some minor modifications to account for `Exception` being rescued instead of `StandardError`. This meant that the additional `rescue Exception` block could go away completely.

**Edit:**  I forgot that @dm1try recommended we deprecate the use of `:all` so this additional option (`rescue_from :exception` - removed from PR after further discussion) is probably not necessary, as you can simply `rescue_from Exception`.  The same as you can `rescue_from StandardError` for `rescue_from :all`.