### PR TITLE
Regex string allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 #### Features
 
 * Your contribution here.
-* [#1942](https://github.com/ruby-grape/grape/pull/1942): Optimized retained memory methods - [@ericproulx](https://github.com/ericproulx).
+* [#1943](https://github.com/ruby-grape/grape/pull/1943): Reduce number of regex string allocations - [@ericproulx](https://github.com/ericproulx).
 * [#1941](https://github.com/ruby-grape/grape/pull/1941): Frozen string literal - [@ericproulx](https://github.com/ericproulx).
 * [#1940](https://github.com/ruby-grape/grape/pull/1940): Get rid of a needless step in HashWithIndifferentAccess - [@dnesteryuk](https://github.com/dnesteryuk).
 * [#1938](https://github.com/ruby-grape/grape/pull/1938): Add project metadata to the gemspec - [@orien](https://github.com/orien).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Your contribution here.
 * [#1943](https://github.com/ruby-grape/grape/pull/1943): Reduce number of regex string allocations - [@ericproulx](https://github.com/ericproulx).
-[#1942](https://github.com/ruby-grape/grape/pull/1942): Optimized retained memory methods - [@ericproulx](https://github.com/ericproulx).
+* [#1942](https://github.com/ruby-grape/grape/pull/1942): Optimized retained memory methods - [@ericproulx](https://github.com/ericproulx).
 * [#1941](https://github.com/ruby-grape/grape/pull/1941): Frozen string literal - [@ericproulx](https://github.com/ericproulx).
 * [#1940](https://github.com/ruby-grape/grape/pull/1940): Get rid of a needless step in HashWithIndifferentAccess - [@dnesteryuk](https://github.com/dnesteryuk).
 * [#1938](https://github.com/ruby-grape/grape/pull/1938): Add project metadata to the gemspec - [@orien](https://github.com/orien).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Your contribution here.
 * [#1943](https://github.com/ruby-grape/grape/pull/1943): Reduce number of regex string allocations - [@ericproulx](https://github.com/ericproulx).
+[#1942](https://github.com/ruby-grape/grape/pull/1942): Optimized retained memory methods - [@ericproulx](https://github.com/ericproulx).
 * [#1941](https://github.com/ruby-grape/grape/pull/1941): Frozen string literal - [@ericproulx](https://github.com/ericproulx).
 * [#1940](https://github.com/ruby-grape/grape/pull/1940): Get rid of a needless step in HashWithIndifferentAccess - [@dnesteryuk](https://github.com/dnesteryuk).
 * [#1938](https://github.com/ruby-grape/grape/pull/1938): Add project metadata to the gemspec - [@orien](https://github.com/orien).

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -38,7 +38,7 @@ module Grape
         routes = map[method]
         @optimized_map[method] = routes.map.with_index do |route, index|
           route.index = index
-          route.regexp = /(?<_#{index}>#{route.pattern.to_regexp})/
+          route.regexp = Regexp.new("(?<_#{index}>#{route.pattern.to_regexp})")
         end
         @optimized_map[method] = Regexp.union(@optimized_map[method])
       end
@@ -50,7 +50,7 @@ module Grape
     end
 
     def associate_routes(pattern, **options)
-      regexp = /(?<_#{@neutral_map.length}>)#{pattern.to_regexp}/
+      regexp = Regexp.new("(?<_#{@neutral_map.length}>)#{pattern.to_regexp}")
       @neutral_map << Any.new(pattern, regexp: regexp, index: @neutral_map.length, **options)
     end
 


### PR DESCRIPTION
While memory profilling our app, I found these strange memory allocations :
```log
1442  "(?<_"
974  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:41
468  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:53

983  ")"
974  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:41
 9  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/mustermann-grape-1.0.0/lib/mustermann/grape.rb:20

974  ">"
974  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:41

468  ">)"
468  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:53
12  "(?-mix:\\A(?-mix:\\/(?<version>(?-mix:(?:v|%76)(?:2|%32)))\\/(?:a|%61)(?:c|%63)(?:c|%63)(?:o|%6f|%6F)(?:u|%75)(?:n|%6e|%6E)(?:t|%74)(?:s|%73)\\/(?<account_id>[^\\/\\?#.]+)\\/(?:m|%6d|%6D)(?:e|%65)(?:s|%73)(?"
10  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:41
 2  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:53

12  "(?-mix:\\A(?-mix:\\/(?<version>(?-mix:(?:v|%76)(?:2|%32)))\\/(?:a|%61)(?:p|%70)(?:p|%70)(?:o|%6f|%6F)(?:i|%69)(?:n|%6e|%6E)(?:t|%74)(?:m|%6d|%6D)(?:e|%65)(?:n|%6e|%6E)(?:t|%74)(?:s|%73)\\/(?:a|%61)(?:v|%7"
10  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:41
 2  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:53

12  "(?-mix:\\A(?-mix:\\/(?<version>(?-mix:(?:v|%76)(?:2|%32)))\\/(?:c|%63)(?:h|%68)(?:a|%61)(?:n|%6e|%6E)(?:g|%67)(?:e|%65)(?:_|%5f|%5F)(?:r|%72)(?:e|%65)(?:q|%71)(?:u|%75)(?:e|%65)(?:s|%73)(?:t|%74)(?:s|%73"
10  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:41
 2  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:53

12  "(?-mix:\\A(?-mix:\\/(?<version>(?-mix:(?:v|%76)(?:2|%32)))\\/(?:c|%63)(?:o|%6f|%6F)(?:n|%6e|%6E)(?:v|%76)(?:e|%65)(?:r|%72)(?:s|%73)(?:a|%61)(?:t|%74)(?:i|%69)(?:o|%6f|%6F)(?:n|%6e|%6E)(?:s|%73)\\/(?<conv"
10  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:41
 2  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:53

12  "(?-mix:\\A(?-mix:\\/(?<version>(?-mix:(?:v|%76)(?:2|%32)))\\/(?:g|%67)(?:r|%72)(?:o|%6f|%6F)(?:u|%75)(?:p|%70)(?:s|%73)\\/(?<group_id>[^\\/\\?#.]+)\\/(?:a|%61)(?:p|%70)(?:p|%70)(?:o|%6f|%6F)(?:i|%69)(?:n|%6e"
10  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:41
 2  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:53

12  "(?-mix:\\A(?-mix:\\/(?<version>(?-mix:(?:v|%76)(?:2|%32)))\\/(?:g|%67)(?:r|%72)(?:o|%6f|%6F)(?:u|%75)(?:p|%70)(?:s|%73)\\/(?<group_id>[^\\/\\?#.]+)\\/(?:f|%66)(?:o|%6f|%6F)(?:r|%72)(?:m|%6d|%6D)(?:s|%73)\\/(?"
10  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:41
 2  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:53

12  "(?-mix:\\A(?-mix:\\/(?<version>(?-mix:(?:v|%76)(?:2|%32)))\\/(?:g|%67)(?:r|%72)(?:o|%6f|%6F)(?:u|%75)(?:p|%70)(?:s|%73)\\/(?<group_id>[^\\/\\?#.]+)\\/(?:m|%6d|%6D)(?:a|%61)(?:n|%6e|%6E)(?:a|%61)(?:g|%67)(?:e"
10  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:41
 2  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:53

12  "(?-mix:\\A(?-mix:\\/(?<version>(?-mix:(?:v|%76)(?:2|%32)))\\/(?:g|%67)(?:r|%72)(?:o|%6f|%6F)(?:u|%75)(?:p|%70)(?:s|%73)\\/(?<group_id>[^\\/\\?#.]+)\\/(?:t|%74)(?:e|%65)(?:a|%61)(?:m|%6d|%6D)(?:s|%73)(?:(?:\\."
10  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:41
 2  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:53

12  "(?-mix:\\A(?-mix:\\/(?<version>(?-mix:(?:v|%76)(?:2|%32)))\\/(?:h|%68)(?:o|%6f|%6F)(?:s|%73)(?:p|%70)(?:i|%69)(?:t|%74)(?:a|%61)(?:l|%6c|%6C)(?:s|%73)\\/(?<hospital_id>[^\\/\\?#.]+)\\/(?:c|%63)(?:o|%6f|%6F)("
10  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:41
 2  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:53

12  "(?-mix:\\A(?-mix:\\/(?<version>(?-mix:(?:v|%76)(?:2|%32)))\\/(?:s|%73)(?:c|%63)(?:h|%68)(?:e|%65)(?:d|%64)(?:u|%75)(?:l|%6c|%6C)(?:e|%65)\\/(?:g|%67)(?:r|%72)(?:o|%6f|%6F)(?:u|%75)(?:p|%70)(?:s|%73)\\/(?<i"
10  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:41
 2  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router.rb:53
```
Turns out, its 2 regex defined in router.rb with interpolation. I replaced the 2 lliteral regexs by the Regexp constructor. Therefore, the strings above (memory profiling) are just allocated once and benefits from the frozen_string_literal
