### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * Your contribution here.
+* [#1938](https://github.com/ruby-grape/grape/pull/1938): Add project metadata to the gemspec - [@orien](https://github.com/orien).
 
 #### Fixes
 

--- a/grape.gemspec
+++ b/grape.gemspec
@@ -11,6 +11,12 @@ Gem::Specification.new do |s|
   s.summary     = 'A simple Ruby framework for building REST-like APIs.'
   s.description = 'A Ruby framework for rapid API development with great conventions.'
   s.license     = 'MIT'
+  s.metadata    = {
+    'bug_tracker_uri'   => 'https://github.com/ruby-grape/grape/issues',
+    'changelog_uri'     => "https://github.com/ruby-grape/grape/blob/v#{s.version}/CHANGELOG.md",
+    'documentation_uri' => "https://www.rubydoc.info/gems/grape/#{s.version}",
+    'source_code_uri'   => "https://github.com/ruby-grape/grape/tree/v#{s.version}"
+  }
 
   s.add_runtime_dependency 'activesupport'
   s.add_runtime_dependency 'builder'


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/grape), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.