### PR TITLE
Update access to rack constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#1917](https://github.com/ruby-grape/grape/pull/1917): Update access to rack constant - [@NikolayRys](https://github.com/NikolayRys).
 * [#1916](https://github.com/ruby-grape/grape/pull/1916): Drop old appraisals - [@NikolayRys](https://github.com/NikolayRys).
 * [#1911](https://github.com/ruby-grape/grape/pull/1911): Make sure `Grape::Valiations::AtLeastOneOfValidator` properly treats nested params in errors - [@dnesteryuk](https://github.com/dnesteryuk).
 * [#1893](https://github.com/ruby-grape/grape/pull/1893): Allows `Grape::API` to behave like a Rack::app in some instances where it was misbehaving - [@myxoh](https://github.com/myxoh).

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -213,7 +213,13 @@ describe Grape::Middleware::Formatter do
   context 'no content responses' do
     let(:no_content_response) { ->(status) { [status, {}, ['']] } }
 
-    Rack::Utils::STATUS_WITH_NO_ENTITY_BODY.each do |status|
+    STATUSES_WITHOUT_BODY = if Gem::Version.new(Rack.release) >= Gem::Version.new('2.1.0')
+                              Rack::Utils::STATUS_WITH_NO_ENTITY_BODY.keys
+                            else
+                              Rack::Utils::STATUS_WITH_NO_ENTITY_BODY
+                            end
+
+    STATUSES_WITHOUT_BODY.each do |status|
       it "does not modify a #{status} response" do
         expected_response = no_content_response[status]
         allow(app).to receive(:call).and_return(expected_response)


### PR DESCRIPTION
A small fix to keep up with the new changes in rack: https://github.com/rack/rack/commit/6746515453a44cc6268c46d525158278cf96307d#diff-7c1a24d5b2fe58a6f925c7cacc6c55e7L558-R558

The format of the object with the possible statuses has changed in a recent release, which breaks the rack-edge appraisal, so this PR fixes it.
