### PR TITLE
Add support for Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,27 +8,31 @@ gemfile:
 
 matrix:
   include:
-    - rvm: 2.6.5
+    - rvm: 2.7.0
       script:
         - bundle exec danger
-    - rvm: 2.6.5
+    - rvm: 2.7.0
       gemfile: Gemfile
-    - rvm: 2.6.5
+    - rvm: 2.7.0
       gemfile: gemfiles/rack_edge.gemfile
-    - rvm: 2.6.5
+    - rvm: 2.7.0
       gemfile: gemfiles/rails_edge.gemfile
-    - rvm: 2.6.5
+    - rvm: 2.7.0
       gemfile: gemfiles/rails_5.gemfile
-    - rvm: 2.6.5
+    - rvm: 2.7.0
       gemfile: gemfiles/multi_json.gemfile
       script:
         - bundle exec rake
         - bundle exec rspec spec/integration/multi_json
-    - rvm: 2.6.5
+    - rvm: 2.7.0
       gemfile: gemfiles/multi_xml.gemfile
       script:
         - bundle exec rake
         - bundle exec rspec spec/integration/multi_xml
+    - rvm: 2.6.5
+      gemfile: Gemfile
+    - rvm: 2.6.5
+      gemfile: gemfiles/rails_5.gemfile
     - rvm: 2.5.7
       gemfile: Gemfile
     - rvm: 2.5.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * Your contribution here.
