### PR TITLE
Fix const errors being hidden by bug in const_missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * Your contribution here.
+* [#1876](https://github.com/ruby-grape/grape/pull/1876): Fix const errors being hidden by bug in `const_missing` - [@dandehavilland](https://github.com/dandehavilland).
 * [#1864](https://github.com/ruby-grape/grape/pull/1864): Adds `finally` on the API - [@myxoh](https://github.com/myxoh).
 * [#1869](https://github.com/ruby-grape/grape/pull/1869): Fix issue with empty headers after `error!` method call - [@anaumov](https://github.com/anaumov).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 #### Features
 
 * Your contribution here.
-* [#1876](https://github.com/ruby-grape/grape/pull/1876): Fix const errors being hidden by bug in `const_missing` - [@dandehavilland](https://github.com/dandehavilland).
 * [#1864](https://github.com/ruby-grape/grape/pull/1864): Adds `finally` on the API - [@myxoh](https://github.com/myxoh).
 * [#1869](https://github.com/ruby-grape/grape/pull/1869): Fix issue with empty headers after `error!` method call - [@anaumov](https://github.com/anaumov).
 
 #### Fixes
 
 * [#1868](https://github.com/ruby-grape/grape/pull/1868): Fix NoMethodError with none hash params - [@ksss](https://github.com/ksss).
+* [#1876](https://github.com/ruby-grape/grape/pull/1876): Fix const errors being hidden by bug in `const_missing` - [@dandehavilland](https://github.com/dandehavilland).
 
 ### 1.2.3 (2019/01/16)
 

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -64,8 +64,6 @@ module Grape
       def const_missing(*args)
         if base_instance.const_defined?(*args)
           base_instance.const_get(*args)
-        elsif @base_parent && @base_parent.const_defined?(*args)
-          @base_parent.const_get(*args)
         else
           super
         end

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -64,7 +64,7 @@ module Grape
       def const_missing(*args)
         if base_instance.const_defined?(*args)
           base_instance.const_get(*args)
-        elsif parent && parent.const_defined?(*args)
+        elsif defined?(parent) && parent.const_defined?(*args)
           parent.const_get(*args)
         else
           super

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -64,8 +64,8 @@ module Grape
       def const_missing(*args)
         if base_instance.const_defined?(*args)
           base_instance.const_get(*args)
-        elsif defined?(parent) && parent.const_defined?(*args)
-          parent.const_get(*args)
+        elsif @base_parent && @base_parent.const_defined?(*args)
+          @base_parent.const_get(*args)
         else
           super
         end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3883,7 +3883,7 @@ XML
     before { subject.mount mounted => '/const' }
 
     it 'raises an error' do
-      expect { get '/const/missing' }.to raise_error(NameError).with_message(/SomeRandomConst/)
+      expect { get '/const/missing' }.to raise_error(NameError).with_message(/SomeRandomConstant/)
     end
   end
 end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3871,16 +3871,19 @@ XML
   end
 
   describe 'const_missing' do
-    class Mounted < Grape::API
-      get '/missing' do
-        SomeRandomConst
+    subject(:grape_api) { Class.new(Grape::API) }
+    let(:mounted) do
+      Class.new(Grape::API) do
+        get '/missing' do
+          SomeRandomConstant
+        end
       end
     end
 
-    before { subject.mount Mounted => '/const' }
+    before { subject.mount mounted => '/const' }
 
     it 'raises an error' do
-      expect { get '/const/missing' }.to raise_error(NameError).with_message('uninitialized constant Mounted::SomeRandomConst')
+      expect { get '/const/missing' }.to raise_error(NameError).with_message(/SomeRandomConst/)
     end
   end
 end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3869,4 +3869,18 @@ XML
       expect(grape_api.eql?(MyAPI))
     end
   end
+
+  describe 'const_missing' do
+    class Mounted < Grape::API
+      get '/missing' do
+        SomeRandomConst
+      end
+    end
+
+    before { subject.mount Mounted => '/const' }
+
+    it 'raises an error' do
+      expect { get '/const/missing' }.to raise_error(NameError).with_message('uninitialized constant Mounted::SomeRandomConst')
+    end
+  end
 end


### PR DESCRIPTION
I had not included a file and so a constant was missing. I did not receive the correct error as the custom `const_missing` was throwing an error of its own.

This PR resolves that for me.

```bash
NameError:
  undefined local variable or method `parent' for MyApiClass
# /repos/grape/lib/grape/api.rb:107:in `method_missing'
# /repos/grape/lib/grape/api.rb:67:in `const_missing'
# ./lib/routes/my_api_class.rb:24:in `block in <class:MyApiClass>'
# /repos/grape/lib/grape/endpoint.rb:57:in `call'
# /repos/grape/lib/grape/endpoint.rb:57:in `block (2 levels) in generate_api_method'
# /repos/grape/lib/grape/endpoint.rb:56:in `block in generate_api_method'
# /repos/grape/lib/grape/endpoint.rb:263:in `block in run'
# /repos/grape/lib/grape/endpoint.rb:243:in `run'
# /repos/grape/lib/grape/endpoint.rb:318:in `block in build_stack'
# /repos/grape/lib/grape/middleware/base.rb:31:in `call!'
# /repos/grape/lib/grape/middleware/base.rb:24:in `call'
# /repos/grape/lib/grape/middleware/error.rb:37:in `block in call!'
# /repos/grape/lib/grape/middleware/error.rb:36:in `catch'
# /repos/grape/lib/grape/middleware/error.rb:36:in `call!'
# ...
```