### PR TITLE
Add upgrade notice for Array[String]

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -42,6 +42,26 @@ end
 
 Custom types which don't depend on Virtus don't require any changes.
 
+#### Ensure that Array[String] types have explicit coercions
+
+Unlike Virtus, dry-types does not perform any implict coercions. If you
+have any uses of `Array[String]`, be sure they use a `coerce_with`
+block. For example:
+
+```ruby
+requires :values, type: Array[String]
+```
+
+It's quite common to pass a comma-separated list, such as `tag1,tag2` as
+`values`. Previously Virtus would implicitly coerce this to
+`Array(values)` so that `["tag1,tag2"]` would pass the type checks, but
+with `dry-types` the values are no longer coerced for you. To fix this,
+you might do:
+
+```ruby
+requires :values, type: Array[String], coerce_with: ->(val) { val.split(',').map(&:strip) }
+```
+
 For more information see [#1920](https://github.com/ruby-grape/grape/pull/1920).
 
 ### Upgrading to >= 1.2.4


### PR DESCRIPTION
If `Array[String]` is used without a `coerce_with` block, existing APIs may
quietly fail without explanation. This change to the upgrade
documentation makes that clear.

Closes https://github.com/ruby-grape/grape/issues/2013