### PR TITLE
Use 415 status for request bodies of unsupported media type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 1.0.4 (Next)
+### 1.1.0 (Next)
 
 #### Features
 
@@ -10,6 +10,7 @@
 * [#1762](https://github.com/ruby-grape/grape/pull/1763): Fix unsafe HTML rendering on errors - [@ctennis](https://github.com/ctennis).
 * [#1759](https://github.com/ruby-grape/grape/pull/1759): Update appraisal for rails_edge - [@zvkemp](https://github.com/zvkemp).
 * [#1758](https://github.com/ruby-grape/grape/pull/1758): Fix expanding load_path in gemspec - [@2maz](https://github.com/2maz).
+* [#1765](https://github.com/ruby-grape/grape/pull/1765): Use 415 when request body is of an unsupported media type - [@jdmurphy](https://github.com/jdmurphy).
 * Your contribution here.
 
 ### 1.0.3 (4/23/2018)

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ content negotiation, versioning and much more.
 
 ## Stable Release
 
-You're reading the documentation for the next release of Grape, which should be **1.0.4**.
+You're reading the documentation for the next release of Grape, which should be **1.1.0**.
 Please read [UPGRADING](UPGRADING.md) when upgrading from a previous version.
 The current stable release is [1.0.3](https://github.com/ruby-grape/grape/blob/v1.0.3/README.md).
 
@@ -2550,6 +2550,9 @@ Built-in formatters are the following.
 * `:txt`: use object's `to_txt` when available, otherwise `to_s`
 * `:serializable_hash`: use object's `serializable_hash` when available, otherwise fallback to `:json`
 * `:binary`: data will be returned "as is"
+
+If a body is present in a request to an API, with a Content-Type header value that is of an unsupported type a
+"415 Unsupported Media Type" error code will be returned by Grape.
 
 Response statuses that indicate no content as defined by [Rack](https://github.com/rack)
 [here](https://github.com/rack/rack/blob/master/lib/rack/utils.rb#L567)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,12 @@
 Upgrading Grape
 ===============
 
+### Upgrading to >= 1.1.0
+
+#### Changes in HTTP Response Code for Unsupported Content Type
+
+For PUT, POST, PATCH, and DELETE requests where a non-empty body and a "Content-Type" header is supplied that is not supported by the Grape API, Grape will no longer return a 406 "Not Acceptable" HTTP status code and will instead return a 415 "Unsupported Media Type" so that the usage of HTTP status code falls more in line with the specification of [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt).
+
 ### Upgrading to >= 1.0.0
 
 #### Changes in XML and JSON Parsers

--- a/gemfiles/multi_json.gemfile
+++ b/gemfiles/multi_json.gemfile
@@ -22,7 +22,7 @@ end
 group :test do
   gem 'cookiejar'
   gem 'coveralls', '~> 0.8.17', require: false
-  gem 'danger-toc', '~> 0.1.0'
+  gem 'danger-toc', '~> 0.1.2'
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
   gem 'mime-types'

--- a/gemfiles/multi_xml.gemfile
+++ b/gemfiles/multi_xml.gemfile
@@ -22,7 +22,7 @@ end
 group :test do
   gem 'cookiejar'
   gem 'coveralls', '~> 0.8.17', require: false
-  gem 'danger-toc', '~> 0.1.0'
+  gem 'danger-toc', '~> 0.1.2'
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
   gem 'mime-types'

--- a/gemfiles/rack_1.5.2.gemfile
+++ b/gemfiles/rack_1.5.2.gemfile
@@ -22,7 +22,7 @@ end
 group :test do
   gem 'cookiejar'
   gem 'coveralls', '~> 0.8.17', require: false
-  gem 'danger-toc', '~> 0.1.0'
+  gem 'danger-toc', '~> 0.1.2'
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
   gem 'mime-types'

--- a/gemfiles/rack_edge.gemfile
+++ b/gemfiles/rack_edge.gemfile
@@ -22,7 +22,7 @@ end
 group :test do
   gem 'cookiejar'
   gem 'coveralls', '~> 0.8.17', require: false
-  gem 'danger-toc', '~> 0.1.0'
+  gem 'danger-toc', '~> 0.1.2'
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
   gem 'mime-types'

--- a/gemfiles/rails_3.gemfile
+++ b/gemfiles/rails_3.gemfile
@@ -23,7 +23,7 @@ end
 group :test do
   gem 'cookiejar'
   gem 'coveralls', '~> 0.8.17', require: false
-  gem 'danger-toc', '~> 0.1.0'
+  gem 'danger-toc', '~> 0.1.2'
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
   gem 'mime-types'

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -22,7 +22,7 @@ end
 group :test do
   gem 'cookiejar'
   gem 'coveralls', '~> 0.8.17', require: false
-  gem 'danger-toc', '~> 0.1.0'
+  gem 'danger-toc', '~> 0.1.2'
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
   gem 'mime-types'

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -22,7 +22,7 @@ end
 group :test do
   gem 'cookiejar'
   gem 'coveralls', '~> 0.8.17', require: false
-  gem 'danger-toc', '~> 0.1.0'
+  gem 'danger-toc', '~> 0.1.2'
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
   gem 'mime-types'

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -22,7 +22,7 @@ end
 group :test do
   gem 'cookiejar'
   gem 'coveralls', '~> 0.8.17', require: false
-  gem 'danger-toc', '~> 0.1.0'
+  gem 'danger-toc', '~> 0.1.2'
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
   gem 'mime-types'

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -95,7 +95,7 @@ module Grape
         fmt = request.media_type ? mime_types[request.media_type] : options[:default_format]
 
         unless content_type_for(fmt)
-          throw :error, status: 406, message: "The requested content-type '#{request.media_type}' is not supported."
+          throw :error, status: 415, message: "The provided content-type '#{request.media_type}' is not supported."
         end
         parser = Grape::Parser.parser_for fmt, options
         if parser

--- a/lib/grape/version.rb
+++ b/lib/grape/version.rb
@@ -1,4 +1,4 @@
 module Grape
   # The current version of Grape.
-  VERSION = '1.0.4'.freeze
+  VERSION = '1.1.0'.freeze
 end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -941,15 +941,15 @@ describe Grape::Endpoint do
       end
     end
 
-    it 'responds with a 406 for an unsupported content-type' do
+    it 'responds with a 415 for an unsupported content-type' do
       subject.format :json
       # subject.content_type :json, "application/json"
       subject.put '/request_body' do
         params[:user]
       end
       put '/request_body', '<user>Bobby T.</user>', 'CONTENT_TYPE' => 'application/xml'
-      expect(last_response.status).to eq(406)
-      expect(last_response.body).to eq('{"error":"The requested content-type \'application/xml\' is not supported."}')
+      expect(last_response.status).to eq(415)
+      expect(last_response.body).to eq('{"error":"The provided content-type \'application/xml\' is not supported."}')
     end
 
     it 'does not accept text/plain in JSON format if application/json is specified as content type' do
@@ -960,8 +960,8 @@ describe Grape::Endpoint do
       end
       put '/request_body', ::Grape::Json.dump(user: 'Bob'), 'CONTENT_TYPE' => 'text/plain'
 
-      expect(last_response.status).to eq(406)
-      expect(last_response.body).to eq('{"error":"The requested content-type \'text/plain\' is not supported."}')
+      expect(last_response.status).to eq(415)
+      expect(last_response.body).to eq('{"error":"The provided content-type \'text/plain\' is not supported."}')
     end
 
     context 'content type with params' do


### PR DESCRIPTION
Noticed that for requests where bodies are present (i.e. PUT, POST, PATCH, etc.), that if the content type header was something unsupported that a 406 would be returned. Reading over the original [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt), a 415 should be used when a request entity is not in a supported format, but currently a 406 is returned. It seems like it should be as simple as changing [this logic](https://github.com/ruby-grape/grape/blob/master/lib/grape/middleware/formatter.rb#L97-L99).