### PR TITLE
Ensure floats are correctly coerced to bigdecimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#2033](https://github.com/ruby-grape/grape/pull/2033): Ensure `Float` params are correctly coerced to `BigDecimal` - [@tlconnor](https://github.com/tlconnor).
 * [#2031](https://github.com/ruby-grape/grape/pull/2031): Fix a regression with an array of a custom type - [@dnesteryuk](https://github.com/dnesteryuk).
 * [#2026](https://github.com/ruby-grape/grape/pull/2026): Fix a regression in `coerce_with` when coercion returns `nil` - [@misdoro](https://github.com/misdoro).
 * [#2025](https://github.com/ruby-grape/grape/pull/2025): Fix Decimal type category - [@kdoya](https://github.com/kdoya).

--- a/lib/grape/validations/validators/coerce.rb
+++ b/lib/grape/validations/validators/coerce.rb
@@ -47,7 +47,9 @@ module Grape
         #     h[:list] = list
         #     h
         #     => #<Hashie::Mash list=[1, 2, 3, 4]>
-        params[attr_name] = new_value unless params[attr_name] == new_value
+        return if params[attr_name].class == new_value.class && params[attr_name] == new_value
+
+        params[attr_name] = new_value
       end
 
       private

--- a/spec/grape/validations/validators/coerce_spec.rb
+++ b/spec/grape/validations/validators/coerce_spec.rb
@@ -162,12 +162,12 @@ describe Grape::Validations::CoerceValidator do
             requires :bigdecimal, type: BigDecimal
           end
           subject.post '/bigdecimal' do
-            params[:bigdecimal]
+            "#{params[:bigdecimal].class} #{params[:bigdecimal].to_f}"
           end
 
           post '/bigdecimal', { bigdecimal: 45.1 }.to_json, headers
           expect(last_response.status).to eq(201)
-          expect(last_response.body).to eq('45.1')
+          expect(last_response.body).to eq('BigDecimal 45.1')
         end
 
         it 'Boolean' do


### PR DESCRIPTION
Possible fix for `Float` coercion to `BigDecimal` https://github.com/ruby-grape/grape/issues/2032.

When checking for equality of params, checks both the class and value of params rather than just the value.



/cc: @dblock @dnesteryuk

