### PR TITLE
Grape exception handling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,3 +21,7 @@ Style/RaiseArgs:
 
 Lint/UnneededDisable:
   Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*_spec.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#1750](https://github.com/ruby-grape/grape/pull/1750): Fix a circular dependency warning due to router being loaded by API - [@salasrod](https://github.com/salasrod).
 * [#1752](https://github.com/ruby-grape/grape/pull/1752): Fix `include_missing` behavior for aliased parameters - [@jonasoberschweiber](https://github.com/jonasoberschweiber).
 * [#1754](https://github.com/ruby-grape/grape/pull/1754): Allow rescue from non-`StandardError` exceptions to use default error handling - [@jelkster](https://github.com/jelkster).
+* [#1756](https://github.com/ruby-grape/grape/pull/1756): Allow custom Grape exception handlers when the built-in exception handling is enabled - [@soylent](https://github.com/soylent).
 * Your contribution here.
 
 ### 1.0.2 (1/10/2018)

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -36,52 +36,15 @@ module Grape
           error_response(catch(:error) do
             return @app.call(@env)
           end)
-        rescue Exception => e # rubocop:disable Lint/RescueException
-          is_rescuable = rescuable?(e.class)
-          if e.is_a?(Grape::Exceptions::Base) && (!is_rescuable || rescuable_by_grape?(e.class))
-            handler = ->(arg) { error_response(arg) }
-          else
-            raise unless is_rescuable
-            handler = find_handler(e.class)
-          end
+        rescue Exception => error # rubocop:disable Lint/RescueException
+          handler =
+            rescue_handler_for_base_only_class(error.class) ||
+            rescue_handler_for_class_or_its_ancestor(error.class) ||
+            rescue_handler_for_grape_exception(error.class) ||
+            rescue_handler_for_any_class(error.class) ||
+            raise
 
-          handler.nil? ? handle_error(e) : exec_handler(e, &handler)
-        end
-      end
-
-      def find_handler(klass)
-        handler = options[:rescue_handlers].find(-> { [] }) { |error, _| klass <= error }[1]
-        handler ||= options[:base_only_rescue_handlers][klass]
-        handler ||= options[:all_rescue_handler]
-
-        if handler.instance_of?(Symbol)
-          raise NoMethodError, "undefined method `#{handler}'" unless respond_to?(handler)
-          handler = self.class.instance_method(handler).bind(self)
-        end
-
-        handler
-      end
-
-      def rescuable?(klass)
-        return false if klass == Grape::Exceptions::InvalidVersionHeader
-
-        if klass <= StandardError
-          rescue_all? || rescue_class_or_its_ancestor?(klass) || rescue_with_base_only_handler?(klass)
-        else
-          rescue_class_or_its_ancestor?(klass) || rescue_with_base_only_handler?(klass)
-        end
-      end
-
-      def rescuable_by_grape?(klass)
-        return false if klass == Grape::Exceptions::InvalidVersionHeader
-        options[:rescue_grape_exceptions]
-      end
-
-      def exec_handler(e, &handler)
-        if handler.lambda? && handler.arity.zero?
-          instance_exec(&handler)
-        else
-          instance_exec(e, &handler)
+          run_rescue_handler(handler, error)
         end
       end
 
@@ -90,7 +53,7 @@ module Grape
         rack_response(format_message(message, backtrace, original_exception), status, headers)
       end
 
-      def handle_error(e)
+      def default_rescue_handler(e)
         error_response(message: e.message, backtrace: e.backtrace, original_exception: e)
       end
 
@@ -122,16 +85,45 @@ module Grape
 
       private
 
-      def rescue_all?
-        options[:rescue_all]
+      def rescue_handler_for_base_only_class(klass)
+        error, handler = options[:base_only_rescue_handlers].find { |err, _handler| klass == err }
+
+        return unless error
+
+        handler || :default_rescue_handler
       end
 
-      def rescue_class_or_its_ancestor?(klass)
-        (options[:rescue_handlers] || []).any? { |error, _handler| klass <= error }
+      def rescue_handler_for_class_or_its_ancestor(klass)
+        error, handler = options[:rescue_handlers].find { |err, _handler| klass <= err }
+
+        return unless error
+
+        handler || :default_rescue_handler
       end
 
-      def rescue_with_base_only_handler?(klass)
-        (options[:base_only_rescue_handlers] || []).include?(klass)
+      def rescue_handler_for_grape_exception(klass)
+        return unless klass <= Grape::Exceptions::Base
+        return :error_response if klass == Grape::Exceptions::InvalidVersionHeader
+        return unless options[:rescue_grape_exceptions] || !options[:rescue_all]
+
+        :error_response
+      end
+
+      def rescue_handler_for_any_class(klass)
+        return unless klass <= StandardError
+        return unless options[:rescue_all] || options[:rescue_grape_exceptions]
+
+        options[:all_rescue_handler] || :default_rescue_handler
+      end
+
+      def run_rescue_handler(handler, error)
+        if handler.instance_of?(Symbol)
+          raise NoMethodError, "undefined method `#{handler}'" unless respond_to?(handler)
+
+          handler = public_method(handler)
+        end
+
+        handler.arity.zero? ? instance_exec(&handler) : instance_exec(error, &handler)
       end
     end
   end


### PR DESCRIPTION
This pull request fixes Grape exception handling for the following case:

```ruby
class App < Grape::API
  rescue_from :grape_exceptions

  rescue_from Grape::Exceptions::ValidationErrors do |error|
    # BUG: This block is never called
    error!('redefined', 403)
  end

  params { requires :foo, type: String }

  get('/') { 'Hello' }
end
```

I reworked `Grape::Middleware::Error` a bit:
* the code is easier to follow now
* it works faster because we iterate over `options[:rescue_handlers]` and `options[:base_only_rescue_handlers]` only once
* it allocates less garbage
* fixed another covert bug: `options[:base_only_rescue_handlers]` should have higher priority than `options[:rescue_handlers]` because it is more restrictive