### PR TITLE
Support security in desc block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#1831](https://github.com/ruby-grape/grape/pull/1831): Support security in desc block - [@fotos](https://github.com/fotos).
 * [#1830](https://github.com/ruby-grape/grape/pull/1830): Restores self_sanity addresses #1829 - [@myxoh](https://github.com/myxoh).
 
 ### 1.2.1 (2018/11/28)

--- a/lib/grape/dsl/desc.rb
+++ b/lib/grape/dsl/desc.rb
@@ -24,6 +24,7 @@ module Grape
       # @option options :nickname [String] nickname of the endpoint
       # @option options :produces [Array[String]] a list of MIME types the endpoint produce
       # @option options :consumes [Array[String]] a list of MIME types the endpoint consume
+      # @option options :security [Array[Hash]] a list of security schemes
       # @option options :tags [Array[String]] a list of tags
       # @yield a block yielding an instance context with methods mapping to
       #   each of the above, except that :entity is also aliased as #success
@@ -100,6 +101,7 @@ module Grape
             :nickname,
             :produces,
             :consumes,
+            :security,
             :tags
           )
 

--- a/lib/grape/dsl/desc.rb
+++ b/lib/grape/dsl/desc.rb
@@ -4,12 +4,12 @@ module Grape
       include Grape::DSL::Settings
 
       # Add a description to the next namespace or function.
-      # @option options :summary [String] summary for this endpoint
       # @param description [String] descriptive string for this endpoint
       #   or namespace
       # @param options [Hash] other properties you can set to describe the
       #   endpoint or namespace. Optional.
       # @option options :detail [String] additional detail about this endpoint
+      # @option options :summary [String] summary for this endpoint
       # @option options :params [Hash] param types and info. normally, you set
       #   these via the `params` dsl method.
       # @option options :entity [Grape::Entity] the entity returned upon a

--- a/spec/grape/dsl/desc_spec.rb
+++ b/spec/grape/dsl/desc_spec.rb
@@ -44,7 +44,8 @@ module Grape
             nickname: 'nickname',
             produces: %w[array of mime_types],
             consumes: %w[array of mime_types],
-            tags: %w[tag1 tag2]
+            tags: %w[tag1 tag2],
+            security: %w[array of security schemes]
           }
 
           subject.desc 'The description' do
@@ -71,6 +72,7 @@ module Grape
             produces %w[array of mime_types]
             consumes %w[array of mime_types]
             tags %w[tag1 tag2]
+            security %w[array of security schemes]
           end
 
           expect(subject.namespace_setting(:description)).to eq(expected_options)

--- a/spec/grape/dsl/desc_spec.rb
+++ b/spec/grape/dsl/desc_spec.rb
@@ -28,14 +28,16 @@ module Grape
             entity: Object,
             http_codes: [[401, 'Unauthorized', 'Entities::Error']],
             named: 'My named route',
-            headers: [XAuthToken: {
-              description: 'Valdates your identity',
-              required: true
-            },
-                      XOptionalHeader: {
-                        description: 'Not really needed',
-                        required: false
-                      }],
+            headers: [
+              XAuthToken: {
+                description: 'Valdates your identity',
+                required: true
+              },
+              XOptionalHeader: {
+                description: 'Not really needed',
+                required: false
+              }
+            ],
             hidden: false,
             deprecated: false,
             is_array: true,
@@ -52,14 +54,16 @@ module Grape
             success Object
             failure [[401, 'Unauthorized', 'Entities::Error']]
             named 'My named route'
-            headers [XAuthToken: {
-              description: 'Valdates your identity',
-              required: true
-            },
-                     XOptionalHeader: {
-                       description: 'Not really needed',
-                       required: false
-                     }]
+            headers [
+              XAuthToken: {
+                description: 'Valdates your identity',
+                required: true
+              },
+              XOptionalHeader: {
+                description: 'Not really needed',
+                required: false
+              }
+            ]
             hidden false
             deprecated false
             is_array true


### PR DESCRIPTION
Adds support for `security` in `desc` block.

Proposing the change since [options hash parameters are marked as deprecated](https://github.com/ruby-grape/grape/blob/v1.2.1/lib/grape/dsl/desc.rb#L58) and the bug in ruby-grape/grape-swagger#706 prevents using both (options are not merged into the block).

```Ruby
desc `Create User` do
  security [
    # security schemes
  ]
  # …
end
````

Includes some minor formatting changes in the spec (in separate commits) and I didn't update the `README.md` since it [already points to `grape-swagger` for more info](https://github.com/ruby-grape/grape#describing-methods).

Related to #1791 and (slightly) to ruby-grape/grape-swagger#729.