### PR TITLE
Makes sure Grape::API behaves as a Rack::App 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#1893](https://github.com/ruby-grape/grape/pull/1893): Allows `Grape::API` to behave like a Rack::app in some instances where it was misbehaving - [@myxoh](https://github.com/myxoh).
 
 ### 1.2.4 (2019/06/13)
 

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -48,9 +48,13 @@ module Grape
       # (http://www.rubydoc.info/github/rack/rack/master/file/SPEC) for more.
       # NOTE: This will only be called on an API directly mounted on RACK
       def call(*args, &block)
-        base_instance.call(*args, &block)
+        instance_for_rack = if never_mounted?
+          base_instance
+        else
+          mounted_instances.first
+        end
+        instance_for_rack.call(*args, &block)
       end
-
       # Allows an API to itself be inheritable:
       def make_inheritable(api)
         # When a child API inherits from a parent API.
@@ -146,6 +150,14 @@ module Grape
             argument
           end
         end
+      end
+
+      def never_mounted?
+        mounted_instances.empty?
+      end
+
+      def mounted_instances
+        instances - [base_instance]
       end
     end
   end

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -49,12 +49,13 @@ module Grape
       # NOTE: This will only be called on an API directly mounted on RACK
       def call(*args, &block)
         instance_for_rack = if never_mounted?
-          base_instance
-        else
-          mounted_instances.first
-        end
+                              base_instance
+                            else
+                              mounted_instances.first
+                            end
         instance_for_rack.call(*args, &block)
       end
+
       # Allows an API to itself be inheritable:
       def make_inheritable(api)
         # When a child API inherits from a parent API.

--- a/spec/grape/integration/rack_spec.rb
+++ b/spec/grape/integration/rack_spec.rb
@@ -31,4 +31,26 @@ describe Rack do
       input.unlink
     end
   end
+
+  context 'when the app is mounted' do
+    def app
+      @main_app ||= Class.new(Grape::API) do
+        get 'ping'
+      end
+    end
+
+    let!(:base) do
+      app_to_mount = app
+      Class.new(Grape::API) do
+        namespace 'namespace' do
+          mount app_to_mount
+        end
+      end
+    end
+
+    it 'finds the app on the namespace' do
+      get '/namespace/ping'
+      expect(last_response.status).to eq 200
+    end
+  end
 end


### PR DESCRIPTION
By calling: 'call' on the first mounted instance rather than the base instance (which is never mounted) which will have the environment information as to where it was mounted

This addresses the underlying issue raised by: https://github.com/ruby-grape/grape/issues/1892