### PR TITLE
Instrument serialization and rendering as 'format_response.grape'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,6 @@ matrix:
     - rvm: 2.3.5
       gemfile: gemfiles/rack_1.5.2.gemfile
     - rvm: 2.3.5
-      gemfile: gemfiles/rails_edge.gemfile
-    - rvm: 2.3.5
       gemfile: gemfiles/rails_5.gemfile
     - rvm: 2.2.8
       gemfile: Gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -16,7 +16,7 @@ appraise 'rack-1.5.2' do
 end
 
 appraise 'rails-edge' do
-  gem 'arel', github: 'rails/arel'
+  gem 'rails', github: 'rails/rails'
 end
 
 appraise 'rack-edge' do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Features
 
-* Your contribution here.
+* [#1759](https://github.com/ruby-grape/grape/pull/1759): Instrument serialization as `'format_response.grape'` - [@zvkemp](https://github.com/zvkemp).
 
 #### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#1759](https://github.com/ruby-grape/grape/pull/1759): Update appraisal for rails_edge - [@zvkemp](https://github.com/zvkemp).
 * Your contribution here.
 
 ### 1.0.3 (4/23/2018)

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@
     - [endpoint_render.grape](#endpoint_rendergrape)
     - [endpoint_run_filters.grape](#endpoint_run_filtersgrape)
     - [endpoint_run_validators.grape](#endpoint_run_validatorsgrape)
+    - [format_response.grape](#format_responsegrape)
   - [Monitoring Products](#monitoring-products)
 - [Contributing to Grape](#contributing-to-grape)
 - [License](#license)
@@ -3483,6 +3484,13 @@ The execution of validators.
 * *endpoint* - The endpoint instance
 * *validators* - The validators being executed
 * *request* - The request being validated
+
+#### format_response.grape
+
+Serialization or template rendering.
+
+* *env* - The request environment
+* *formatter* - The formatter object (e.g., `Grape::Formatter::Json`)
 
 See the [ActiveSupport::Notifications documentation](http://api.rubyonrails.org/classes/ActiveSupport/Notifications.html) for information on how to subscribe to these events.
 

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'arel', github: 'rails/arel'
+gem 'rails', github: 'rails/rails'
 
 group :development, :test do
   gem 'bundler'

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -41,7 +41,9 @@ module Grape
         else
           # Allow content-type to be explicitly overwritten
           formatter = fetch_formatter(headers, options)
-          bodymap = bodies.collect { |body| formatter.call(body, env) }
+          bodymap = ActiveSupport::Notifications.instrument('format_response.grape', formatter: formatter, env: env) do
+            bodies.collect { |body| formatter.call(body, env) }
+          end
           Rack::Response.new(bodymap, status, headers)
         end
       rescue Grape::Exceptions::InvalidFormatter => e

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -1493,7 +1493,9 @@ describe Grape::Endpoint do
                                                                        filters: [],
                                                                        type: :after }),
         have_attributes(name: 'endpoint_run.grape', payload: { endpoint: a_kind_of(Grape::Endpoint),
-                                                               env: an_instance_of(Hash) })
+                                                               env: an_instance_of(Hash) }),
+        have_attributes(name: 'format_response.grape', payload: { env: an_instance_of(Hash),
+                                                                  formatter: a_kind_of(Module) })
       )
 
       # In order that events were initialized
@@ -1515,7 +1517,9 @@ describe Grape::Endpoint do
         have_attributes(name: 'endpoint_render.grape',      payload: { endpoint: a_kind_of(Grape::Endpoint) }),
         have_attributes(name: 'endpoint_run_filters.grape', payload: { endpoint: a_kind_of(Grape::Endpoint),
                                                                        filters: [],
-                                                                       type: :after })
+                                                                       type: :after }),
+        have_attributes(name: 'format_response.grape', payload: { env: an_instance_of(Hash),
+                                                                  formatter: a_kind_of(Module) })
       )
     end
   end


### PR DESCRIPTION
A good portion of a grape API response is currently uninstrumented — when `endpoint_run.grape` closes, the response bodies still haven't been serialized or rendered into their appropriate templates. Adding `format_response.grape` instrumentation will allow us to measure time spent in this portion of the request.