+* [#1948](https://github.com/ruby-grape/grape/pull/1949): Add support for Ruby 2.7 - [@nbulaj](https://github.com/nbulaj).
 * [#1948](https://github.com/ruby-grape/grape/pull/1948): Relax `dry-types` dependency version - [@nbulaj](https://github.com/nbulaj).
 * [#1944](https://github.com/ruby-grape/grape/pull/1944): Reduces `attribute_translator` string allocations - [@ericproulx](https://github.com/ericproulx).
 * [#1943](https://github.com/ruby-grape/grape/pull/1943): Reduces number of regex string allocations - [@ericproulx](https://github.com/ericproulx).

--- a/lib/grape/api/instance.rb
+++ b/lib/grape/api/instance.rb
@@ -234,7 +234,7 @@ module Grape
               end
 
               attributes = config.merge(allowed_methods: allowed_methods, allow_header: allow_header)
-              generate_not_allowed_method(config[:pattern], attributes)
+              generate_not_allowed_method(config[:pattern], **attributes)
             end
           end
         end

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -30,7 +30,7 @@ module Grape
       module PostBeforeFilter
         def declared(passed_params, options = {}, declared_params = nil)
           options = options.reverse_merge(include_missing: true, include_parent_namespaces: true)
-          declared_params ||= optioned_declared_params(options)
+          declared_params ||= optioned_declared_params(**options)
 
           if passed_params.is_a?(Array)
             declared_array(passed_params, options, declared_params)
@@ -98,7 +98,7 @@ module Grape
           options[:stringify] ? declared_param.to_s : declared_param.to_sym
         end
 
-        def optioned_declared_params(options)
+        def optioned_declared_params(**options)
           declared_params = if options[:include_parent_namespaces]
                               # Declared params including parent namespaces
                               route_setting(:saved_declared_params).flatten | Array(route_setting(:declared_params))
@@ -387,7 +387,7 @@ module Grape
       def entity_representation_for(entity_class, object, options)
         embeds = { env: env }
         embeds[:version] = env[Grape::Env::API_VERSION] if env[Grape::Env::API_VERSION]
-        entity_class.represent(object, embeds.merge(options))
+        entity_class.represent(object, **embeds.merge(options))
       end
     end
   end

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -133,7 +133,7 @@ module Grape
           require_required_and_optional_fields(attrs.first, opts)
         else
           validate_attributes(attrs, opts, &block)
-          block_given? ? new_scope(orig_attrs, &block) : push_declared_params(attrs, opts.slice(:as))
+          block_given? ? new_scope(orig_attrs, &block) : push_declared_params(attrs, **opts.slice(:as))
         end
       end
 
@@ -159,7 +159,7 @@ module Grape
         else
           validate_attributes(attrs, opts, &block)
 
-          block_given? ? new_scope(orig_attrs, true, &block) : push_declared_params(attrs, opts.slice(:as))
+          block_given? ? new_scope(orig_attrs, true, &block) : push_declared_params(attrs, **opts.slice(:as))
         end
       end
 

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -22,7 +22,7 @@ module Grape
           if new_format
             namespace_inheritable(:format, new_format.to_sym)
             # define the default error formatters
-            namespace_inheritable(:default_error_formatter, Grape::ErrorFormatter.formatter_for(new_format, {}))
+            namespace_inheritable(:default_error_formatter, Grape::ErrorFormatter.formatter_for(new_format, **{}))
             # define a single mime type
             mime_type = content_types[new_format.to_sym]
             raise Grape::Exceptions::MissingMimeType.new(new_format) unless mime_type
@@ -45,7 +45,7 @@ module Grape
         # Specify a default error formatter.
         def default_error_formatter(new_formatter_name = nil)
           if new_formatter_name
-            new_formatter = Grape::ErrorFormatter.formatter_for(new_formatter_name, {})
+            new_formatter = Grape::ErrorFormatter.formatter_for(new_formatter_name, **{})
             namespace_inheritable(:default_error_formatter, new_formatter)
           else
             namespace_inheritable(:default_error_formatter)

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -169,7 +169,7 @@ module Grape
               @namespace_description = (@namespace_description || {}).deep_merge(namespace_setting(:description) || {})
               nest(block) do
                 if space
-                  namespace_stackable(:namespace, Namespace.new(space, options))
+                  namespace_stackable(:namespace, Namespace.new(space, **options))
                 end
               end
               @namespace_description = previous_namespace_description

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -157,7 +157,7 @@ module Grape
           end
           methods.each do |method|
             unless route.request_method == method
-              route = Grape::Router::Route.new(method, route.origin, route.attributes.to_h)
+              route = Grape::Router::Route.new(method, route.origin, **route.attributes.to_h)
             end
             router.append(route.apply(self))
           end
@@ -169,8 +169,8 @@ module Grape
       route_options = prepare_default_route_attributes
       map_routes do |method, path|
         path = prepare_path(path)
-        params = merge_route_options(route_options.merge(suffix: path.suffix))
-        route = Router::Route.new(method, path.path, params)
+        params = merge_route_options(**route_options.merge(suffix: path.suffix))
+        route = Router::Route.new(method, path.path, **params)
         route.apply(self)
       end.flatten
     end
@@ -359,7 +359,7 @@ module Grape
     def run_validators(validator_factories, request)
       validation_errors = []
 
-      validators = validator_factories.map { |options| Grape::Validations::ValidatorFactory.create_validator(options) }
+      validators = validator_factories.map { |options| Grape::Validations::ValidatorFactory.create_validator(**options) }
 
       ActiveSupport::Notifications.instrument('endpoint_run_validators.grape', endpoint: self, validators: validators, request: request) do
         validators.each do |validator|
@@ -375,7 +375,7 @@ module Grape
         end
       end
 
-      validation_errors.any? && raise(Grape::Exceptions::ValidationErrors, errors: validation_errors, headers: header)
+      validation_errors.any? && raise(Grape::Exceptions::ValidationErrors.new(errors: validation_errors, headers: header))
     end
 
     def run_filters(filters, type = :other)

--- a/lib/grape/error_formatter.rb
+++ b/lib/grape/error_formatter.rb
@@ -15,7 +15,7 @@ module Grape
         }
       end
 
-      def formatters(options)
+      def formatters(**options)
         builtin_formatters.merge(default_elements).merge!(options[:error_formatters] || {})
       end
 

--- a/lib/grape/exceptions/base.rb
+++ b/lib/grape/exceptions/base.rb
@@ -39,16 +39,16 @@ module Grape
         end
       end
 
-      def problem(key, attributes)
-        translate_message("#{key}.problem".to_sym, attributes)
+      def problem(key, **attributes)
+        translate_message("#{key}.problem".to_sym, **attributes)
       end
 
-      def summary(key, attributes)
-        translate_message("#{key}.summary".to_sym, attributes)
+      def summary(key, **attributes)
+        translate_message("#{key}.summary".to_sym, **attributes)
       end
 
-      def resolution(key, attributes)
-        translate_message("#{key}.resolution".to_sym, attributes)
+      def resolution(key, **attributes)
+        translate_message("#{key}.resolution".to_sym, **attributes)
       end
 
       def translate_attributes(keys, **options)

--- a/lib/grape/formatter.rb
+++ b/lib/grape/formatter.rb
@@ -5,7 +5,7 @@ module Grape
     extend Util::Registrable
 
     class << self
-      def builtin_formmaters
+      def builtin_formatters
         @builtin_formatters ||= {
           json: Grape::Formatter::Json,
           jsonapi: Grape::Formatter::Json,
@@ -15,8 +15,8 @@ module Grape
         }
       end
 
-      def formatters(options)
-        builtin_formmaters.merge(default_elements).merge!(options[:formatters] || {})
+      def formatters(**options)
+        builtin_formatters.merge(default_elements).merge!(options[:formatters] || {})
       end
 
       def formatter_for(api_format, **options)

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -79,7 +79,7 @@ module Grape
 
       def format_message(message, backtrace, original_exception = nil)
         format = env[Grape::Env::API_FORMAT] || options[:format]
-        formatter = Grape::ErrorFormatter.formatter_for(format, options)
+        formatter = Grape::ErrorFormatter.formatter_for(format, **options)
         throw :error,
               status: 406,
               message: "The requested format '#{format}' is not supported.",

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -54,7 +54,7 @@ module Grape
 
       def fetch_formatter(headers, options)
         api_format = mime_types[headers[Grape::Http::Headers::CONTENT_TYPE]] || env[Grape::Env::API_FORMAT]
-        Grape::Formatter.formatter_for(api_format, options)
+        Grape::Formatter.formatter_for(api_format, **options)
       end
 
       # Set the content type header for the API format if it is not already present.
@@ -99,7 +99,7 @@ module Grape
         unless content_type_for(fmt)
           throw :error, status: 415, message: "The provided content-type '#{request.media_type}' is not supported."
         end
-        parser = Grape::Parser.parser_for fmt, options
+        parser = Grape::Parser.parser_for fmt, **options
         if parser
           begin
             body = (env[Grape::Env::API_REQUEST_BODY] = parser.call(body, env))

--- a/lib/grape/parser.rb
+++ b/lib/grape/parser.rb
@@ -13,7 +13,7 @@ module Grape
         }
       end
 
-      def parsers(options)
+      def parsers(**options)
         builtin_parsers.merge(default_elements).merge!(options[:parsers] || {})
       end
 

--- a/lib/grape/router/pattern.rb
+++ b/lib/grape/router/pattern.rb
@@ -19,8 +19,8 @@ module Grape
       def initialize(pattern, **options)
         @origin  = pattern
         @path    = build_path(pattern, **options)
-        @capture = extract_capture(options)
-        @pattern = Mustermann.new(@path, pattern_options)
+        @capture = extract_capture(**options)
+        @pattern = Mustermann.new(@path, **pattern_options)
         @regexp  = to_regexp
       end
 

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -123,7 +123,7 @@ module Grape
       # @param attrs [Array] (see Grape::DSL::Parameters#requires)
       def push_declared_params(attrs, **opts)
         if lateral?
-          @parent.push_declared_params(attrs, opts)
+          @parent.push_declared_params(attrs, **opts)
         else
           if opts && opts[:as]
             @api.route_setting(:renamed_params, @api.route_setting(:renamed_params) || [])

--- a/lib/grape/validations/validators/all_or_none.rb
+++ b/lib/grape/validations/validators/all_or_none.rb
@@ -8,7 +8,7 @@ module Grape
       def validate_params!(params)
         keys = keys_in_common(params)
         return if keys.empty? || keys.length == all_keys.length
-        raise Grape::Exceptions::Validation, params: all_keys, message: message(:all_or_none)
+        raise Grape::Exceptions::Validation.new(params: all_keys, message: message(:all_or_none))
       end
     end
   end

--- a/lib/grape/validations/validators/allow_blank.rb
+++ b/lib/grape/validations/validators/allow_blank.rb
@@ -11,7 +11,7 @@ module Grape
 
         return if value == false || value.present?
 
-        raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:blank)
+        raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message(:blank))
       end
     end
   end

