### PR TITLE
Remount API regression spec

### DIFF
--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3209,6 +3209,43 @@ XML
           expect { a.mount b }.to_not raise_error
         end
       end
+
+      it 'should correctly include module in nested mount' do
+
+        module Test
+          def self.included(base)
+             base.extend(ClassMethods)
+          end
+          module ClassMethods
+            def my_method
+              @test = true
+            end
+          end
+        end
+
+        self.class.send :include, Test
+        expect(self.class.my_method).to be_truthy
+
+        v1 = Class.new(Grape::API) do
+          version :v1, using: :path
+          include Test
+          my_method
+        end
+        v2 = Class.new(Grape::API) do
+          version :v1, using: :path
+        end
+        segment_base = Class.new(Grape::API) do
+          mount v1
+          mount v2
+        end
+
+        base = Class.new(Grape::API) do
+           mount segment_base
+        end
+
+        expect(v1.my_method).to be_truthy
+
+      end
     end
   end
 


### PR DESCRIPTION
After introducing the ReMountable API branch nested mounted API are failing when including external modules.