### PR TITLE
Add .configuration to Grape::API (fixes #1906)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Your contribution here.
 * [#1904](https://github.com/ruby-grape/grape/pull/1904): Allows Grape to load files on startup rather than on the first call - [@myxoh](https://github.com/myxoh).
+* [#1907](https://github.com/ruby-grape/grape/pull/1907): Adds outside configuration to Grape with `configure` - [@unleashy](https://github.com/unleashy).
 
 #### Fixes
 

--- a/README.md
+++ b/README.md
@@ -631,6 +631,17 @@ Grape.configure do |config|
 end
 ```
 
+You can also configure a single API:
+
+```ruby
+API.configure do |config|
+  config[key] = value
+end
+```
+
+This will be available inside the API with `configuration`, as if it were
+[mount configuration](#mount-configuration).
+
 ## Parameters
 
 Request parameters are available through the `params` hash object. This includes `GET`, `POST`

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -42,6 +42,11 @@ module Grape
         end
       end
 
+      # Configure an API from the outside. If a block is given, it'll pass a
+      # configuration hash to the block which you can use to configure your
+      # API. If no block is given, returns the configuration hash.
+      # The configuration set here is accessible from inside an API with
+      # `configuration` as normal.
       def configure
         config = @base_instance.configuration
         if block_given?

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -46,6 +46,7 @@ module Grape
         config.each do |key, value|
           base_instance.configuration[key] = value
         end
+        self
       end
 
       # This is the interface point between Rack and Grape; it accepts a request

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -42,6 +42,12 @@ module Grape
         end
       end
 
+      def with_configuration(config)
+        config.each do |key, value|
+          base_instance.configuration[key] = value
+        end
+      end
+
       # This is the interface point between Rack and Grape; it accepts a request
       # from Rack and ultimately returns an array of three values: the status,
       # the headers, and the body. See [the rack specification]

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -42,11 +42,14 @@ module Grape
         end
       end
 
-      def with_configuration(config)
-        config.each do |key, value|
-          base_instance.configuration[key] = value
+      def configure
+        config = @base_instance.configuration
+        if block_given?
+          yield config
+          self
+        else
+          config
         end
-        self
       end
 
       # This is the interface point between Rack and Grape; it accepts a request

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3754,6 +3754,42 @@ XML
     end
   end
 
+  describe '.with_configuration' do
+    it 'passes configuration from outside' do
+      subject.with_configuration(hello: 'hello', bread: 'bread')
+      subject.get '/hello-bread' do
+        "#{configuration[:hello]} #{configuration[:bread]}"
+      end
+
+      get '/hello-bread'
+      expect(last_response.body).to eq 'hello bread'
+    end
+
+    it 'inherits configuration on mounted APIs' do
+      a = Class.new(Grape::API) do
+          get '/hello' do
+            configuration[:hello]
+          end
+        end
+
+        b = Class.new(Grape::API) do
+          get '/bread' do
+            configuration[:bread]
+          end
+        end
+
+        subject.mount a
+        a.mount b
+        subject.with_configuration(hello: 'hello', bread: 'bread')
+
+        get '/hello'
+        expect(last_response.body).to eq 'hello'
+
+        get '/bread'
+        expect(last_response.body).to eq 'bread'
+    end
+  end
+
   context 'catch-all' do
     before do
       api1 = Class.new(Grape::API)

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3754,7 +3754,7 @@ XML
     end
   end
 
-  fdescribe '.configure' do
+  describe '.configure' do
     context 'when given a block' do
       it 'returns self' do
         expect(subject.configure {}).to be subject

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3790,33 +3790,6 @@ XML
       get '/hello-bread'
       expect(last_response.body).to eq 'hello bread'
     end
-
-    it 'inherits configuration on mounted APIs' do
-      a = Class.new(Grape::API) do
-          get '/hello' do
-            configuration[:hello]
-          end
-        end
-
-        b = Class.new(Grape::API) do
-          get '/bread' do
-            configuration[:bread]
-          end
-        end
-
-        subject.mount a
-        a.mount b
-        subject.configure do |config|
-          config[:hello] = 'hello'
-          config[:bread] = 'bread'
-        end
-
-        get '/hello'
-        expect(last_response.body).to eq 'hello'
-
-        get '/bread'
-        expect(last_response.body).to eq 'bread'
-    end
   end
 
   context 'catch-all' do

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3755,6 +3755,10 @@ XML
   end
 
   describe '.with_configuration' do
+    it 'returns self' do
+      expect(subject.with_configuration({})).to be subject
+    end
+
     it 'passes configuration from outside' do
       subject.with_configuration(hello: 'hello', bread: 'bread')
       subject.get '/hello-bread' do

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3754,13 +3754,35 @@ XML
     end
   end
 
-  describe '.with_configuration' do
-    it 'returns self' do
-      expect(subject.with_configuration({})).to be subject
+  fdescribe '.configure' do
+    context 'when given a block' do
+      it 'returns self' do
+        expect(subject.configure {}).to be subject
+      end
+
+      it 'calls the block passing the config' do
+        call = [false, nil]
+        subject.configure do |config|
+          call = [true, config]
+        end
+
+        expect(call[0]).to be true
+        expect(call[1]).not_to be_nil
+      end
     end
 
-    it 'passes configuration from outside' do
-      subject.with_configuration(hello: 'hello', bread: 'bread')
+    context 'when not given a block' do
+      it 'returns a configuration object' do
+        expect(subject.configure).to respond_to(:[], :[]=)
+      end
+    end
+
+    it 'allows configuring the api' do
+      subject.configure do |config|
+        config[:hello] = 'hello'
+        config[:bread] = 'bread'
+      end
+
       subject.get '/hello-bread' do
         "#{configuration[:hello]} #{configuration[:bread]}"
       end
@@ -3784,7 +3806,10 @@ XML
 
         subject.mount a
         a.mount b
-        subject.with_configuration(hello: 'hello', bread: 'bread')
+        subject.configure do |config|
+          config[:hello] = 'hello'
+          config[:bread] = 'bread'
+        end
 
         get '/hello'
         expect(last_response.body).to eq 'hello'


### PR DESCRIPTION
Still work in progress... includes an intentionally failing test for the inheritance of config to mounted APIs, which I am totally unsure of how to implement and would really like some help with :)

Also if the method name is appropriate. I prefer `with_configuration(hash)` but @myxoh thought of `with(configuration: hash)`.

Todo list:
- [x] ~~inheritance of config on mounted endpoints~~
- [x] documentation
- [x] changelog

Thanks!