### PR TITLE
Run specs in random order

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --format=documentation
+--order=rand

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Your contribution here.
 * [#1904](https://github.com/ruby-grape/grape/pull/1904): Allows Grape to load files on startup rather than on the first call - [@myxoh](https://github.com/myxoh).
 * [#1907](https://github.com/ruby-grape/grape/pull/1907): Adds outside configuration to Grape with `configure` - [@unleashy](https://github.com/unleashy).
+* [#1914](https://github.com/ruby-grape/grape/pull/1914): Run specs in random order - [@splattael](https://github.com/splattael).
 
 #### Fixes
 

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -8,7 +8,7 @@ describe Grape::Endpoint do
   end
 
   describe '.before_each' do
-    after { Grape::Endpoint.before_each(nil) }
+    after { Grape::Endpoint.before_each.clear }
 
     it 'is settable via block' do
       block = ->(_endpoint) { 'noop' }

--- a/spec/grape/exceptions/base_spec.rb
+++ b/spec/grape/exceptions/base_spec.rb
@@ -8,8 +8,11 @@ describe Grape::Exceptions::Base do
     let(:attributes) { { klass: String, to_format: 'xml' } }
 
     after do
+      I18n.enforce_available_locales = true
       I18n.available_locales = %i[en]
+      I18n.locale = :en
       I18n.default_locale = :en
+      I18n.reload!
     end
 
     context 'when I18n enforces available locales' do
@@ -29,6 +32,7 @@ describe Grape::Exceptions::Base do
       context 'when the fallback locale is not available' do
         before do
           I18n.available_locales = %i[de jp]
+          I18n.locale = :de
           I18n.default_locale = :de
         end
 

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -391,6 +391,10 @@ describe Grape::Middleware::Formatter do
       Grape::Formatter.register :invalid, InvalidFormatter
       Grape::ContentTypes::CONTENT_TYPES[:invalid] = 'application/x-invalid'
     end
+    after do
+      Grape::ContentTypes::CONTENT_TYPES.delete(:invalid)
+      Grape::Formatter.default_elements.delete(:invalid)
+    end
 
     it 'returns response by invalid formatter' do
       env = { 'PATH_INFO' => '/hello.invalid', 'HTTP_ACCEPT' => 'application/x-invalid' }

--- a/spec/grape/validations/validators/coerce_spec.rb
+++ b/spec/grape/validations/validators/coerce_spec.rb
@@ -20,10 +20,13 @@ describe Grape::Validations::CoerceValidator do
 
     context 'i18n' do
       after :each do
+        I18n.available_locales = %i[en]
         I18n.locale = :en
+        I18n.default_locale = :en
       end
 
       it 'i18n error on malformed input' do
+        I18n.available_locales = %i[en zh-CN]
         I18n.load_path << File.expand_path('../zh-CN.yml', __FILE__)
         I18n.reload!
         I18n.locale = 'zh-CN'.to_sym
@@ -40,6 +43,7 @@ describe Grape::Validations::CoerceValidator do
       end
 
       it 'gives an english fallback error when default locale message is blank' do
+        I18n.available_locales = %i[en pt-BR]
         I18n.locale = 'pt-BR'.to_sym
         subject.params do
           requires :age, type: Integer


### PR DESCRIPTION
This PR enables spec randomization by default. It also fixes a couple of failures discovered after enabling `--order=rand` :nerd_face: 