### PR TITLE
update existing spec to test correct behavior of missing nested array

### DIFF
--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -369,7 +369,7 @@ describe Grape::Endpoint do
       end
       get '/declared?first=present'
       expect(last_response.status).to eq(200)
-      expect(JSON.parse(last_response.body).keys.size).to eq(5)
+      expect(JSON.parse(last_response.body).keys.size).to eq(4)
     end
 
     it 'has a optional param with default value all the time' do
@@ -388,7 +388,7 @@ describe Grape::Endpoint do
 
       get '/declared?first=present&nested[fourth]=1'
       expect(last_response.status).to eq(200)
-      expect(JSON.parse(last_response.body)['nested'].keys.size).to eq 3
+      expect(JSON.parse(last_response.body)['nested'].keys.size).to eq(4)
     end
 
     it 'builds nested params when given array' do

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -294,9 +294,9 @@ describe Grape::Endpoint do
               optional :seventh
             end
           end
-        end
-        optional :nested_arr, type: Array do
-          optional :eighth
+          optional :nested_arr, type: Array do
+            optional :eighth
+          end
         end
       end
     end
@@ -429,7 +429,7 @@ describe Grape::Endpoint do
 
         get '/declared?first=present'
         expect(last_response.status).to eq(200)
-        expect(JSON.parse(last_response.body)['nested_arr']).to be_a(Array)
+        expect(JSON.parse(last_response.body)['nested']['nested_arr']).to be_a(Array)
       end
 
       it 'to be nil when include_missing is false' do


### PR DESCRIPTION
Modifies existing test for nested arrays to verify that the key is mapped to an Array object. Test fails because `declared` transforms the missing Array params into a Hash.

Related Issue: https://github.com/ruby-grape/grape/issues/1847