### PR TITLE
Add documented but not implemented feature so a user can insert a middleware at a specific point in the stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * Your contribution here.
 * [#1776](https://github.com/ruby-grape/grape/pull/1776): Validate response returned by the exception handler - [@darren987469](https://github.com/darren987469).
+* [#1787](https://github.com/ruby-grape/grape/pull/1787): Add documented but not implemented ability to `.insert` a middleware in the stack - [@michaellennox](https://github.com/michaellennox).
 
 ### 1.1.0 (8/4/2018)
 

--- a/lib/grape/dsl/middleware.rb
+++ b/lib/grape/dsl/middleware.rb
@@ -21,6 +21,13 @@ module Grape
           namespace_stackable(:middleware, arr)
         end
 
+        def insert(*args, &block)
+          arr = [:insert, *args]
+          arr << block if block_given?
+
+          namespace_stackable(:middleware, arr)
+        end
+
         def insert_before(*args, &block)
           arr = [:insert_before, *args]
           arr << block if block_given?

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1348,6 +1348,28 @@ XML
     end
   end
 
+  describe '.insert' do
+    it 'inserts middleware in a specific location in the stack' do
+      m = Class.new(Grape::Middleware::Base) do
+        def call(env)
+          env['phony.args'] ||= []
+          env['phony.args'] << @options[:message]
+          @app.call(env)
+        end
+      end
+
+      subject.use ApiSpec::PhonyMiddleware, 'bye'
+      subject.insert 0, m, message: 'good'
+      subject.insert 0, m, message: 'hello'
+      subject.get '/' do
+        env['phony.args'].join(' ')
+      end
+
+      get '/'
+      expect(last_response.body).to eql 'hello good bye'
+    end
+  end
+
   describe '.http_basic' do
     it 'protects any resources on the same scope' do
       subject.http_basic do |u, _p|

--- a/spec/grape/dsl/middleware_spec.rb
+++ b/spec/grape/dsl/middleware_spec.rb
@@ -22,6 +22,14 @@ module Grape
         end
       end
 
+      describe '.insert' do
+        it 'adds a middleware with the right operation' do
+          expect(subject).to receive(:namespace_stackable).with(:middleware, [:insert, 0, :arg1, proc])
+
+          subject.insert 0, :arg1, &proc
+        end
+      end
+
       describe '.insert_before' do
         it 'adds a middleware with the right operation' do
           expect(subject).to receive(:namespace_stackable).with(:middleware, [:insert_before, foo_middleware, :arg1, proc])


### PR DESCRIPTION
### What does this PR do?

Adds the ability for a user to insert a middleware at a specific point in the middleware stack using the `insert` method.

### Where should the reviewer start?

First commit demonstrates failing integration test case. Second fixes it. Recommended to step through.

### Any background context to be provided?

In the README of this project it is documented that a user can insert a middleware at a specific point in the stack using the `.insert` method. 

Notable passage:

```
You can add your custom middleware with use, that push the middleware onto the stack, and you can also control where the middleware is inserted using insert, insert_before and insert_after.
```

Notable example:

```ruby
class CustomOverwriter < Grape::Middleware::Base
  def after
    [200, { 'Content-Type' => 'text/plain' }, [@options[:message]]]
  end
end

class API < Grape::API
  use Overwriter
  insert_before Overwriter, CustomOverwriter, message: 'Overwritten again.'
  insert 0, CustomOverwriter, message: 'Overwrites all other middleware.'

  get '/' do
  end
end
```

This was added in https://github.com/ruby-grape/grape/commit/c2e41f72b344f478abdfdc780461963a994838d3 but it appears that the `insert` method was missed from the public API and only exposed on the internal middleware stack class.

### Any specific implementation details?

I added the CHANGELOG entry under `Fixes` as it is 'fixing' a discrepancy between the documentation and the code but unsure whether it belongs best under this or under `Features`. 