### PR TITLE
Fix expanding LOAD_PATH in gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * [#1759](https://github.com/ruby-grape/grape/pull/1759): Update appraisal for rails_edge - [@zvkemp](https://github.com/zvkemp).
+* [#1758](https://github.com/ruby-grape/grape/pull/1758): Fix expanding load_path in gemspec - [@2maz](https://github.com/2maz).
 * Your contribution here.
 
 ### 1.0.3 (4/23/2018)

--- a/grape.gemspec
+++ b/grape.gemspec
@@ -1,4 +1,4 @@
-$LOAD_PATH.push File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
 require 'grape/version'
 
 Gem::Specification.new do |s|


### PR DESCRIPTION
Otherwise Grape::VERSION might refer to another, e.g.,
 system wide installed gem version