### PR TITLE
Fix route requirements bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Your contribution here.
 * [#1776](https://github.com/ruby-grape/grape/pull/1776): Validate response returned by the exception handler - [@darren987469](https://github.com/darren987469).
 * [#1787](https://github.com/ruby-grape/grape/pull/1787): Add documented but not implemented ability to `.insert` a middleware in the stack - [@michaellennox](https://github.com/michaellennox).
+* [#1788](https://github.com/ruby-grape/grape/pull/1788): Fix route requirements bug - [@darren987469](https://github.com/darren987469), [@darrellnash](https://github.com/darrellnash).
 
 ### 1.1.0 (8/4/2018)
 

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -200,7 +200,7 @@ module Grape
     end
 
     def merge_route_options(**default)
-      options[:route_options].clone.reverse_merge(**default)
+      options[:route_options].clone.merge(**default)
     end
 
     def map_routes

--- a/spec/grape/api/routes_with_requirements_spec.rb
+++ b/spec/grape/api/routes_with_requirements_spec.rb
@@ -22,7 +22,7 @@ describe Grape::Endpoint do
 
     it 'routes to a path with multiple params with dots' do
       subject.get ':id_with_dots/:another_id_with_dots', requirements: { id_with_dots: %r{[^\/]+},
-                                                                         another_id_with_dots: %r{[^\/]+} }  do
+                                                                         another_id_with_dots: %r{[^\/]+} } do
         "#{params[:id_with_dots]}/#{params[:another_id_with_dots]}"
       end
 

--- a/spec/grape/api/routes_with_requirements_spec.rb
+++ b/spec/grape/api/routes_with_requirements_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe Grape::Endpoint do
+  subject { Class.new(Grape::API) }
+
+  def app
+    subject
+  end
+
+  context 'get' do
+    it 'routes to a namespace param with dots' do
+      subject.namespace ':ns_with_dots', requirements: { ns_with_dots: %r{[^\/]+} } do
+        get '/' do
+          params[:ns_with_dots]
+        end
+      end
+
+      get '/test.id.with.dots'
+      expect(last_response.status).to eq 200
+      expect(last_response.body).to eq 'test.id.with.dots'
+    end
+
+    it 'routes to a path with multiple params with dots' do
+      subject.get ':id_with_dots/:another_id_with_dots', requirements: { id_with_dots: %r{[^\/]+},
+                                                                         another_id_with_dots: %r{[^\/]+} }  do
+        "#{params[:id_with_dots]}/#{params[:another_id_with_dots]}"
+      end
+
+      get '/test.id/test2.id'
+      expect(last_response.status).to eq 200
+      expect(last_response.body).to eq 'test.id/test2.id'
+    end
+
+    it 'routes to namespace and path params with dots, with overridden requirements' do
+      subject.namespace ':ns_with_dots', requirements: { ns_with_dots: %r{[^\/]+} } do
+        get ':another_id_with_dots',     requirements: { ns_with_dots: %r{[^\/]+},
+                                                         another_id_with_dots: %r{[^\/]+} } do
+          "#{params[:ns_with_dots]}/#{params[:another_id_with_dots]}"
+        end
+      end
+
+      get '/test.id/test2.id'
+      expect(last_response.status).to eq 200
+      expect(last_response.body).to eq 'test.id/test2.id'
+    end
+
+    it 'routes to namespace and path params with dots, with merged requirements' do
+      subject.namespace ':ns_with_dots', requirements: { ns_with_dots: %r{[^\/]+} } do
+        get ':another_id_with_dots',     requirements: { another_id_with_dots: %r{[^\/]+} } do
+          "#{params[:ns_with_dots]}/#{params[:another_id_with_dots]}"
+        end
+      end
+
+      get '/test.id/test2.id'
+      expect(last_response.status).to eq 200
+      expect(last_response.body).to eq 'test.id/test2.id'
+    end
+  end
+end


### PR DESCRIPTION
Fix spec in #1787 

This was a bug introduced by commit 9f4ba67. 

The commit replaces [options[:route_options].clone.merge(...)](https://github.com/ruby-grape/grape/commit/9f4ba67#diff-8e15cddb80f42ca7d43872846d80ecbeL176) with [options[:route_options].clone.reverse_merge(...)](https://github.com/ruby-grape/grape/commit/9f4ba67#diff-8e15cddb80f42ca7d43872846d80ecbeR179).
That causes disappear of the requirements in namespace.
