### PR TITLE
Fix typo in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Your contribution here.
 
 #### Fixes
+* [#1994](https://github.com/ruby-grape/grape/pull/1993): Fix typos in README - [@bellmyer](https://github.com/bellmyer).
 * [#1993](https://github.com/ruby-grape/grape/pull/1993): Lazy join allow header - [@ericproulx](https://github.com/ericproulx).
 * [#1987](https://github.com/ruby-grape/grape/pull/1987): Re-add exactly_one_of mutually exclusive error message - [@ZeroInputCtrl](https://github.com/ZeroInputCtrl).
 * [#1977](https://github.com/ruby-grape/grape/pull/1977): Skip validation for a file if it is optional and nil - [@dnesteryuk](https://github.com/dnesteryuk).

--- a/README.md
+++ b/README.md
@@ -1723,7 +1723,7 @@ params do
 end
 ```
 
-Every validation will have it's own instance of the validator, which means that the validator can have a state.
+Every validation will have its own instance of the validator, which means that the validator can have a state.
 
 ### Validation Errors
 
@@ -3302,7 +3302,7 @@ end
 
 Blocks can be executed before or after every API call, using `before`, `after`,
 `before_validation` and `after_validation`.
-If the API fails the `after` call will not be trigered, if you need code to execute for sure
+If the API fails the `after` call will not be triggered, if you need code to execute for sure
 use the `finally`.
 
 Before and after callbacks execute in the following order:


### PR DESCRIPTION
I found a typo in the README ("trigered" instead of "triggered") so I thought I'd be helpful. After that I fixed another typo so hopefully this is merge-worthy :)