### PR TITLE
Move block call to separate method so it can be spied on

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -44,7 +44,7 @@ Metrics/BlockLength:
 # Offense count: 10
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 302
+  Max: 305
 
 # Offense count: 30
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * [#1913](https://github.com/ruby-grape/grape/pull/1913): Fix multiple params validators to return correct messages for nested params - [@bikolya](https://github.com/bikolya).
 * [#1926](https://github.com/ruby-grape/grape/pull/1926): Fixes configuration within given or mounted blocks - [@myxoh](https://github.com/myxoh).
 * [#1937](https://github.com/ruby-grape/grape/pull/1937): Fix bloat in released gem - [@dblock](https://github.com/dblock).
+* [#1930](https://github.com/ruby-grape/grape/pull/1930): Move block call to separate method so it can be spied on - [@estolfo](https://github.com/estolfo).
 
 ### 1.2.4 (2019/06/13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 #### Fixes
 
 * [#1931](https://github.com/ruby-grape/grape/pull/1946): Fixes issue when using namespaces in `Grape::API::Instance` mounted directly - [@myxoh](https://github.com/myxoh).
+* [#1930](https://github.com/ruby-grape/grape/pull/1930): Move block call to separate method so it can be spied on - [@estolfo](https://github.com/estolfo).
 
 ### 1.2.5 (2019/12/01)
 
@@ -38,7 +39,6 @@
 * [#1913](https://github.com/ruby-grape/grape/pull/1913): Fix multiple params validators to return correct messages for nested params - [@bikolya](https://github.com/bikolya).
 * [#1926](https://github.com/ruby-grape/grape/pull/1926): Fixes configuration within given or mounted blocks - [@myxoh](https://github.com/myxoh).
 * [#1937](https://github.com/ruby-grape/grape/pull/1937): Fix bloat in released gem - [@dblock](https://github.com/dblock).
-* [#1930](https://github.com/ruby-grape/grape/pull/1930): Move block call to separate method so it can be spied on - [@estolfo](https://github.com/estolfo).
 
 ### 1.2.4 (2019/06/13)
 

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -262,7 +262,7 @@ module Grape
             run_validators validations, request
             remove_renamed_params
             run_filters after_validations, :after_validation
-            response_object = @block ? @block.call(self) : nil
+            response_object = execute
           end
 
           run_filters afters, :after
@@ -334,6 +334,10 @@ module Grape
     end
 
     private :build_stack, :build_helpers, :remove_renamed_params
+
+    def execute
+      @block ? @block.call(self) : nil
+    end
 
     def helpers
       lazy_initialize! && @helpers


### PR DESCRIPTION
See [this comment](https://github.com/ruby-grape/grape/issues/1929#issuecomment-552834501)

This PR moves calling `@block` in `Endpoint` to its own method so the Elastic APM agent can overwrite the method and get a stacktrace for the span.

As noted in the comment, we'll propose a more sustainable solution in the future consisting of an interface to hook into.