### PR TITLE
Fix entity data type identification

### DIFF
--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -84,7 +84,7 @@ module Grape
         end
 
         def declared_param_is_array?(declared_param)
-          route_options_params[declared_param.to_s] && route_options_params[declared_param.to_s][:type] == 'Array'
+          route_options_params[declared_param.to_s] && route_options_params[declared_param.to_s][:type] <= Array
         end
 
         def route_options_params

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -241,7 +241,7 @@ module Grape
 
         coerce_type = infer_coercion(validations)
 
-        doc_attrs[:type] = coerce_type.to_s if coerce_type
+        doc_attrs[:type] = coerce_type if coerce_type
 
         desc = validations.delete(:desc) || validations.delete(:description)
         doc_attrs[:desc] = desc if desc

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -2795,10 +2795,10 @@ XML
       subject.get 'method'
 
       expect(subject.routes.map(&:params)).to eq [{
-        'group1'         => { required: true, type: 'Array' },
+        'group1'         => { required: true, type: Array },
         'group1[param1]' => { required: false, desc: 'group1 param1 desc' },
         'group1[param2]' => { required: true, desc: 'group1 param2 desc' },
-        'group2'         => { required: true, type: 'Array' },
+        'group2'         => { required: true, type: Array },
         'group2[param1]' => { required: false, desc: 'group2 param1 desc' },
         'group2[param2]' => { required: true, desc: 'group2 param2 desc' }
       }]
@@ -2818,7 +2818,7 @@ XML
         { description: 'nesting',
           params: {
             'root_param' => { required: true, desc: 'root param' },
-            'nested' => { required: true, type: 'Array' },
+            'nested' => { required: true, type: Array },
             'nested[nested_param]' => { required: true, desc: 'nested param' }
           } }
       ]


### PR DESCRIPTION
I hit a pretty obscure bug 🐛.

The `grape-swagger` gem uses the `type` documentation parameter in order to [identify the deduce name](https://github.com/ruby-grape/grape-swagger/blob/v0.32.1/lib/grape-swagger/doc_methods/data_type.rb#L50-L60). When the type (class) is stringified `grape-swagger` cannot check for method existance and falls back to taking the [last module as the name](https://github.com/ruby-grape/grape-swagger/blob/v0.32.1/lib/grape-swagger/doc_methods/data_type.rb#L58).

Here is a (simplified) example of the problem:


```Ruby
class API::V1::Entities::Event::Date < Grape::Entity
  expose :id
end

module API
  module V1
    class Events < Grape::API
      class Dates < Grape::API
        resources :events do
          route_param :event_id do
            params do
              requires :event_id, type: String, uuid: true, documentation: { format: 'uuid' }
            end

            resources :dates do
              params do
                requires :date, type: API::V1::Entities::Event::Date
              end
              post do
                # do something meaningful

                present date, with: API::V1::Entities::Event::Date
              end
            end
          end
        end
      end
    end
  end
end
```

If the entity name ends in `Date` then it's regarded as `primitive` and the swagger documentation is generated as a `formData`:

```YAML
post:
  parameters:
    - in: path
      name: event_id
      type: string
      format: uuid
      required: true
    - in: formData
      name: date
      type: string
      format: null
      required: true
```

(where the `date` type is then also marked as a `string` instead of object).

While generating the param documentation `type` attribute, the `type` is converted to a string. The string `type` is only used to check whether the param is an `Array`, which can be accomplished by a class inheritance check as well.

With the changes in this PR and by adding `API::V1::Events::Date.entity_name`

```Ruby
class API::V1::Entities::Event::Date < Grape::Entity
  expose :id

  def self.entity_name
    'EventDate'
  end
end
```

the generated swagger doc is correct:

```YAML
post:
  parameters:
    - in: path
      name: event_id
      type: string
      format: uuid
      required: true
    - name: EventsEventIdDates
      in: body
      required: true
      schema:
        $ref: '#/definitions/postEventsEventIdDates'
```

Everything works as expected, the specs pass and I didn't see any regressions.

I'm not 100% sure if I got this right, please let me know what you think.