### PR TITLE
Allows for a block of code to always run after the endpoint

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,7 +38,7 @@ Metrics/BlockLength:
 # Offense count: 9
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 295
+  Max: 297
 
 # Offense count: 31
 Metrics/CyclomaticComplexity:
@@ -53,7 +53,7 @@ Metrics/LineLength:
 # Offense count: 57
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 33
+  Max: 34
 
 # Offense count: 12
 # Configuration parameters: CountComments.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,7 +38,7 @@ Metrics/BlockLength:
 # Offense count: 9
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 297
+  Max: 302
 
 # Offense count: 31
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 #### Features
 
 * Your contribution here.
-* [#1864](https://github.com/ruby-grape/grape/pull/1864): Adds `ensure_block` on the API - [@myxoh](https://github.com/myxoh).
+* [#1864](https://github.com/ruby-grape/grape/pull/1864): Adds `finally` on the API - [@myxoh](https://github.com/myxoh).
 
 #### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * Your contribution here.
+* [#1864](https://github.com/ruby-grape/grape/pull/1864): Adds `ensure_block` on the API - [@myxoh](https://github.com/myxoh).
 
 #### Fixes
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@
   - [Register custom middleware for authentication](#register-custom-middleware-for-authentication)
 - [Describing and Inspecting an API](#describing-and-inspecting-an-api)
 - [Current Route and Endpoint](#current-route-and-endpoint)
-- [Before, After and Ensure](#before-after-and-ensure)
+- [Before, After and Finally](#before-after-and-finally)
 - [Anchoring](#anchoring)
 - [Using Custom Middleware](#using-custom-middleware)
   - [Grape Middleware](#grape-middleware)
@@ -3089,12 +3089,12 @@ class ApiLogger < Grape::Middleware::Base
 end
 ```
 
-## Before, After and Ensure
+## Before, After and Finally
 
 Blocks can be executed before or after every API call, using `before`, `after`,
 `before_validation` and `after_validation`.
 If the API fails the `after` call will not be trigered, if you need code to execute for sure
-use the `ensure_block`
+use the `finally`
 
 Before and after callbacks execute in the following order:
 
@@ -3104,7 +3104,7 @@ Before and after callbacks execute in the following order:
 4. `after_validation` (if Validation Successful)
 5. _the API call_ (if Validation Successful)
 6. `after` (if Validation & API Successful)
-7. `ensure_block` (ALWAYS)
+7. `finally` (ALWAYS)
 
 Steps 4, 5 and 6 only happen if validation succeeds.
 
@@ -3124,9 +3124,9 @@ before do
 end
 ```
 
-You can ensure a block of code runs after every request (including failures) with `ensure`:
+You can ensure a block of code runs after every request (including failures) with `finally`:
 ```ruby
-ensure_block do
+finally do
   This.block(of: code) # Will definetely run after every request
 end
 ```

--- a/README.md
+++ b/README.md
@@ -1603,7 +1603,7 @@ end
 
 Every validation will have it's own instance of the validator, which means that the validator can have a state.
 
-### Validation Errors
+### Validation Errors and Rescuing
 
 Validation and coercion errors are collected and an exception of type `Grape::Exceptions::ValidationErrors` is raised. If the exception goes uncaught it will respond with a status of 400 and an error message. The validation errors are grouped by parameter name and can be accessed via `Grape::Exceptions::ValidationErrors#errors`.
 
@@ -1654,6 +1654,13 @@ Similarly, no regular expression test will be performed if `:blah` is blank in t
 ```ruby
 params do
   required :blah, allow_blank: false, regexp: /blah/, fail_fast: true
+end
+```
+
+You can ensure a block of code runs after every request (including failures) with `ensure`:
+```ruby
+ensure_block do
+  This.block(of: code) # Will definetely run after every request
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -3094,17 +3094,17 @@ end
 Blocks can be executed before or after every API call, using `before`, `after`,
 `before_validation` and `after_validation`.
 If the API fails the `after` call will not be trigered, if you need code to execute for sure
-use the `finally`
+use the `finally`.
 
 Before and after callbacks execute in the following order:
 
 1. `before`
 2. `before_validation`
 3. _validations_
-4. `after_validation` (if Validation Successful)
-5. _the API call_ (if Validation Successful)
-6. `after` (if Validation & API Successful)
-7. `finally` (ALWAYS)
+4. `after_validation` (upon successful validation)
+5. _the API call_ (upon successful validation)
+6. `after` (upon successful validation and API call)
+7. `finally` (always)
 
 Steps 4, 5 and 6 only happen if validation succeeds.
 
@@ -3125,9 +3125,10 @@ end
 ```
 
 You can ensure a block of code runs after every request (including failures) with `finally`:
+
 ```ruby
 finally do
-  This.block(of: code) # Will definetely run after every request
+  # this code will run after every request (successful or failed)
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@
     - [Nested mutually_exclusive, exactly_one_of, at_least_one_of, all_or_none_of](#nested-mutually_exclusive-exactly_one_of-at_least_one_of-all_or_none_of)
   - [Namespace Validation and Coercion](#namespace-validation-and-coercion)
   - [Custom Validators](#custom-validators)
-  - [Validation Errors](#validation-errors)
+  - [Validation Errors and Rescuing](#validation-errors-and-rescuing)
   - [I18n](#i18n)
   - [Custom Validation messages](#custom-validation-messages)
     - [presence, allow_blank, values, regexp](#presence-allow_blank-values-regexp)

--- a/lib/grape/dsl/callbacks.rb
+++ b/lib/grape/dsl/callbacks.rb
@@ -43,6 +43,26 @@ module Grape
         def after(&block)
           namespace_stackable(:afters, block)
         end
+
+        # Allows you to specify a block of code to be executed after every
+        # API call. Unlike the `after` block, this code will run even on
+        # unsuccesful requests
+        # @example
+        #   class ExampleAPI < Grape::API
+        #     before do
+        #       ApiLogger.start
+        #     end
+        #     ensure_block do
+        #       ApiLogger.close
+        #     end
+        #   end
+        #
+        # This will make sure that the ApiLogger is opened and close around every
+        # request
+        # @param  ensured_block [Proc] The block to be executed after every api_call
+        def ensure_block(&block)
+          namespace_stackable(:finallies, block)
+        end
       end
     end
   end

--- a/lib/grape/dsl/callbacks.rb
+++ b/lib/grape/dsl/callbacks.rb
@@ -44,7 +44,7 @@ module Grape
           namespace_stackable(:afters, block)
         end
 
-        # Allows you to specify a block of code to be executed after every
+        # Allows you to specify a something that will always be executed after a call
         # API call. Unlike the `after` block, this code will run even on
         # unsuccesful requests
         # @example
@@ -52,7 +52,7 @@ module Grape
         #     before do
         #       ApiLogger.start
         #     end
-        #     ensure_block do
+        #     finally do
         #       ApiLogger.close
         #     end
         #   end
@@ -60,7 +60,7 @@ module Grape
         # This will make sure that the ApiLogger is opened and close around every
         # request
         # @param  ensured_block [Proc] The block to be executed after every api_call
-        def ensure_block(&block)
+        def finally(&block)
           namespace_stackable(:finallies, block)
         end
       end

--- a/lib/grape/dsl/callbacks.rb
+++ b/lib/grape/dsl/callbacks.rb
@@ -46,7 +46,7 @@ module Grape
 
         # Allows you to specify a something that will always be executed after a call
         # API call. Unlike the `after` block, this code will run even on
-        # unsuccesful requests
+        # unsuccesful requests.
         # @example
         #   class ExampleAPI < Grape::API
         #     before do

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -131,7 +131,7 @@ module Grape
           namespace_stackable(:rescue_options, options)
         end
 
-        def ensure(&ensured_block)
+        def ensure_block(&ensured_block)
           namespace_inheritable(:ensured, true)
           namespace_inheritable(:ensured_block, ensured_block)
         end

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -131,6 +131,22 @@ module Grape
           namespace_stackable(:rescue_options, options)
         end
 
+        # Allows you to specify a block of code to be executed after every
+        # API call. Unlike the `after` block, this code will run even on
+        # unsuccesful requests
+        # @example
+        #   class ExampleAPI < Grape::API
+        #     before do
+        #       ApiLogger.start
+        #     end
+        #     ensure_block do
+        #       ApiLogger.close
+        #     end
+        #   end
+        #
+        # This will make sure that the ApiLogger is opened and close around every
+        # request
+        # @param  ensured_block [Proc] The block to be executed after every api_call
         def ensure_block(&ensured_block)
           namespace_inheritable(:ensured, true)
           namespace_inheritable(:ensured_block, ensured_block)

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -131,6 +131,11 @@ module Grape
           namespace_stackable(:rescue_options, options)
         end
 
+        def ensure(&ensured_block)
+          namespace_inheritable(:ensured, true)
+          namespace_inheritable(:ensured_block, ensured_block)
+        end
+
         # Allows you to specify a default representation entity for a
         # class. This allows you to map your models to their respective
         # entities once and then simply call `present` with the model.

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -131,27 +131,6 @@ module Grape
           namespace_stackable(:rescue_options, options)
         end
 
-        # Allows you to specify a block of code to be executed after every
-        # API call. Unlike the `after` block, this code will run even on
-        # unsuccesful requests
-        # @example
-        #   class ExampleAPI < Grape::API
-        #     before do
-        #       ApiLogger.start
-        #     end
-        #     ensure_block do
-        #       ApiLogger.close
-        #     end
-        #   end
-        #
-        # This will make sure that the ApiLogger is opened and close around every
-        # request
-        # @param  ensured_block [Proc] The block to be executed after every api_call
-        def ensure_block(&ensured_block)
-          namespace_inheritable(:ensured, true)
-          namespace_inheritable(:ensured_block, ensured_block)
-        end
-
         # Allows you to specify a default representation entity for a
         # class. This allows you to map your models to their respective
         # entities once and then simply call `present` with the model.

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -274,8 +274,7 @@ module Grape
 
           [status, header, response_object]
         ensure
-          # An error on the finallies should not prevent a succesful request from executing
-          begin run_filters finallies, :finally end
+          run_filters finallies, :finally
         end
       end
     end

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -272,7 +272,6 @@ module Grape
           # The Body commonly is an Array of Strings, the application instance itself, or a File-like object
           response_object = file || [body]
 
-
           [status, header, response_object]
         ensure
           # An error on the finallies should not prevent a succesful request from executing

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -291,7 +291,9 @@ module Grape
                 rescue_options: namespace_stackable_with_hash(:rescue_options) || {},
                 rescue_handlers: namespace_reverse_stackable_with_hash(:rescue_handlers) || {},
                 base_only_rescue_handlers: namespace_stackable_with_hash(:base_only_rescue_handlers) || {},
-                all_rescue_handler: namespace_inheritable(:all_rescue_handler)
+                all_rescue_handler: namespace_inheritable(:all_rescue_handler),
+                ensured: namespace_inheritable(:ensured),
+                ensured_block: namespace_inheritable(:ensured_block)
 
       stack.concat namespace_stackable(:middleware)
 

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -269,7 +269,7 @@ module Grape
           # status verifies body presence when DELETE
           @body ||= response_object
 
-          # The Body commonly is an Array of Strings, the application instance itself, or a File-like object
+          # The body commonly is an Array of Strings, the application instance itself, or a File-like object
           response_object = file || [body]
 
           [status, header, response_object]

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -47,7 +47,7 @@ module Grape
           run_rescue_handler(handler, error)
         end
       end
-      
+
       def error!(message, status = options[:default_status], headers = {}, backtrace = [], original_exception = nil)
         headers = headers.reverse_merge(Grape::Http::Headers::CONTENT_TYPE => content_type)
         rack_response(format_message(message, backtrace, original_exception), status, headers)

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -22,8 +22,6 @@ module Grape
           rescue_handlers: {}, # rescue handler blocks
           base_only_rescue_handlers: {}, # rescue handler blocks rescuing only the base class
           all_rescue_handler: nil, # rescue handler block to rescue from all exceptions
-          ensured: false,
-          ensured_block: nil # This should always be present if ensured is present
         }
       end
 
@@ -47,19 +45,9 @@ module Grape
             raise
 
           run_rescue_handler(handler, error)
-        ensure
-          execute_ensured_block! if should_ensure?
         end
       end
-
-      def should_ensure?
-        options[:ensured]
-      end
-
-      def execute_ensured_block!
-        options[:ensured_block].call
-      end
-
+      
       def error!(message, status = options[:default_status], headers = {}, backtrace = [], original_exception = nil)
         headers = headers.reverse_merge(Grape::Http::Headers::CONTENT_TYPE => content_type)
         rack_response(format_message(message, backtrace, original_exception), status, headers)

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1631,15 +1631,15 @@ XML
   describe 'lifecycle' do
     let!(:lifecycle) { [] }
     let!(:standard_cycle) do
-      %i[before before_validation after_validation api_call after ensure_block]
+      %i[before before_validation after_validation api_call after finally]
     end
 
     let!(:validation_error) do
-      %i[before before_validation ensure_block]
+      %i[before before_validation finally]
     end
 
     let!(:errored_cycle) do
-      %i[before before_validation after_validation api_call ensure_block]
+      %i[before before_validation after_validation api_call finally]
     end
 
     before do
@@ -1661,8 +1661,8 @@ XML
         current_cycle << :after
       end
 
-      subject.ensure_block do
-        current_cycle << :ensure_block
+      subject.finally do
+        current_cycle << :finally
       end
     end
 
@@ -1733,7 +1733,7 @@ XML
     end
   end
 
-  describe '.ensure_block' do
+  describe '.finally' do
     let!(:code) { { has_executed: false } }
     let(:block_to_run) do
       code_to_execute = code
@@ -1743,7 +1743,7 @@ XML
     end
 
     context 'when the ensure block has no exceptions' do
-      before { subject.ensure_block(&block_to_run) }
+      before { subject.finally(&block_to_run) }
 
       context 'when no API call is made' do
         it 'has not executed the ensure code' do
@@ -1778,7 +1778,7 @@ XML
                 'some_value'
               end
             end
-            
+
             subject.get '/with_helpers' do
               'success'
             end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1628,13 +1628,13 @@ XML
     end
   end
 
-  describe '.ensure' do
+  describe '.ensure_block' do
     let!(:code) { { has_executed: false } }
 
     context 'when the ensure block has no exceptions' do
       before do
         code_to_execute = code
-        subject.ensure do
+        subject.ensure_block do
           code_to_execute[:has_executed] = true
         end
       end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -1492,6 +1492,9 @@ describe Grape::Endpoint do
         have_attributes(name: 'endpoint_run_filters.grape', payload: { endpoint: a_kind_of(Grape::Endpoint),
                                                                        filters: [],
                                                                        type: :after }),
+        have_attributes(name: 'endpoint_run_filters.grape', payload: { endpoint: a_kind_of(Grape::Endpoint),
+                                                                       filters: [],
+                                                                       type: :finally }),
         have_attributes(name: 'endpoint_run.grape', payload: { endpoint: a_kind_of(Grape::Endpoint),
                                                                env: an_instance_of(Hash) }),
         have_attributes(name: 'format_response.grape', payload: { env: an_instance_of(Hash),
@@ -1518,6 +1521,9 @@ describe Grape::Endpoint do
         have_attributes(name: 'endpoint_run_filters.grape', payload: { endpoint: a_kind_of(Grape::Endpoint),
                                                                        filters: [],
                                                                        type: :after }),
+        have_attributes(name: 'endpoint_run_filters.grape', payload: { endpoint: a_kind_of(Grape::Endpoint),
+                                                                       filters: [],
+                                                                       type: :finally }),
         have_attributes(name: 'format_response.grape', payload: { env: an_instance_of(Hash),
                                                                   formatter: a_kind_of(Module) })
       )


### PR DESCRIPTION
https://github.com/ruby-grape/grape/issues/1865

Motive: Sometime we do things like logging, or open sessions, or other actions during an API request and we want to make sure those actions are wrapped up afterwards.

This introduces a DSL way of handling this after every request on an API