--- a/lib/grape/validations/validators/at_least_one_of.rb
+++ b/lib/grape/validations/validators/at_least_one_of.rb
@@ -7,7 +7,7 @@ module Grape
     class AtLeastOneOfValidator < MultipleParamsBase
       def validate_params!(params)
         return unless keys_in_common(params).empty?
-        raise Grape::Exceptions::Validation, params: all_keys, message: message(:at_least_one)
+        raise Grape::Exceptions::Validation.new(params: all_keys, message: message(:at_least_one))
       end
     end
   end

--- a/lib/grape/validations/validators/exactly_one_of.rb
+++ b/lib/grape/validations/validators/exactly_one_of.rb
@@ -7,7 +7,7 @@ module Grape
     class ExactlyOneOfValidator < MultipleParamsBase
       def validate_params!(params)
         return if keys_in_common(params).length == 1
-        raise Grape::Exceptions::Validation, params: all_keys, message: message(:exactly_one)
+        raise Grape::Exceptions::Validation.new(params: all_keys, message: message(:exactly_one))
       end
     end
   end

--- a/lib/grape/validations/validators/except_values.rb
+++ b/lib/grape/validations/validators/except_values.rb
@@ -15,7 +15,7 @@ module Grape
         return if excepts.nil?
 
         param_array = params[attr_name].nil? ? [nil] : Array.wrap(params[attr_name])
