### PR TITLE
Add YARD configuration

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+--asset grape.png


### PR DESCRIPTION
This should fix the broken logo in https://www.rubydoc.info/gems/grape/1.1.0.