### PR TITLE
AtLeastOneOfValidator properly treats nested params in errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#1911](https://github.com/ruby-grape/grape/pull/1911): Make sure `Grape::Valiations::AtLeastOneOfValidator` properly treats nested params in errors - [@dnesteryuk](https://github.com/dnesteryuk).
 * [#1893](https://github.com/ruby-grape/grape/pull/1893): Allows `Grape::API` to behave like a Rack::app in some instances where it was misbehaving - [@myxoh](https://github.com/myxoh).
 * [#1898](https://github.com/ruby-grape/grape/pull/1898): Refactor `ValidatorFactory` to improve memory allocation - [@Bhacaz](https://github.com/Bhacaz).
 * [#1900](https://github.com/ruby-grape/grape/pull/1900): Define boolean for `Grape::Api::Instance` - [@Bhacaz](https://github.com/Bhacaz).
@@ -17,7 +18,7 @@
 
 #### Features
 
-* [#1888](https://github.com/ruby-grape/grape/pull/1888): Makes the `configuration` hash widly available - [@myxoh](https://github.com/myxoh).
+* [#1888](https://github.com/ruby-grape/grape/pull/1888): Makes the `configuration` hash widely available - [@myxoh](https://github.com/myxoh).
 * [#1864](https://github.com/ruby-grape/grape/pull/1864): Adds `finally` on the API - [@myxoh](https://github.com/myxoh).
 * [#1869](https://github.com/ruby-grape/grape/pull/1869): Fix issue with empty headers after `error!` method call - [@anaumov](https://github.com/anaumov).
 

--- a/lib/grape/validations/validators/at_least_one_of.rb
+++ b/lib/grape/validations/validators/at_least_one_of.rb
@@ -1,11 +1,14 @@
+require 'grape/validations/validators/multiple_params_base'
+
 module Grape
   module Validations
-    require 'grape/validations/validators/multiple_params_base'
     class AtLeastOneOfValidator < MultipleParamsBase
       def validate!(params)
         super
         if scope_requires_params && no_exclusive_params_are_present
-          raise Grape::Exceptions::Validation, params: all_keys, message: message(:at_least_one)
+          scoped_params = all_keys.map { |key| @scope.full_name(key) }
+          raise Grape::Exceptions::Validation, params: scoped_params,
+                                               message: message(:at_least_one)
         end
         params
       end

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -1485,16 +1485,16 @@ describe Grape::Validations do
         before :each do
           subject.params do
             requires :nested, type: Hash do
-              optional :beer_nested
-              optional :wine_nested
-              optional :juice_nested
-              at_least_one_of :beer_nested, :wine_nested, :juice_nested
+              optional :beer
+              optional :wine
+              optional :juice
+              at_least_one_of :beer, :wine, :juice
             end
             optional :nested2, type: Array do
-              optional :beer_nested2
-              optional :wine_nested2
-              optional :juice_nested2
-              at_least_one_of :beer_nested2, :wine_nested2, :juice_nested2
+              optional :beer
+              optional :wine
+              optional :juice
+              at_least_one_of :beer, :wine, :juice
             end
           end
           subject.get '/at_least_one_of_nested' do
@@ -1505,17 +1505,17 @@ describe Grape::Validations do
         it 'errors when none are present' do
           get '/at_least_one_of_nested'
           expect(last_response.status).to eq(400)
-          expect(last_response.body).to eq 'nested is missing, beer_nested, wine_nested, juice_nested are missing, at least one parameter must be provided'
+          expect(last_response.body).to eq 'nested is missing, nested[beer], nested[wine], nested[juice] are missing, at least one parameter must be provided'
         end
 
         it 'does not error when one is present' do
-          get '/at_least_one_of_nested', nested: { beer_nested: 'string' }, nested2: [{ beer_nested2: 'string' }]
+          get '/at_least_one_of_nested', nested: { beer: 'string' }, nested2: [{ beer: 'string' }]
           expect(last_response.status).to eq(200)
           expect(last_response.body).to eq 'at_least_one_of works!'
         end
 
         it 'does not error when two are present' do
-          get '/at_least_one_of_nested', nested: { beer_nested: 'string', wine_nested: 'string' }, nested2: [{ beer_nested2: 'string', wine_nested2: 'string' }]
+          get '/at_least_one_of_nested', nested: { beer: 'string', wine: 'string' }, nested2: [{ beer: 'string', wine: 'string' }]
           expect(last_response.status).to eq(200)
           expect(last_response.body).to eq 'at_least_one_of works!'
         end


### PR DESCRIPTION
Unlike other validators `Grape::Valiations::AtLeastOneOfValidator` didn't wrap params into a scope (namespace) for errors when params were nested.

Closes #1849