### PR TITLE
Fix alias on dependent param bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * [#1776](https://github.com/ruby-grape/grape/pull/1776): Validate response returned by the exception handler - [@darren987469](https://github.com/darren987469).
 * [#1787](https://github.com/ruby-grape/grape/pull/1787): Add documented but not implemented ability to `.insert` a middleware in the stack - [@michaellennox](https://github.com/michaellennox).
 * [#1788](https://github.com/ruby-grape/grape/pull/1788): Fix route requirements bug - [@darren987469](https://github.com/darren987469), [@darrellnash](https://github.com/darrellnash).
-* [#1810](https://github.com/ruby-grape/grape/pull/1810): Fix alias on dependent param bug - [@darren987469](https://github.com/darren987469).
+* [#1810](https://github.com/ruby-grape/grape/pull/1810): Fix support in `given` for aliased params - [@darren987469](https://github.com/darren987469).
 
 ### 1.1.0 (8/4/2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#1776](https://github.com/ruby-grape/grape/pull/1776): Validate response returned by the exception handler - [@darren987469](https://github.com/darren987469).
 * [#1787](https://github.com/ruby-grape/grape/pull/1787): Add documented but not implemented ability to `.insert` a middleware in the stack - [@michaellennox](https://github.com/michaellennox).
 * [#1788](https://github.com/ruby-grape/grape/pull/1788): Fix route requirements bug - [@darren987469](https://github.com/darren987469), [@darrellnash](https://github.com/darrellnash).
+* [#1810](https://github.com/ruby-grape/grape/pull/1810): Fix alias on dependent param bug - [@darren987469](https://github.com/darren987469).
 
 ### 1.1.0 (8/4/2018)
 

--- a/README.md
+++ b/README.md
@@ -1175,6 +1175,18 @@ params do
 end
 ```
 
+You can set alias for parameter:
+
+```ruby
+params do
+  optional :category, as: :type
+  given type: ->(val) { val == 'foo' } do
+    requires :description
+  end
+end
+```
+
+Note: param in `given` should be the aliased one. In the example, it should be `type`, not `category`.
 
 ### Group Options
 

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -121,6 +121,7 @@ module Grape
           if opts && opts[:as]
             @api.route_setting(:aliased_params, @api.route_setting(:aliased_params) || [])
             @api.route_setting(:aliased_params) << { attrs.first => opts[:as] }
+            attrs = [opts[:as]]
           end
 
           @declared_params.concat attrs

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -497,6 +497,23 @@ describe Grape::Validations::ParamsScope do
       expect(body.keys).to_not include('b')
     end
 
+    it 'allows aliasing of dependent on parameter' do
+      subject.params do
+        optional :a, as: :b
+        given b: ->(val) { val == 'x' } do
+          requires :c
+        end
+      end
+      subject.get('/') { declared(params) }
+
+      get '/', a: 'x'
+      expect(last_response.status).to eq 400
+      expect(last_response.body).to eq 'c is missing'
+
+      get '/', a: 'y'
+      expect(last_response.status).to eq 200
+    end
+
     it 'does not validate nested requires when given is false' do
       subject.params do
         requires :a, type: String, allow_blank: false, values: %w[x y z]

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -514,6 +514,17 @@ describe Grape::Validations::ParamsScope do
       expect(last_response.status).to eq 200
     end
 
+    it 'raises an error if the dependent parameter is not the aliased one' do
+      expect do
+        subject.params do
+          optional :a, as: :b
+          given :a do
+            requires :c
+          end
+        end
+      end.to raise_error(Grape::Exceptions::UnknownParameter)
+    end
+
     it 'does not validate nested requires when given is false' do
       subject.params do
         requires :a, type: String, allow_blank: false, values: %w[x y z]


### PR DESCRIPTION
Fixes #1808 

> It seems like we cannot access to the value inside the proc for an alias param
> 
> ```ruby
> requires :type, as: :action
> given type: ->(val) { ActionService::ACTIONS.include?(val) } do #val not present inside the proc
>   requires :comment, type: String
> end
> ```

The root cause is `as: :action` alias would change `params` from `{ type: 'some type' }` to `{ action: 'some type' }` in as validator.
https://github.com/ruby-grape/grape/blob/3bb835a747f8ef2a9542ef2e6b66c795f377dd87/lib/grape/validations/validators/as.rb#L9-L12
When checking `->(val) { ActionService::ACTIONS.include?(val) }` in the following snippet(line 61), dependency_key is still `:type`, so params[:type] is nil because the params is changed in previous validator. 
https://github.com/ruby-grape/grape/blob/3bb835a747f8ef2a9542ef2e6b66c795f377dd87/lib/grape/validations/params_scope.rb#L57-L65

The idea to fix is let attribute name in `given` the same as the aliased one. That means the usage now becomes:

```ruby
reuiqres :type, as: :action
given action: ->(val) { ... }
```