### PR TITLE
Add ruby 2.5 support, drop 2.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     - rvm: 2.5.3
       gemfile: gemfiles/rack_edge.gemfile
     - rvm: 2.5.3
-      gemfile: gemfiles/rack_1.5.2.gemfile
+      gemfile: gemfiles/rack_1.5.5.gemfile
     - rvm: 2.5.3
       gemfile: gemfiles/rails_edge.gemfile
     - rvm: 2.5.3
@@ -32,7 +32,7 @@ matrix:
     - rvm: 2.4.5
       gemfile: gemfiles/rack_edge.gemfile
     - rvm: 2.4.5
-      gemfile: gemfiles/rack_1.5.2.gemfile
+      gemfile: gemfiles/rack_1.5.5.gemfile
     - rvm: 2.4.5
       gemfile: gemfiles/rails_5.gemfile
     - rvm: 2.3.8
@@ -40,7 +40,7 @@ matrix:
     - rvm: 2.3.8
       gemfile: gemfiles/rack_edge.gemfile
     - rvm: 2.3.8
-      gemfile: gemfiles/rack_1.5.2.gemfile
+      gemfile: gemfiles/rack_1.5.5.gemfile
     - rvm: 2.3.8
       gemfile: gemfiles/rails_5.gemfile
     - rvm: 2.2.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,46 +4,46 @@ sudo: false
 
 matrix:
   include:
-    - rvm: 2.4.2
+    - rvm: 2.4.5
       script:
         - bundle exec danger
-    - rvm: 2.4.2
+    - rvm: 2.4.5
       gemfile: Gemfile
-    - rvm: 2.4.2
+    - rvm: 2.4.5
       gemfile: gemfiles/rack_edge.gemfile
-    - rvm: 2.4.2
+    - rvm: 2.4.5
       gemfile: gemfiles/rack_1.5.2.gemfile
-    - rvm: 2.4.2
+    - rvm: 2.4.5
       gemfile: gemfiles/rails_edge.gemfile
-    - rvm: 2.4.2
+    - rvm: 2.4.5
       gemfile: gemfiles/rails_5.gemfile
-    - rvm: 2.4.2
+    - rvm: 2.4.5
       gemfile: gemfiles/multi_json.gemfile
       script:
         - bundle exec rake
         - bundle exec rspec spec/integration/multi_json
-    - rvm: 2.4.2
+    - rvm: 2.4.5
       gemfile: gemfiles/multi_xml.gemfile
       script:
         - bundle exec rake
         - bundle exec rspec spec/integration/multi_xml
-    - rvm: 2.3.5
+    - rvm: 2.3.8
       gemfile: Gemfile
-    - rvm: 2.3.5
+    - rvm: 2.3.8
       gemfile: gemfiles/rack_edge.gemfile
-    - rvm: 2.3.5
+    - rvm: 2.3.8
       gemfile: gemfiles/rack_1.5.2.gemfile
-    - rvm: 2.3.5
+    - rvm: 2.3.8
       gemfile: gemfiles/rails_5.gemfile
-    - rvm: 2.2.8
+    - rvm: 2.2.10
       gemfile: Gemfile
-    - rvm: 2.2.8
+    - rvm: 2.2.10
       gemfile: gemfiles/rack_1.5.2.gemfile
-    - rvm: 2.2.8
+    - rvm: 2.2.10
       gemfile: gemfiles/rails_5.gemfile
-    - rvm: 2.2.8
+    - rvm: 2.2.10
       gemfile: gemfiles/rails_4.gemfile
-    - rvm: 2.2.8
+    - rvm: 2.2.10
       gemfile: gemfiles/rails_3.gemfile
     - rvm: ruby-head
     - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,29 +4,37 @@ sudo: false
 
 matrix:
   include:
-    - rvm: 2.4.5
+    - rvm: 2.5.3
       script:
         - bundle exec danger
-    - rvm: 2.4.5
+    - rvm: 2.5.3
       gemfile: Gemfile
-    - rvm: 2.4.5
+    - rvm: 2.5.3
       gemfile: gemfiles/rack_edge.gemfile
-    - rvm: 2.4.5
+    - rvm: 2.5.3
       gemfile: gemfiles/rack_1.5.2.gemfile
-    - rvm: 2.4.5
+    - rvm: 2.5.3
       gemfile: gemfiles/rails_edge.gemfile
-    - rvm: 2.4.5
+    - rvm: 2.5.3
       gemfile: gemfiles/rails_5.gemfile
