### PR TITLE
Remountable APIs, allows to re-mount APIs that inherit from this class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * Your contribution here.
+* [#1802](https://github.com/ruby-grape/grape/pull/1802): Adds the ability to re-mount endpoints that inherit from RemountableAPI - [@myxoh](https://github.com/myxoh).
 * [#1795](https://github.com/ruby-grape/grape/pull/1795): Fix vendor/subtype parsing of an invalid Accept header - [@bschmeck](https://github.com/bschmeck).
 * [#1791](https://github.com/ruby-grape/grape/pull/1791): Support `summary`, `hidden`, `deprecated`, `is_array`, `nickname`, `produces`, `consumes`, `tags` options in `desc` block - [@darren987469](https://github.com/darren987469).
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
   - [Alongside Sinatra (or other frameworks)](#alongside-sinatra-or-other-frameworks)
   - [Rails](#rails)
   - [Modules](#modules)
+- [Remounting](#remounting)
+  - [Configuration](#configuration)
 - [Versioning](#versioning)
   - [Path](#path)
   - [Header](#header)

--- a/README.md
+++ b/README.md
@@ -366,6 +366,59 @@ class Twitter::API < Grape::API
 end
 ```
 
+## Remounting
+
+You can mount the same endpoints in two different locations using `RemountableAPI`
+
+```ruby
+class Voting::API < Grape::RemountableAPI
+  namespace 'votes' do
+    get do
+      # Your logic
+    end
+
+    post do
+      # Your logic
+    end
+  end
+end
+
+class Post::API < Grape::API
+  mount Voting::API
+end
+
+class Comment::API < Grape::API
+  mount Voting::API
+end
+```
+
+Assuming that the post and comment endpoints are mounted in `/posts` and `/comments`,
+you should now be able to do `get /posts/votes`, `post /posts/votes`, `get /comments/votes`
+
+### Configuration
+
+You can configure remountable endpoints for small details changing according to where
+they are mounted
+
+```ruby
+class Voting::API < Grape::RemountableAPI
+  namespace 'votes' do
+    desc "Vote for your #{configuration[:votable]}"
+    get do
+      # Your logic
+    end
+  end
+end
+
+class Post::API < Grape::API
+  mount Voting::API, with: {votable: 'posts'}
+end
+
+class Comment::API < Grape::API
+  mount Voting::API, with: {votable: 'comments'}
+end
+```
+
 ## Versioning
 
 There are four strategies in which clients can reach your API's endpoints: `:path`,

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -29,6 +29,7 @@ module Grape
 
   eager_autoload do
     autoload :API
+    autoload :RemountableAPI
     autoload :Endpoint
 
     autoload :Namespace

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -77,9 +77,12 @@ module Grape
           namespace_inheritable(:do_not_route_options, true)
         end
 
-        def mount(mounts)
+        def mount(mounts, with: {})
           mounts = { mounts => '/' } unless mounts.respond_to?(:each_pair)
           mounts.each_pair do |app, path|
+            if app.is_a?(Class) && app.ancestors.include?(Grape::RemountableAPI)
+              return mount(app.new_instance(configuration: with) => path)
+            end
             in_setting = inheritable_setting
 
             if app.respond_to?(:inheritable_setting, true)

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -80,8 +80,8 @@ module Grape
         def mount(mounts, with: {})
           mounts = { mounts => '/' } unless mounts.respond_to?(:each_pair)
           mounts.each_pair do |app, path|
-            if app.is_a?(Class) && app.ancestors.include?(Grape::RemountableAPI)
-              return mount(app.new_instance(configuration: with) => path)
+            if app.respond_to?(:mount_instance)
+              return mount(app.mount_instance(configuration: with) => path)
             end
             in_setting = inheritable_setting
 

--- a/lib/grape/remountable_api.rb
+++ b/lib/grape/remountable_api.rb
@@ -1,0 +1,64 @@
+module Grape
+  # The RemountableAPI class can replace most API classes, except for the base one that is to be mounted in rack.
+  # should subclass this class in order to build an API.
+  class RemountableAPI
+    class << self
+      # When inherited, will create a list of all instances (times the API was mounted)
+      # It will listen to the setup required to mount that endpoint, and replicate it on any new instance
+      def inherited(remountable_class)
+        remountable_class.instance_variable_set(:@instances, [])
+        remountable_class.instance_variable_set(:@setup, [])
+
+        base_instance = Class.new(Grape::API)
+        base_instance.define_singleton_method(:configuration) { {} }
+
+        remountable_class.instance_variable_set(:@base_instance, base_instance)
+        base_instance.constants.each do |constant_name|
+          remountable_class.const_set(constant_name, base_instance.const_get(constant_name))
+        end
+      end
+
+      # The remountable class can have a configuration hash to provide some dynamic class-level variables.
+      # For instance, a descripcion could be done using: `desc configuration[:description]` if it may vary
+      # depending on where the endpoint is mounted. Use with care, if you find yourself using configuration
+      # too much, you may actually want to provide a new API rather than remount it.
+      def new_instance(configuration: {})
+        instance = Class.new(Grape::API)
+        instance.instance_variable_set(:@configuration, configuration)
+        instance.define_singleton_method(:configuration) { @configuration }
+        replay_setup_on(instance)
+        @instances << instance
+        instance
+      end
+
+      # Replays the set up to produce an API as defined in this class, can be called
+      # on classes that inherit from Grape::API
+      def replay_setup_on(instance)
+        @setup.each do |setup_stage|
+          instance.send(setup_stage[:method], *setup_stage[:args], &setup_stage[:block])
+        end
+      end
+
+      private
+
+      # Adds a new stage to the set up require to get a Grape::API up and running
+      def add_setup(method, *args, &block)
+        setup_stage = { method: method, args: args, block: block }
+        @setup << setup_stage
+        @base_instance.send(setup_stage[:method], *setup_stage[:args], &setup_stage[:block])
+      end
+
+      def method_missing(method, *args, &block)
+        if respond_to_missing?(method, true)
+          add_setup(method, *args, &block)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(name, include_private = false)
+        @base_instance.respond_to?(name, include_private)
+      end
+    end
+  end
+end

--- a/spec/grape/remountable_api_spec.rb
+++ b/spec/grape/remountable_api_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+require 'shared/versioning_examples'
+
+describe Grape::RemountableAPI do
+  subject(:a_remountable_api) { Class.new(Grape::RemountableAPI) }
+  let(:root_api) { Class.new(Grape::API) }
+
+  def app
+    root_api
+  end
+
+  describe 'mounted RemountableAPI' do
+    context 'with a defined route' do
+      before do
+        a_remountable_api.get '/votes' do
+          '10 votes'
+        end
+      end
+
+      context 'when mounting one instance' do
+        before do
+          root_api.mount a_remountable_api
+        end
+
+        it 'can access the endpoint' do
+          get '/votes'
+          expect(last_response.body).to eql '10 votes'
+        end
+      end
+
+      context 'when mounting twice' do
+        before do
+          root_api.mount a_remountable_api => '/posts'
+          root_api.mount a_remountable_api => '/comments'
+        end
+
+        it 'can access the votes in both places' do
+          get '/posts/votes'
+          expect(last_response.body).to eql '10 votes'
+          get '/comments/votes'
+          expect(last_response.body).to eql '10 votes'
+        end
+      end
+
+      context 'when mounting on namespace' do
+        before do
+          stub_const('StaticRefToAPI', a_remountable_api)
+          root_api.namespace 'posts' do
+            mount StaticRefToAPI
+          end
+
+          root_api.namespace 'comments' do
+            mount StaticRefToAPI
+          end
+        end
+
+        it 'can access the votes in both places' do
+          get '/posts/votes'
+          expect(last_response.body).to eql '10 votes'
+          get '/comments/votes'
+          expect(last_response.body).to eql '10 votes'
+        end
+      end
+    end
+
+    context 'with a dynamically configured route' do
+      before do
+        a_remountable_api.namespace 'api' do
+          get "/#{configuration[:path]}" do
+            '10 votes'
+          end
+        end
+        root_api.mount a_remountable_api, with: { path: 'votes' }
+        root_api.mount a_remountable_api, with: { path: 'scores' }
+      end
+
+      it 'will use the dynamic configuration on all routes' do
+        get 'api/votes'
+        expect(last_response.body).to eql '10 votes'
+        get 'api/scores'
+        expect(last_response.body).to eql '10 votes'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Addresses this feature request: https://github.com/ruby-grape/grape/issues/570

A lot of times (specially when using versioning) we want to re-mount an endpoint in a different namespace, perhaps with some tiny bit of different configuration each time.

On our project, for example, we have a massive API using Grape, and while we want to introduce versioning we don't want to: 
1- Have to copy & paste the whole project (nor re-write the whole project at once), 
2- Have to re-write our project to use one of the proposed meta-programming approaches.

As such, this solution allows you to replace Grape::API for Grape::RemountableAPI on inheritance, and with that alone the API will now be mountable in several places.

This is a first pass, but I'd appreciate feedback and comments