### PR TITLE
Fixes issue by checking if there's a base is there at all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 #### Fixes
 
-* [#1931](https://github.com/ruby-grape/grape/pull/1946): Fixes issue when using namespaces in Grape::API::Instance mounted directly - [@myxoh](https://github.com/myxoh)
+* [#1931](https://github.com/ruby-grape/grape/pull/1946): Fixes issue when using namespaces in `Grape::API::Instance` mounted directly - [@myxoh](https://github.com/myxoh).
 
 ### 1.2.5 (2019/12/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 #### Fixes
 
-* Your contribution here.
+* [#1931](https://github.com/ruby-grape/grape/pull/1946): Fixes issue when using namespaces in Grape::API::Instance mounted directly - [@myxoh](https://github.com/myxoh)
 
 ### 1.2.5 (2019/12/01)
 

--- a/lib/grape/api/instance.rb
+++ b/lib/grape/api/instance.rb
@@ -121,7 +121,7 @@ module Grape
             self.configuration = value_for_configuration
             response
           end
-          if base_instance? && lazy
+          if base && base_instance? && lazy
             lazy_block
           else
             lazy_block.evaluate_from(configuration)

--- a/spec/grape/api/instance_spec.rb
+++ b/spec/grape/api/instance_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'shared/versioning_examples'
+
+describe Grape::API::Instance do
+  subject(:an_instance) do
+    Class.new(Grape::API::Instance) do
+      namespace :some_namespace do
+        get 'some_endpoint' do
+          'success'
+        end
+      end
+    end
+  end
+
+  let(:root_api) do
+    to_mount = an_instance
+    Class.new(Grape::API) do
+      mount to_mount
+    end
+  end
+
+  def app
+    root_api
+  end
+
+  context 'when an instance is mounted on the root' do
+    it 'can call the instance endpoint' do
+      get '/some_namespace/some_endpoint'
+      expect(last_response.body).to eq 'success'
+    end
+  end
+
+  context 'when an instance is the root' do
+    let(:root_api) do
+      to_mount = an_instance
+      Class.new(Grape::API::Instance) do
+        mount to_mount
+      end
+    end
+
+    it 'can call the instance endpoint' do
+      get '/some_namespace/some_endpoint'
+      expect(last_response.body).to eq 'success'
+    end
+  end
+end


### PR DESCRIPTION
Addresses issue raised here: https://github.com/ruby-grape/grape/issues/1945

The cause of the issue is the introduction of the `LazyBlock` where blocks would only be excecuted on properly mounted instances, the side effect is for people using just `Instance` they had no base at all.