-    - rvm: 2.4.5
+    - rvm: 2.5.3
       gemfile: gemfiles/multi_json.gemfile
       script:
         - bundle exec rake
         - bundle exec rspec spec/integration/multi_json
-    - rvm: 2.4.5
+    - rvm: 2.5.3
       gemfile: gemfiles/multi_xml.gemfile
       script:
         - bundle exec rake
         - bundle exec rspec spec/integration/multi_xml
+    - rvm: 2.4.5
+      gemfile: Gemfile
+    - rvm: 2.4.5
+      gemfile: gemfiles/rack_edge.gemfile
+    - rvm: 2.4.5
+      gemfile: gemfiles/rack_1.5.2.gemfile
+    - rvm: 2.4.5
+      gemfile: gemfiles/rails_5.gemfile
     - rvm: 2.3.8
       gemfile: Gemfile
     - rvm: 2.3.8
@@ -36,19 +44,11 @@ matrix:
     - rvm: 2.3.8
       gemfile: gemfiles/rails_5.gemfile
     - rvm: 2.2.10
-      gemfile: Gemfile
-    - rvm: 2.2.10
-      gemfile: gemfiles/rack_1.5.2.gemfile
-    - rvm: 2.2.10
-      gemfile: gemfiles/rails_5.gemfile
-    - rvm: 2.2.10
-      gemfile: gemfiles/rails_4.gemfile
-    - rvm: 2.2.10
-      gemfile: gemfiles/rails_3.gemfile
     - rvm: ruby-head
     - rvm: jruby-head
     - rvm: rbx-3
   allow_failures:
+    - rvm: 2.2.10
     - rvm: ruby-head
     - rvm: jruby-head
     - rvm: rbx-3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 #### Features
 
 * Your contribution here.
-* [#1795](https://github.com/ruby-grape/grape/pull/1803): Adds the ability to re-mount all endpoints in any location - [@myxoh](https://github.com/bschmeck).
+* [#1813](https://github.com/ruby-grape/grape/pull/1813): Add ruby 2.5 support, drop 2.2. Update rails version in travis - [@darren987469](https://github.com/darren987469).
+* [#1803](https://github.com/ruby-grape/grape/pull/1803): Adds the ability to re-mount all endpoints in any location - [@myxoh](https://github.com/bschmeck).
 * [#1795](https://github.com/ruby-grape/grape/pull/1795): Fix vendor/subtype parsing of an invalid Accept header - [@bschmeck](https://github.com/bschmeck).
 * [#1791](https://github.com/ruby-grape/grape/pull/1791): Support `summary`, `hidden`, `deprecated`, `is_array`, `nickname`, `produces`, `consumes`, `tags` options in `desc` block - [@darren987469](https://github.com/darren987469).
 

--- a/gemfiles/rack_1.5.5.gemfile
+++ b/gemfiles/rack_1.5.5.gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'rack', '1.5.2'
+gem 'rack', '1.5.5'
 
 group :development, :test do
   gem 'bundler'

--- a/gemfiles/rails_3.gemfile
+++ b/gemfiles/rails_3.gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'rails', '3.2.19'
+gem 'rails', '3.2.22.5'
 gem 'rack-cache', '<= 1.2'
 
 group :development, :test do

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'rails', '4.1.6'
+gem 'rails', '4.2.10'
 
 group :development, :test do
   gem 'bundler'

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'rails', '5.0.0'
+gem 'rails', '5.2.1'
 
 group :development, :test do
   gem 'bundler'

--- a/spec/grape/integration/rack_spec.rb
+++ b/spec/grape/integration/rack_spec.rb
@@ -22,7 +22,7 @@ describe Rack do
       unless RUBY_PLATFORM == 'java'
         major, minor, patch = Rack.release.split('.').map(&:to_i)
         patch ||= 0 # rack <= 1.5.2 does not specify patch version
-        pending 'Rack 1.5.3 or 1.6.1 required' unless major >= 2 || (major >= 1 && ((minor == 5 && patch >= 3) || (minor >= 6)))
+        pending 'Rack 1.5.5 or 1.6.1 required' unless major >= 2 || (major >= 1 && ((minor == 5 && patch >= 5) || (minor >= 6)))
       end
 
       expect(JSON.parse(app.call(env)[2].body.first)['params_keys']).to match_array('test')


### PR DESCRIPTION
### Summary

* Update ruby, rails, rack version in travis.
* Add ruby 2.5 support, drop 2.2.

The new version of ruby is released.  Update travis settings.
Reference: https://www.ruby-lang.org/zh_tw/