### PR TITLE
Validates response processed by exception handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#1776](https://github.com/ruby-grape/grape/pull/1776): Validates response processed by exception handler - [@darren987469](https://github.com/darren987469).
 
 ### 1.1.0 (8/4/2018)
 
@@ -21,7 +22,6 @@
 * [#1758](https://github.com/ruby-grape/grape/pull/1758): Fix expanding load_path in gemspec - [@2maz](https://github.com/2maz).
 * [#1765](https://github.com/ruby-grape/grape/pull/1765): Use 415 when request body is of an unsupported media type - [@jdmurphy](https://github.com/jdmurphy).
 * [#1771](https://github.com/ruby-grape/grape/pull/1771): Fix param aliases with 'given' blocks - [@jereynolds](https://github.com/jereynolds).
-* [#1776](https://github.com/ruby-grape/grape/pull/1776): Validates response processed by exception handler - [@darren987469](https://github.com/darren987469).
 
 ### 1.0.3 (4/23/2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#1758](https://github.com/ruby-grape/grape/pull/1758): Fix expanding load_path in gemspec - [@2maz](https://github.com/2maz).
 * [#1765](https://github.com/ruby-grape/grape/pull/1765): Use 415 when request body is of an unsupported media type - [@jdmurphy](https://github.com/jdmurphy).
 * [#1771](https://github.com/ruby-grape/grape/pull/1771): Fix param aliases with 'given' blocks - [@jereynolds](https://github.com/jereynolds).
+* [#1776](https://github.com/ruby-grape/grape/pull/1776): Validates response processed by exception handler - [@darren987469](https://github.com/darren987469).
 
 ### 1.0.3 (4/23/2018)
 

--- a/README.md
+++ b/README.md
@@ -2254,16 +2254,7 @@ class Twitter::API < Grape::API
 end
 ```
 
-By default, object returned by `rescue_from` would be taken as response message. It is suggested to call `error!` in the last line of `rescue_from` block. But you could return `String`, `Hash`, `Array`, `Rack::Response` or even `nil` as well.
-
-```ruby
-rescue_from(:all) { error!('error') }
-rescue_from(:all) { 'error' }
-rescue_from(:all) { { message: 'error' } }
-rescue_from(:all) { [500, 'error', { 'Content-Type' => 'text/error' }] }
-rescue_from(:all) { Rack::Response.new('error', 500) }
-rescue_from(:all) { nil } # response default_message and default_status
-```
+The `rescue_from` block must return a `Rack::Response` object, or call `error!`.
 
 The `with` keyword is available as `rescue_from` options, it can be passed method name or Proc object.
 

--- a/README.md
+++ b/README.md
@@ -2183,7 +2183,7 @@ You can also rescue all exceptions with a code block and handle the Rack respons
 ```ruby
 class Twitter::API < Grape::API
   rescue_from :all do |e|
-    Rack::Response.new([ e.message ], 500, { 'Content-type' => 'text/error' }).finish
+    Rack::Response.new([ e.message ], 500, { 'Content-type' => 'text/error' })
   end
 end
 ```
@@ -2254,7 +2254,16 @@ class Twitter::API < Grape::API
 end
 ```
 
-The `rescue_from` block must return a `Rack::Response` object, call `error!` or re-raise an exception.
+By default, object returned by `rescue_from` would be taken as response message. It is suggested to call `error!` in the last line of `rescue_from` block. But you could return `String`, `Hash`, `Array`, `Rack::Response` or even `nil` as well.
+
+```ruby
+rescue_from(:all) { error!('error') }
+rescue_from(:all) { 'error' }
+rescue_from(:all) { { message: 'error' } }
+rescue_from(:all) { [500, 'error', { 'Content-Type' => 'text/error' }] }
+rescue_from(:all) { Rack::Response.new('error', 500) }
+rescue_from(:all) { nil } # response default_message and default_status
+```
 
 The `with` keyword is available as `rescue_from` options, it can be passed method name or Proc object.
 

--- a/README.md
+++ b/README.md
@@ -2254,7 +2254,7 @@ class Twitter::API < Grape::API
 end
 ```
 
-The `rescue_from` block must return a `Rack::Response` object, or call `error!`.
+The `rescue_from` block must return a `Rack::Response` object, or call `error!` or raise an exception, either original exception or another custom exception. The exception raised in `rescue_from` would be handled outside grape. For example, if you mount grape in Rails, the exception would be handle by [Rails](https://guides.rubyonrails.org/action_controller_overview.html#rescue).
 
 The `with` keyword is available as `rescue_from` options, it can be passed method name or Proc object.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,25 @@
 Upgrading Grape
 ===============
 
+### Upgrading to >= 1.1.1
+
+#### Changes in rescue_from returned object
+
+Grape add a validation to check object returned from `rescue_from` block is a Rack::Response. That makes sure response is valid and prevent exposing service information. If you return `Rack::Response.new(...).finish` in `rescue_from` block, change it to `Rack::Response.new(...)` to comply with the validation.
+
+```ruby
+class Twitter::API < Grape::API
+  rescue_from :all do |e|
+    # version prior to 1.1.1
+    Rack::Response.new([ e.message ], 500, { 'Content-type' => 'text/error' }).finish
+    # 1.1.1 version
+    Rack::Response.new([ e.message ], 500, { 'Content-type' => 'text/error' })
+  end
+end
+```
+
+See [#1757](https://github.com/ruby-grape/grape/pull/1757), [#1776](https://github.com/ruby-grape/grape/pull/1776) for more details.
+
 ### Upgrading to >= 1.1.0
 
 #### Changes in HTTP Response Code for Unsupported Content Type

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -75,6 +75,7 @@ module Grape
     autoload :InvalidAcceptHeader
     autoload :InvalidVersionHeader
     autoload :MethodNotAllowed
+    autoload :InvalidResponse
   end
 
   module Extensions

--- a/lib/grape/exceptions/invalid_response.rb
+++ b/lib/grape/exceptions/invalid_response.rb
@@ -1,0 +1,9 @@
+module Grape
+  module Exceptions
+    class InvalidResponse < Base
+      def initialize
+        super(message: compose_message(:invalid_response))
+      end
+    end
+  end
+end

--- a/lib/grape/locale/en.yml
+++ b/lib/grape/locale/en.yml
@@ -49,4 +49,5 @@ en:
         invalid_version_header:
           problem: 'Invalid version header'
           resolution: '%{message}'
+        invalid_response: 'Invalid response'
 

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -128,18 +128,11 @@ module Grape
         end
 
         response = handler.arity.zero? ? instance_exec(&handler) : instance_exec(error, &handler)
-        return response if response.is_a?(Rack::Response)
 
-        # take object returned from handler as [message, status, headers]
-        # assign default value if they are nil
-        message, status, headers = response
-        message ||= default_options[:default_message]
-        status ||= default_options[:default_status]
-
-        if headers.present? && headers.is_a?(Hash)
-          error!(message, status, headers)
+        if response.is_a?(Rack::Response)
+          response
         else
-          error!(message, status)
+          run_rescue_handler(:default_rescue_handler, Grape::Exceptions::InvalidResponse.new)
         end
       end
     end

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -127,7 +127,13 @@ module Grape
           handler = public_method(handler)
         end
 
-        handler.arity.zero? ? instance_exec(&handler) : instance_exec(error, &handler)
+        response = handler.arity.zero? ? instance_exec(&handler) : instance_exec(error, &handler)
+        valid_response?(response) ? response : error!('Internal Server Error(Invalid Response)')
+      end
+
+      def valid_response?(response)
+        # Rack::Response.new(...).finish generates an array with size 3
+        response.is_a?(Array) && response.size == 3
       end
     end
   end

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -128,7 +128,7 @@ module Grape
         end
 
         response = handler.arity.zero? ? instance_exec(&handler) : instance_exec(error, &handler)
-        valid_response?(response) ? response : error!('Internal Server Error(Invalid Response)')
+        valid_response?(response) ? response : run_rescue_handler(:default_rescue_handler, error)
       end
 
       def valid_response?(response)

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -127,13 +127,7 @@ module Grape
           handler = public_method(handler)
         end
 
-        response = handler.arity.zero? ? instance_exec(&handler) : instance_exec(error, &handler)
-        valid_response?(response) ? response : run_rescue_handler(:default_rescue_handler, error)
-      end
-
-      def valid_response?(response)
-        # Rack::Response.new(...).finish generates an array with size 3
-        response.is_a?(Array) && response.size == 3
+        handler.arity.zero? ? instance_exec(&handler) : instance_exec(error, &handler)
       end
     end
   end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1724,52 +1724,14 @@ XML
       expect(last_response.body).to eq('Formatter Error')
     end
 
-    context 'takes object returned by rescue_from as error message' do
-      it 'accepts nil and returns default message and status' do
-        subject.rescue_from(:all) { nil }
-        subject.get('/') { raise }
+    it 'uses default_rescue_handler to handle invalid response from rescue_from' do
+      subject.rescue_from(:all) { 'error' }
+      subject.get('/') { raise }
 
-        get '/'
-        expect(last_response.status).to eql 500
-        expect(last_response.body).to eql ''
-      end
-
-      it 'accepts string' do
-        subject.rescue_from(:all) { 'whatever' }
-        subject.get('/') { raise }
-
-        get '/'
-        expect(last_response.status).to eql 500
-        expect(last_response.body).to eql 'whatever'
-      end
-
-      it 'accepts hash' do
-        hash = { message: 'error' }
-        subject.rescue_from(:all) { hash }
-        subject.get('/') { raise }
-
-        get '/'
-        expect(last_response.status).to eql 500
-        expect(last_response.body).to eql hash.to_json
-      end
-
-      it 'accepts Array' do
-        subject.rescue_from(:all) { ['error', 400] }
-        subject.get('/') { raise }
-
-        get '/'
-        expect(last_response.status).to eql 400
-        expect(last_response.body).to eql 'error'
-      end
-
-      it 'accepts Rack::Response' do
-        subject.rescue_from(:all) { Rack::Response.new('error', 400) }
-        subject.get('/') { raise }
-
-        get '/'
-        expect(last_response.status).to eql 400
-        expect(last_response.body).to eql 'error'
-      end
+      expect_any_instance_of(Grape::Middleware::Error).to receive(:default_rescue_handler).and_call_original
+      get '/'
+      expect(last_response.status).to eql 500
+      expect(last_response.body).to eql 'Invalid response'
     end
   end
 

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1724,24 +1724,30 @@ XML
       expect(last_response.body).to eq('Formatter Error')
     end
 
-    it 'validates response processed by exception handler' do
-      subject.rescue_from ArgumentError do
-        error!('rain!')
-        nil # invalid response caused by return nil
-      end
-      subject.rescue_from :all do
-        error!('rain!')
-      end
-      subject.get('/invalid_response') { raise ArgumentError }
-      subject.get('/valid_response') { raise 'rain!' }
+    context 'validates response processed by exception handler' do
+      it 'calls default_rescue_handler when response is invalid' do
+        subject.rescue_from :all do
+          error!('Internal Server Error')
+          nil # invalid response caused by return nil
+        end
+        subject.get('/invalid_response') { raise 'rain!' }
 
-      get '/invalid_response'
-      expect(last_response.status).to eql 500
-      expect(last_response.body).to eq('Internal Server Error(Invalid Response)')
+        expect_any_instance_of(Grape::Middleware::Error).to receive(:default_rescue_handler).and_call_original
+        get '/invalid_response'
+        expect(last_response.status).to eql 500
+        expect(last_response.body).to eq('rain!')
+      end
 
-      get '/valid_response'
-      expect(last_response.status).to eql 500
-      expect(last_response.body).to eq('rain!')
+      it 'calls custom handler when response is valid' do
+        subject.rescue_from :all do
+          error!('Internal Server Error')
+        end
+        subject.get('/valid_response') { raise 'rain!' }
+
+        get '/valid_response'
+        expect(last_response.status).to eql 500
+        expect(last_response.body).to eq('Internal Server Error')
+      end
     end
   end
 

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1723,6 +1723,26 @@ XML
       expect(last_response.status).to eql 500
       expect(last_response.body).to eq('Formatter Error')
     end
+
+    it 'validates response processed by exception handler' do
+      subject.rescue_from ArgumentError do
+        error!('rain!')
+        nil # invalid response caused by return nil
+      end
+      subject.rescue_from :all do
+        error!('rain!')
+      end
+      subject.get('/invalid_response') { raise ArgumentError }
+      subject.get('/valid_response') { raise 'rain!' }
+
+      get '/invalid_response'
+      expect(last_response.status).to eql 500
+      expect(last_response.body).to eq('Internal Server Error(Invalid Response)')
+
+      get '/valid_response'
+      expect(last_response.status).to eql 500
+      expect(last_response.body).to eq('rain!')
+    end
   end
 
   describe '.rescue_from klass, block' do

--- a/spec/grape/exceptions/invalid_response_spec.rb
+++ b/spec/grape/exceptions/invalid_response_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Grape::Exceptions::InvalidResponse do
+  describe '#message' do
+    let(:error) { described_class.new }
+
+    it 'contains the problem in the message' do
+      expect(error.message).to include('Invalid response')
+    end
+  end
+end

--- a/spec/grape/middleware/exception_spec.rb
+++ b/spec/grape/middleware/exception_spec.rb
@@ -128,7 +128,7 @@ describe Grape::Middleware::Error do
       subject do
         Rack::Builder.app do
           use Spec::Support::EndpointFaker
-          use Grape::Middleware::Error, rescue_handlers: { NotImplementedError => -> { [200, {}, 'rescued'] } }
+          use Grape::Middleware::Error, rescue_handlers: { NotImplementedError => -> { ['rescued', 200, {}] } }
           run ExceptionSpec::OtherExceptionApp
         end
       end

--- a/spec/grape/middleware/exception_spec.rb
+++ b/spec/grape/middleware/exception_spec.rb
@@ -128,7 +128,7 @@ describe Grape::Middleware::Error do
       subject do
         Rack::Builder.app do
           use Spec::Support::EndpointFaker
-          use Grape::Middleware::Error, rescue_handlers: { NotImplementedError => -> { ['rescued', 200, {}] } }
+          use Grape::Middleware::Error, rescue_handlers: { NotImplementedError => -> { Rack::Response.new('rescued', 200, {}) } }
           run ExceptionSpec::OtherExceptionApp
         end
       end


### PR DESCRIPTION
Try to fix #1757.

### Problem  
```ruby
class Api < Grape::API
  rescue_from :all do
    error!('rain')
    nil
  end
end
```
The `rescue_from` block return nil, that cause response like
```
500,
NoMethodError (undefined method `[]' for nil:NilClass):

grape (1.0.2) lib/grape/router.rb:163:in `cascade?'
grape (1.0.2) lib/grape/router.rb:95:in `transaction'
grape (1.0.2) lib/grape/router.rb:72:in `identity'
grape (1.0.2) lib/grape/router.rb:57:in `block in call'
...
```
Response exposes the system information.

### After PR
Response would like
```
500, Internal Server Error(Invalid Response)
```
Not sure the message is proper or not.
