### PR TITLE
Reduced MatchData allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features
 * Your contribution here.
+* [#2015](https://github.com/ruby-grape/grape/pull/2014): Reduce MatchData allocation - [@ericproulx](https://github.com/ericproulx).
 * [#2014](https://github.com/ruby-grape/grape/pull/2014): Reduce total allocated arrays - [@ericproulx](https://github.com/ericproulx).
 * [#2011](https://github.com/ruby-grape/grape/pull/2011): Reduce total retained regexes - [@ericproulx](https://github.com/ericproulx).
 

--- a/lib/grape/middleware/versioner/header.rb
+++ b/lib/grape/middleware/versioner/header.rb
@@ -63,7 +63,7 @@ module Grape
 
         def an_accept_header_with_version_and_vendor_is_present?
           header.qvalues.keys.any? do |h|
-            VENDOR_VERSION_HEADER_REGEX =~ h.sub('application/', '')
+            VENDOR_VERSION_HEADER_REGEX.match?(h.sub('application/', ''))
           end
         end
 

--- a/lib/grape/middleware/versioner/parse_media_type_patch.rb
+++ b/lib/grape/middleware/versioner/parse_media_type_patch.rb
@@ -8,7 +8,7 @@ module Rack
         # Corrected version of https://github.com/mjackson/rack-accept/blob/master/lib/rack/accept/header.rb#L40-L44
         def parse_media_type(media_type)
           # see http://tools.ietf.org/html/rfc6838#section-4.2 for allowed characters in media type names
-          m = media_type.match(ALLOWED_CHARACTERS)
+          m = media_type&.match(ALLOWED_CHARACTERS)
           m ? [m[1], m[2], m[3] || ''] : []
         end
       end

--- a/lib/grape/middleware/versioner/parse_media_type_patch.rb
+++ b/lib/grape/middleware/versioner/parse_media_type_patch.rb
@@ -3,11 +3,12 @@
 module Rack
   module Accept
     module Header
+      ALLOWED_CHARACTERS = %r{^([a-z*]+)\/([a-z0-9*\&\^\-_#\$!.+]+)(?:;([a-z0-9=;]+))?$}.freeze
       class << self
         # Corrected version of https://github.com/mjackson/rack-accept/blob/master/lib/rack/accept/header.rb#L40-L44
         def parse_media_type(media_type)
           # see http://tools.ietf.org/html/rfc6838#section-4.2 for allowed characters in media type names
-          m = media_type.to_s.match(%r{^([a-z*]+)\/([a-z0-9*\&\^\-_#\$!.+]+)(?:;([a-z0-9=;]+))?$})
+          m = media_type.match(ALLOWED_CHARACTERS)
           m ? [m[1], m[2], m[3] || ''] : []
         end
       end

--- a/lib/grape/path.rb
+++ b/lib/grape/path.rb
@@ -42,11 +42,11 @@ module Grape
     end
 
     def namespace?
-      namespace && namespace.to_s =~ /^\S/ && namespace != '/'
+      namespace&.match?(/^\S/) && namespace != '/'
     end
 
     def path?
-      raw_path && raw_path.to_s =~ /^\S/ && raw_path != '/'
+      raw_path&.match?(/^\S/) && raw_path != '/'
     end
 
     def suffix

--- a/lib/grape/router/route.rb
+++ b/lib/grape/router/route.rb
@@ -31,7 +31,7 @@ module Grape
       end
 
       def respond_to_missing?(method_id, _)
-        ROUTE_ATTRIBUTE_REGEXP.match(method_id.to_s)
+        ROUTE_ATTRIBUTE_REGEXP.match?(method_id.to_s)
       end
 
       %i[
@@ -67,7 +67,6 @@ module Grape
         method_s = method.to_s
         method_upcase = Grape::Http::Headers.find_supported_method(method_s) || method_s.upcase
 
-        @suffix     = options[:suffix]
         @options    = options.merge(method: method_upcase)
         @pattern    = Pattern.new(pattern, **options)
         @translator = AttributeTranslator.new(**options, request_method: method_upcase)

--- a/lib/grape/validations/types/json.rb
+++ b/lib/grape/validations/types/json.rb
@@ -20,7 +20,7 @@ module Grape
           return input if coerced?(input)
 
           # Allow nulls and blank strings
-          return if input.nil? || input =~ /^\s*$/
+          return if input.nil? || input.match?(/^\s*$/)
           JSON.parse(input, symbolize_names: true)
         end
 

--- a/lib/grape/validations/validators/regexp.rb
+++ b/lib/grape/validations/validators/regexp.rb
@@ -5,7 +5,7 @@ module Grape
     class RegexpValidator < Base
       def validate_param!(attr_name, params)
         return unless params.respond_to?(:key?) && params.key?(attr_name)
-        return if Array.wrap(params[attr_name]).all? { |param| param.nil? || (param.to_s =~ (options_key?(:value) ? @option[:value] : @option)) }
+        return if Array.wrap(params[attr_name]).all? { |param| param.nil? || param.to_s.match?((options_key?(:value) ? @option[:value] : @option)) }
         raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message(:regexp))
       end
     end

--- a/spec/grape/path_spec.rb
+++ b/spec/grape/path_spec.rb
@@ -87,12 +87,12 @@ module Grape
     describe '#namespace?' do
       it 'is false when the namespace is nil' do
         path = Path.new(anything, nil, anything)
-        expect(path.namespace?).to be nil
+        expect(path.namespace?).to be_falsey
       end
 
       it 'is false when the namespace starts with whitespace' do
         path = Path.new(anything, ' /foo', anything)
-        expect(path.namespace?).to be nil
+        expect(path.namespace?).to be_falsey
       end
 
       it 'is false when the namespace is the root path' do
@@ -109,12 +109,12 @@ module Grape
     describe '#path?' do
       it 'is false when the path is nil' do
         path = Path.new(nil, anything, anything)
-        expect(path.path?).to be nil
+        expect(path.path?).to be_falsey
       end
 
       it 'is false when the path starts with whitespace' do
         path = Path.new(' /foo', anything, anything)
-        expect(path.path?).to be nil
+        expect(path.path?).to be_falsey
       end
 
       it 'is false when the path is the root path' do


### PR DESCRIPTION
```log
# Based on our app

# master
allocated memory by class
-----------------------------------
  15730608  Hash
   6726012  String
   5870664  Array
   3079724  Regexp
    202016  MatchData
# this PR

allocated memory by class
-----------------------------------
  15730608  Hash
   6726012  String
   5870664  Array
   3079724  Regexp
     81024  Grape::Router::Route
     72936  Grape::Router::Pattern
     40520  Grape::Router::AttributeTranslator
     38960  Grape::Router::Any
     25840  Grape::Path
     23376  MatchData
```