### PR TITLE
refactored the full_messages method and stop overriding full_message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [#1976](https://github.com/ruby-grape/grape/pull/1976): Ensure classes/modules listed for autoload really exist - [@dnesteryuk](https://github.com/dnesteryuk).
 * [#1971](https://github.com/ruby-grape/grape/pull/1971): Fix BigDecimal coercion - [@FlickStuart](https://github.com/FlickStuart).
 * [#1968](https://github.com/ruby-grape/grape/pull/1968): Fix args forwarding in Grape::Middleware::Stack#merge_with for ruby 2.7.0 - [@dm1try](https://github.com/dm1try).
-
+* [#1988](https://github.com/ruby-grape/grape/pull/1988): Refactored the full_messages method and stop overriding full_message - [@hosseintoussi](https://github.com/hosseintoussi).
 ### 1.3.0 (2020/01/11)
 
 #### Features

--- a/lib/grape/exceptions/base.rb
+++ b/lib/grape/exceptions/base.rb
@@ -57,10 +57,6 @@ module Grape
         end.join(', ')
       end
 
-      def translate_attribute(key, **options)
-        translate("#{BASE_ATTRIBUTES_KEY}.#{key}", default: key, **options)
-      end
-
       def translate_message(key, **options)
         case key
         when Symbol

--- a/lib/grape/exceptions/validation_errors.rb
+++ b/lib/grape/exceptions/validation_errors.rb
@@ -5,6 +5,9 @@ require 'grape/exceptions/base'
 module Grape
   module Exceptions
     class ValidationErrors < Grape::Exceptions::Base
+      ERRORS_FORMAT_KEY = 'grape.errors.format'
+      DEFAULT_ERRORS_FORMAT = '%{attributes} %{message}'
+
       include Enumerable
 
       attr_reader :errors
@@ -41,20 +44,16 @@ module Grape
       end
 
       def full_messages
-        messages = map { |attributes, error| full_message(attributes, error) }
+        messages = map do |attributes, error|
+          I18n.t(
+            ERRORS_FORMAT_KEY,
+            default: DEFAULT_ERRORS_FORMAT,
+            attributes: translate_attributes(attributes),
+            message: error.message
+          )
+        end
         messages.uniq!
         messages
-      end
-
-      private
-
-      def full_message(attributes, error)
-        I18n.t(
-          'grape.errors.format',
-          default: '%{attributes} %{message}',
-          attributes: attributes.count == 1 ? translate_attribute(attributes.first) : translate_attributes(attributes),
-          message: error.message
-        )
       end
     end
   end


### PR DESCRIPTION
Hi, Thank you for your work here 🙏.

This PR is an attempt to address: https://github.com/ruby-grape/grape/issues/1954. 

As mentioned in the issue, Ruby 2.5 add a `full_message` to Exception (https://ruby-doc.org/core-2.5.0/Exception.html#full_message-method). Grape overrides this and to stop that this PR removes the `full_message` private method.