### PR TITLE
Lazy join over allow headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Your contribution here.
 
 #### Fixes
-
+* [#1993](https://github.com/ruby-grape/grape/pull/1993): Lazy join allow header - [@ericproulx](https://github.com/ericproulx).
 * [#1987](https://github.com/ruby-grape/grape/pull/1987): Re-add exactly_one_of mutually exclusive error message - [@ZeroInputCtrl](https://github.com/ZeroInputCtrl).
 * [#1977](https://github.com/ruby-grape/grape/pull/1977): Skip validation for a file if it is optional and nil - [@dnesteryuk](https://github.com/dnesteryuk).
 * [#1976](https://github.com/ruby-grape/grape/pull/1976): Ensure classes/modules listed for autoload really exist - [@dnesteryuk](https://github.com/dnesteryuk).

--- a/lib/grape/api/instance.rb
+++ b/lib/grape/api/instance.rb
@@ -227,7 +227,7 @@ module Grape
                 allowed_methods |= [Grape::Http::Headers::HEAD] if allowed_methods.include?(Grape::Http::Headers::GET)
               end
 
-              allow_header = (self.class.namespace_inheritable(:do_not_route_options) ? allowed_methods : [Grape::Http::Headers::OPTIONS] | allowed_methods).join(', ')
+              allow_header = (self.class.namespace_inheritable(:do_not_route_options) ? allowed_methods : [Grape::Http::Headers::OPTIONS] | allowed_methods)
 
               unless self.class.namespace_inheritable(:do_not_route_options) || allowed_methods.include?(Grape::Http::Headers::OPTIONS)
                 config[:endpoint].options[:options_route_enabled] = true

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -106,7 +106,7 @@ module Grape
         env,
         neighbor.allow_header,
         neighbor.endpoint
-      ) if neighbor && method == 'OPTIONS' && !cascade
+      ) if neighbor && method == Grape::Http::Headers::OPTIONS && !cascade
 
       route = match?(input, '*')
       return neighbor.endpoint.call(env) if neighbor && cascade && route
@@ -160,7 +160,7 @@ module Grape
     end
 
     def call_with_allow_headers(env, methods, endpoint)
-      env[Grape::Env::GRAPE_ALLOWED_METHODS] = methods
+      env[Grape::Env::GRAPE_ALLOWED_METHODS] = methods.join(', ')
       endpoint.call(env)
     end
 


### PR DESCRIPTION
Hi,

While profiling my app, I found this :

```log
266 "GET, HEAD"
266 /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape1.3.0/lib/grape/api/instance.rb:230

60  "POST"
60  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape1.3.0/lib/grape/api/instance.rb:230

30  "PATCH"
30  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape1.3.0/lib/grape/api/instance.rb:230

22  "GET, POST, HEAD"
22  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape1.3.0/lib/grape/api/instance.rb:230

20  "GET, PATCH, HEAD"
20  /Users/eproulx/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/grape1.3.0/lib/grape/api/instance.rb:230
```

I figured that joining allowed headers while not actually requesting OPTIONS is a small waste of memory.  Instead, we could join them only when needed.

I also replaced string literal 'OPTIONS' by the Http::Headers::OPTIONS

Thanks