### PR TITLE
restores self_sanity Addresses #1829

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#1830](https://github.com/ruby-grape/grape/pull/1830): Restores self_sanity addresses #1829 - [@myxoh](https://github.com/myxoh).
 
 ### 1.2.1 (11/28/2018)
 

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -6,12 +6,16 @@ module Grape
   # should subclass this class in order to build an API.
   class API
     # Class methods that we want to call on the API rather than on the API object
-    NON_OVERRIDABLE = %I[define_singleton_method instance_variable_set inspect class is_a? ! kind_of?
-                         respond_to? respond_to_missing? const_defined? const_missing parent
-                         parent_name name equal? to_s parents anonymous?].freeze
+    NON_OVERRIDABLE = Class.new.methods.freeze
 
     class << self
       attr_accessor :base_instance, :instances
+
+      # Rather than initializing an object of type Grape::API, create an object of type Instance
+      def new(*args, &block)
+        base_instance.new(*args, &block)
+      end
+
       # When inherited, will create a list of all instances (times the API was mounted)
       # It will listen to the setup required to mount that endpoint, and replicate it on any new instance
       def inherited(api, base_instance_parent = Grape::API::Instance)

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3649,4 +3649,22 @@ XML
       end
     end
   end
+
+  describe 'normal class methods' do
+    subject(:grape_api) { Class.new(Grape::API) }
+
+    before do
+      stub_const('MyAPI', grape_api)
+    end
+
+    it 'can find the appropiate name' do
+      expect(grape_api.name).to eq 'MyAPI'
+    end
+
+    it 'is equal to itself' do
+      expect(grape_api.itself).to eq grape_api
+      expect(grape_api).to eq MyAPI
+      expect(grape_api.eql?(MyAPI))
+    end
+  end
 end


### PR DESCRIPTION
Thanks to https://github.com/ruby-grape/grape/issues/1829 I've realized that actually I could just avoid overriding all of the class methods, other than new, on the specs