### PR TITLE
Documentation hint for mount configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,15 @@ class Comment::API < Grape::API
 end
 ```
 
+Note that if you're passing a hash as the first parameter to `mount`, you will need to explicitly put `()` around parameters:
+```ruby
+# good
+mount({ ::Some::Api => '/some/api' }, with: { condition: true })
+
+# bad
+mount ::Some::Api => '/some/api', with: { condition: true }
+```
+
 You can access `configuration` on the class (to use as dynamic attributes), inside blocks (like namespace)
 
 If you want logic happening given on an `configuration`, you can use the helper `given`.


### PR DESCRIPTION
Add a documentation hint for mount configuration.

I know it might sound like a newbie issue (and it is, probably) but I just spent half an hour trying to find out where my configuration was.

Feel free to remove if it's not relevant as it's 100% Ruby matter and 0% Grape. 
¯\_(ツ)_/¯

I didn't write a changelog as it's not a feature, also feel free to ask for one. :)

BTW thank you so much for this incredible gem, love it!