### PR TITLE
Rubocop todo fixes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -188,6 +188,14 @@ Style/NumericPredicate:
     - 'spec/**/*'
     - 'lib/grape/middleware/formatter.rb'
 
+# Offense count: 1
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: implicit, explicit
+Style/RescueStandardError:
+  Exclude:
+    - 'lib/grape/validations/validators/coerce.rb'
+
 # Offense count: 11
 # Cop supports --auto-correct.
 # Configuration parameters: ConvertCodeThatCanStartToReturnNil, AllowedMethods.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,14 +47,6 @@ Lint/AmbiguousBlockAssociation:
   Exclude:
     - 'spec/grape/dsl/routing_spec.rb'
 
-# Offense count: 4
-Lint/DisjunctiveAssignmentInConstructor:
-  Exclude:
-    - 'lib/grape/namespace.rb'
-    - 'lib/grape/path.rb'
-    - 'lib/grape/router.rb'
-    - 'lib/grape/router/pattern.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 Lint/NonDeterministicRequireOrder:
@@ -66,12 +58,6 @@ Lint/NonDeterministicRequireOrder:
 Lint/RedundantCopDisableDirective:
   Exclude:
     - 'lib/grape/router/attribute_translator.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Lint/RedundantRequireStatement:
-  Exclude:
-    - 'lib/grape.rb'
 
 # Offense count: 2
 # Cop supports --auto-correct.
@@ -144,12 +130,6 @@ Performance/InefficientHashSearch:
   Exclude:
     - 'spec/grape/validations/validators/values_spec.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Performance/RegexpMatch:
-  Exclude:
-    - 'lib/grape/middleware/versioner/path.rb'
-
 # Offense count: 5
 # Cop supports --auto-correct.
 Style/EmptyLambdaParameter:
@@ -173,12 +153,6 @@ Style/ExpandPathArguments:
 # SupportedStyles: annotated, template, unannotated
 Style/FormatStringToken:
   EnforcedStyle: template
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/HashTransformValues:
-  Exclude:
-    - 'lib/grape/api.rb'
 
 # Offense count: 23
 # Cop supports --auto-correct.
@@ -205,15 +179,6 @@ Style/MethodMissingSuper:
   Exclude:
     - 'lib/grape/router/attribute_translator.rb'
 
-# Offense count: 5
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: literals, strict
-Style/MutableConstant:
-  Exclude:
-    - 'lib/grape/middleware/versioner/header.rb'
-    - 'lib/grape/router/route.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, EnforcedStyle, IgnoredMethods.
@@ -222,14 +187,6 @@ Style/NumericPredicate:
   Exclude:
     - 'spec/**/*'
     - 'lib/grape/middleware/formatter.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: implicit, explicit
-Style/RescueStandardError:
-  Exclude:
-    - 'lib/grape/validations/validators/coerce.rb'
 
 # Offense count: 11
 # Cop supports --auto-correct.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * [#2002](https://github.com/ruby-grape/grape/pull/2002): Objects allocation optimization (lazy_lookup) - [@ericproulx](https://github.com/ericproulx).
 
 #### Fixes
