### PR TITLE
Use defined? to correct not initialized warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Fixes
 
+* Your contribution here.
 * [#1909](https://github.com/ruby-grape/grape/pull/1909): Use defined? to correct not initialized warnings - [@nbeyer](https://github.com/nbeyer).
 * [#1893](https://github.com/ruby-grape/grape/pull/1893): Allows `Grape::API` to behave like a Rack::app in some instances where it was misbehaving - [@myxoh](https://github.com/myxoh).
 * [#1898](https://github.com/ruby-grape/grape/pull/1898): Refactor `ValidatorFactory` to improve memory allocation - [@Bhacaz](https://github.com/Bhacaz).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 #### Fixes
 
-* Your contribution here.
+* [#1909](https://github.com/ruby-grape/grape/pull/1909): Use defined? to correct not initialized warnings - [@nbeyer](https://github.com/nbeyer).
 * [#1893](https://github.com/ruby-grape/grape/pull/1893): Allows `Grape::API` to behave like a Rack::app in some instances where it was misbehaving - [@myxoh](https://github.com/myxoh).
 * [#1898](https://github.com/ruby-grape/grape/pull/1898): Refactor `ValidatorFactory` to improve memory allocation - [@Bhacaz](https://github.com/Bhacaz).
 * [#1900](https://github.com/ruby-grape/grape/pull/1900): Define boolean for `Grape::Api::Instance` - [@Bhacaz](https://github.com/Bhacaz).

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -49,7 +49,7 @@ module Grape
             end
           end
 
-          @versions.last unless @versions.nil?
+          @versions.last if defined?(@versions) && @versions
         end
 
         # Define a root URL prefix for your entire API.
@@ -163,8 +163,8 @@ module Grape
         def namespace(space = nil, options = {}, &block)
           if space || block_given?
             within_namespace do
-              previous_namespace_description = @namespace_description
-              @namespace_description = (@namespace_description || {}).deep_merge(namespace_setting(:description) || {})
+              previous_namespace_description = defined?(@namespace_description) ? @namespace_description : nil
+              @namespace_description = (previous_namespace_description || {}).deep_merge(namespace_setting(:description) || {})
               nest(block) do
                 if space
                   namespace_stackable(:namespace, Namespace.new(space, options))


### PR DESCRIPTION
The class instances variables `@versions` and `@namespace_description` may not be initialized when used and Ruby will report their access as a warning. Using the defined? keyword will correct that. There are plenty of alternative changes could be made to avoid this, but I just picked the most minimal change.