-        raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:except_values) if param_array.any? { |param| excepts.include?(param) }
+        raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message(:except_values)) if param_array.any? { |param| excepts.include?(param) }
       end
     end
   end

--- a/lib/grape/validations/validators/mutual_exclusion.rb
+++ b/lib/grape/validations/validators/mutual_exclusion.rb
@@ -8,7 +8,7 @@ module Grape
       def validate_params!(params)
         keys = keys_in_common(params)
         return if keys.length <= 1
-        raise Grape::Exceptions::Validation, params: keys, message: message(:mutual_exclusion)
+        raise Grape::Exceptions::Validation.new(params: keys, message: message(:mutual_exclusion))
       end
     end
   end

--- a/lib/grape/validations/validators/presence.rb
+++ b/lib/grape/validations/validators/presence.rb
@@ -5,7 +5,7 @@ module Grape
     class PresenceValidator < Base
       def validate_param!(attr_name, params)
         return if params.respond_to?(:key?) && params.key?(attr_name)
-        raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:presence)
+        raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message(:presence))
       end
     end
   end

--- a/lib/grape/validations/validators/regexp.rb
+++ b/lib/grape/validations/validators/regexp.rb
@@ -6,7 +6,7 @@ module Grape
       def validate_param!(attr_name, params)
         return unless params.respond_to?(:key?) && params.key?(attr_name)
         return if Array.wrap(params[attr_name]).all? { |param| param.nil? || (param.to_s =~ (options_key?(:value) ? @option[:value] : @option)) }
-        raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:regexp)
+        raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message(:regexp))
       end
     end
   end

--- a/lib/grape/validations/validators/same_as.rb
+++ b/lib/grape/validations/validators/same_as.rb
@@ -6,9 +6,10 @@ module Grape
       def validate_param!(attr_name, params)
         confirmation = options_key?(:value) ? @option[:value] : @option
         return if params[attr_name] == params[confirmation]
-        raise Grape::Exceptions::Validation,
-              params: [@scope.full_name(attr_name)],
-              message: build_message
+        raise Grape::Exceptions::Validation.new(
+          params: [@scope.full_name(attr_name)],
+          message: build_message
+        )
       end
 
       private

--- a/lib/grape/validations/validators/values.rb
+++ b/lib/grape/validations/validators/values.rb
@@ -30,13 +30,13 @@ module Grape
 
         param_array = params[attr_name].nil? ? [nil] : Array.wrap(params[attr_name])
 
-        raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: except_message \
+        raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: except_message) \
           unless check_excepts(param_array)
 
-        raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:values) \
+        raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message(:values)) \
           unless check_values(param_array, attr_name)
 
-        raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message(:values) \
+        raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message(:values)) \
           if @proc && !param_array.all? { |param| @proc.call(param) }
       end
 

--- a/spec/grape/api/custom_validations_spec.rb
+++ b/spec/grape/api/custom_validations_spec.rb
@@ -10,7 +10,7 @@ describe Grape::Validations do
           def validate_param!(attr_name, params)
             @option = params[:max].to_i if params.key?(:max)
             return if params[attr_name].length <= @option
-            raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: "must be at the most #{@option} characters long"
+            raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: "must be at the most #{@option} characters long")
           end
         end
       end
@@ -89,7 +89,7 @@ describe Grape::Validations do
       module CustomValidationsSpec
         class WithMessageKey < Grape::Validations::PresenceValidator
           def validate_param!(attr_name, _params)
