### PR TITLE
Fix Hash params renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#1893](https://github.com/ruby-grape/grape/pull/1893): Allows `Grape::API` to behave like a Rack::app in some instances where it was misbehaving - [@myxoh](https://github.com/myxoh).
 * [#1898](https://github.com/ruby-grape/grape/pull/1898): Refactor `ValidatorFactory` to improve memory allocation - [@Bhacaz](https://github.com/Bhacaz).
 * [#1900](https://github.com/ruby-grape/grape/pull/1900): Define boolean for `Grape::Api::Instance` - [@Bhacaz](https://github.com/Bhacaz).
+* [#1903](https://github.com/ruby-grape/grape/pull/1903): Allow nested params renaming (Hash/Array) - [@bikolya](https://github.com/bikolya).
 
 ### 1.2.4 (2019/06/13)
 

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -186,7 +186,7 @@ module Grape
 
         self.class.new(
           api:      @api,
-          element:  attrs.first,
+          element:  attrs[1][:as] || attrs.first,
           parent:   self,
           optional: optional,
           type:     type || Array,

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -165,6 +165,19 @@ describe Grape::Validations::ParamsScope do
 
       expect(last_response.status).to eq(200)
     end
+
+    it do
+      subject.params do
+        requires :foo, as: :baz, type: Hash do
+          requires :bar, as: :qux
+        end
+      end
+      subject.get('/nested-renaming') { declared(params).to_json }
+      get '/nested-renaming', foo: { bar: 'any' }
+
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq('{"baz":{"qux":"any"}}')
+    end
   end
 
   context 'array without coerce type explicitly given' do


### PR DESCRIPTION
Previously it wasn't possible to rename attributes that have a block: https://github.com/ruby-grape/grape/blob/master/lib/grape/dsl/parameters.rb#L134. Known side effects: renamed keys aren't removed from `params` and cause duplication there, but `declared(params)` keeps only the correct keys.

This PR doesn't fix the problem with duplication of keys in the `params` hash when a deeply nested attribute or an attribute with a block is renamed. Here we remove renamed keys https://github.com/ruby-grape/grape/blob/master/lib/grape/endpoint.rb#L327-L332, but the only place we mark keys for deletion is here: https://github.com/ruby-grape/grape/blob/master/lib/grape/validations/params_scope.rb#L128 and it doesn't cover the case of hash/array attributes with block or even ordinary nested attributes.