### PR TITLE
Added spec to demonstrate bug with nested requirements.

### DIFF
--- a/spec/grape/api/routes_with_requirements_spec.rb
+++ b/spec/grape/api/routes_with_requirements_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe Grape::Endpoint do
+  subject { Class.new(Grape::API) }
+
+  def app
+    subject
+  end
+
+  context 'get' do
+    it 'routes to a namespace param with dots' do
+      subject.namespace ':ns_with_dots', requirements: { ns_with_dots: %r{[^\/]+} } do
+        get '/' do
+          params[:ns_with_dots]
+        end
+      end
+
+      get '/test.id.with.dots'
+      expect(last_response.status).to eq 200
+      expect(last_response.body).to eq 'test.id.with.dots'
+    end
+
+    it 'routes to a path with multiple params with dots' do
+      subject.get ':id_with_dots/:another_id_with_dots', requirements: { id_with_dots: %r{[^\/]+},
+                                                                         another_id_with_dots: %r{[^\/]+} }  do
+        "#{params[:id_with_dots]}/#{params[:another_id_with_dots]}"
+      end
+
+      get '/test.id/test2.id'
+      expect(last_response.status).to eq 200
+      expect(last_response.body).to eq 'test.id/test2.id'
+    end
+
+    it 'routes to namespace and path params with dots, with overridden requirements' do
+      subject.namespace ':ns_with_dots', requirements: { ns_with_dots: %r{[^\/]+} } do
+        get ':another_id_with_dots',     requirements: { ns_with_dots: %r{[^\/]+},
+                                                         another_id_with_dots: %r{[^\/]+} } do
+          "#{params[:ns_with_dots]}/#{params[:another_id_with_dots]}"
+        end
+      end
+
+      get '/test.id/test2.id'
+      expect(last_response.status).to eq 200
+      expect(last_response.body).to eq 'test.id/test2.id'
+    end
+
+    it 'routes to namespace and path params with dots, with merged requirements' do
+      subject.namespace ':ns_with_dots', requirements: { ns_with_dots: %r{[^\/]+} } do
+        get ':another_id_with_dots',     requirements: { another_id_with_dots: %r{[^\/]+} } do
+          "#{params[:ns_with_dots]}/#{params[:another_id_with_dots]}"
+        end
+      end
+
+      get '/test.id/test2.id'
+      expect(last_response.status).to eq 200
+      expect(last_response.body).to eq 'test.id/test2.id'
+    end
+  end
+end


### PR DESCRIPTION
I believe there's a bug that was introduced sometime after Grape 0.13 (we were running a very old version). We have several nested namespaces that have requirements to allow for dots in the path parameters.

e.g. /:user_id/:attr_id, where both :user_id and :attr_id can have dots in them.

When I upgraded to the latest Grape, these stopped working for the first namespace (:user_id) - it appears it's because when you pass in a requirements hash on a route, it replaces any existing requirements on the wrapping namespace.

This spec demonstrates the expected (and previous) behavior, especially the last test case which is failing against master.

A simplified example:

With:
```ruby
namespace ':user_id', requirements: { user_id: %r{[^\/]+} } do
  get ':attr_id',    requirements: { attr_id: %r{[^\/]+} } do
    "#{params[:user_id]}/#{params[:attr_id]}"
  end
end
```

Expected:

GET `/user.with.dots/attribute.with.dots` should work.

Current behavior:

GET `/user.with.dots/attribute.with.dots` returns a 404 error.