-            raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: :presence
+            raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: :presence)
           end
         end
       end
@@ -128,7 +128,7 @@ describe Grape::Validations do
             return unless @option
             # check if user is admin or not
             # as an example get a token from request and check if it's admin or not
-            raise Grape::Exceptions::Validation, params: @attrs, message: 'Can not set Admin only field.' unless request.headers['X-Access-Token'] == 'admin'
+            raise Grape::Exceptions::Validation.new(params: @attrs, message: 'Can not set Admin only field.') unless request.headers['X-Access-Token'] == 'admin'
           end
         end
       end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1960,7 +1960,7 @@ XML
           rack_response('New Error', e.status)
         end
         subject.get '/custom_error' do
-          raise ApiSpec::CustomError, status: 400, message: 'Custom Error'
+          raise ApiSpec::CustomError.new(status: 400, message: 'Custom Error')
         end
 
         get '/custom_error'

--- a/spec/grape/exceptions/base_spec.rb
+++ b/spec/grape/exceptions/base_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Grape::Exceptions::Base do
   describe '#compose_message' do
-    subject { described_class.new.send(:compose_message, key, attributes) }
+    subject { described_class.new.send(:compose_message, key, **attributes) }
 
     let(:key) { :invalid_formatter }
     let(:attributes) { { klass: String, to_format: 'xml' } }

--- a/spec/grape/exceptions/validation_spec.rb
+++ b/spec/grape/exceptions/validation_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Grape::Exceptions::Validation do
   it 'fails when params are missing' do
-    expect { Grape::Exceptions::Validation.new(message: 'presence') }.to raise_error(ArgumentError, 'missing keyword: params')
+    expect { Grape::Exceptions::Validation.new(message: 'presence') }.to raise_error(ArgumentError, /missing keyword:.+?params/)
   end
   context 'when message is a symbol' do
     it 'stores message_key' do

--- a/spec/grape/middleware/exception_spec.rb
+++ b/spec/grape/middleware/exception_spec.rb
@@ -55,7 +55,7 @@ describe Grape::Middleware::Error do
     class CustomErrorApp
       class << self
         def call(_env)
-          raise CustomError, status: 400, message: 'failed validation'
+          raise CustomError.new(status: 400, message: 'failed validation')
         end
       end
     end

--- a/spec/grape/middleware/versioner/accept_version_header_spec.rb
+++ b/spec/grape/middleware/versioner/accept_version_header_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Grape::Middleware::Versioner::AcceptVersionHeader do
   let(:app) { ->(env) { [200, env, env] } }
