### PR TITLE
more tests for Grape::Validations::Types::PrimitiveCoercer

### DIFF
--- a/lib/grape/validations/types/primitive_coercer.rb
+++ b/lib/grape/validations/types/primitive_coercer.rb
@@ -6,12 +6,13 @@ module Grape
   module Validations
     module Types
       # Coerces the given value to a type defined via a +type+ argument during
-      # initialization.
+      # initialization. When +strict+ is true, it doesn't coerce a value but check
+      # that it has the proper type.
       class PrimitiveCoercer < DryTypeCoercer
         MAPPING = {
           Grape::API::Boolean => DryTypes::Params::Bool,
 
-          # unfortunatelly, a +Params+ scope doesn't contain String
+          # unfortunately, a +Params+ scope doesn't contain String
           String              => DryTypes::Coercible::String,
           BigDecimal          => DryTypes::Coercible::Decimal
         }.freeze

--- a/spec/grape/validations/types/primitive_coercer_spec.rb
+++ b/spec/grape/validations/types/primitive_coercer_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Grape::Validations::Types::PrimitiveCoercer do
+  let(:strict) { false }
+
+  subject { described_class.new(type, strict) }
+
+  describe '.call' do
+    context 'Boolean' do
+      let(:type) { Grape::API::Boolean }
+
+      it 'coerces to Boolean' do
+        expect(subject.call(0)).to eq(false)
+      end
+    end
+
+    context 'String' do
+      let(:type) { String }
+
+      it 'coerces to String' do
+        expect(subject.call(10)).to eq('10')
+      end
+    end
+
+    context 'BigDecimal' do
+      let(:type) { BigDecimal }
+
+      it 'coerces to BigDecimal' do
+        expect(subject.call(5)).to eq(BigDecimal(5))
+      end
+    end
+
+    context 'the strict mode' do
+      let(:strict) { true }
+
+      context 'Boolean' do
+        let(:type) { Grape::API::Boolean }
+
+        it 'returns an error when the given value is not Boolean' do
+          expect(subject.call(1)).to be_instance_of(Grape::Validations::Types::InvalidValue)
+        end
+
+        it 'returns a value as it is when the given value is Boolean' do
+          expect(subject.call(true)).to eq(true)
+        end
+      end
+
+      context 'BigDecimal' do
+        let(:type) { BigDecimal }
+
+        it 'returns an error when the given value is not BigDecimal' do
+          expect(subject.call(1)).to be_instance_of(Grape::Validations::Types::InvalidValue)
+        end
+
+        it 'returns a value as it is when the given value is BigDecimal' do
+          expect(subject.call(BigDecimal(0))).to eq(BigDecimal(0))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Unit tests better focus on corner cases in this case than integration tests which might be too high level.

I guess changelog isn't required for this.