### PR TITLE
[LazyBlock] Allows using complex expressions with configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * Your contribution here.
+* [#1931](https://github.com/ruby-grape/grape/pull/1931): Introduces LazyBlock to generate expressions that will executed at mount time - [@myxoh](https://github.com/myxoh).
 * [#1918](https://github.com/ruby-grape/grape/pull/1918): Helper methods to access controller context from middleware - [@NikolayRys](https://github.com/NikolayRys).
 * [#1915](https://github.com/ruby-grape/grape/pull/1915): Micro optimizations in allocating hashes and arrays - [@dnesteryuk](https://github.com/dnesteryuk).
 * [#1904](https://github.com/ruby-grape/grape/pull/1904): Allows Grape to load files on startup rather than on the first call - [@myxoh](https://github.com/myxoh).

--- a/README.md
+++ b/README.md
@@ -485,6 +485,42 @@ class ConditionalEndpoint::API < Grape::API
 end
 ```
 
+More complex results can be achieved by using mounted as an expression within which the `configuration` is already evaluated as a Hash.
+
+```ruby
+class ExpressionEndpointAPI < Grape::API
+  get(mounted { configuration[:route_name] || 'default_name' }) do
+    # some logic
+  end
+end
+```
+
+```ruby
+class BasicAPI < Grape::API
+  desc 'Statuses index' do
+    params: mounted { configuration[:entity] || API::Entities::Status }.documentation
+  end
+  params do
+    requires :all, using: mounted { configuration[:entity] || API::Entities::Status }.documentation
+  end
+  get '/statuses' do
+    statuses = Status.all
+    type = current_user.admin? ? :full : :default
+    present statuses, with: mounted { configuration[:entity] || API::Entities::Status }, type: type
+  end
+end
+
+class V1 < Grape::API
+  version 'v1'
+  mount BasicAPI, with: { entity: mounted { configuration[:entity] || API::Enitities::Status } }
+end
+
+class V2 < Grape::API
+  version 'v2'
+  mount BasicAPI, with: { entity: mounted { configuration[:entity] || API::Enitities::V2::Status } }
+end
+```
+
 ## Versioning
 
 There are four strategies in which clients can reach your API's endpoints: `:path`,

--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ class ConditionalEndpoint::API < Grape::API
 end
 ```
 
-More complex results can be achieved by using mounted as an expression within which the `configuration` is already evaluated as a Hash.
+More complex results can be achieved by using `mounted` as an expression within which the `configuration` is already evaluated as a Hash.
 
 ```ruby
 class ExpressionEndpointAPI < Grape::API

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -221,6 +221,7 @@ end
 require 'grape/config'
 require 'grape/util/content_types'
 require 'grape/util/lazy_value'
+require 'grape/util/lazy_block'
 require 'grape/util/endpoint_configuration'
 
 require 'grape/validations/validators/base'

--- a/lib/grape/api/instance.rb
+++ b/lib/grape/api/instance.rb
@@ -17,8 +17,13 @@ module Grape
         end
 
         def mounted(&block)
-          Grape::Util::LazyBlock.new do |configuration|
+          lazy_block = Grape::Util::LazyBlock.new do |configuration|
             evaluate_as_instance_with_configuration(block, configuration)
+          end
+          if base_instance?
+            lazy_block
+          else
+            lazy_block.evaluate_from(configuration)
           end
         end
 

--- a/lib/grape/util/lazy_block.rb
+++ b/lib/grape/util/lazy_block.rb
@@ -1,0 +1,25 @@
+module Grape
+  module Util
+    class LazyBlock
+      def initialize(&new_block)
+        @block = new_block
+      end
+
+      def evaluate_from(configuration)
+        @block.call(configuration)
+      end
+
+      def evaluate
+        @block.call({})
+      end
+
+      def lazy?
+        true
+      end
+
+      def to_s
+        evaluate.to_s
+      end
+    end
+  end
+end

--- a/lib/grape/util/lazy_value.rb
+++ b/lib/grape/util/lazy_value.rb
@@ -7,6 +7,11 @@ module Grape
         @access_keys = access_keys
       end
 
+      def evaluate_from(configuration)
+        matching_lazy_value = configuration.fetch(@access_keys)
+        matching_lazy_value.evaluate
+      end
+
       def evaluate
         @value
       end

--- a/spec/grape/api_remount_spec.rb
+++ b/spec/grape/api_remount_spec.rb
@@ -97,6 +97,32 @@ describe Grape::API do
         end
       end
 
+      context 'when using an expression derived from a configuration' do
+        subject(:a_remounted_api) do
+          Class.new(Grape::API) do
+            get mounted { "api_name_#{configuration[:api_name]}" } do
+              'success'
+            end
+          end
+        end
+
+        before do
+          root_api.mount a_remounted_api, with: {
+            api_name: 'a_name'
+          }
+        end
+
+        it 'mounts the endpoint with the name' do
+          get 'api_name_a_name'
+          expect(last_response.body).to eq 'success'
+        end
+
+        it 'does not mount the endpoint with a null name' do
+          get 'api_name_'
+          expect(last_response.body).not_to eq 'success'
+        end
+      end
+
       context 'when executing a standard block within a `mounted` block with all dynamic params' do
         subject(:a_remounted_api) do
           Class.new(Grape::API) do

--- a/spec/grape/api_remount_spec.rb
+++ b/spec/grape/api_remount_spec.rb
@@ -121,6 +121,28 @@ describe Grape::API do
           get 'api_name_'
           expect(last_response.body).not_to eq 'success'
         end
+
+        context 'when the expression lives in a namespace' do
+          subject(:a_remounted_api) do
+            Class.new(Grape::API) do
+              namespace :base do
+                get mounted { "api_name_#{configuration[:api_name]}" } do
+                  'success'
+                end
+              end
+            end
+          end
+
+          it 'mounts the endpoint with the name' do
+            get 'base/api_name_a_name'
+            expect(last_response.body).to eq 'success'
+          end
+
+          it 'does not mount the endpoint with a null name' do
+            get 'base/api_name_'
+            expect(last_response.body).not_to eq 'success'
+          end
+        end
       end
 
       context 'when executing a standard block within a `mounted` block with all dynamic params' do

--- a/spec/grape/api_remount_spec.rb
+++ b/spec/grape/api_remount_spec.rb
@@ -100,7 +100,7 @@ describe Grape::API do
       context 'when using an expression derived from a configuration' do
         subject(:a_remounted_api) do
           Class.new(Grape::API) do
-            get mounted { "api_name_#{configuration[:api_name]}" } do
+            get(mounted { "api_name_#{configuration[:api_name]}" }) do
               'success'
             end
           end
@@ -126,7 +126,7 @@ describe Grape::API do
           subject(:a_remounted_api) do
             Class.new(Grape::API) do
               namespace :base do
-                get mounted { "api_name_#{configuration[:api_name]}" } do
+                get(mounted { "api_name_#{configuration[:api_name]}" }) do
                   'success'
                 end
               end
@@ -351,6 +351,74 @@ describe Grape::API do
           expect(last_response.body).to eql '10 votes'
           get 'api/scores'
           expect(last_response.body).to eql '10 votes'
+        end
+      end
+
+      context 'a very complex configuration example' do
+        before do
+          top_level_api = Class.new(Grape::API) do
+            remounted_api = Class.new(Grape::API) do
+              get configuration[:endpoint_name] do
+                configuration[:response]
+              end
+            end
+
+            expression_namespace = mounted { configuration[:namespace].to_s * 2 }
+            given(mounted { configuration[:should_mount_expressed] != false }) do
+              namespace expression_namespace do
+                mount remounted_api, with: { endpoint_name: configuration[:endpoint_name], response: configuration[:endpoint_response] }
+              end
+            end
+          end
+          root_api.mount top_level_api, with: configuration_options
+        end
+
+        context 'when the namespace should be mounted' do
+          let(:configuration_options) do
+            {
+              should_mount_expressed: true,
+              namespace: 'bang',
+              endpoint_name: 'james',
+              endpoint_response: 'bond'
+            }
+          end
+
+          it 'gets a response' do
+            get 'bangbang/james'
+            expect(last_response.body).to eq 'bond'
+          end
+        end
+
+        context 'when should be mounted is nil' do
+          let(:configuration_options) do
+            {
+              should_mount_expressed: nil,
+              namespace: 'bang',
+              endpoint_name: 'james',
+              endpoint_response: 'bond'
+            }
+          end
+
+          it 'gets a response' do
+            get 'bangbang/james'
+            expect(last_response.body).to eq 'bond'
+          end
+        end
+
+        context 'when it should not be mounted' do
+          let(:configuration_options) do
+            {
+              should_mount_expressed: false,
+              namespace: 'bang',
+              endpoint_name: 'james',
+              endpoint_response: 'bond'
+            }
+          end
+
+          it 'gets a response' do
+            get 'bangbang/james'
+            expect(last_response.body).not_to eq 'bond'
+          end
         end
       end
 


### PR DESCRIPTION
This PR is motivated by a bug I've introduced on our system.
The problem, when you are trying to waterfall a configuration, is that `LazyValue` doesn't play nicely inside an expression so this code
 ```ruby
value = configuration[:attribute] || 'default_value' 
```
Is evaluated when the class is load as: configuration[:attribute] => LazyValue || 'default_value' => LazyValue
Which means that even when you mount the API with `attribute: nil` the value will equal `nil` rather than `'default_value'` as a developer might expect.

To mitigate this, I've introduced a lazy block, so you are able to put that expression within a `mounted` block which will only be evaluated when the API is mounted, and furthermore, will prevent methods using the response of the expression to running before the API is mounted