### PR TITLE
Memory profiling fix, Refactor ValidatorFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * Your contribution here.
 * [#1893](https://github.com/ruby-grape/grape/pull/1893): Allows `Grape::API` to behave like a Rack::app in some instances where it was misbehaving - [@myxoh](https://github.com/myxoh).
+* [#1898](https://github.com/ruby-grape/grape/pull/1898): Refactor ValidatorFactory to improve memory allocation - [@Bhacaz](https://github.com/Bhacaz).
 
 ### 1.2.4 (2019/06/13)
 

--- a/lib/grape/dsl/validations.rb
+++ b/lib/grape/dsl/validations.rb
@@ -27,10 +27,11 @@ module Grape
           setting = description_field(:params)
           setting ||= description_field(:params, {})
           Array(names).each do |name|
-            setting[name[:full_name].to_s] ||= {}
-            setting[name[:full_name].to_s].merge!(opts)
+            full_name_string = name[:full_name].to_s
+            setting[full_name_string] ||= {}
+            setting[full_name_string].merge!(opts)
 
-            namespace_stackable(:params, name[:full_name].to_s => opts)
+            namespace_stackable(:params, full_name_string => opts)
           end
         end
       end

--- a/lib/grape/dsl/validations.rb
+++ b/lib/grape/dsl/validations.rb
@@ -27,11 +27,11 @@ module Grape
           setting = description_field(:params)
           setting ||= description_field(:params, {})
           Array(names).each do |name|
-            full_name_string = name[:full_name].to_s
-            setting[full_name_string] ||= {}
-            setting[full_name_string].merge!(opts)
+            full_name = name[:full_name].to_s
+            setting[full_name] ||= {}
+            setting[full_name].merge!(opts)
 
-            namespace_stackable(:params, full_name_string => opts)
+            namespace_stackable(:params, full_name => opts)
           end
         end
       end

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -353,7 +353,7 @@ module Grape
     def run_validators(validator_factories, request)
       validation_errors = []
 
-      validators = validator_factories.map(&:create_validator)
+      validators = validator_factories.map { |options| Grape::Validations::ValidatorFactory.create_validator(options) }
 
       ActiveSupport::Notifications.instrument('endpoint_run_validators.grape', endpoint: self, validators: validators, request: request) do
         validators.each do |validator|
@@ -363,7 +363,7 @@ module Grape
             validation_errors << e
             break if validator.fail_fast?
           rescue Grape::Exceptions::ValidationArrayErrors => e
-            validation_errors += e.errors
+            validation_errors.concat e.errors
             break if validator.fail_fast?
           end
         end

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -76,7 +76,7 @@ module Grape
       def full_name(name, index: nil)
         if nested?
           # Find our containing element's name, and append ours.
-          [@parent.full_name(@element), [@index || index, name].map(&method(:brackets))].compact.join
+          "#{@parent.full_name(@element)}#{brackets(@index || index)}#{brackets(name)}"
         elsif lateral?
           # Find the name of the element as if it was at the same nesting level
           # as our parent. We need to forward our index upward to achieve this.
@@ -184,14 +184,12 @@ module Grape
           raise Grape::Exceptions::UnsupportedGroupTypeError.new unless Grape::Validations::Types.group?(type)
         end
 
-        opts = attrs[1] || { type: Array }
-
         self.class.new(
           api:      @api,
           element:  attrs.first,
           parent:   self,
           optional: optional,
-          type:     opts[:type],
+          type:     type || Array,
           &block
         )
       end
@@ -412,13 +410,15 @@ module Grape
 
         raise Grape::Exceptions::UnknownValidator.new(type) unless validator_class
 
-        factory = Grape::Validations::ValidatorFactory.new(attributes:      attrs,
-                                                           options:         options,
-                                                           required:        doc_attrs[:required],
-                                                           params_scope:    self,
-                                                           opts:            opts,
-                                                           validator_class: validator_class)
-        @api.namespace_stackable(:validations, factory)
+        validator_options = {
+          attributes:      attrs,
+          options:         options,
+          required:        doc_attrs[:required],
+          params_scope:    self,
+          opts:            opts,
+          validator_class: validator_class
+        }
+        @api.namespace_stackable(:validations, validator_options)
       end
 
       def validate_value_coercion(coerce_type, *values_list)

--- a/lib/grape/validations/validator_factory.rb
+++ b/lib/grape/validations/validator_factory.rb
@@ -2,11 +2,11 @@ module Grape
   module Validations
     class ValidatorFactory
       def self.create_validator(**options)
-        options.delete(:validator_class).new(options[:attributes],
-                                             options[:options],
-                                             options[:required],
-                                             options[:params_scope],
-                                             options[:opts])
+        options[:validator_class].new(options[:attributes],
+                                      options[:options],
+                                      options[:required],
+                                      options[:params_scope],
+                                      options[:opts])
       end
     end
   end

--- a/lib/grape/validations/validator_factory.rb
+++ b/lib/grape/validations/validator_factory.rb
@@ -1,17 +1,12 @@
 module Grape
   module Validations
     class ValidatorFactory
-      def initialize(**options)
-        @validator_class = options.delete(:validator_class)
-        @options         = options
-      end
-
-      def create_validator
-        @validator_class.new(@options[:attributes],
-                             @options[:options],
-                             @options[:required],
-                             @options[:params_scope],
-                             @options[:opts])
+      def self.create_validator(**options)
+        options.delete(:validator_class).new(options[:attributes],
+                                             options[:options],
+                                             options[:required],
+                                             options[:params_scope],
+                                             options[:opts])
       end
     end
   end


### PR DESCRIPTION
While doing some profiling for my organisation Rails app, l have found some quick wins to improve the memory of this gem. 

The major change was to refactor the `Grape::Validations::ValidatorFactory` to use singleton methods instead of instances.

I have done some tests to see how many bytes I can save by params.

```ruby
require 'memory_profiler'

report = MemoryProfiler.report do
  require 'grape'

  class EchoAPI < Grape::API
    version 'v1'
    format :json
    prefix :api

    params do
      requires :message, type: String # I use a loop to try many param
    end
    post :echo do
      params[:message]
    end
  end
end

report.pretty_print(to_file: 'grape.txt')
```

## The result

### 1 param
```
# GEM
# allocated memory by gem
# -----------------------------------
#     450750  grape-1.2.4
#
# AFTER REFACTOR
# Total allocated: 22411303 bytes (191577 objects)
# Total retained:  1837180 bytes (14401 objects)
#
# allocated memory by gem
# -----------------------------------
#    428248  grape/lib
#
# Saved allocated: 450750 - 428248 = 22502 bytes (0.022 mb)
```

### 10 params
```
# GEM
# allocated memory by gem
# -----------------------------------
#     493062  grape-1.2.4
#
# AFTER REFACTOR
# allocated memory by gem
# -----------------------------------
#     461488  grape/lib
#
# Saved allocated: 493062 - 461488 = 31574 bytes (0.032 mb)
```
### 1000 params
```
# GEM
# allocated memory by gem
# -----------------------------------
#    5095446  grape-1.2.4
#
# AFTER REFACTOR
# allocated memory by gem
# -----------------------------------
#    4065952  grape/lib
#
# Saved allocated: 5095446 - 4065952 = 1029494 bytes (1.029 mb)
```
The result is ~1010 bytes per param.
mb save per params = **0.00101** * x + 0.0213
