### PR TITLE
Fix a regression in coerce_with when coercion returns nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#2026](https://github.com/ruby-grape/grape/pull/2026): Fix a regression in coerce_with when coercion returns nil - [@misdoro](https://github.com/misdoro).
 * [#2025](https://github.com/ruby-grape/grape/pull/2025): Fix Decimal type category - [@kdoya](https://github.com/kdoya).
 * [#2019](https://github.com/ruby-grape/grape/pull/2019): Avoid coercing parameter with multiple types to an empty Array - [@stanhu](https://github.com/stanhu).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 #### Fixes
 
 * Your contribution here.
-* [#2026](https://github.com/ruby-grape/grape/pull/2026): Fix a regression in coerce_with when coercion returns nil - [@misdoro](https://github.com/misdoro).
+* [#2026](https://github.com/ruby-grape/grape/pull/2026): Fix a regression in `coerce_with` when coercion returns `nil` - [@misdoro](https://github.com/misdoro).
 * [#2025](https://github.com/ruby-grape/grape/pull/2025): Fix Decimal type category - [@kdoya](https://github.com/kdoya).
 * [#2019](https://github.com/ruby-grape/grape/pull/2019): Avoid coercing parameter with multiple types to an empty Array - [@stanhu](https://github.com/stanhu).
 

--- a/lib/grape/validations/types/custom_type_coercer.rb
+++ b/lib/grape/validations/types/custom_type_coercer.rb
@@ -60,7 +60,7 @@ module Grape
         end
 
         def coerced?(val)
-          @type_check.call val
+          val.nil? || @type_check.call(val)
         end
 
         private


### PR DESCRIPTION
Previously nil was handled as valid value for coercion for integer parameters.

With refactoring introduced in 1.3.0 integer parameter coerced with a custom method can't coerce to nil any more.

This change reverts back to previous behaviour where coercion to nil was allowed.