-
+* [#2004](https://github.com/ruby-grape/grape/pull/2004): Rubocop fixes - [@ericproulx](https://github.com/ericproulx).
 * [#1995](https://github.com/ruby-grape/grape/pull/1995): Fix: "undefined instance variables" and "method redefined" warnings - [@nbeyer](https://github.com/nbeyer).
 * [#1994](https://github.com/ruby-grape/grape/pull/1993): Fix typos in README - [@bellmyer](https://github.com/bellmyer).
 * [#1993](https://github.com/ruby-grape/grape/pull/1993): Lazy join allow header - [@ericproulx](https://github.com/ericproulx).

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -20,7 +20,6 @@ require 'active_support/core_ext/hash/conversions'
 require 'active_support/dependencies/autoload'
 require 'active_support/notifications'
 require 'i18n'
-require 'thread'
 
 I18n.load_path << File.expand_path('../grape/locale/en.yml', __FILE__)
 

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -175,7 +175,7 @@ module Grape
           if argument.respond_to?(:lazy?) && argument.lazy?
             argument.evaluate_from(configuration)
           elsif argument.is_a?(Hash)
-            argument.map { |key, value| [key, evaluate_arguments(configuration, value).first] }.to_h
+            argument.transform_values { |value| evaluate_arguments(configuration, value).first }
           elsif argument.is_a?(Array)
             evaluate_arguments(configuration, *argument)
           else

--- a/lib/grape/middleware/versioner/header.rb
+++ b/lib/grape/middleware/versioner/header.rb
@@ -26,10 +26,10 @@ module Grape
       # route.
       class Header < Base
         VENDOR_VERSION_HEADER_REGEX =
-          /\Avnd\.([a-z0-9.\-_!#\$&\^]+?)(?:-([a-z0-9*.]+))?(?:\+([a-z0-9*\-.]+))?\z/
+          /\Avnd\.([a-z0-9.\-_!#\$&\^]+?)(?:-([a-z0-9*.]+))?(?:\+([a-z0-9*\-.]+))?\z/.freeze
 
-        HAS_VENDOR_REGEX = /\Avnd\.[a-z0-9.\-_!#\$&\^]+/
-        HAS_VERSION_REGEX = /\Avnd\.([a-z0-9.\-_!#\$&\^]+?)(?:-([a-z0-9*.]+))+/
+        HAS_VENDOR_REGEX = /\Avnd\.[a-z0-9.\-_!#\$&\^]+/.freeze
+        HAS_VERSION_REGEX = /\Avnd\.([a-z0-9.\-_!#\$&\^]+?)(?:-([a-z0-9*.]+))+/.freeze
 
         def before
           strict_header_checks if strict?

--- a/lib/grape/middleware/versioner/path.rb
+++ b/lib/grape/middleware/versioner/path.rb
@@ -36,7 +36,7 @@ module Grape
 
           pieces = path.split('/')
           potential_version = pieces[1]
-          return unless potential_version =~ options[:pattern]
+          return unless potential_version&.match?(options[:pattern])
           throw :error, status: 404, message: '404 API Version Not Found' if options[:versions] && !options[:versions].find { |v| v.to_s == potential_version }
           env[Grape::Env::API_VERSION] = potential_version
         end

--- a/lib/grape/namespace.rb
+++ b/lib/grape/namespace.rb
@@ -38,7 +38,7 @@ module Grape
 
     class JoinedSpaceCache < Grape::Util::Cache
       def initialize
-        @cache ||= Hash.new do |h, joined_space|
+        @cache = Hash.new do |h, joined_space|
           h[joined_space] = -joined_space.join('/')
         end
       end

--- a/lib/grape/path.rb
+++ b/lib/grape/path.rb
@@ -75,7 +75,7 @@ module Grape
 
     class PartsCache < Grape::Util::Cache
       def initialize
-        @cache ||= Hash.new do |h, parts|
+        @cache = Hash.new do |h, parts|
           h[parts] = -parts.join('/')
         end
       end

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -19,7 +19,7 @@ module Grape
 
     class NormalizePathCache < Grape::Util::Cache
       def initialize
-        @cache ||= Hash.new do |h, path|
+        @cache = Hash.new do |h, path|
           normalized_path = +"/#{path}"
           normalized_path.squeeze!('/')
           normalized_path.sub!(%r{/+\Z}, '')

--- a/lib/grape/router/pattern.rb
+++ b/lib/grape/router/pattern.rb
@@ -57,7 +57,7 @@ module Grape
 
       class PatternCache < Grape::Util::Cache
         def initialize
-          @cache ||= Hash.new do |h, (pattern, suffix)|
+          @cache = Hash.new do |h, (pattern, suffix)|
             h[[pattern, suffix]] = -"#{pattern}#{suffix}"
           end
         end

--- a/lib/grape/router/route.rb
+++ b/lib/grape/router/route.rb
@@ -8,8 +8,8 @@ require 'pathname'
 module Grape
   class Router
     class Route
-      ROUTE_ATTRIBUTE_REGEXP = /route_([_a-zA-Z]\w*)/
-      SOURCE_LOCATION_REGEXP = /^(.*?):(\d+?)(?::in `.+?')?$/
+      ROUTE_ATTRIBUTE_REGEXP = /route_([_a-zA-Z]\w*)/.freeze
+      SOURCE_LOCATION_REGEXP = /^(.*?):(\d+?)(?::in `.+?')?$/.freeze
       FIXED_NAMED_CAPTURES = %w[format version].freeze
 
       attr_accessor :pattern, :translator, :app, :index, :regexp, :options

--- a/lib/grape/validations/validators/coerce.rb
+++ b/lib/grape/validations/validators/coerce.rb
@@ -76,7 +76,7 @@ module Grape
         converter.call(val)
 
       # Some custom types might fail, so it should be treated as an invalid value
-      rescue StandardError
+      rescue
         Types::InvalidValue.new
       end
 

--- a/lib/grape/validations/validators/coerce.rb
+++ b/lib/grape/validations/validators/coerce.rb
@@ -76,7 +76,7 @@ module Grape
         converter.call(val)
 
       # Some custom types might fail, so it should be treated as an invalid value
-      rescue
+      rescue StandardError
         Types::InvalidValue.new
       end
 


### PR DESCRIPTION
Hello,

Here are some fixes based on rubocop todo:
- Style/HashTransformValues
- Style/RescueStandardError
- Lint/RedundantRequireStatement
- Performance/RegexpMatch
- Style/MutableConstant
- Lint/DisjunctiveAssignmentInConstructor