### PR TITLE
Change misleading naming of alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
   - [Validation of Nested Parameters](#validation-of-nested-parameters)
   - [Dependent Parameters](#dependent-parameters)
   - [Group Options](#group-options)
-  - [Alias](#alias)
+  - [Renaming](#renaming)
   - [Built-in Validators](#built-in-validators)
     - [allow_blank](#allow_blank)
     - [values](#values)
@@ -1215,7 +1215,7 @@ params do
 end
 ```
 
-You can set alias for parameter:
+You can rename parameters:
 
 ```ruby
 params do
@@ -1226,7 +1226,7 @@ params do
 end
 ```
 
-Note: param in `given` should be the aliased one. In the example, it should be `type`, not `category`.
+Note: param in `given` should be the renamed one. In the example, it should be `type`, not `category`.
 
 ### Group Options
 
@@ -1255,9 +1255,9 @@ params do
 end
 ```
 
-### Alias
+### Renaming
 
-You can set an alias for parameters using `as`, which can be useful when refactoring existing APIs:
+You can rename parameters using `as`, which can be useful when refactoring existing APIs:
 
 ```ruby
 resource :users do

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -61,13 +61,13 @@ module Grape
             else
               # If it is not a Hash then it does not have children.
               # Find its value or set it to nil.
-              has_alias = route_setting(:aliased_params) && route_setting(:aliased_params).find { |current| current[declared_param] }
-              param_alias = has_alias[declared_param] if has_alias
+              has_renaming = route_setting(:renamed_params) && route_setting(:renamed_params).find { |current| current[declared_param] }
+              param_renaming = has_renaming[declared_param] if has_renaming
 
-              next unless options[:include_missing] || passed_params.key?(declared_param) || (param_alias && passed_params.key?(param_alias))
+              next unless options[:include_missing] || passed_params.key?(declared_param) || (param_renaming && passed_params.key?(param_renaming))
 
-              if param_alias
-                memo[optioned_param_key(param_alias, options)] = passed_params[param_alias]
+              if param_renaming
+                memo[optioned_param_key(param_renaming, options)] = passed_params[param_renaming]
               else
                 memo[optioned_param_key(declared_param, options)] = passed_params[declared_param]
               end

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -258,7 +258,7 @@ module Grape
           else
             run_filters before_validations, :before_validation
             run_validators validations, request
-            remove_aliased_params
+            remove_renamed_params
             run_filters after_validations, :after_validation
             response_object = @block ? @block.call(self) : nil
           end
@@ -324,14 +324,14 @@ module Grape
       Module.new { helpers.each { |mod_to_include| include mod_to_include } }
     end
 
-    def remove_aliased_params
-      return unless route_setting(:aliased_params)
-      route_setting(:aliased_params).flat_map(&:keys).each do |aliased_param|
-        @params.delete(aliased_param)
+    def remove_renamed_params
+      return unless route_setting(:renamed_params)
+      route_setting(:renamed_params).flat_map(&:keys).each do |renamed_param|
+        @params.delete(renamed_param)
       end
     end
 
-    private :build_stack, :build_helpers, :remove_aliased_params
+    private :build_stack, :build_helpers, :remove_renamed_params
 
     def helpers
       lazy_initialize! && @helpers

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -120,8 +120,8 @@ module Grape
           @parent.push_declared_params(attrs, opts)
         else
           if opts && opts[:as]
-            @api.route_setting(:aliased_params, @api.route_setting(:aliased_params) || [])
-            @api.route_setting(:aliased_params) << { attrs.first => opts[:as] }
+            @api.route_setting(:renamed_params, @api.route_setting(:renamed_params) || [])
+            @api.route_setting(:renamed_params) << { attrs.first => opts[:as] }
             attrs = [opts[:as]]
           end
 

--- a/lib/grape/validations/validators/as.rb
+++ b/lib/grape/validations/validators/as.rb
@@ -2,12 +2,12 @@ module Grape
   module Validations
     class AsValidator < Base
       def initialize(attrs, options, required, scope, opts = {})
-        @alias = options
+        @renamed_options = options
         super
       end
 
       def validate_param!(attr_name, params)
-        params[@alias] = params[attr_name]
+        params[@renamed_options] = params[attr_name]
       end
     end
   end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -472,12 +472,12 @@ describe Grape::Endpoint do
       expect(last_response.status).to eq(200)
     end
 
-    it 'does not include aliased missing attributes if that option is passed' do
+    it 'does not include renamed missing attributes if that option is passed' do
       subject.params do
-        optional :aliased_original, as: :aliased
+        optional :renamed_original, as: :renamed
       end
       subject.get '/declared' do
-        error! 'expected nil', 400 if declared(params, include_missing: false).key?(:aliased)
+        error! 'expected nil', 400 if declared(params, include_missing: false).key?(:renamed)
         ''
       end
 

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -121,14 +121,14 @@ describe Grape::Validations::ParamsScope do
     end
   end
 
-  context 'param alias' do
+  context 'param renaming' do
     it do
       subject.params do
         requires :foo, as: :bar
         optional :super, as: :hiper
       end
-      subject.get('/alias') { "#{declared(params)['bar']}-#{declared(params)['hiper']}" }
-      get '/alias', foo: 'any', super: 'any2'
+      subject.get('/renaming') { "#{declared(params)['bar']}-#{declared(params)['hiper']}" }
+      get '/renaming', foo: 'any', super: 'any2'
 
       expect(last_response.status).to eq(200)
       expect(last_response.body).to eq('any-any2')
@@ -138,8 +138,8 @@ describe Grape::Validations::ParamsScope do
       subject.params do
         requires :foo, as: :bar, type: String, coerce_with: ->(c) { c.strip }
       end
-      subject.get('/alias-coerced') { "#{params['bar']}-#{params['foo']}" }
-      get '/alias-coerced', foo: ' there we go '
+      subject.get('/renaming-coerced') { "#{params['bar']}-#{params['foo']}" }
+      get '/renaming-coerced', foo: ' there we go '
 
       expect(last_response.status).to eq(200)
       expect(last_response.body).to eq('there we go-')
@@ -149,8 +149,8 @@ describe Grape::Validations::ParamsScope do
       subject.params do
         requires :foo, as: :bar, allow_blank: false
       end
-      subject.get('/alias-not-blank') {}
-      get '/alias-not-blank', foo: ''
+      subject.get('/renaming-not-blank') {}
+      get '/renaming-not-blank', foo: ''
 
       expect(last_response.status).to eq(400)
       expect(last_response.body).to eq('foo is empty')
@@ -160,8 +160,8 @@ describe Grape::Validations::ParamsScope do
       subject.params do
         requires :foo, as: :bar, allow_blank: false
       end
-      subject.get('/alias-not-blank-with-value') {}
-      get '/alias-not-blank-with-value', foo: 'any'
+      subject.get('/renaming-not-blank-with-value') {}
+      get '/renaming-not-blank-with-value', foo: 'any'
 
       expect(last_response.status).to eq(200)
     end
@@ -532,7 +532,7 @@ describe Grape::Validations::ParamsScope do
       expect(last_response.body).to eq({ a: 'a', b: 'b', c: 'c', d: 'd' }.to_json)
     end
 
-    it 'allows aliasing of dependent parameters' do
+    it 'allows renaming of dependent parameters' do
       subject.params do
         optional :a
         given :a do
@@ -550,7 +550,7 @@ describe Grape::Validations::ParamsScope do
       expect(body.keys).to_not include('b')
     end
 
-    it 'allows aliasing of dependent on parameter' do
+    it 'allows renaming of dependent on parameter' do
       subject.params do
         optional :a, as: :b
         given b: ->(val) { val == 'x' } do
@@ -567,7 +567,7 @@ describe Grape::Validations::ParamsScope do
       expect(last_response.status).to eq 200
     end
 
-    it 'raises an error if the dependent parameter is not the aliased one' do
+    it 'raises an error if the dependent parameter is not the renamed one' do
       expect do
         subject.params do
           optional :a, as: :b


### PR DESCRIPTION
Closes #1875. 

This PR is to rename misleading term "alias" to "renaming". Changes cover docs and variables naming.