### PR TITLE
AttributeTranslator optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * Your contribution here.
+* [#1943](https://github.com/ruby-grape/grape/pull/1944): Reduced attribute_translator string allocations - [@ericproulx](https://github.com/ericproulx).
 * [#1942](https://github.com/ruby-grape/grape/pull/1942): Optimized retained memory methods - [@ericproulx](https://github.com/ericproulx).
 * [#1941](https://github.com/ruby-grape/grape/pull/1941): Frozen string literal - [@ericproulx](https://github.com/ericproulx).
 * [#1940](https://github.com/ruby-grape/grape/pull/1940): Get rid of a needless step in HashWithIndifferentAccess - [@dnesteryuk](https://github.com/dnesteryuk).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 #### Features
 
 * Your contribution here.
-* [#1943](https://github.com/ruby-grape/grape/pull/1944): Reduced attribute_translator string allocations - [@ericproulx](https://github.com/ericproulx).
+* [#1944](https://github.com/ruby-grape/grape/pull/1944): Reduced attribute_translator string allocations - [@ericproulx](https://github.com/ericproulx).
 * [#1942](https://github.com/ruby-grape/grape/pull/1942): Optimized retained memory methods - [@ericproulx](https://github.com/ericproulx).
 * [#1941](https://github.com/ruby-grape/grape/pull/1941): Frozen string literal - [@ericproulx](https://github.com/ericproulx).
 * [#1940](https://github.com/ruby-grape/grape/pull/1940): Get rid of a needless step in HashWithIndifferentAccess - [@dnesteryuk](https://github.com/dnesteryuk).

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -7,8 +7,11 @@ module Grape
     attr_reader :map, :compiled
 
     class Any < AttributeTranslator
-      def initialize(pattern, **attributes)
+      attr_reader :pattern, :regexp, :index
+      def initialize(pattern, regexp, index, **attributes)
         @pattern = pattern
+        @regexp = regexp
+        @index = index
         super(attributes)
       end
     end
@@ -51,7 +54,7 @@ module Grape
 
     def associate_routes(pattern, **options)
       regexp = /(?<_#{@neutral_map.length}>)#{pattern.to_regexp}/
-      @neutral_map << Any.new(pattern, regexp: regexp, index: @neutral_map.length, **options)
+      @neutral_map << Any.new(pattern, regexp, @neutral_map.length, **options)
     end
 
     def call(env)

--- a/lib/grape/router/attribute_translator.rb
+++ b/lib/grape/router/attribute_translator.rb
@@ -8,14 +8,12 @@ module Grape
 
       def initialize(attributes = {})
         @attributes = attributes
-        @request_method = attributes.delete(:request_method)
-        @requirements = attributes.delete(:requirements)
+        @request_method = attributes[:request_method]
+        @requirements = attributes[:requirements]
       end
 
       def to_h
-        attributes.merge(request_method: request_method).tap do |attr|
-          attr[:requirements] = requirements if requirements
-        end
+        attributes
       end
 
       def method_missing(method_name, *args) # rubocop:disable Style/MethodMissing

--- a/lib/grape/router/attribute_translator.rb
+++ b/lib/grape/router/attribute_translator.rb
@@ -4,30 +4,40 @@ module Grape
   class Router
     # this could be an OpenStruct, but doesn't work in Ruby 2.3.0, see https://bugs.ruby-lang.org/issues/12251
     class AttributeTranslator
+      attr_reader :attributes, :request_method, :requirements
+
       def initialize(attributes = {})
         @attributes = attributes
+        @request_method = attributes.delete(:request_method)
+        @requirements = attributes.delete(:requirements)
       end
 
       def to_h
-        @attributes
+        attributes.merge(request_method: request_method).tap do |attr|
+          attr[:requirements] = requirements if requirements
+        end
       end
 
-      def method_missing(m, *args)
-        if m[-1] == '='
-          @attributes[m[0..-1]] = *args
-        elsif m[-1] != '='
-          @attributes[m]
+      def method_missing(method_name, *args) # rubocop:disable Style/MethodMissing
+        if setter?(method_name[-1])
+          attributes[method_name[0..-1]] = *args
         else
-          super
+          attributes[method_name]
         end
       end
 
       def respond_to_missing?(method_name, _include_private = false)
-        if method_name[-1] == '='
+        if setter?(method_name[-1])
           true
         else
           @attributes.key?(method_name)
         end
+      end
+
+      private
+
+      def setter?(method_name)
+        method_name[-1] == '='
       end
     end
   end


### PR DESCRIPTION
Still memory profiling
```log
Allocated String Report
-----------------------------------
      7640  "d"
      3820  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router/attribute_translator.rb:16
      3820  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router/attribute_translator.rb:18

      1248  "s"
       624  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router/attribute_translator.rb:16
       624  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router/attribute_translator.rb:18

       936  "p"
       468  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router/attribute_translator.rb:16
       468  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape-1.2.6/lib/grape/router/attribute_translator.rb:18
```
d = [request_method](https://github.com/ruby-grape/grape/blob/1d35559084432883f335cdea4b483ddb6dd8d53a/lib/grape/router/route.rb#L73)
s = `:requirements`
p = [regexp](https://github.com/ruby-grape/grape/blob/1d35559084432883f335cdea4b483ddb6dd8d53a/lib/grape/router.rb#L54)

Instead of using `method_missing` to fetch the data, I thought it would be better to define the methods
