### PR TITLE
Relax dry-types dependency version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * Your contribution here.
+* [#1948](https://github.com/ruby-grape/grape/pull/1948): Relax `dry-types` dependency version - [@nbulaj](https://github.com/nbulaj).
 * [#1944](https://github.com/ruby-grape/grape/pull/1944): Reduces `attribute_translator` string allocations - [@ericproulx](https://github.com/ericproulx).
 * [#1943](https://github.com/ruby-grape/grape/pull/1943): Reduces number of regex string allocations - [@ericproulx](https://github.com/ericproulx).
 * [#1942](https://github.com/ruby-grape/grape/pull/1942): Optimizes retained memory methods - [@ericproulx](https://github.com/ericproulx).

--- a/grape.gemspec
+++ b/grape.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'activesupport'
   s.add_runtime_dependency 'builder'
-  s.add_runtime_dependency 'dry-types', '~> 1.1.1'
+  s.add_runtime_dependency 'dry-types', '>= 1.1'
   s.add_runtime_dependency 'mustermann-grape', '~> 1.0.0'
   s.add_runtime_dependency 'rack', '>= 1.3.0'
   s.add_runtime_dependency 'rack-accept'


### PR DESCRIPTION
From the PR discussion: https://github.com/ruby-grape/grape/pull/1920#issuecomment-569010623

Ruby 2.7.0 was released December 25, 2019, and has some noisy [deprecation messages about keyword arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/). 

Thanks to PR #1920 we migrated from Virtus to dry-types, but set too strict version for it - `~> 1.1.1`, so new versions of the dry-types gem couldn't be used with Grape (like current 1.2.2 from December 14, 2019). Also 1.1.x versions of dry-types produces a lot of deprecation warnings with Ruby 2.7 that can be too noisy.

I relaxed dependency version to `>= 1.1` and tested it against latest dry-types version on rubygems.org and everything seems to be good.

### RSpec results with dry-types 1.2.2

![image](https://user-images.githubusercontent.com/1443426/71475243-6f3b1a00-27f0-11ea-82d6-79abe67eb576.png)
