### PR TITLE
Small Ruby 2.7 + changelog fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 #### Features
 
 * Your contribution here.
-* [#1948](https://github.com/ruby-grape/grape/pull/1949): Add support for Ruby 2.7 - [@nbulaj](https://github.com/nbulaj).
+* [#1949](https://github.com/ruby-grape/grape/pull/1949): Add support for Ruby 2.7 - [@nbulaj](https://github.com/nbulaj).
 * [#1948](https://github.com/ruby-grape/grape/pull/1948): Relax `dry-types` dependency version - [@nbulaj](https://github.com/nbulaj).
 * [#1944](https://github.com/ruby-grape/grape/pull/1944): Reduces `attribute_translator` string allocations - [@ericproulx](https://github.com/ericproulx).
 * [#1943](https://github.com/ruby-grape/grape/pull/1943): Reduces number of regex string allocations - [@ericproulx](https://github.com/ericproulx).

--- a/lib/grape/exceptions/validation.rb
+++ b/lib/grape/exceptions/validation.rb
@@ -14,7 +14,7 @@ module Grape
           @message_key = message if message.is_a?(Symbol)
           args[:message] = translate_message(message)
         end
-        super(args)
+        super(**args)
       end
 
       # remove all the unnecessary stuff from Grape::Exceptions::Base like status


### PR DESCRIPTION
As from the title: small fix for kwargs in `Grape::Exceptions::Validation` class and typo fix in changelog.