### PR TITLE
Special types provided by Grape are custom ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#2031](https://github.com/ruby-grape/grape/pull/2031): Fix a regression with an array of a custom type - [@dnesteryuk](https://github.com/dnesteryuk).
 * [#2026](https://github.com/ruby-grape/grape/pull/2026): Fix a regression in `coerce_with` when coercion returns `nil` - [@misdoro](https://github.com/misdoro).
 * [#2025](https://github.com/ruby-grape/grape/pull/2025): Fix Decimal type category - [@kdoya](https://github.com/kdoya).
 * [#2019](https://github.com/ruby-grape/grape/pull/2019): Avoid coercing parameter with multiple types to an empty Array - [@stanhu](https://github.com/stanhu).

--- a/lib/grape/validations/types.rb
+++ b/lib/grape/validations/types.rb
@@ -42,7 +42,6 @@ module Grape
         Grape::API::Boolean,
         String,
         Symbol,
-        Rack::Multipart::UploadedFile,
         TrueClass,
         FalseClass
       ].freeze
@@ -54,8 +53,7 @@ module Grape
         Set
       ].freeze
 
-      # Types for which Grape provides special coercion
-      # and type-checking logic.
+      # Special custom types provided by Grape.
       SPECIAL = {
         JSON => Json,
         Array[JSON] => JsonArray,
@@ -130,7 +128,6 @@ module Grape
         !primitive?(type) &&
           !structure?(type) &&
           !multiple?(type) &&
-          !special?(type) &&
           type.respond_to?(:parse) &&
           type.method(:parse).arity == 1
       end
@@ -143,7 +140,11 @@ module Grape
       def self.collection_of_custom?(type)
         (type.is_a?(Array) || type.is_a?(Set)) &&
           type.length == 1 &&
-          custom?(type.first)
+          (custom?(type.first) || special?(type.first))
+      end
+
+      def self.map_special(type)
+        SPECIAL.fetch(type, type)
       end
     end
   end

--- a/lib/grape/validations/types/build_coercer.rb
+++ b/lib/grape/validations/types/build_coercer.rb
@@ -42,6 +42,9 @@ module Grape
       end
 
       def self.create_coercer_instance(type, method, strict)
+        # Maps a custom type provided by Grape, it doesn't map types wrapped by collections!!!
+        type = Types.map_special(type)
+
         # Use a special coercer for multiply-typed parameters.
         if Types.multiple?(type)
           MultipleTypeCoercer.new(type, method)
@@ -55,10 +58,8 @@ module Grape
         # method is supplied.
         elsif Types.collection_of_custom?(type)
           Types::CustomTypeCollectionCoercer.new(
-            type.first, type.is_a?(Set)
+            Types.map_special(type.first), type.is_a?(Set)
           )
-        elsif Types.special?(type)
-          Types::SPECIAL[type].new
         elsif type.is_a?(Array)
           ArrayCoercer.new type, strict
         elsif type.is_a?(Set)

--- a/lib/grape/validations/types/file.rb
+++ b/lib/grape/validations/types/file.rb
@@ -7,21 +7,23 @@ module Grape
       # Actual handling of these objects is provided by +Rack::Request+;
       # this class is here only to assert that rack's handling has succeeded.
       class File
-        def call(input)
-          return if input.nil?
-          return InvalidValue.new unless coerced?(input)
+        class << self
+          def parse(input)
+            return if input.nil?
+            return InvalidValue.new unless parsed?(input)
 
-          # Processing of multipart file objects
-          # is already taken care of by Rack::Request.
-          # Nothing to do here.
-          input
-        end
+            # Processing of multipart file objects
+            # is already taken care of by Rack::Request.
+            # Nothing to do here.
+            input
+          end
 
-        def coerced?(value)
-          # Rack::Request creates a Hash with filename,
-          # content type and an IO object. Do a bit of basic
-          # duck-typing.
-          value.is_a?(::Hash) && value.key?(:tempfile) && value[:tempfile].is_a?(Tempfile)
+          def parsed?(value)
+            # Rack::Request creates a Hash with filename,
+            # content type and an IO object. Do a bit of basic
+            # duck-typing.
+            value.is_a?(::Hash) && value.key?(:tempfile) && value[:tempfile].is_a?(Tempfile)
+          end
         end
       end
     end

--- a/lib/grape/validations/types/json.rb
+++ b/lib/grape/validations/types/json.rb
@@ -12,35 +12,37 @@ module Grape
       # validation system will apply nested validation rules to
       # all returned objects.
       class Json
-        # Coerce the input into a JSON-like data structure.
-        #
-        # @param input [String] a JSON-encoded parameter value
-        # @return [Hash,Array<Hash>,nil]
-        def call(input)
-          return input if coerced?(input)
+        class << self
+          # Coerce the input into a JSON-like data structure.
+          #
+          # @param input [String] a JSON-encoded parameter value
+          # @return [Hash,Array<Hash>,nil]
+          def parse(input)
+            return input if parsed?(input)
 
-          # Allow nulls and blank strings
-          return if input.nil? || input.match?(/^\s*$/)
-          JSON.parse(input, symbolize_names: true)
-        end
+            # Allow nulls and blank strings
+            return if input.nil? || input.match?(/^\s*$/)
+            JSON.parse(input, symbolize_names: true)
+          end
 
-        # Checks that the input was parsed successfully
-        # and isn't something odd such as an array of primitives.
-        #
-        # @param value [Object] result of {#coerce}
-        # @return [true,false]
-        def coerced?(value)
-          value.is_a?(::Hash) || coerced_collection?(value)
-        end
+          # Checks that the input was parsed successfully
+          # and isn't something odd such as an array of primitives.
+          #
+          # @param value [Object] result of {#parse}
+          # @return [true,false]
+          def parsed?(value)
+            value.is_a?(::Hash) || coerced_collection?(value)
+          end
 
-        protected
+          protected
 
-        # Is the value an array of JSON-like objects?
-        #
-        # @param value [Object] result of {#coerce}
-        # @return [true,false]
-        def coerced_collection?(value)
-          value.is_a?(::Array) && value.all? { |i| i.is_a? ::Hash }
+          # Is the value an array of JSON-like objects?
+          #
+          # @param value [Object] result of {#parse}
+          # @return [true,false]
+          def coerced_collection?(value)
+            value.is_a?(::Array) && value.all? { |i| i.is_a? ::Hash }
+          end
         end
       end
 
@@ -49,18 +51,20 @@ module Grape
       # objects and arrays of objects, but wraps single objects
       # in an Array.
       class JsonArray < Json
-        # See {Json#coerce}. Wraps single objects in an array.
-        #
-        # @param input [String] JSON-encoded parameter value
-        # @return [Array<Hash>]
-        def call(input)
-          json = super
-          Array.wrap(json) unless json.nil?
-        end
+        class << self
+          # See {Json#parse}. Wraps single objects in an array.
+          #
+          # @param input [String] JSON-encoded parameter value
+          # @return [Array<Hash>]
+          def parse(input)
+            json = super
+            Array.wrap(json) unless json.nil?
+          end
 
-        # See {Json#coerced_collection?}
-        def coerced?(value)
-          coerced_collection? value
+          # See {Json#coerced_collection?}
+          def parsed?(value)
+            coerced_collection? value
+          end
         end
       end
     end

--- a/spec/grape/validations/types_spec.rb
+++ b/spec/grape/validations/types_spec.rb
@@ -17,7 +17,7 @@ describe Grape::Validations::Types do
     [
       Integer, Float, Numeric, BigDecimal,
       Grape::API::Boolean, String, Symbol,
-      Date, DateTime, Time, Rack::Multipart::UploadedFile
+      Date, DateTime, Time
     ].each do |type|
       it "recognizes #{type} as a primitive" do
         expect(described_class.primitive?(type)).to be_truthy


### PR DESCRIPTION
Users tries to use types provided by Grape as an example how to write custom types. So, it makes sense to treat them as custom.

Besides that, it fixes #1986 where a collection of a custom type wasn't coerced properly.