### PR TITLE
Support nested dependent parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#1787](https://github.com/ruby-grape/grape/pull/1787): Add documented but not implemented ability to `.insert` a middleware in the stack - [@michaellennox](https://github.com/michaellennox).
 * [#1788](https://github.com/ruby-grape/grape/pull/1788): Fix route requirements bug - [@darren987469](https://github.com/darren987469), [@darrellnash](https://github.com/darrellnash).
 * [#1810](https://github.com/ruby-grape/grape/pull/1810): Fix support in `given` for aliased params - [@darren987469](https://github.com/darren987469).
+* [#1811](https://github.com/ruby-grape/grape/pull/1811): Support nested dependent parameters - [@darren987469](https://github.com/darren987469), [@andreacfm](https://github.com/andreacfm).
 
 ### 1.1.0 (8/4/2018)
 

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -211,10 +211,15 @@ module Grape
       # block yet.
       # @return [Boolean] whether the parameter has been defined
       def declared_param?(param)
-        # @declared_params also includes hashes of options and such, but those
-        # won't be flattened out.
-        @declared_params.flatten.any? do |declared_param|
-          first_hash_key_or_param(declared_param) == param
+        if lateral?
+          # Elements of @declared_params of lateral scope are pushed in @parent. So check them in @parent.
+          @parent.declared_param?(param)
+        else
+          # @declared_params also includes hashes of options and such, but those
+          # won't be flattened out.
+          @declared_params.flatten.any? do |declared_param|
+            first_hash_key_or_param(declared_param) == param
+          end
         end
       end
 

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -479,6 +479,22 @@ describe Grape::Validations::ParamsScope do
       end.to_not raise_error
     end
 
+    it 'does not raise an error if when using nested given' do
+      expect do
+        subject.params do
+          optional :a, type: Hash do
+            requires :b
+          end
+          given :a do
+            requires :c
+            given :c do
+              requires :d
+            end
+          end
+        end
+      end.to_not raise_error
+    end
+
     it 'allows aliasing of dependent parameters' do
       subject.params do
         optional :a

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -495,6 +495,33 @@ describe Grape::Validations::ParamsScope do
       end.to_not raise_error
     end
 
+    it 'allows nested dependent parameters' do
+      subject.params do
+        optional :a
+        given a: ->(val) { val == 'a' } do
+          optional :b
+          given b: ->(val) { val == 'b' } do
+            optional :c
+            given c: ->(val) { val == 'c' } do
+              requires :d
+            end
+          end
+        end
+      end
+      subject.get('/') { declared(params).to_json }
+
+      get '/'
+      expect(last_response.status).to eq 200
+
+      get '/', a: 'a', b: 'b', c: 'c'
+      expect(last_response.status).to eq 400
+      expect(last_response.body).to eq 'd is missing'
+
+      get '/', a: 'a', b: 'b', c: 'c', d: 'd'
+      expect(last_response.status).to eq 200
+      expect(last_response.body).to eq({ a: 'a', b: 'b', c: 'c', d: 'd' }.to_json)
+    end
+
     it 'allows aliasing of dependent parameters' do
       subject.params do
         optional :a


### PR DESCRIPTION
Fixes #1800. Continue of #1804.

`given` will check whether attribute is declared in its scope.
If not, it [raises an error](https://github.com/ruby-grape/grape/blob/b8b85af12ad4860b6ee4ae2074f864a849400209/lib/grape/dsl/parameters.rb#L202-L208).

```ruby
optional :a
given a: ->(val) { val == 'a' } do
  optional :b
  given b: ->(val) { val == 'b' } do
    requires :c
  end
end
```

In the example, [`optional :a` creates a scope](https://github.com/ruby-grape/grape/blob/master/lib/grape/dsl/parameters.rb#L160). [`given a: ...` creates
another scope](https://github.com/ruby-grape/grape/blob/master/lib/grape/dsl/parameters.rb#L207), which parent scope is the one created by `optional :a`,
and [attributes `:b` declared in `optional :b` is pushed to parent scope](https://github.com/ruby-grape/grape/blob/b8b85af12ad4860b6ee4ae2074f864a849400209/lib/grape/validations/params_scope.rb#L117-L129).

The bug here is `given b: ...` cannot find `:b` in its scope. Since the
attribute `:b` is pushed to its parent scope. So, [fix the code](https://github.com/ruby-grape/grape/pull/1811/files#diff-720e18632121176ab27887e38663f186R216) to
check attribute in its parent scope if it has parent scope.