### PR TITLE
Fix error messages for nested multiple params validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#1898](https://github.com/ruby-grape/grape/pull/1898): Refactor `ValidatorFactory` to improve memory allocation - [@Bhacaz](https://github.com/Bhacaz).
 * [#1900](https://github.com/ruby-grape/grape/pull/1900): Define boolean for `Grape::Api::Instance` - [@Bhacaz](https://github.com/Bhacaz).
 * [#1903](https://github.com/ruby-grape/grape/pull/1903): Allow nested params renaming (Hash/Array) - [@bikolya](https://github.com/bikolya).
+* [#1913](https://github.com/ruby-grape/grape/pull/1913): Fix multiple params validators to return correct messages for nested params - [@bikolya](https://github.com/bikolya).
 
 ### 1.2.4 (2019/06/13)
 

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -225,6 +225,8 @@ require 'grape/util/endpoint_configuration'
 
 require 'grape/validations/validators/base'
 require 'grape/validations/attributes_iterator'
+require 'grape/validations/single_attribute_iterator'
+require 'grape/validations/multiple_attributes_iterator'
 require 'grape/validations/validators/allow_blank'
 require 'grape/validations/validators/as'
 require 'grape/validations/validators/at_least_one_of'

--- a/lib/grape/validations/attributes_iterator.rb
+++ b/lib/grape/validations/attributes_iterator.rb
@@ -5,12 +5,11 @@ module Grape
 
       attr_reader :scope
 
-      def initialize(validator, scope, params, multiple_params: false)
+      def initialize(validator, scope, params)
         @scope = scope
         @attrs = validator.attrs
         @original_params = scope.params(params)
         @params = Array.wrap(@original_params)
-        @multiple_params = multiple_params
       end
 
       def each(&block)
@@ -42,14 +41,12 @@ module Grape
             @scope.index = index
           end
 
-          if @multiple_params
-            yield resource_params, @attrs
-          else
-            @attrs.each do |attr_name|
-              yield resource_params, attr_name
-            end
-          end
+          yield_attributes(resource_params, @attrs, &block)
         end
+      end
+
+      def yield_attributes(_resource_params, _attrs)
+        raise NotImplementedError
       end
     end
   end

--- a/lib/grape/validations/attributes_iterator.rb
+++ b/lib/grape/validations/attributes_iterator.rb
@@ -5,11 +5,12 @@ module Grape
 
       attr_reader :scope
 
-      def initialize(validator, scope, params)
+      def initialize(validator, scope, params, multiple_params: false)
         @scope = scope
         @attrs = validator.attrs
         @original_params = scope.params(params)
         @params = Array.wrap(@original_params)
+        @multiple_params = multiple_params
       end
 
       def each(&block)
@@ -41,8 +42,12 @@ module Grape
             @scope.index = index
           end
 
-          @attrs.each do |attr_name|
-            yield resource_params, attr_name, inside_array
+          if @multiple_params
+            yield resource_params, @attrs
+          else
+            @attrs.each do |attr_name|
+              yield resource_params, attr_name
+            end
           end
         end
       end

--- a/lib/grape/validations/multiple_attributes_iterator.rb
+++ b/lib/grape/validations/multiple_attributes_iterator.rb
@@ -1,0 +1,11 @@
+module Grape
+  module Validations
+    class MultipleAttributesIterator < AttributesIterator
+      private
+
+      def yield_attributes(resource_params, _attrs)
+        yield resource_params
+      end
+    end
+  end
+end

--- a/lib/grape/validations/single_attribute_iterator.rb
+++ b/lib/grape/validations/single_attribute_iterator.rb
@@ -1,0 +1,13 @@
+module Grape
+  module Validations
+    class SingleAttributeIterator < AttributesIterator
+      private
+
+      def yield_attributes(resource_params, attrs)
+        attrs.each do |attr_name|
+          yield resource_params, attr_name
+        end
+      end
+    end
+  end
+end

--- a/lib/grape/validations/validators/all_or_none.rb
+++ b/lib/grape/validations/validators/all_or_none.rb
@@ -1,19 +1,12 @@
+require 'grape/validations/validators/multiple_params_base'
+
 module Grape
   module Validations
-    require 'grape/validations/validators/multiple_params_base'
     class AllOrNoneOfValidator < MultipleParamsBase
-      def validate!(params)
-        super
-        if scope_requires_params && only_subset_present
-          raise Grape::Exceptions::Validation, params: all_keys, message: message(:all_or_none)
-        end
-        params
-      end
-
-      private
-
-      def only_subset_present
-        scoped_params.any? { |resource_params| !keys_in_common(resource_params).empty? && keys_in_common(resource_params).length < attrs.length }
+      def validate_params!(params)
+        keys = keys_in_common(params)
+        return if keys.empty? || keys.length == all_keys.length
+        raise Grape::Exceptions::Validation, params: all_keys, message: message(:all_or_none)
       end
     end
   end

--- a/lib/grape/validations/validators/at_least_one_of.rb
+++ b/lib/grape/validations/validators/at_least_one_of.rb
@@ -3,20 +3,9 @@ require 'grape/validations/validators/multiple_params_base'
 module Grape
   module Validations
     class AtLeastOneOfValidator < MultipleParamsBase
-      def validate!(params)
-        super
-        if scope_requires_params && no_exclusive_params_are_present
-          scoped_params = all_keys.map { |key| @scope.full_name(key) }
-          raise Grape::Exceptions::Validation, params: scoped_params,
-                                               message: message(:at_least_one)
-        end
-        params
-      end
-
-      private
-
-      def no_exclusive_params_are_present
-        scoped_params.any? { |resource_params| keys_in_common(resource_params).empty? }
+      def validate_params!(params)
+        return unless keys_in_common(params).empty?
+        raise Grape::Exceptions::Validation, params: all_keys, message: message(:at_least_one)
       end
     end
   end

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -35,7 +35,7 @@ module Grape
       # @raise [Grape::Exceptions::Validation] if validation failed
       # @return [void]
       def validate!(params)
-        attributes = AttributesIterator.new(self, @scope, params)
+        attributes = SingleAttributeIterator.new(self, @scope, params)
         # we collect errors inside array because
         # there may be more than one error per field
         array_errors = []

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -36,17 +36,18 @@ module Grape
       # @return [void]
       def validate!(params)
         attributes = AttributesIterator.new(self, @scope, params)
+        # we collect errors inside array because
+        # there may be more than one error per field
         array_errors = []
+
         attributes.each do |resource_params, attr_name|
           next if !@scope.required? && resource_params.empty?
-          next unless @required || (resource_params.respond_to?(:key?) && resource_params.key?(attr_name))
           next unless @scope.meets_dependency?(resource_params, params)
-
           begin
-            validate_param!(attr_name, resource_params)
+            if @required || resource_params.respond_to?(:key?) && resource_params.key?(attr_name)
+              validate_param!(attr_name, resource_params)
+            end
           rescue Grape::Exceptions::Validation => e
-            # we collect errors inside array because
-            # there may be more than one error per field
             array_errors << e
           end
         end

--- a/lib/grape/validations/validators/default.rb
+++ b/lib/grape/validations/validators/default.rb
@@ -18,7 +18,7 @@ module Grape
       end
 
       def validate!(params)
-        attrs = AttributesIterator.new(self, @scope, params)
+        attrs = SingleAttributeIterator.new(self, @scope, params)
         attrs.each do |resource_params, attr_name|
           if resource_params.is_a?(Hash) && resource_params[attr_name].nil?
             validate_param!(attr_name, resource_params)

--- a/lib/grape/validations/validators/exactly_one_of.rb
+++ b/lib/grape/validations/validators/exactly_one_of.rb
@@ -1,28 +1,11 @@
 module Grape
   module Validations
-    require 'grape/validations/validators/mutual_exclusion'
-    class ExactlyOneOfValidator < MutualExclusionValidator
-      def validate!(params)
-        super
-        if scope_requires_params && none_of_restricted_params_is_present
+    require 'grape/validations/validators/multiple_params_base'
+    class ExactlyOneOfValidator < MultipleParamsBase
+      def validate_params!(params)
+        if keys_in_common(params).length != 1
           raise Grape::Exceptions::Validation, params: all_keys, message: message(:exactly_one)
         end
-        params
-      end
-
-      def message(default_key = nil)
-        options = instance_variable_get(:@option)
-        if options_key?(:message)
-          (options_key?(default_key, options[:message]) ? options[:message][default_key] : options[:message])
-        else
-          default_key
-        end
-      end
-
-      private
-
-      def none_of_restricted_params_is_present
-        scoped_params.any? { |resource_params| keys_in_common(resource_params).empty? }
       end
     end
   end

--- a/lib/grape/validations/validators/exactly_one_of.rb
+++ b/lib/grape/validations/validators/exactly_one_of.rb
@@ -1,11 +1,11 @@
+require 'grape/validations/validators/multiple_params_base'
+
 module Grape
   module Validations
-    require 'grape/validations/validators/multiple_params_base'
     class ExactlyOneOfValidator < MultipleParamsBase
       def validate_params!(params)
-        if keys_in_common(params).length != 1
-          raise Grape::Exceptions::Validation, params: all_keys, message: message(:exactly_one)
-        end
+        return if keys_in_common(params).length == 1
+        raise Grape::Exceptions::Validation, params: all_keys, message: message(:exactly_one)
       end
     end
   end

--- a/lib/grape/validations/validators/multiple_params_base.rb
+++ b/lib/grape/validations/validators/multiple_params_base.rb
@@ -1,12 +1,11 @@
 module Grape
   module Validations
     class MultipleParamsBase < Base
-      # rubocop:disable HashEachMethods
       def validate!(params)
-        attributes = AttributesIterator.new(self, @scope, params, multiple_params: true)
+        attributes = MultipleAttributesIterator.new(self, @scope, params)
         array_errors = []
 
-        attributes.each do |resource_params, _|
+        attributes.each do |resource_params|
           begin
             validate_params!(resource_params)
           rescue Grape::Exceptions::Validation => e
@@ -16,7 +15,6 @@ module Grape
 
         raise Grape::Exceptions::ValidationArrayErrors, array_errors if array_errors.any?
       end
-      # rubocop:enable HashEachMethods
 
       private
 

--- a/lib/grape/validations/validators/mutual_exclusion.rb
+++ b/lib/grape/validations/validators/mutual_exclusion.rb
@@ -1,24 +1,12 @@
+require 'grape/validations/validators/multiple_params_base'
+
 module Grape
   module Validations
-    require 'grape/validations/validators/multiple_params_base'
     class MutualExclusionValidator < MultipleParamsBase
-      attr_reader :processing_keys_in_common
-
-      def validate!(params)
-        super
-        if two_or_more_exclusive_params_are_present
-          raise Grape::Exceptions::Validation, params: processing_keys_in_common, message: message(:mutual_exclusion)
-        end
-        params
-      end
-
-      private
-
-      def two_or_more_exclusive_params_are_present
-        scoped_params.any? do |resource_params|
-          @processing_keys_in_common = keys_in_common(resource_params)
-          @processing_keys_in_common.length > 1
-        end
+      def validate_params!(params)
+        keys = keys_in_common(params)
+        return if keys.length <= 1
+        raise Grape::Exceptions::Validation, params: keys, message: message(:mutual_exclusion)
       end
     end
   end

--- a/spec/grape/exceptions/validation_errors_spec.rb
+++ b/spec/grape/exceptions/validation_errors_spec.rb
@@ -77,10 +77,12 @@ describe Grape::Exceptions::ValidationErrors do
       end
       get '/exactly_one_of', beer: 'string', wine: 'anotherstring'
       expect(last_response.status).to eq(400)
-      expect(JSON.parse(last_response.body)).to eq([
-                                                     'params' => %w[beer wine],
-                                                     'messages' => ['are mutually exclusive']
-                                                   ])
+      expect(JSON.parse(last_response.body)).to eq(
+        [
+          'params' => %w[beer wine juice],
+          'messages' => ['are missing, exactly one parameter must be provided']
+        ]
+      )
     end
   end
 end

--- a/spec/grape/validations/multiple_attributes_iterator_spec.rb
+++ b/spec/grape/validations/multiple_attributes_iterator_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Grape::Validations::MultipleAttributesIterator do
+  describe '#each' do
+    subject(:iterator) { described_class.new(validator, scope, params) }
+    let(:scope) { Grape::Validations::ParamsScope.new(api: Class.new(Grape::API)) }
+    let(:validator) { double(attrs: %i[first second third]) }
+
+    context 'when params is a hash' do
+      let(:params) do
+        { first: 'string', second: 'string' }
+      end
+
+      it 'yields the whole params hash without the list of attrs' do
+        expect { |b| iterator.each(&b) }.to yield_with_args(params)
+      end
+    end
+
+    context 'when params is an array' do
+      let(:params) do
+        [{ first: 'string1', second: 'string1' }, { first: 'string2', second: 'string2' }]
+      end
+
+      it 'yields each element of the array without the list of attrs' do
+        expect { |b| iterator.each(&b) }.to yield_successive_args(params[0], params[1])
+      end
+    end
+  end
+end

--- a/spec/grape/validations/single_attribute_iterator_spec.rb
+++ b/spec/grape/validations/single_attribute_iterator_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Grape::Validations::SingleAttributeIterator do
+  describe '#each' do
+    subject(:iterator) { described_class.new(validator, scope, params) }
+    let(:scope) { Grape::Validations::ParamsScope.new(api: Class.new(Grape::API)) }
+    let(:validator) { double(attrs: %i[first second third]) }
+
+    context 'when params is a hash' do
+      let(:params) do
+        { first: 'string', second: 'string' }
+      end
+
+      it 'yields params and every single attribute from the list' do
+        expect { |b| iterator.each(&b) }
+          .to yield_successive_args([params, :first], [params, :second], [params, :third])
+      end
+    end
+
+    context 'when params is an array' do
+      let(:params) do
+        [{ first: 'string1', second: 'string1' }, { first: 'string2', second: 'string2' }]
+      end
+
+      it 'yields every single attribute from the list for each of the array elements' do
+        expect { |b| iterator.each(&b) }.to yield_successive_args(
+          [params[0], :first], [params[0], :second], [params[0], :third],
+          [params[1], :first], [params[1], :second], [params[1], :third]
+        )
+      end
+    end
+  end
+end

--- a/spec/grape/validations/validators/all_or_none_spec.rb
+++ b/spec/grape/validations/validators/all_or_none_spec.rb
@@ -2,58 +2,166 @@ require 'spec_helper'
 
 describe Grape::Validations::AllOrNoneOfValidator do
   describe '#validate!' do
-    let(:scope) do
-      Struct.new(:opts) do
-        def params(arg)
-          arg
-        end
+    subject(:validate) { post path, params }
 
-        def required?; end
+    module ValidationsSpec
+      module AllOrNoneOfValidatorSpec
+        class API < Grape::API
+          rescue_from Grape::Exceptions::ValidationErrors do |e|
+            error!(e.errors.transform_keys! { |key| key.join(',') }, 400)
+          end
+
+          params do
+            optional :beer, :wine, type: Boolean
+            all_or_none_of :beer, :wine
+          end
+          post do
+          end
+
+          params do
+            optional :beer, :wine, :other, type: Boolean
+            all_or_none_of :beer, :wine
+          end
+          post 'mixed-params' do
+          end
+
+          params do
+            optional :beer, :wine, type: Boolean
+            all_or_none_of :beer, :wine, message: 'choose all or none'
+          end
+          post '/custom-message' do
+          end
+
+          params do
+            requires :item, type: Hash do
+              optional :beer, :wine, type: Boolean
+              all_or_none_of :beer, :wine
+            end
+          end
+          post '/nested-hash' do
+          end
+
+          params do
+            requires :items, type: Array do
+              optional :beer, :wine, type: Boolean
+              all_or_none_of :beer, :wine
+            end
+          end
+          post '/nested-array' do
+          end
+
+          params do
+            requires :items, type: Array do
+              requires :nested_items, type: Array do
+                optional :beer, :wine, type: Boolean
+                all_or_none_of :beer, :wine
+              end
+            end
+          end
+          post '/deeply-nested-array' do
+          end
+        end
       end
     end
-    let(:all_or_none_params) { %i[beer wine grapefruit] }
-    let(:validator) { described_class.new(all_or_none_params, {}, false, scope.new) }
+
+    def app
+      ValidationsSpec::AllOrNoneOfValidatorSpec::API
+    end
 
     context 'when all restricted params are present' do
-      let(:params) { { beer: true, wine: true, grapefruit: true } }
+      let(:path) { '/' }
+      let(:params) { { beer: true, wine: true } }
 
-      it 'does not raise a validation exception' do
-        expect(validator.validate!(params)).to eql params
+      it 'does not return a validation error' do
+        validate
+        expect(last_response.status).to eq 201
       end
 
       context 'mixed with other params' do
-        let(:mixed_params) { params.merge!(other: true, andanother: true) }
+        let(:path) { '/mixed-params' }
+        let(:params) { { beer: true, wine: true, other: true } }
 
-        it 'does not raise a validation exception' do
-          expect(validator.validate!(mixed_params)).to eql mixed_params
+        it 'does not return a validation error' do
+          validate
+          expect(last_response.status).to eq 201
         end
       end
     end
 
-    context 'when none of the restricted params is selected' do
+    context 'when a subset of restricted params are present' do
+      let(:path) { '/' }
+      let(:params) { { beer: true } }
+
+      it 'returns a validation error' do
+        validate
+        expect(last_response.status).to eq 400
+        expect(JSON.parse(last_response.body)).to eq(
+          'beer,wine' => ['provide all or none of parameters']
+        )
+      end
+    end
+
+    context 'when custom message is specified' do
+      let(:path) { '/custom-message' }
+      let(:params) { { beer: true } }
+
+      it 'returns a validation error' do
+        validate
+        expect(last_response.status).to eq 400
+        expect(JSON.parse(last_response.body)).to eq(
+          'beer,wine' => ['choose all or none']
+        )
+      end
+    end
+
+    context 'when no restricted params are present' do
+      let(:path) { '/' }
       let(:params) { { somethingelse: true } }
 
-      it 'does not raise a validation exception' do
-        expect(validator.validate!(params)).to eql params
+      it 'does not return a validation error' do
+        validate
+        expect(last_response.status).to eq 201
       end
     end
 
-    context 'when only a subset of restricted params are present' do
-      let(:params) { { beer: true, grapefruit: true } }
+    context 'when restricted params are nested inside required hash' do
+      let(:path) { '/nested-hash' }
+      let(:params) { { item: { beer: true } } }
 
-      it 'raises a validation exception' do
-        expect do
-          validator.validate! params
-        end.to raise_error(Grape::Exceptions::Validation)
+      it 'returns a validation error with full names of the params' do
+        validate
+        expect(last_response.status).to eq 400
+        expect(JSON.parse(last_response.body)).to eq(
+          'item[beer],item[wine]' => ['provide all or none of parameters']
+        )
       end
-      context 'mixed with other params' do
-        let(:mixed_params) { params.merge!(other: true, andanother: true) }
+    end
 
-        it 'raise a validation exception' do
-          expect do
-            validator.validate! params
-          end.to raise_error(Grape::Exceptions::Validation)
-        end
+    context 'when mutually exclusive params are nested inside array' do
+      let(:path) { '/nested-array' }
+      let(:params) { { items: [{ beer: true, wine: true }, { wine: true }] } }
+
+      it 'returns a validation error with full names of the params' do
+        validate
+        expect(last_response.status).to eq 400
+        expect(JSON.parse(last_response.body)).to eq(
+          'items[1][beer],items[1][wine]' => ['provide all or none of parameters']
+        )
+      end
+    end
+
+    context 'when mutually exclusive params are deeply nested' do
+      let(:path) { '/deeply-nested-array' }
+      let(:params) { { items: [{ nested_items: [{ beer: true }] }] } }
+
+      it 'returns a validation error with full names of the params' do
+        validate
+        expect(last_response.status).to eq 400
+        expect(JSON.parse(last_response.body)).to eq(
+          'items[0][nested_items][0][beer],items[0][nested_items][0][wine]' => [
+            'provide all or none of parameters'
+          ]
+        )
       end
     end
   end

--- a/spec/grape/validations/validators/at_least_one_of_spec.rb
+++ b/spec/grape/validations/validators/at_least_one_of_spec.rb
@@ -2,75 +2,209 @@ require 'spec_helper'
 
 describe Grape::Validations::AtLeastOneOfValidator do
   describe '#validate!' do
-    let(:scope) do
-      Struct.new(:opts) do
-        def params(arg)
-          arg
-        end
+    subject(:validate) { post path, params }
 
-        def required?; end
+    module ValidationsSpec
+      module AtLeastOneOfValidatorSpec
+        class API < Grape::API
+          rescue_from Grape::Exceptions::ValidationErrors do |e|
+            error!(e.errors.transform_keys! { |key| key.join(',') }, 400)
+          end
 
-        # mimics a method from Grape::Validations::ParamsScope which decides how a parameter must
-        # be named in errors
-        def full_name(name)
-          "food[#{name}]"
+          params do
+            optional :beer, :wine, :grapefruit
+            at_least_one_of :beer, :wine, :grapefruit
+          end
+          post do
+          end
+
+          params do
+            optional :beer, :wine, :grapefruit, :other
+            at_least_one_of :beer, :wine, :grapefruit
+          end
+          post 'mixed-params' do
+          end
+
+          params do
+            optional :beer, :wine, :grapefruit
+            at_least_one_of :beer, :wine, :grapefruit, message: 'you should choose something'
+          end
+          post '/custom-message' do
+          end
+
+          params do
+            requires :item, type: Hash do
+              optional :beer, :wine, :grapefruit
+              at_least_one_of :beer, :wine, :grapefruit, message: 'fail'
+            end
+          end
+          post '/nested-hash' do
+          end
+
+          params do
+            requires :items, type: Array do
+              optional :beer, :wine, :grapefruit
+              at_least_one_of :beer, :wine, :grapefruit, message: 'fail'
+            end
+          end
+          post '/nested-array' do
+          end
+
+          params do
+            requires :items, type: Array do
+              requires :nested_items, type: Array do
+                optional :beer, :wine, :grapefruit
+                at_least_one_of :beer, :wine, :grapefruit, message: 'fail'
+              end
+            end
+          end
+          post '/deeply-nested-array' do
+          end
         end
       end
     end
 
-    let(:at_least_one_of_params) { %i[beer wine grapefruit] }
-    let(:validator) { described_class.new(at_least_one_of_params, {}, false, scope.new) }
+    def app
+      ValidationsSpec::AtLeastOneOfValidatorSpec::API
+    end
 
     context 'when all restricted params are present' do
+      let(:path) { '/' }
       let(:params) { { beer: true, wine: true, grapefruit: true } }
 
-      it 'does not raise a validation exception' do
-        expect(validator.validate!(params)).to eql params
+      it 'does not return a validation error' do
+        validate
+        expect(last_response.status).to eq 201
       end
 
       context 'mixed with other params' do
-        let(:mixed_params) { params.merge!(other: true, andanother: true) }
+        let(:path) { '/mixed-params' }
+        let(:params) { { beer: true, wine: true, grapefruit: true, other: true } }
 
-        it 'does not raise a validation exception' do
-          expect(validator.validate!(mixed_params)).to eql mixed_params
+        it 'does not return a validation error' do
+          validate
+          expect(last_response.status).to eq 201
         end
       end
     end
 
     context 'when a subset of restricted params are present' do
+      let(:path) { '/' }
       let(:params) { { beer: true, grapefruit: true } }
 
-      it 'does not raise a validation exception' do
-        expect(validator.validate!(params)).to eql params
-      end
-    end
-
-    context 'when params keys come as strings' do
-      let(:params) { { 'beer' => true, 'grapefruit' => true } }
-
-      it 'does not raise a validation exception' do
-        expect(validator.validate!(params)).to eql params
+      it 'does not return a validation error' do
+        validate
+        expect(last_response.status).to eq 201
       end
     end
 
     context 'when none of the restricted params is selected' do
-      let(:params) { { somethingelse: true } }
-      it 'raises a validation exception' do
-        expected_params = at_least_one_of_params.map { |p| "food[#{p}]" }
+      let(:path) { '/' }
+      let(:params) { { other: true } }
 
-        expect { validator.validate! params }.to raise_error do |error|
-          expect(error).to be_a(Grape::Exceptions::Validation)
-          expect(error.params).to eq(expected_params)
-          expect(error.message).to eq(I18n.t('grape.errors.messages.at_least_one'))
+      it 'returns a validation error' do
+        validate
+        expect(last_response.status).to eq 400
+        expect(JSON.parse(last_response.body)).to eq(
+          'beer,wine,grapefruit' => ['are missing, at least one parameter must be provided']
+        )
+      end
+
+      context 'when custom message is specified' do
+        let(:path) { '/custom-message' }
+
+        it 'returns a validation error' do
+          validate
+          expect(last_response.status).to eq 400
+          expect(JSON.parse(last_response.body)).to eq(
+            'beer,wine,grapefruit' => ['you should choose something']
+          )
         end
       end
     end
 
     context 'when exactly one of the restricted params is selected' do
-      let(:params) { { beer: true, somethingelse: true } }
+      let(:path) { '/' }
+      let(:params) { { beer: true } }
 
-      it 'does not raise a validation exception' do
-        expect(validator.validate!(params)).to eql params
+      it 'does not return a validation error' do
+        validate
+        expect(last_response.status).to eq 201
+      end
+    end
+
+    context 'when restricted params are nested inside hash' do
+      let(:path) { '/nested-hash' }
+
+      context 'when at least one of them is present' do
+        let(:params) { { item: { beer: true, wine: true } } }
+
+        it 'does not return a validation error' do
+          validate
+          expect(last_response.status).to eq 201
+        end
+      end
+
+      context 'when none of them are present' do
+        let(:params) { { item: { other: true } } }
+
+        it 'returns a validation error with full names of the params' do
+          validate
+          expect(last_response.status).to eq 400
+          expect(JSON.parse(last_response.body)).to eq(
+            'item[beer],item[wine],item[grapefruit]' => ['fail']
+          )
+        end
+      end
+    end
+
+    context 'when restricted params are nested inside array' do
+      let(:path) { '/nested-array' }
+
+      context 'when at least one of them is present' do
+        let(:params) { { items: [{ beer: true, wine: true }, { grapefruit: true }] } }
+
+        it 'does not return a validation error' do
+          validate
+          expect(last_response.status).to eq 201
+        end
+      end
+
+      context 'when none of them are present' do
+        let(:params) { { items: [{ beer: true, other: true }, { other: true }] } }
+
+        it 'returns a validation error with full names of the params' do
+          validate
+          expect(last_response.status).to eq 400
+          expect(JSON.parse(last_response.body)).to eq(
+            'items[1][beer],items[1][wine],items[1][grapefruit]' => ['fail']
+          )
+        end
+      end
+    end
+
+    context 'when restricted params are deeply nested' do
+      let(:path) { '/deeply-nested-array' }
+
+      context 'when at least one of them is present' do
+        let(:params) { { items: [{ nested_items: [{ wine: true }] }] } }
+
+        it 'does not return a validation error' do
+          validate
+          expect(last_response.status).to eq 201
+        end
+      end
+
+      context 'when none of them are present' do
+        let(:params) { { items: [{ nested_items: [{ other: true }] }] } }
+
+        it 'returns a validation error with full names of the params' do
+          validate
+          expect(last_response.status).to eq 400
+          expect(JSON.parse(last_response.body)).to eq(
+            'items[0][nested_items][0][beer],items[0][nested_items][0][wine],items[0][nested_items][0][grapefruit]' => ['fail']
+          )
+        end
       end
     end
   end

--- a/spec/grape/validations/validators/exactly_one_of_spec.rb
+++ b/spec/grape/validations/validators/exactly_one_of_spec.rb
@@ -2,73 +2,237 @@ require 'spec_helper'
 
 describe Grape::Validations::ExactlyOneOfValidator do
   describe '#validate!' do
-    let(:scope) do
-      Struct.new(:opts) do
-        def params(arg)
-          arg
-        end
+    subject(:validate) { post path, params }
 
-        def required?; end
+    module ValidationsSpec
+      module ExactlyOneOfValidatorSpec
+        class API < Grape::API
+          rescue_from Grape::Exceptions::ValidationErrors do |e|
+            error!(e.errors.transform_keys! { |key| key.join(',') }, 400)
+          end
+
+          params do
+            optional :beer
+            optional :wine
+            optional :grapefruit
+            exactly_one_of :beer, :wine, :grapefruit
+          end
+          post do
+          end
+
+          params do
+            optional :beer
+            optional :wine
+            optional :grapefruit
+            optional :other
+            exactly_one_of :beer, :wine, :grapefruit
+          end
+          post 'mixed-params' do
+          end
+
+          params do
+            optional :beer
+            optional :wine
+            optional :grapefruit
+            exactly_one_of :beer, :wine, :grapefruit, message: 'you should choose one'
+          end
+          post '/custom-message' do
+          end
+
+          params do
+            requires :item, type: Hash do
+              optional :beer
+              optional :wine
+              optional :grapefruit
+              exactly_one_of :beer, :wine, :grapefruit
+            end
+          end
+          post '/nested-hash' do
+          end
+
+          params do
+            optional :item, type: Hash do
+              optional :beer
+              optional :wine
+              optional :grapefruit
+              exactly_one_of :beer, :wine, :grapefruit
+            end
+          end
+          post '/nested-optional-hash' do
+          end
+
+          params do
+            requires :items, type: Array do
+              optional :beer
+              optional :wine
+              optional :grapefruit
+              exactly_one_of :beer, :wine, :grapefruit
+            end
+          end
+          post '/nested-array' do
+          end
+
+          params do
+            requires :items, type: Array do
+              requires :nested_items, type: Array do
+                optional :beer, :wine, :grapefruit, type: Boolean
+                exactly_one_of :beer, :wine, :grapefruit
+              end
+            end
+          end
+          post '/deeply-nested-array' do
+          end
+        end
       end
     end
-    let(:exactly_one_of_params) { %i[beer wine grapefruit] }
-    let(:validator) { described_class.new(exactly_one_of_params, {}, false, scope.new) }
 
-    context 'when all restricted params are present' do
+    def app
+      ValidationsSpec::ExactlyOneOfValidatorSpec::API
+    end
+
+    context 'when all params are present' do
+      let(:path) { '/' }
       let(:params) { { beer: true, wine: true, grapefruit: true } }
 
-      it 'raises a validation exception' do
-        expect do
-          validator.validate! params
-        end.to raise_error(Grape::Exceptions::Validation)
+      it 'returns a validation error' do
+        validate
+        expect(last_response.status).to eq 400
+        expect(JSON.parse(last_response.body)).to eq(
+          'beer,wine,grapefruit' => ['are missing, exactly one parameter must be provided']
+        )
       end
 
       context 'mixed with other params' do
-        let(:mixed_params) { params.merge!(other: true, andanother: true) }
+        let(:path) { '/mixed-params' }
+        let(:params) { { beer: true, wine: true, grapefruit: true, other: true } }
 
-        it 'still raises a validation exception' do
-          expect do
-            validator.validate! mixed_params
-          end.to raise_error(Grape::Exceptions::Validation)
+        it 'returns a validation error' do
+          validate
+          expect(last_response.status).to eq 400
+          expect(JSON.parse(last_response.body)).to eq(
+            'beer,wine,grapefruit' => ['are missing, exactly one parameter must be provided']
+          )
         end
       end
     end
 
-    context 'when a subset of restricted params are present' do
+    context 'when a subset of params are present' do
+      let(:path) { '/' }
       let(:params) { { beer: true, grapefruit: true } }
 
-      it 'raises a validation exception' do
-        expect do
-          validator.validate! params
-        end.to raise_error(Grape::Exceptions::Validation)
+      it 'returns a validation error' do
+        validate
+        expect(last_response.status).to eq 400
+        expect(JSON.parse(last_response.body)).to eq(
+          'beer,wine,grapefruit' => ['are missing, exactly one parameter must be provided']
+        )
       end
     end
 
-    context 'when params keys come as strings' do
-      let(:params) { { 'beer' => true, 'grapefruit' => true } }
+    context 'when custom message is specified' do
+      let(:path) { '/custom-message' }
+      let(:params) { { beer: true, wine: true } }
 
-      it 'raises a validation exception' do
-        expect do
-          validator.validate! params
-        end.to raise_error(Grape::Exceptions::Validation)
+      it 'returns a validation error' do
+        validate
+        expect(last_response.status).to eq 400
+        expect(JSON.parse(last_response.body)).to eq(
+          'beer,wine,grapefruit' => ['you should choose one']
+        )
       end
     end
 
-    context 'when none of the restricted params is selected' do
-      let(:params) { { somethingelse: true } }
-
-      it 'raises a validation exception' do
-        expect do
-          validator.validate! params
-        end.to raise_error(Grape::Exceptions::Validation)
-      end
-    end
-
-    context 'when exactly one of the restricted params is selected' do
+    context 'when exacly one param is present' do
+      let(:path) { '/' }
       let(:params) { { beer: true, somethingelse: true } }
 
-      it 'does not raise a validation exception' do
-        expect(validator.validate!(params)).to eql params
+      it 'does not return a validation error' do
+        validate
+        expect(last_response.status).to eq 201
+      end
+    end
+
+    context 'when none of the params are present' do
+      let(:path) { '/' }
+      let(:params) { { somethingelse: true } }
+
+      it 'returns a validation error' do
+        validate
+        expect(last_response.status).to eq 400
+        expect(JSON.parse(last_response.body)).to eq(
+          'beer,wine,grapefruit' => ['are missing, exactly one parameter must be provided']
+        )
+      end
+    end
+
+    context 'when params are nested inside required hash' do
+      let(:path) { '/nested-hash' }
+      let(:params) { { item: { beer: true, wine: true } } }
+
+      it 'returns a validation error with full names of the params' do
+        validate
+        expect(last_response.status).to eq 400
+        expect(JSON.parse(last_response.body)).to eq(
+          'item[beer],item[wine],item[grapefruit]' => ['are missing, exactly one parameter must be provided']
+        )
+      end
+    end
+
+    context 'when params are nested inside optional hash' do
+      let(:path) { '/nested-optional-hash' }
+
+      context 'when params are passed' do
+        let(:params) { { item: { beer: true, wine: true } } }
+
+        it 'returns a validation error with full names of the params' do
+          validate
+          expect(last_response.status).to eq 400
+          expect(JSON.parse(last_response.body)).to eq(
+            'item[beer],item[wine],item[grapefruit]' => ['are missing, exactly one parameter must be provided']
+          )
+        end
+      end
+
+      context 'when params are empty' do
+        let(:params) { { other: true } }
+
+        it 'does not return a validation error' do
+          validate
+          expect(last_response.status).to eq 201
+        end
+      end
+    end
+
+    context 'when params are nested inside array' do
+      let(:path) { '/nested-array' }
+      let(:params) { { items: [{ beer: true, wine: true }, { wine: true, grapefruit: true }] } }
+
+      it 'returns a validation error with full names of the params' do
+        validate
+        expect(last_response.status).to eq 400
+        expect(JSON.parse(last_response.body)).to eq(
+          'items[0][beer],items[0][wine],items[0][grapefruit]' => [
+            'are missing, exactly one parameter must be provided'
+          ],
+          'items[1][beer],items[1][wine],items[1][grapefruit]' => [
+            'are missing, exactly one parameter must be provided'
+          ]
+        )
+      end
+    end
+
+    context 'when params are deeply nested' do
+      let(:path) { '/deeply-nested-array' }
+      let(:params) { { items: [{ nested_items: [{ beer: true, wine: true }] }] } }
+
+      it 'returns a validation error with full names of the params' do
+        validate
+        expect(last_response.status).to eq 400
+        expect(JSON.parse(last_response.body)).to eq(
+          'items[0][nested_items][0][beer],items[0][nested_items][0][wine],items[0][nested_items][0][grapefruit]' => [
+            'are missing, exactly one parameter must be provided'
+          ]
+        )
       end
     end
   end

--- a/spec/grape/validations/validators/mutual_exclusion_spec.rb
+++ b/spec/grape/validations/validators/mutual_exclusion_spec.rb
@@ -2,61 +2,218 @@ require 'spec_helper'
 
 describe Grape::Validations::MutualExclusionValidator do
   describe '#validate!' do
-    let(:scope) do
-      Struct.new(:opts) do
-        def params(arg)
-          arg
+    subject(:validate) { post path, params }
+
+    module ValidationsSpec
+      module MutualExclusionValidatorSpec
+        class API < Grape::API
+          rescue_from Grape::Exceptions::ValidationErrors do |e|
+            error!(e.errors.transform_keys! { |key| key.join(',') }, 400)
+          end
+
+          params do
+            optional :beer
+            optional :wine
+            optional :grapefruit
+            mutually_exclusive :beer, :wine, :grapefruit
+          end
+          post do
+          end
+
+          params do
+            optional :beer
+            optional :wine
+            optional :grapefruit
+            optional :other
+            mutually_exclusive :beer, :wine, :grapefruit
+          end
+          post 'mixed-params' do
+          end
+
+          params do
+            optional :beer
+            optional :wine
+            optional :grapefruit
+            mutually_exclusive :beer, :wine, :grapefruit, message: 'you should not mix beer and wine'
+          end
+          post '/custom-message' do
+          end
+
+          params do
+            requires :item, type: Hash do
+              optional :beer
+              optional :wine
+              optional :grapefruit
+              mutually_exclusive :beer, :wine, :grapefruit
+            end
+          end
+          post '/nested-hash' do
+          end
+
+          params do
+            optional :item, type: Hash do
+              optional :beer
+              optional :wine
+              optional :grapefruit
+              mutually_exclusive :beer, :wine, :grapefruit
+            end
+          end
+          post '/nested-optional-hash' do
+          end
+
+          params do
+            requires :items, type: Array do
+              optional :beer
+              optional :wine
+              optional :grapefruit
+              mutually_exclusive :beer, :wine, :grapefruit
+            end
+          end
+          post '/nested-array' do
+          end
+
+          params do
+            requires :items, type: Array do
+              requires :nested_items, type: Array do
+                optional :beer, :wine, :grapefruit, type: Boolean
+                mutually_exclusive :beer, :wine, :grapefruit
+              end
+            end
+          end
+          post '/deeply-nested-array' do
+          end
         end
       end
     end
-    let(:mutually_exclusive_params) { %i[beer wine grapefruit] }
-    let(:validator) { described_class.new(mutually_exclusive_params, {}, false, scope.new) }
+
+    def app
+      ValidationsSpec::MutualExclusionValidatorSpec::API
+    end
 
     context 'when all mutually exclusive params are present' do
+      let(:path) { '/' }
       let(:params) { { beer: true, wine: true, grapefruit: true } }
 
-      it 'raises a validation exception' do
-        expect do
-          validator.validate! params
-        end.to raise_error(Grape::Exceptions::Validation)
+      it 'returns a validation error' do
+        validate
+        expect(last_response.status).to eq 400
+        expect(JSON.parse(last_response.body)).to eq(
+          'beer,wine,grapefruit' => ['are mutually exclusive']
+        )
       end
 
       context 'mixed with other params' do
-        let(:mixed_params) { params.merge!(other: true, andanother: true) }
+        let(:path) { '/mixed-params' }
+        let(:params) { { beer: true, wine: true, grapefruit: true, other: true } }
 
-        it 'still raises a validation exception' do
-          expect do
-            validator.validate! mixed_params
-          end.to raise_error(Grape::Exceptions::Validation)
+        it 'returns a validation error' do
+          validate
+          expect(last_response.status).to eq 400
+          expect(JSON.parse(last_response.body)).to eq(
+            'beer,wine,grapefruit' => ['are mutually exclusive']
+          )
         end
       end
     end
 
     context 'when a subset of mutually exclusive params are present' do
+      let(:path) { '/' }
       let(:params) { { beer: true, grapefruit: true } }
 
-      it 'raises a validation exception' do
-        expect do
-          validator.validate! params
-        end.to raise_error(Grape::Exceptions::Validation)
+      it 'returns a validation error' do
+        validate
+        expect(last_response.status).to eq 400
+        expect(JSON.parse(last_response.body)).to eq(
+          'beer,grapefruit' => ['are mutually exclusive']
+        )
       end
     end
 
-    context 'when params keys come as strings' do
-      let(:params) { { 'beer' => true, 'grapefruit' => true } }
+    context 'when custom message is specified' do
+      let(:path) { '/custom-message' }
+      let(:params) { { beer: true, wine: true } }
 
-      it 'raises a validation exception' do
-        expect do
-          validator.validate! params
-        end.to raise_error(Grape::Exceptions::Validation)
+      it 'returns a validation error' do
+        validate
+        expect(last_response.status).to eq 400
+        expect(JSON.parse(last_response.body)).to eq(
+          'beer,wine' => ['you should not mix beer and wine']
+        )
       end
     end
 
     context 'when no mutually exclusive params are present' do
+      let(:path) { '/' }
       let(:params) { { beer: true, somethingelse: true } }
 
-      it 'params' do
-        expect(validator.validate!(params)).to eql params
+      it 'does not return a validation error' do
+        validate
+        expect(last_response.status).to eq 201
+      end
+    end
+
+    context 'when mutually exclusive params are nested inside required hash' do
+      let(:path) { '/nested-hash' }
+      let(:params) { { item: { beer: true, wine: true } } }
+
+      it 'returns a validation error with full names of the params' do
+        validate
+        expect(last_response.status).to eq 400
+        expect(JSON.parse(last_response.body)).to eq(
+          'item[beer],item[wine]' => ['are mutually exclusive']
+        )
+      end
+    end
+
+    context 'when mutually exclusive params are nested inside optional hash' do
+      let(:path) { '/nested-optional-hash' }
+
+      context 'when params are passed' do
+        let(:params) { { item: { beer: true, wine: true } } }
+
+        it 'returns a validation error with full names of the params' do
+          validate
+          expect(last_response.status).to eq 400
+          expect(JSON.parse(last_response.body)).to eq(
+            'item[beer],item[wine]' => ['are mutually exclusive']
+          )
+        end
+      end
+
+      context 'when params are empty' do
+        let(:params) { {} }
+
+        it 'does not return a validation error' do
+          validate
+          expect(last_response.status).to eq 201
+        end
+      end
+    end
+
+    context 'when mutually exclusive params are nested inside array' do
+      let(:path) { '/nested-array' }
+      let(:params) { { items: [{ beer: true, wine: true }, { wine: true, grapefruit: true }] } }
+
+      it 'returns a validation error with full names of the params' do
+        validate
+        expect(last_response.status).to eq 400
+        expect(JSON.parse(last_response.body)).to eq(
+          'items[0][beer],items[0][wine]' => ['are mutually exclusive'],
+          'items[1][wine],items[1][grapefruit]' => ['are mutually exclusive']
+        )
+      end
+    end
+
+    context 'when mutually exclusive params are deeply nested' do
+      let(:path) { '/deeply-nested-array' }
+      let(:params) { { items: [{ nested_items: [{ beer: true, wine: true }] }] } }
+
+      it 'returns a validation error with full names of the params' do
+        validate
+        expect(last_response.status).to eq 400
+        expect(JSON.parse(last_response.body)).to eq(
+          'items[0][nested_items][0][beer],items[0][nested_items][0][wine]' => ['are mutually exclusive']
+        )
       end
     end
   end

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -1233,7 +1233,9 @@ describe Grape::Validations do
             end
             get '/custom_message/mutually_exclusive', beer: 'true', wine: 'true', nested: { scotch: 'true', aquavit: 'true' }, nested2: [{ scotch2: 'true' }, { scotch2: 'true', aquavit2: 'true' }]
             expect(last_response.status).to eq(400)
-            expect(last_response.body).to eq 'beer, wine are mutually exclusive pass only one, scotch, aquavit are mutually exclusive pass only one, scotch2, aquavit2 are mutually exclusive pass only one'
+            expect(last_response.body).to eq(
+              'beer, wine are mutually exclusive pass only one, nested[scotch], nested[aquavit] are mutually exclusive pass only one, nested2[1][scotch2], nested2[1][aquavit2] are mutually exclusive pass only one'
+            )
           end
         end
 
@@ -1259,7 +1261,7 @@ describe Grape::Validations do
 
           get '/mutually_exclusive', beer: 'true', wine: 'true', nested: { scotch: 'true', aquavit: 'true' }, nested2: [{ scotch2: 'true' }, { scotch2: 'true', aquavit2: 'true' }]
           expect(last_response.status).to eq(400)
-          expect(last_response.body).to eq 'beer, wine are mutually exclusive, scotch, aquavit are mutually exclusive, scotch2, aquavit2 are mutually exclusive'
+          expect(last_response.body).to eq 'beer, wine are mutually exclusive, nested[scotch], nested[aquavit] are mutually exclusive, nested2[1][scotch2], nested2[1][aquavit2] are mutually exclusive'
         end
       end
 
@@ -1328,7 +1330,7 @@ describe Grape::Validations do
               optional :beer
               optional :wine
               optional :juice
-              exactly_one_of :beer, :wine, :juice, message: { exactly_one: 'are missing, exactly one parameter is required', mutual_exclusion: 'are mutually exclusive, exactly one parameter is required' }
+              exactly_one_of :beer, :wine, :juice, message: 'are missing, exactly one parameter is required'
             end
             get '/exactly_one_of' do
               'exactly_one_of works!'
@@ -1362,7 +1364,7 @@ describe Grape::Validations do
           it 'errors when two or more are present' do
             get '/custom_message/exactly_one_of', beer: 'string', wine: 'anotherstring'
             expect(last_response.status).to eq(400)
-            expect(last_response.body).to eq 'beer, wine are mutually exclusive, exactly one parameter is required'
+            expect(last_response.body).to eq 'beer, wine, juice are missing, exactly one parameter is required'
           end
         end
 
@@ -1381,7 +1383,7 @@ describe Grape::Validations do
         it 'errors when two or more are present' do
           get '/exactly_one_of', beer: 'string', wine: 'anotherstring'
           expect(last_response.status).to eq(400)
-          expect(last_response.body).to eq 'beer, wine are mutually exclusive'
+          expect(last_response.body).to eq 'beer, wine, juice are missing, exactly one parameter must be provided'
         end
       end
 
@@ -1409,7 +1411,7 @@ describe Grape::Validations do
         it 'errors when none are present' do
           get '/exactly_one_of_nested'
           expect(last_response.status).to eq(400)
-          expect(last_response.body).to eq 'nested is missing, beer_nested, wine_nested, juice_nested are missing, exactly one parameter must be provided'
+          expect(last_response.body).to eq 'nested is missing, nested[beer_nested], nested[wine_nested], nested[juice_nested] are missing, exactly one parameter must be provided'
         end
 
         it 'succeeds when one is present' do
@@ -1421,7 +1423,7 @@ describe Grape::Validations do
         it 'errors when two or more are present' do
           get '/exactly_one_of_nested', nested: { beer_nested: 'string' }, nested2: [{ beer_nested2: 'string', wine_nested2: 'anotherstring' }]
           expect(last_response.status).to eq(400)
-          expect(last_response.body).to eq 'beer_nested2, wine_nested2 are mutually exclusive'
+          expect(last_response.body).to eq 'nested2[0][beer_nested2], nested2[0][wine_nested2], nested2[0][juice_nested2] are missing, exactly one parameter must be provided'
         end
       end
     end


### PR DESCRIPTION
Previously multiple params validators returned messages without considering the scope.
For example, in case of hash params:
`{ "param_1,param_2": 'error message' }`
instead of:
`{ "hash[param_1],hash[param_2]": 'error message' }`

Or in case of arrays, indexes were ignored completely:
`{ "param_1,param_2": 'error message' }`
instead of:
`{ "array[1][param_1],array[1][param_2]": 'error message' }`

This PR fixes it by using `AttributesIterator` in a similar way to `Grape::Validations::Base`.

Also the specs are refactored to work in a similar way to the ordinary single-parameter validations.