### PR TITLE
Drop retained regexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Features
 
-* Your contribution here.
+* [#2011](https://github.com/ruby-grape/grape/pull/2011): Reduce total retained regexes - [@ericproulx](https://github.com/ericproulx).
 
 #### Fixes
 

--- a/lib/grape/router/route.rb
+++ b/lib/grape/router/route.rb
@@ -12,7 +12,7 @@ module Grape
       SOURCE_LOCATION_REGEXP = /^(.*?):(\d+?)(?::in `.+?')?$/.freeze
       FIXED_NAMED_CAPTURES = %w[format version].freeze
 
-      attr_accessor :pattern, :translator, :app, :index, :regexp, :options
+      attr_accessor :pattern, :translator, :app, :index, :options
 
       alias attributes translator
 


### PR DESCRIPTION
I removed the code that retain regexes in Route and Any classes since its union.

```log
# Based on our app
# 1.3.1
Total allocated: 41885240 bytes (308172 objects)
Total retained:  6000260 bytes (11806 objects)

#next version
Total allocated: 41851936 bytes (305115 objects)
Total retained:  3419455 bytes (8907 objects)
```
Almost half total retained :)