### PR TITLE
Re-add exactly_one_of mutually exclusive error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#1987](https://github.com/ruby-grape/grape/pull/1987): Re-add exactly_one_of mutually exclusive error message - [@ZeroInputCtrl](https://github.com/ZeroInputCtrl).
 * [#1977](https://github.com/ruby-grape/grape/pull/1977): Skip validation for a file if it is optional and nil - [@dnesteryuk](https://github.com/dnesteryuk).
 * [#1976](https://github.com/ruby-grape/grape/pull/1976): Ensure classes/modules listed for autoload really exist - [@dnesteryuk](https://github.com/dnesteryuk).
 * [#1971](https://github.com/ruby-grape/grape/pull/1971): Fix BigDecimal coercion - [@FlickStuart](https://github.com/FlickStuart).

--- a/lib/grape/validations/validators/exactly_one_of.rb
+++ b/lib/grape/validations/validators/exactly_one_of.rb
@@ -7,7 +7,8 @@ module Grape
     class ExactlyOneOfValidator < MultipleParamsBase
       def validate_params!(params)
         return if keys_in_common(params).length == 1
-        raise Grape::Exceptions::Validation.new(params: all_keys, message: message(:exactly_one))
+        raise Grape::Exceptions::Validation.new(params: all_keys, message: message(:exactly_one)) if keys_in_common(params).length.zero?
+        raise Grape::Exceptions::Validation.new(params: keys_in_common(params), message: message(:mutual_exclusion))
       end
     end
   end

--- a/lib/grape/validations/validators/exactly_one_of.rb
+++ b/lib/grape/validations/validators/exactly_one_of.rb
@@ -6,9 +6,10 @@ module Grape
   module Validations
     class ExactlyOneOfValidator < MultipleParamsBase
       def validate_params!(params)
-        return if keys_in_common(params).length == 1
-        raise Grape::Exceptions::Validation.new(params: all_keys, message: message(:exactly_one)) if keys_in_common(params).length.zero?
-        raise Grape::Exceptions::Validation.new(params: keys_in_common(params), message: message(:mutual_exclusion))
+        keys = keys_in_common(params)
+        return if keys.length == 1
+        raise Grape::Exceptions::Validation.new(params: all_keys, message: message(:exactly_one)) if keys.length.zero?
+        raise Grape::Exceptions::Validation.new(params: keys, message: message(:mutual_exclusion))
       end
     end
   end

--- a/spec/grape/exceptions/validation_errors_spec.rb
+++ b/spec/grape/exceptions/validation_errors_spec.rb
@@ -81,8 +81,8 @@ describe Grape::Exceptions::ValidationErrors do
       expect(last_response.status).to eq(400)
       expect(JSON.parse(last_response.body)).to eq(
         [
-          'params' => %w[beer wine juice],
-          'messages' => ['are missing, exactly one parameter must be provided']
+          'params' => %w[beer wine],
+          'messages' => ['are mutually exclusive']
         ]
       )
     end

--- a/spec/grape/validations/validators/exactly_one_of_spec.rb
+++ b/spec/grape/validations/validators/exactly_one_of_spec.rb
@@ -100,7 +100,7 @@ describe Grape::Validations::ExactlyOneOfValidator do
         validate
         expect(last_response.status).to eq 400
         expect(JSON.parse(last_response.body)).to eq(
-          'beer,wine,grapefruit' => ['are missing, exactly one parameter must be provided']
+          'beer,wine,grapefruit' => ['are mutually exclusive']
         )
       end
 
@@ -112,7 +112,7 @@ describe Grape::Validations::ExactlyOneOfValidator do
           validate
           expect(last_response.status).to eq 400
           expect(JSON.parse(last_response.body)).to eq(
-            'beer,wine,grapefruit' => ['are missing, exactly one parameter must be provided']
+            'beer,wine,grapefruit' => ['are mutually exclusive']
           )
         end
       end
@@ -126,7 +126,7 @@ describe Grape::Validations::ExactlyOneOfValidator do
         validate
         expect(last_response.status).to eq 400
         expect(JSON.parse(last_response.body)).to eq(
-          'beer,wine,grapefruit' => ['are missing, exactly one parameter must be provided']
+          'beer,grapefruit' => ['are mutually exclusive']
         )
       end
     end
@@ -139,7 +139,7 @@ describe Grape::Validations::ExactlyOneOfValidator do
         validate
         expect(last_response.status).to eq 400
         expect(JSON.parse(last_response.body)).to eq(
-          'beer,wine,grapefruit' => ['you should choose one']
+          'beer,wine' => ['you should choose one']
         )
       end
     end
@@ -175,7 +175,7 @@ describe Grape::Validations::ExactlyOneOfValidator do
         validate
         expect(last_response.status).to eq 400
         expect(JSON.parse(last_response.body)).to eq(
-          'item[beer],item[wine],item[grapefruit]' => ['are missing, exactly one parameter must be provided']
+          'item[beer],item[wine]' => ['are mutually exclusive']
         )
       end
     end
@@ -190,7 +190,7 @@ describe Grape::Validations::ExactlyOneOfValidator do
           validate
           expect(last_response.status).to eq 400
           expect(JSON.parse(last_response.body)).to eq(
-            'item[beer],item[wine],item[grapefruit]' => ['are missing, exactly one parameter must be provided']
+            'item[beer],item[wine]' => ['are mutually exclusive']
           )
         end
       end
@@ -213,11 +213,11 @@ describe Grape::Validations::ExactlyOneOfValidator do
         validate
         expect(last_response.status).to eq 400
         expect(JSON.parse(last_response.body)).to eq(
-          'items[0][beer],items[0][wine],items[0][grapefruit]' => [
-            'are missing, exactly one parameter must be provided'
+          'items[0][beer],items[0][wine]' => [
+            'are mutually exclusive'
           ],
-          'items[1][beer],items[1][wine],items[1][grapefruit]' => [
-            'are missing, exactly one parameter must be provided'
+          'items[1][wine],items[1][grapefruit]' => [
+            'are mutually exclusive'
           ]
         )
       end
@@ -231,8 +231,8 @@ describe Grape::Validations::ExactlyOneOfValidator do
         validate
         expect(last_response.status).to eq 400
         expect(JSON.parse(last_response.body)).to eq(
-          'items[0][nested_items][0][beer],items[0][nested_items][0][wine],items[0][nested_items][0][grapefruit]' => [
-            'are missing, exactly one parameter must be provided'
+          'items[0][nested_items][0][beer],items[0][nested_items][0][wine]' => [
+            'are mutually exclusive'
           ]
         )
       end

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -1418,7 +1418,7 @@ describe Grape::Validations do
           it 'errors when two or more are present' do
             get '/custom_message/exactly_one_of', beer: 'string', wine: 'anotherstring'
             expect(last_response.status).to eq(400)
-            expect(last_response.body).to eq 'beer, wine, juice are missing, exactly one parameter is required'
+            expect(last_response.body).to eq 'beer, wine are missing, exactly one parameter is required'
           end
         end
 
@@ -1437,7 +1437,7 @@ describe Grape::Validations do
         it 'errors when two or more are present' do
           get '/exactly_one_of', beer: 'string', wine: 'anotherstring'
           expect(last_response.status).to eq(400)
-          expect(last_response.body).to eq 'beer, wine, juice are missing, exactly one parameter must be provided'
+          expect(last_response.body).to eq 'beer, wine are mutually exclusive'
         end
       end
 
@@ -1477,7 +1477,7 @@ describe Grape::Validations do
         it 'errors when two or more are present' do
           get '/exactly_one_of_nested', nested: { beer_nested: 'string' }, nested2: [{ beer_nested2: 'string', wine_nested2: 'anotherstring' }]
           expect(last_response.status).to eq(400)
-          expect(last_response.body).to eq 'nested2[0][beer_nested2], nested2[0][wine_nested2], nested2[0][juice_nested2] are missing, exactly one parameter must be provided'
+          expect(last_response.body).to eq 'nested2[0][beer_nested2], nested2[0][wine_nested2] are mutually exclusive'
         end
       end
     end


### PR DESCRIPTION
Breaking change at revision 96e4e1044e73e64414af709352b270ab4f88c864
Before the breaking change specs only tested a `Grape::Exceptions::Validation` error was returned rather than the message itself so this fell through when changed over to the new `MultipleParamsBase` code.