### PR TITLE
Handle improper Accept headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * Your contribution here.
+* [#1795](https://github.com/ruby-grape/grape/pull/1795): Fix Accept header parsing bug - [@bschmeck](https://github.com/bschmeck)
 * [#1791](https://github.com/ruby-grape/grape/pull/1791): Support `summary`, `hidden`, `deprecated`, `is_array`, `nickname`, `produces`, `consumes`, `tags` options in `desc` block - [@darren987469](https://github.com/darren987469).
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 #### Features
 
 * Your contribution here.
-* [#1795](https://github.com/ruby-grape/grape/pull/1795): Fix Accept header parsing bug - [@bschmeck](https://github.com/bschmeck)
+* [#1795](https://github.com/ruby-grape/grape/pull/1795): Fix vendor/subtype parsing of an invalid Accept header. - [@bschmeck](https://github.com/bschmeck)
 * [#1791](https://github.com/ruby-grape/grape/pull/1791): Support `summary`, `hidden`, `deprecated`, `is_array`, `nickname`, `produces`, `consumes`, `tags` options in `desc` block - [@darren987469](https://github.com/darren987469).
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 #### Features
 
 * Your contribution here.
-* [#1795](https://github.com/ruby-grape/grape/pull/1795): Fix vendor/subtype parsing of an invalid Accept header. - [@bschmeck](https://github.com/bschmeck)
+* [#1795](https://github.com/ruby-grape/grape/pull/1795): Fix vendor/subtype parsing of an invalid Accept header - [@bschmeck](https://github.com/bschmeck).
 * [#1791](https://github.com/ruby-grape/grape/pull/1791): Support `summary`, `hidden`, `deprecated`, `is_array`, `nickname`, `produces`, `consumes`, `tags` options in `desc` block - [@darren987469](https://github.com/darren987469).
 
 #### Fixes

--- a/lib/grape/middleware/versioner/header.rb
+++ b/lib/grape/middleware/versioner/header.rb
@@ -173,7 +173,7 @@ module Grape
         # @return [Boolean] whether the content type sets a vendor
         def vendor?(media_type)
           _, subtype = Rack::Accept::Header.parse_media_type(media_type)
-          subtype[HAS_VENDOR_REGEX]
+          subtype.present? && subtype[HAS_VENDOR_REGEX]
         end
 
         def request_vendor(media_type)
@@ -190,7 +190,7 @@ module Grape
         # @return [Boolean] whether the content type sets an API version
         def version?(media_type)
           _, subtype = Rack::Accept::Header.parse_media_type(media_type)
-          subtype[HAS_VERSION_REGEX]
+          subtype.present? && subtype[HAS_VERSION_REGEX]
         end
       end
     end

--- a/spec/grape/middleware/versioner/header_spec.rb
+++ b/spec/grape/middleware/versioner/header_spec.rb
@@ -160,6 +160,12 @@ describe Grape::Middleware::Versioner::Header do
     expect(subject.call({}).first).to eq(200)
   end
 
+  it 'succeeds if :strict is set to false and given an invalid header' do
+    @options[:version_options][:strict] = false
+    expect(subject.call('HTTP_ACCEPT' => 'yaml').first).to eq(200)
+    expect(subject.call({}).first).to eq(200)
+  end
+
   context 'when :strict is set' do
     before do
       @options[:versions] = ['v1']


### PR DESCRIPTION
We have observed situations where our API has received a request from a network scanner that has an improperly formatted Accept header.  In these cases, `Rack:Accept::Header.parse_media_type` returns an empty array (https://github.com/mjackson/rack-accept/blob/master/lib/rack/accept/header.rb#L42) and `subtype` is set to `nil`.

This PR checks that we actually received a subtype before checking against the vendor and version regexes.