-  subject { Grape::Middleware::Versioner::AcceptVersionHeader.new(app, @options || {}) }
+  subject { Grape::Middleware::Versioner::AcceptVersionHeader.new(app, **(@options || {})) }
 
   before do
     @options = {

--- a/spec/grape/middleware/versioner/header_spec.rb
+++ b/spec/grape/middleware/versioner/header_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Grape::Middleware::Versioner::Header do
   let(:app) { ->(env) { [200, env, env] } }
-  subject { Grape::Middleware::Versioner::Header.new(app, @options || {}) }
+  subject { Grape::Middleware::Versioner::Header.new(app, **(@options || {})) }
 
   before do
     @options = {

--- a/spec/grape/middleware/versioner/param_spec.rb
+++ b/spec/grape/middleware/versioner/param_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe Grape::Middleware::Versioner::Param do
   let(:app) { ->(env) { [200, env, env['api.version']] } }
   let(:options) { {} }
-  subject { Grape::Middleware::Versioner::Param.new(app, options) }
+  subject { Grape::Middleware::Versioner::Param.new(app, **options) }
 
   it 'sets the API version based on the default param (apiver)' do
     env = Rack::MockRequest.env_for('/awesome', params: { 'apiver' => 'v1' })

--- a/spec/grape/middleware/versioner/path_spec.rb
+++ b/spec/grape/middleware/versioner/path_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe Grape::Middleware::Versioner::Path do
   let(:app) { ->(env) { [200, env, env['api.version']] } }
   let(:options) { {} }
-  subject { Grape::Middleware::Versioner::Path.new(app, options) }
+  subject { Grape::Middleware::Versioner::Path.new(app, **options) }
 
   it 'sets the API version based on the first path' do
     expect(subject.call('PATH_INFO' => '/v1/awesome').last).to eq('v1')

--- a/spec/grape/parser_spec.rb
+++ b/spec/grape/parser_spec.rb
@@ -17,11 +17,11 @@ describe Grape::Parser do
 
   describe '.parsers' do
     it 'returns an instance of Hash' do
-      expect(subject.parsers({})).to be_an_instance_of(Hash)
+      expect(subject.parsers(**{})).to be_an_instance_of(Hash)
     end
 
     it 'includes built-in parsers' do
-      expect(subject.parsers({})).to include(subject.builtin_parsers)
+      expect(subject.parsers(**{})).to include(subject.builtin_parsers)
     end
 
     context 'with :parsers option' do
@@ -35,7 +35,7 @@ describe Grape::Parser do
       let(:added_parser) { Class.new }
       before { subject.register :added, added_parser }
       it 'includes added parser' do
-        expect(subject.parsers({})).to include(added: added_parser)
+        expect(subject.parsers(**{})).to include(added: added_parser)
       end
     end
   end
@@ -44,8 +44,8 @@ describe Grape::Parser do
     let(:options) { {} }
 
     it 'calls .parsers' do
-      expect(subject).to receive(:parsers).with(options).and_return(subject.builtin_parsers)
-      subject.parser_for(:json, options)
+      expect(subject).to receive(:parsers).with(any_args).and_return(subject.builtin_parsers)
+      subject.parser_for(:json, **options)
     end
 
     it 'returns parser correctly' do

--- a/spec/grape/validations/instance_behaivour_spec.rb
+++ b/spec/grape/validations/instance_behaivour_spec.rb
@@ -7,8 +7,8 @@ describe 'Validator with instance variables' do
     Class.new(Grape::Validations::Base) do
       def validate_param!(_attr_name, _params)
         if @instance_variable
-          raise Grape::Exceptions::Validation, params: ['params'],
-                                               message: 'This should never happen'
+          raise Grape::Exceptions::Validation.new(params: ['params'],
+                                                  message: 'This should never happen')
         end
         @instance_variable = true
       end

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -494,7 +494,7 @@ describe Grape::Validations do
           class DateRangeValidator < Grape::Validations::Base
             def validate_param!(attr_name, params)
               return if params[attr_name][:from] <= params[attr_name][:to]
-              raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: "'from' must be lower or equal to 'to'"
+              raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: "'from' must be lower or equal to 'to'")
             end
           end
         end
@@ -909,7 +909,7 @@ describe Grape::Validations do
         class Customvalidator < Grape::Validations::Base
           def validate_param!(attr_name, params)
             return if params[attr_name] == 'im custom'
-            raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: 'is not custom!'
+            raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: 'is not custom!')
           end
         end
       end
@@ -1057,7 +1057,7 @@ describe Grape::Validations do
           class CustomvalidatorWithOptions < Grape::Validations::Base
             def validate_param!(attr_name, params)
               return if params[attr_name] == @option[:text]
-              raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message
+              raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message)
             end
           end
         end

--- a/spec/support/versioned_helpers.rb
+++ b/spec/support/versioned_helpers.rb
@@ -21,7 +21,7 @@ module Spec
         end
       end
 
-      def versioned_headers(options)
+      def versioned_headers(**options)
         case options[:using]
         when :path
           {}  # no-op
@@ -45,7 +45,7 @@ module Spec
 
       def versioned_get(path, version_name, version_options = {})
         path    = versioned_path(version_options.merge(version: version_name, path: path))
-        headers = versioned_headers(version_options.merge(version: version_name))
+        headers = versioned_headers(**version_options.merge(version: version_name))
         params = {}
         if version_options[:using] == :param
           params = { version_options[:parameter] => version_name }


### PR DESCRIPTION
Add support for Ruby 2.7 both in Travis and in Grape itself

---

Ruby 2.7.0 was released December 25, 2019, and has some noisy [deprecation messages about wrong usage of keyword arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).

Grape gem already correctly uses double-splat operator in some places, but not all over the code-base. That must be fixed.

### So, what's done here:

* Add Ruby 2.7 to Travis matrix, use 2.6.x for Gemfile and rails 5 as it's already done for previous versions.
* Fix method signatures and calls that produce deprecation messages for kwargs used.

To see a ton of deprecation messages you can just install Ruby 2.7, checkout current `master` branch and run test suite. There are still some messages not related to the gem itself that comes from `mustermann`, `multi_json` and a few other gems that must be fixed themselves. 