### PR TITLE
Fix Decimal type category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#2025](https://github.com/ruby-grape/grape/pull/2025): Fix Decimal type category - [@kdoya](https://github.com/kdoya).
 * [#2019](https://github.com/ruby-grape/grape/pull/2019): Avoid coercing parameter with multiple types to an empty Array - [@stanhu](https://github.com/stanhu).
 
 ### 1.3.1 (2020/03/11)

--- a/lib/grape/validations/types/primitive_coercer.rb
+++ b/lib/grape/validations/types/primitive_coercer.rb
@@ -14,7 +14,7 @@ module Grape
           BigDecimal          => DryTypes::Params::Decimal,
 
           # unfortunately, a +Params+ scope doesn't contain String
-          String              => DryTypes::Coercible::String,
+          String              => DryTypes::Coercible::String
         }.freeze
 
         STRICT_MAPPING = {

--- a/lib/grape/validations/types/primitive_coercer.rb
+++ b/lib/grape/validations/types/primitive_coercer.rb
@@ -11,10 +11,10 @@ module Grape
       class PrimitiveCoercer < DryTypeCoercer
         MAPPING = {
           Grape::API::Boolean => DryTypes::Params::Bool,
+          BigDecimal          => DryTypes::Params::Decimal,
 
           # unfortunately, a +Params+ scope doesn't contain String
           String              => DryTypes::Coercible::String,
-          BigDecimal          => DryTypes::Coercible::Decimal
         }.freeze
 
         STRICT_MAPPING = {

--- a/spec/grape/validations/validators/coerce_spec.rb
+++ b/spec/grape/validations/validators/coerce_spec.rb
@@ -154,6 +154,36 @@ describe Grape::Validations::CoerceValidator do
     end
 
     context 'coerces' do
+      context 'json' do
+        let(:headers) { { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' } }
+
+        it 'BigDecimal' do
+          subject.params do
+            requires :bigdecimal, type: BigDecimal
+          end
+          subject.post '/bigdecimal' do
+            params[:bigdecimal]
+          end
+
+          post '/bigdecimal', { bigdecimal: 45.1 }.to_json, headers
+          expect(last_response.status).to eq(201)
+          expect(last_response.body).to eq('45.1')
+        end
+
+        it 'Boolean' do
+          subject.params do
+            requires :boolean, type: Boolean
+          end
+          subject.post '/boolean' do
+            params[:boolean]
+          end
+
+          post '/boolean', { boolean: 'true' }.to_json, headers
+          expect(last_response.status).to eq(201)
+          expect(last_response.body).to eq('true')
+        end
+      end
+
       it 'BigDecimal' do
         subject.params do
           requires :bigdecimal, coerce: BigDecimal


### PR DESCRIPTION
It may be more useful by using `DryTypes::Params::Decimal`.  Because `DryTypes::Coercible::Decimal` fails coercing `45.1` for json reqeust.