### PR TITLE
Helper method to access controller context in middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * Your contribution here.
+* [#1918](https://github.com/ruby-grape/grape/pull/1918): Helper methods to access controller context from middleware - [@NikolayRys](https://github.com/NikolayRys).
 * [#1915](https://github.com/ruby-grape/grape/pull/1915): Micro optimizations in allocating hashes and arrays - [@dnesteryuk](https://github.com/dnesteryuk).
 * [#1904](https://github.com/ruby-grape/grape/pull/1904): Allows Grape to load files on startup rather than on the first call - [@myxoh](https://github.com/myxoh).
 * [#1907](https://github.com/ruby-grape/grape/pull/1907): Adds outside configuration to Grape with `configure` - [@unleashy](https://github.com/unleashy).

--- a/README.md
+++ b/README.md
@@ -2497,6 +2497,17 @@ class Twitter::API < Grape::API
 end
 ```
 
+Inside the `rescue_from` block, the environment of the original controller method(`.self` receiver) is accessible through the `#context` method.
+
+```ruby
+class Twitter::API < Grape::API
+  rescue_from :all do |e|
+    user_id = context.params[:user_id]
+    error!("error for #{user_id}")
+  end
+end
+```
+
 #### Rescuing exceptions inside namespaces
 
 You could put `rescue_from` clauses inside a namespace and they will take precedence over ones
@@ -3121,6 +3132,8 @@ end
 
 Use [Doorkeeper](https://github.com/doorkeeper-gem/doorkeeper), [warden-oauth2](https://github.com/opperator/warden-oauth2) or [rack-oauth2](https://github.com/nov/rack-oauth2) for OAuth2 support.
 
+You can access the controller params, headers, and helpers through the context with the `#context` method inside any auth middleware inherited from `Grape::Middlware::Auth::Base`.
+
 ## Describing and Inspecting an API
 
 Grape routes can be reflected at runtime. This can notably be useful for generating documentation.
@@ -3432,6 +3445,8 @@ class API < Grape::API
   end
 end
 ```
+
+You can access the controller params, headers, and helpers through the context with the `#context` method inside any middleware inherited from `Grape::Middlware::Base`.
 
 ### Rails Middleware
 

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -111,6 +111,7 @@ module Grape
       autoload :Error
       autoload :Globals
       autoload :Stack
+      autoload :Helpers
     end
 
     module Auth

--- a/lib/grape/middleware/auth/base.rb
+++ b/lib/grape/middleware/auth/base.rb
@@ -4,15 +4,13 @@ module Grape
   module Middleware
     module Auth
       class Base
+        include Helpers
+
         attr_accessor :options, :app, :env
 
         def initialize(app, **options)
           @app = app
           @options = options
-        end
-
-        def context
-          env[Grape::Env::API_ENDPOINT]
         end
 
         def call(env)

--- a/lib/grape/middleware/base.rb
+++ b/lib/grape/middleware/base.rb
@@ -3,6 +3,8 @@ require 'grape/dsl/headers'
 module Grape
   module Middleware
     class Base
+      include Helpers
+
       attr_reader :app, :env, :options
       TEXT_HTML = 'text/html'.freeze
 

--- a/lib/grape/middleware/helpers.rb
+++ b/lib/grape/middleware/helpers.rb
@@ -1,0 +1,10 @@
+module Grape
+  module Middleware
+    # Common methods for all types of Grape middleware
+    module Helpers
+      def context
+        env[Grape::Env::API_ENDPOINT]
+      end
+    end
+  end
+end

--- a/spec/grape/middleware/base_spec.rb
+++ b/spec/grape/middleware/base_spec.rb
@@ -114,6 +114,14 @@ describe Grape::Middleware::Base do
     end
   end
 
+  describe '#context' do
+    subject { Grape::Middleware::Base.new(blank_app) }
+    it 'allows access to response context' do
+      subject.call(Grape::Env::API_ENDPOINT => { header: 'some header' })
+      expect(subject.context).to eq(header: 'some header')
+    end
+  end
+
   context 'options' do
     it 'persists options passed at initialization' do
       expect(Grape::Middleware::Base.new(blank_app, abc: true).options[:abc]).to be true


### PR DESCRIPTION
This is a feature suggestion.

Recently, working with Grape and writing some `rescue_from` handlers, I've encountered a need to access the request params, headers, and some other stuff how it was in the original controller method.

It was possible, but there was no documented and elegant way to do it. And I needed to go through the Grape source code to figure out a way to reach it. 

With this change, we can save effort and time for other clients by preventing the need to rediscover this. It is useful not only for the error handling, but also for every piece of the middleware, including formatters, and any custom middleware inherited from Grape::Middleware::Base.

This PR adds the actual helper method for accessing the context, tests, and documentation for it.