### PR TITLE
Reduced array allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ### 1.3.2 (Next)
 
 #### Features
-
+* Your contribution here.
+* [#2014](https://github.com/ruby-grape/grape/pull/2014): Reduce total allocated arrays - [@ericproulx](https://github.com/ericproulx).
 * [#2011](https://github.com/ruby-grape/grape/pull/2011): Reduce total retained regexes - [@ericproulx](https://github.com/ericproulx).
 
 #### Fixes

--- a/lib/grape/util/reverse_stackable_values.rb
+++ b/lib/grape/util/reverse_stackable_values.rb
@@ -8,8 +8,10 @@ module Grape
       protected
 
       def concat_values(inherited_value, new_value)
+        return inherited_value unless new_value
+
         [].tap do |value|
-          value.concat(new_value) if new_value
+          value.concat(new_value)
           value.concat(inherited_value)
         end
       end

--- a/lib/grape/util/stackable_values.rb
+++ b/lib/grape/util/stackable_values.rb
@@ -29,9 +29,11 @@ module Grape
       protected
 
       def concat_values(inherited_value, new_value)
+        return inherited_value unless new_value
+
         [].tap do |value|
           value.concat(inherited_value)
-          value.concat(new_value) if new_value
+          value.concat(new_value)
         end
       end
     end


### PR DESCRIPTION
```log
# Still based on our app

# current Grape master
allocated memory by class
-----------------------------------
  15834248  Array
  15730608  Hash
   6726012  String
   3079724  Regexp
    202016  MatchData

# next_version
allocated memory by class
-----------------------------------
  15730608  Hash
   6726012  String
   5870664  Array
   3079724  Regexp
    202016  MatchData
```