### PR TITLE
Report endpoint_call.grape which includes the whole stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -3810,9 +3810,17 @@ Grape has built-in support for [ActiveSupport::Notifications](http://api.rubyonr
 
 The following are currently supported:
 
+#### endpoint_call.grape
+
+The main execution of an endpoint, includes filters, rendering and all middlewares.
+
+* *endpoint* - The endpoint instance
+* *response* - A typical Rack response, for example `[404, {"Content-Type"=>"application/json; charset=UTF-8"}, ["{\"error\":\"not_found\"}"]]`
+
 #### endpoint_run.grape
 
-The main execution of an endpoint, includes filters and rendering.
+Similar to `endpoint_call.grape` but does not include middlewares, thus might be inaccurate.
+One more difference that it returns original exceptions, before `rescue_from` handlers.
 
 * *endpoint* - The endpoint instance
 

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -226,7 +226,10 @@ module Grape
     def call!(env)
       env[Grape::Env::API_ENDPOINT] = self
       @env = env
-      @app.call(env)
+      context = {endpoint: self, env: @env}
+      ActiveSupport::Notifications.instrument('endpoint_call.grape', context) do
+        @app.call(env).tap { |response| context[:response] = response }
+      end
     end
 
     # Return the collection of endpoints within this endpoint.

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -1530,11 +1530,15 @@ describe Grape::Endpoint do
         have_attributes(name: 'endpoint_run.grape', payload: { endpoint: a_kind_of(Grape::Endpoint),
                                                                env: an_instance_of(Hash) }),
         have_attributes(name: 'format_response.grape', payload: { env: an_instance_of(Hash),
-                                                                  formatter: a_kind_of(Module) })
+                                                                  formatter: a_kind_of(Module) }),
+        have_attributes(name: 'endpoint_call.grape', payload: { endpoint: a_kind_of(Grape::Endpoint),
+                                                                env: an_instance_of(Hash),
+                                                                response: match([200, be_a(Hash), be_a(Array)]) })
       )
 
       # In order that events were initialized
       expect(@events.sort_by(&:time)).to contain_exactly(
+        have_attributes(name: 'endpoint_call.grape'),
         have_attributes(name: 'endpoint_run.grape', payload: { endpoint: a_kind_of(Grape::Endpoint),
                                                                env: an_instance_of(Hash) }),
         have_attributes(name: 'endpoint_run_filters.grape', payload: { endpoint: a_kind_of(Grape::Endpoint),


### PR DESCRIPTION
Fixes #2010 

To keep the backward compatibility, I introduced a new event. The integration works fine in my project with this change.