### PR TITLE
Fix #1880 to prevent header case change in some RSpec test scenarios

### DIFF
--- a/lib/grape/request.rb
+++ b/lib/grape/request.rb
@@ -32,7 +32,7 @@ module Grape
       env.each_pair do |k, v|
         next unless k.to_s.start_with? HTTP_PREFIX
 
-        k = k[5..-1].split('_').each(&:capitalize!).join('-')
+        k = k[5..-1].split('_').each(&:capitalize).join('-')
         headers[k] = v
       end
       headers


### PR DESCRIPTION
When using Grape with RSpec and some variation of Ruby versions, the case of headers is not maintained, causing header key lookups to fail.