### PR TITLE
Fix NoMethodError with none Hash params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 #### Fixes
 
-* Your contribution here.
+* [#1868](https://github.com/ruby-grape/grape/pull/1868): Fix NoMethodError with none hash params - [@ksss](https://github.com/ksss).
 
 ### 1.2.3 (2019/01/16)
 

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -52,6 +52,7 @@ module Grape
 
         return true unless @dependent_on
         return params.any? { |param| meets_dependency?(param, request_params) } if params.is_a?(Array)
+        return false unless params.respond_to?(:with_indifferent_access)
         params = params.with_indifferent_access
 
         @dependent_on.each do |dependency|

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -703,6 +703,26 @@ describe Grape::Validations::ParamsScope do
     before do
       subject.params do
         requires :foos, type: Array do
+          optional :foo
+          given :foo do
+            requires :bar
+          end
+        end
+      end
+      subject.get('/test') { 'ok' }
+    end
+
+    it 'should pass none Hash params' do
+      get '/test', foos: ['']
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq('ok')
+    end
+  end
+
+  context 'when validations are dependent on a parameter within an array param within #declared(params).to_json' do
+    before do
+      subject.params do
+        requires :foos, type: Array do
           optional :foo_type, :baz_type
           given :foo_type do
             requires :bar


### PR DESCRIPTION
```rb
params do
  requires :foos, type: Array do
    optional :bar
    given :bar do
      requires :baz
    end
  end
end
get '/test' { 'ok' }
```

```
client.get('/test', foos: ['abc'])
#=> NoMethodError (undefined method `with_indifferent_access' for "abc":String)
```