### PR TITLE
Fixes methods defined on included modules after remountable APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 * Your contribution here.
 * [#1813](https://github.com/ruby-grape/grape/pull/1813): Add ruby 2.5 support, drop 2.2. Update rails version in travis - [@darren987469](https://github.com/darren987469).
-* [#1803](https://github.com/ruby-grape/grape/pull/1803): Adds the ability to re-mount all endpoints in any location - [@myxoh](https://github.com/bschmeck).
+* [#1803](https://github.com/ruby-grape/grape/pull/1803): Adds the ability to re-mount all endpoints in any location - [@myxoh](https://github.com/myxoh).
 * [#1795](https://github.com/ruby-grape/grape/pull/1795): Fix vendor/subtype parsing of an invalid Accept header - [@bschmeck](https://github.com/bschmeck).
 * [#1791](https://github.com/ruby-grape/grape/pull/1791): Support `summary`, `hidden`, `deprecated`, `is_array`, `nickname`, `produces`, `consumes`, `tags` options in `desc` block - [@darren987469](https://github.com/darren987469).
 
 #### Fixes
 
-* Your contribution here.
+* [#1818](https://github.com/ruby-grape/grape/pull/1818): Fixes methods defined on included modules after remountable apis - [@myxoh](https://github.com/myxoh).
 * [#1796](https://github.com/ruby-grape/grape/pull/1796): Fix crash when available locales are enforced but fallback locale unavailable - [@Morred](https://github.com/Morred).
 * [#1776](https://github.com/ruby-grape/grape/pull/1776): Validate response returned by the exception handler - [@darren987469](https://github.com/darren987469).
 * [#1787](https://github.com/ruby-grape/grape/pull/1787): Add documented but not implemented ability to `.insert` a middleware in the stack - [@michaellennox](https://github.com/michaellennox).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 #### Fixes
 
-* [#1818](https://github.com/ruby-grape/grape/pull/1818): Fixes methods defined on included modules after remountable apis - [@myxoh](https://github.com/myxoh).
+* Your contribution here.
 * [#1796](https://github.com/ruby-grape/grape/pull/1796): Fix crash when available locales are enforced but fallback locale unavailable - [@Morred](https://github.com/Morred).
 * [#1776](https://github.com/ruby-grape/grape/pull/1776): Validate response returned by the exception handler - [@darren987469](https://github.com/darren987469).
 * [#1787](https://github.com/ruby-grape/grape/pull/1787): Add documented but not implemented ability to `.insert` a middleware in the stack - [@michaellennox](https://github.com/michaellennox).

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3209,6 +3209,43 @@ XML
           expect { a.mount b }.to_not raise_error
         end
       end
+
+      it 'should correctly include module in nested mount' do
+
+        module Test
+          def self.included(base)
+             base.extend(ClassMethods)
+          end
+          module ClassMethods
+            def my_method
+              @test = true
+            end
+          end
+        end
+
+        self.class.send :include, Test
+        expect(self.class.my_method).to be_truthy
+
+        v1 = Class.new(Grape::API) do
+          version :v1, using: :path
+          include Test
+          my_method
+        end
+        v2 = Class.new(Grape::API) do
+          version :v1, using: :path
+        end
+        segment_base = Class.new(Grape::API) do
+          mount v1
+          mount v2
+        end
+
+        base = Class.new(Grape::API) do
+           mount segment_base
+        end
+
+        expect(v1.my_method).to be_truthy
+
+      end
     end
   end
 

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3211,10 +3211,9 @@ XML
       end
 
       it 'should correctly include module in nested mount' do
-
         module Test
           def self.included(base)
-             base.extend(ClassMethods)
+            base.extend(ClassMethods)
           end
           module ClassMethods
             def my_method
@@ -3232,19 +3231,18 @@ XML
           my_method
         end
         v2 = Class.new(Grape::API) do
-          version :v1, using: :path
+          version :v2, using: :path
         end
         segment_base = Class.new(Grape::API) do
           mount v1
           mount v2
         end
 
-        base = Class.new(Grape::API) do
-           mount segment_base
+        Class.new(Grape::API) do
+          mount segment_base
         end
 
         expect(v1.my_method).to be_truthy
-
       end
     end
   end


### PR DESCRIPTION
Related to the issue raised here:
https://github.com/ruby-grape/grape/issues/1815

Uses the following failing specs:
https://github.com/ruby-grape/grape/pull/1816