### PR TITLE
Retained Grape::Http::Headers in memory instead of new ones created.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * Your contribution here.
+* [#1942](https://github.com/ruby-grape/grape/pull/1942): Optimized retained memory methods - [@ericproulx](https://github.com/ericproulx).
 * [#1941](https://github.com/ruby-grape/grape/pull/1941): Frozen string literal - [@ericproulx](https://github.com/ericproulx).
 * [#1940](https://github.com/ruby-grape/grape/pull/1940): Get rid of a needless step in HashWithIndifferentAccess - [@dnesteryuk](https://github.com/dnesteryuk).
 * [#1938](https://github.com/ruby-grape/grape/pull/1938): Add project metadata to the gemspec - [@orien](https://github.com/orien).

--- a/lib/grape/http/headers.rb
+++ b/lib/grape/http/headers.rb
@@ -26,6 +26,10 @@ module Grape
       HTTP_ACCEPT            = 'HTTP_ACCEPT'
 
       FORMAT                 = 'format'
+
+      def self.find_supported_method(route_method)
+        Grape::Http::Headers::SUPPORTED_METHODS.detect { |supported_method| supported_method.casecmp(route_method).zero? }
+      end
     end
   end
 end

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -46,7 +46,7 @@ module Grape
     end
 
     def append(route)
-      map[route.request_method.to_s.upcase] << route
+      map[route.request_method] << route
     end
 
     def associate_routes(pattern, **options)

--- a/lib/grape/router/route.rb
+++ b/lib/grape/router/route.rb
@@ -64,12 +64,13 @@ module Grape
       end
 
       def initialize(method, pattern, **options)
-        upcased_method = method.to_s.upcase
+        method_s = method.to_s
+        method_upcase = Grape::Http::Headers.find_supported_method(method_s) || method_s.upcase
 
         @suffix     = options[:suffix]
-        @options    = options.merge(method: upcased_method)
+        @options    = options.merge(method: method_upcase)
         @pattern    = Pattern.new(pattern, **options)
-        @translator = AttributeTranslator.new(**options, request_method: upcased_method)
+        @translator = AttributeTranslator.new(**options, request_method: method_upcase)
       end
 
       def exec(env)


### PR DESCRIPTION
I ran a memory profiling (memory_profiler gem) on my app by hitting our Grape api first. I found it odd that it retains a bunch of http verbs when they are defined as const in Grape::Http::Headers :

```log
       354  "HEAD"
       353  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router/route.rb:67
         1  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:30

       352  "GET"
       351  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router/route.rb:67
         1  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:30

       168  "POST"
       107  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router/route.rb:67
        60  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/api/instance.rb:230
         1  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:30

       113  "PATCH"
        82  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router/route.rb:67
        30  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/api/instance.rb:230
         1  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:30

        50  "DELETE"
        46  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router/route.rb:67
         3  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/api/instance.rb:230
         1  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:30

        43  "PUT"
        34  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router/route.rb:67
         8  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/api/instance.rb:230
         1  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:30
```
I looked at the code and made a fix by detecting `supported_methods` instead of retaining the route method received.

Actual memory footprint on first call
```log
Total allocated: 50532358 bytes (526479 objects)
Total retained:  6386850 bytes (17587 objects)
```
And with the improvement
```log
Total allocated: 50453158 bytes (524521 objects)
Total retained:  6346610 bytes (16603 objects)
```
1958 less objects allocated (79 200 bytes)
984 less objects retained (40 240 bytes)



