### PR TITLE
fix proc forwarding in Middleware::Stack#merge_with for ruby 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#1968](https://github.com/ruby-grape/grape/pull/1968): Fix args forwarding in Grape::Middleware::Stack#merge_with for ruby 2.7.0 - [@dm1try](https://github.com/dm1try).
 
 ### 1.3.0 (2020/01/11)
 

--- a/lib/grape/middleware/stack.rb
+++ b/lib/grape/middleware/stack.rb
@@ -78,7 +78,8 @@ module Grape
       def merge_with(middleware_specs)
         middleware_specs.each do |operation, *args|
           if args.last.is_a?(Proc)
-            public_send(operation, *args, &args.pop)
+            last_proc = args.pop
+            public_send(operation, *args, &last_proc)
           else
             public_send(operation, *args)
           end

--- a/spec/grape/middleware/stack_spec.rb
+++ b/spec/grape/middleware/stack_spec.rb
@@ -111,6 +111,15 @@ describe Grape::Middleware::Stack do
       expect(subject[1]).to eq(StackSpec::BlockMiddleware)
       expect(subject[2]).to eq(StackSpec::BarMiddleware)
     end
+
+    context 'middleware spec with proc declaration exists' do
+      let(:middleware_spec_with_proc) { [:use, StackSpec::FooMiddleware, proc] }
+
+      it 'properly forwards spec arguments' do
+        expect(subject).to receive(:use).with(StackSpec::FooMiddleware)
+        subject.merge_with([middleware_spec_with_proc])
+      end
+    end
   end
 
   describe '#build' do


### PR DESCRIPTION
ref #1967

~it fails on ruby 2.7.0 because of an "extra" argument(the proc) is forwarded~(FIXED)

`public_send(operation, *args, &args.pop)` works differently in ruby 2.7.0, `args` is not modified by `pop` if placed in the method call before the `pop`; though it looks more expected to me.