### PR TITLE
Upgrade rack-test to 1.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test', '~> 0.6.3'
+  gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.0'
   gem 'ruby-grape-danger', '~> 0.1.0', require: false
 end

--- a/gemfiles/multi_json.gemfile
+++ b/gemfiles/multi_json.gemfile
@@ -27,7 +27,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test', '~> 0.6.3'
+  gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.0'
   gem 'ruby-grape-danger', '~> 0.1.0', require: false
 end

--- a/gemfiles/multi_xml.gemfile
+++ b/gemfiles/multi_xml.gemfile
@@ -27,7 +27,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test', '~> 0.6.3'
+  gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.0'
   gem 'ruby-grape-danger', '~> 0.1.0', require: false
 end

--- a/gemfiles/rack_edge.gemfile
+++ b/gemfiles/rack_edge.gemfile
@@ -27,7 +27,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test', '~> 0.6.3'
+  gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.0'
   gem 'ruby-grape-danger', '~> 0.1.0', require: false
 end

--- a/gemfiles/rails_3.gemfile
+++ b/gemfiles/rails_3.gemfile
@@ -28,7 +28,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test', '~> 0.6.3'
+  gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.0'
   gem 'ruby-grape-danger', '~> 0.1.0', require: false
 end

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -27,7 +27,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test', '~> 0.6.3'
+  gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.0'
   gem 'ruby-grape-danger', '~> 0.1.0', require: false
 end

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -27,7 +27,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test', '~> 0.6.3'
+  gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.0'
   gem 'ruby-grape-danger', '~> 0.1.0', require: false
 end

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -27,7 +27,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test', '~> 0.6.3'
+  gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.0'
   gem 'ruby-grape-danger', '~> 0.1.0', require: false
 end

--- a/spec/grape/validations/validators/coerce_spec.rb
+++ b/spec/grape/validations/validators/coerce_spec.rb
@@ -576,7 +576,7 @@ describe Grape::Validations::CoerceValidator do
         expect(last_response.status).to eq(200)
         expect(last_response.body).to eq('arrays work')
 
-        get '/', splines: [{ x: 2, ints: [] }, { x: 3, ints: [4], obj: { y: 'quack' } }]
+        get '/', splines: [{ x: 2, ints: [5] }, { x: 3, ints: [4], obj: { y: 'quack' } }]
         expect(last_response.status).to eq(200)
         expect(last_response.body).to eq('arrays work')
 
@@ -592,7 +592,7 @@ describe Grape::Validations::CoerceValidator do
         expect(last_response.status).to eq(400)
         expect(last_response.body).to eq('splines[x] does not have a valid value')
 
-        get '/', splines: [{ x: 1, ints: [] }, { x: 4, ints: [] }]
+        get '/', splines: [{ x: 1, ints: [5] }, { x: 4, ints: [6] }]
         expect(last_response.status).to eq(400)
         expect(last_response.body).to eq('splines[x] does not have a valid value')
       end

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -540,7 +540,10 @@ describe Grape::Validations do
         ]
 
         expect(last_response.status).to eq(400)
-        expect(last_response.body).to eq('children[0][parents] is missing, children[1][parents] is missing')
+        expect(last_response.body).to eq(
+          'children[0][parents][0][name] is missing, ' \
+          'children[1][parents][0][name] is missing'
+        )
       end
 
       it 'safely handles empty arrays and blank parameters' do
@@ -548,7 +551,14 @@ describe Grape::Validations do
         # should actually return 200, since an empty array is valid.
         get '/within_array', children: []
         expect(last_response.status).to eq(400)
-        expect(last_response.body).to eq('children is missing')
+        expect(last_response.body).to eq(
+          'children[0][name] is missing, ' \
+          'children[0][parents] is missing, ' \
+          'children[0][parents] is invalid, ' \
+          'children[0][parents][0][name] is missing, ' \
+          'children[0][parents][0][name] is empty'
+        )
+
         get '/within_array', children: [name: 'Jay']
         expect(last_response.status).to eq(400)
         expect(last_response.body).to eq('children[0][parents] is missing')


### PR DESCRIPTION
As it was mentioned in #1658 empty arrays aren't ignored anymore, so specs should be updated.

Is a note in the changlelog required for this PR? It isn't a new feature, neither a bugfix :thinking:  

Closes #1656 