### PR TITLE
Fixes the issue with the autoloader #1815

### DIFF
--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -8,7 +8,7 @@ module Grape
     # Class methods that we want to call on the API rather than on the API object
     NON_OVERRIDABLE = %I[define_singleton_method instance_variable_set inspect class is_a? ! kind_of?
                          respond_to? respond_to_missing? const_defined? const_missing parent
-                         parent_name name equal? to_s parents].freeze
+                         parent_name name equal? to_s parents anonymous?].freeze
 
     class << self
       attr_accessor :base_instance, :instances


### PR DESCRIPTION
In order to properly use the autoloader, we do not want to delegate `anonymous?` to the instance.


This should fix most remaining issues with the autoloader in master: https://github.com/ruby-grape/grape/issues/1815

Sorry for the lack of specs. It's really hard to reproduce without setting up a new project.

This was tested using: https://github.com/myxoh/testing-grape/commits/master
(If you run rspec it crashes, when you add this commit, it stops crashing)