### PR TITLE
Addresses memory issues related to new multi-instance approach

### DIFF
--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -6,7 +6,7 @@ module Grape
   # should subclass this class in order to build an API.
   class API
     # Class methods that we want to call on the API rather than on the API object
-    NON_OVERRIDABLE = Class.new.methods.freeze
+    NON_OVERRIDABLE = Class.new.methods.freeze + %i[call call!]
 
     class << self
       attr_accessor :base_instance, :instances
@@ -40,6 +40,15 @@ module Grape
             add_setup(method_override, *args, &block)
           end
         end
+      end
+
+      # This is the interface point between Rack and Grape; it accepts a request
+      # from Rack and ultimately returns an array of three values: the status,
+      # the headers, and the body. See [the rack specification]
+      # (http://www.rubydoc.info/github/rack/rack/master/file/SPEC) for more.
+      # NOTE: This will only be called on an API directly mounted on RACK
+      def call(*args, &block)
+        base_instance.call(*args, &block)
       end
 
       # Allows an API to itself be inheritable:

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -220,6 +220,15 @@ describe Grape::API do
     end
   end
 
+  describe '.call' do
+    context 'it does not add to the app setup' do
+      it 'calls the app' do
+        expect(subject).not_to receive(:add_setup)
+        subject.call({})
+      end
+    end
+  end
+
   describe '.route_param' do
     it 'adds a parameterized route segment namespace' do
       subject.namespace :users do


### PR DESCRIPTION
As part of the new multi-instance approach, class calls to the API are being intercepted, and stored so that they can be call as part of the setup to all instances. 
However, when you are running the API in Rack, the method `call` is not part of the configuration, but an action. We do NOT want to store every time the method `call` was called for security and memory management issues:

Addresses: https://github.com/ruby-grape/grape/issues/1835