### PR TITLE
Change HTTP DELETE status code and body logic, use nil for HTTP 204

### DIFF
--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -178,10 +178,10 @@ module Grape
           when Grape::Http::Headers::POST
             201
           when Grape::Http::Headers::DELETE
-            if @body.present?
-              200
-            else
+            if @body.nil?
               204
+            else
+              200
             end
           else
             200
@@ -222,12 +222,17 @@ module Grape
       #   end
       #
       #   GET /body # => "Body"
-      def body(value = nil)
-        if value
-          @body = value
-        elsif value == false
-          @body = ''
-          status 204
+      def body(*value)
+        raise ArgumentError 'you can only set a body with one argument' if value.length > 1
+
+        if value.length == 1
+          value = value.first
+          if value.nil?
+            @body = ''
+            status 204
+          else
+            @body = value
+          end
         else
           @body
         end
@@ -244,7 +249,7 @@ module Grape
       #   DELETE /12 # => 204 No Content, ""
       def return_no_content
         status 204
-        body false
+        body nil
       end
 
       # Allows you to define the response as a file-like object.

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3553,10 +3553,10 @@ XML
   end
 
   context 'body' do
-    context 'false' do
+    context 'nil' do
       before do
         subject.get '/blank' do
-          body false
+          body nil
         end
       end
       it 'returns blank body' do

--- a/spec/grape/dsl/inside_route_spec.rb
+++ b/spec/grape/dsl/inside_route_spec.rb
@@ -111,11 +111,42 @@ describe Grape::Endpoint do
       expect(subject.status).to eq 204
     end
 
-    it 'defaults to 200 on DELETE with a body present' do
-      request = Grape::Request.new(Rack::MockRequest.env_for('/', method: 'DELETE'))
-      subject.body 'content here'
-      expect(subject).to receive(:request).and_return(request)
-      expect(subject.status).to eq 200
+    describe 'defaulting to 200 on DELETE' do
+      it 'defaults to 200 on DELETE with a body present' do
+        request = Grape::Request.new(Rack::MockRequest.env_for('/', method: 'DELETE'))
+        subject.body 'content here'
+        expect(subject).to receive(:request).and_return(request)
+        expect(subject.status).to eq 200
+      end
+
+      it 'regards an empty string as content' do
+        request = Grape::Request.new(Rack::MockRequest.env_for('/', method: 'DELETE'))
+        subject.body ''
+        expect(subject).to receive(:request).and_return(request)
+        expect(subject.status).to eq 200
+      end
+
+      it 'regards an empty hash as content' do
+        request = Grape::Request.new(Rack::MockRequest.env_for('/', method: 'DELETE'))
+        subject.body({}) # Use brackets, because it's a block otherwise
+        expect(subject).to receive(:request).and_return(request)
+        expect(subject.status).to eq 200
+      end
+
+      it 'regards an empty array as content' do
+        request = Grape::Request.new(Rack::MockRequest.env_for('/', method: 'DELETE'))
+        subject.body []
+        expect(subject).to receive(:request).and_return(request)
+        expect(subject.status).to eq 200
+      end
+
+      # Still failing for some weird kind of reason.
+      it 'regards a nil as no content' do
+        request = Grape::Request.new(Rack::MockRequest.env_for('/', method: 'DELETE'))
+        subject.body nil
+        expect(subject).to receive(:request).and_return(request)
+        expect(subject.status).to eq 204
+      end
     end
 
     it 'returns status set' do
@@ -184,9 +215,9 @@ describe Grape::Endpoint do
       end
     end
 
-    describe 'false' do
+    describe 'nil' do
       before do
-        subject.body false
+        subject.body nil
       end
 
       it 'sets status to 204' do

--- a/spec/grape/dsl/inside_route_spec.rb
+++ b/spec/grape/dsl/inside_route_spec.rb
@@ -111,8 +111,8 @@ describe Grape::Endpoint do
       expect(subject.status).to eq 204
     end
 
-    describe 'defaulting to 200 on DELETE' do
-      it 'defaults to 200 on DELETE with a body present' do
+    describe 'what is regarded as content on DELETE' do
+      it 'regards a string as content' do
         request = Grape::Request.new(Rack::MockRequest.env_for('/', method: 'DELETE'))
         subject.body 'content here'
         expect(subject).to receive(:request).and_return(request)

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -1320,18 +1320,18 @@ describe Grape::Endpoint do
       end
     end
 
-    describe 'delete 204, with nil has return value (no explicit body)' do
+    describe 'delete 200, with empty string as return value' do
       it 'responds to /example delete method' do
-        subject.delete(:example) { nil }
+        subject.delete(:example) { '' }
         delete '/example'
-        expect(last_response.status).to eql 204
+        expect(last_response.status).to eql 200
         expect(last_response.body).to be_empty
       end
     end
 
-    describe 'delete 204, with empty array has return value (no explicit body)' do
+    describe 'delete 204, with nil as return value (no explicit body)' do
       it 'responds to /example delete method' do
-        subject.delete(:example) { '' }
+        subject.delete(:example) { nil }
         delete '/example'
         expect(last_response.status).to eql 204
         expect(last_response.body).to be_empty


### PR DESCRIPTION
This PR has two goals:
- Change HTTP DELETE status code and body logic
presenting {}. [], false will be regarded as content and will use HTTP status code 200. The content body will be presented with the set content.

- Change using nil to set NO_CONTENT
Using nil will be more consistent with the way the content is regarded in the previous point. 

Fixes #1578 

- [ ] Receive and process first round of feedback
- [ ] Need to fix the spec at spec/grape/dsl/inside_route_spec.rb:144 (I do not understand the reason of failure).
