### PR TITLE
Exposes the name of the API  via `to_s` (Addresses #1825)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Your contribution here.
 * [#1825](https://github.com/ruby-grape/grape/pull/1825): `to_s` on a mounted class now responses with the API name - [@myxoh](https://github.com/myxoh).
 
-### 1.2.0 (29/11/2018)
+### 1.2.0 (11/29/2018)
 
 #### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#1825](https://github.com/ruby-grape/grape/pull/1825): `to_s` on a mounted class now responses with the API name - [@myxoh](https://github.com/myxoh).
 
 ### 1.2.0 (29/11/2018)
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -5,6 +5,8 @@ Upgrading Grape
 
 #### Changes in the Grape::API class
 
+##### Patching the class
+
 In an effort to make APIs re-mountable, The class `Grape::API` no longer refers to an API instance,
 rather, what used to be `Grape::API` is now `Grape::API::Instance` and `Grape::API` was replaced
 with a class that can contain several instances of `Grape::API`.
@@ -27,6 +29,23 @@ class Grape::API::Instance
   # your patched logic
   ...
 end
+```
+
+##### `name` (and other caveats) of the mounted API
+
+After the patch, the mounted API is no longer a Named class inheriting from `Grape::API`, it is an anonymous class
+which inherit from `Grape::API::Instance`.
+What this means in practice, is:
+- Generally: you can access the named class from the instance calling the getter `base`.
+- In particular: If you need the `name`, you can use `.to_s`, which will fallback on: `base`.`name`
+
+**Deprecated**
+```ruby
+  payload[:endpoint].options[:for].name
+```
+**New**
+```ruby
+  payload[:endpoint].options[:for].to_s # or `.base.name`
 ```
 
 #### Changes in rescue_from returned object

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,21 @@
 Upgrading Grape
 ===============
 
+### Upgrading to >= 1.2.1
+
+#### Obtaining the name of a mounted class
+
+In order to make obtaining the name of a mounted class simpler, we've delegated `.to_s` to `base.name`
+
+**Deprecated in 1.2.0**
+```ruby
+  payload[:endpoint].options[:for].name
+```
+**New**
+```ruby
+  payload[:endpoint].options[:for].to_s
+```
+
 ### Upgrading to >= 1.2.0
 
 #### Changes in the Grape::API class
@@ -37,7 +52,7 @@ After the patch, the mounted API is no longer a Named class inheriting from `Gra
 which inherit from `Grape::API::Instance`.
 What this means in practice, is:
 - Generally: you can access the named class from the instance calling the getter `base`.
-- In particular: If you need the `name`, you can use `.to_s`, which will fallback on: `base`.`name`
+- In particular: If you need the `name`, you can use `base`.`name`
 
 **Deprecated**
 ```ruby
@@ -45,7 +60,7 @@ What this means in practice, is:
 ```
 **New**
 ```ruby
-  payload[:endpoint].options[:for].to_s # or `.base.name`
+  payload[:endpoint].options[:for].base.name
 ```
 
 #### Changes in rescue_from returned object

--- a/lib/grape/api/instance.rb
+++ b/lib/grape/api/instance.rb
@@ -17,6 +17,10 @@ module Grape
           grape_api.instances << self
         end
 
+        def to_s
+          base&.to_s || super
+        end
+
         # A class-level lock to ensure the API is not compiled by multiple
         # threads simultaneously within the same process.
         LOCK = Mutex.new

--- a/lib/grape/api/instance.rb
+++ b/lib/grape/api/instance.rb
@@ -18,7 +18,7 @@ module Grape
         end
 
         def to_s
-          base&.to_s || super
+          (base && base.to_s) || super
         end
 
         # A class-level lock to ensure the API is not compiled by multiple

--- a/spec/grape/named_api_spec.rb
+++ b/spec/grape/named_api_spec.rb
@@ -1,13 +1,17 @@
 require 'spec_helper'
 
 describe 'A named API' do
-  NamedAPI = Class.new(Grape::API) do
-    get 'test' do
-      'response'
+  subject(:api_name) { NamedAPI.endpoints.last.options[:for].to_s }
+
+  let(:api) do
+    Class.new(Grape::API) do
+      get 'test' do
+        'response'
+      end
     end
   end
 
-  subject(:api_name) { NamedAPI.endpoints.last.options[:for].to_s }
+  before { stub_const('NamedAPI', api) }
 
   it 'can access the name of the API' do
     expect(api_name).to eq 'NamedAPI'

--- a/spec/grape/named_api_spec.rb
+++ b/spec/grape/named_api_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'A named API' do
+  NamedAPI = Class.new(Grape::API) do
+    get 'test' do
+      'response'
+    end
+  end
+
+  subject(:api_name) { NamedAPI.endpoints.last.options[:for].to_s }
+
+  it 'can access the name of the API' do
+    expect(api_name).to eq 'NamedAPI'
+  end
+end


### PR DESCRIPTION
Addresses: https://github.com/ruby-grape/grape/issues/1825

It does so by exposing the base's `to_s`