### PR TITLE
Fix coerce_nil when Array of Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#2040](https://github.com/ruby-grape/grape/pull/2040): Fix a regression with Array of type nil - [@ericproulx](https://github.com/ericproulx).
 
 ### 1.3.2 (2020/04/12)
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,65 @@
 Upgrading Grape
 ===============
 
+### Upgrading to >= 1.4.0
+
+#### Nil values for structures
+
+Nil values always been a special case when dealing with types especially with the following structures:
+ - Array
+ - Hash
+ - Set
+ 
+The behaviour for these structures has change through out the latest releases. For instance:
+
+```ruby
+class Api < Grape::API
+  params do
+    require :my_param, type: Array[Integer]
+  end
+
+  get 'example' do
+     params[:my_param]
+  end
+  get '/example', params: { my_param: nil }
+  # 1.3.1 = []
+  # 1.3.2 = nil
+end
+```
+For now on, `nil` values stay `nil` values for all types, including arrays, sets and hashes.
+
+If you want to have the same behavior as 1.3.1, apply a `default` validator
+
+```ruby
+class Api < Grape::API
+  params do
+    require :my_param, type: Array[Integer], default: []
+  end
+
+  get 'example' do
+     params[:my_param]
+  end
+  get '/example', params: { my_param: nil } # => []
+end
+```
+
+#### Default validator
+
+Default validator is now applied for `nil` values.
+
+```ruby
+class Api < Grape::API
+  params do
+    requires :my_param, type: Integer, default: 0
+  end
+
+  get 'example' do
+     params[:my_param]
+  end
+  get '/example', params: { my_param: nil } #=> before: nil, after: 0
+end
+```
+
 ### Upgrading to >= 1.3.0
 
 #### Ruby

--- a/lib/grape/validations/types/array_coercer.rb
+++ b/lib/grape/validations/types/array_coercer.rb
@@ -32,6 +32,8 @@ module Grape
         protected
 
         def coerce_elements(collection)
+          return if collection.nil?
+
           collection.each_with_index do |elem, index|
             return InvalidValue.new if reject?(elem)
 

--- a/lib/grape/validations/types/dry_type_coercer.rb
+++ b/lib/grape/validations/types/dry_type_coercer.rb
@@ -27,6 +27,8 @@ module Grape
         #
         # @param val [Object]
         def call(val)
+          return if val.nil?
+
           @coercer[val]
         rescue Dry::Types::CoercionError => _e
           InvalidValue.new

--- a/lib/grape/validations/types/variant_collection_coercer.rb
+++ b/lib/grape/validations/types/variant_collection_coercer.rb
@@ -33,7 +33,7 @@ module Grape
         #   the coerced result, or an instance
         #   of {InvalidValue} if the value could not be coerced.
         def call(value)
-          return InvalidValue.new unless value.is_a? Array
+          return unless value.is_a? Array
 
           value =
             if @method

--- a/lib/grape/validations/validators/coerce.rb
+++ b/lib/grape/validations/validators/coerce.rb
@@ -67,19 +67,10 @@ module Grape
       end
 
       def coerce_value(val)
-        val.nil? ? coerce_nil(val) : converter.call(val)
+        converter.call(val)
       # Some custom types might fail, so it should be treated as an invalid value
       rescue StandardError
         Types::InvalidValue.new
-      end
-
-      def coerce_nil(val)
-        # define default values for structures, the dry-types lib which is used
-        # for coercion doesn't accept nil as a value, so it would fail
-        return []      if type == Array
-        return Set.new if type == Set
-        return {}      if type == Hash
-        val
       end
 
       # Type to which the parameter will be coerced.

--- a/lib/grape/validations/validators/default.rb
+++ b/lib/grape/validations/validators/default.rb
@@ -9,7 +9,6 @@ module Grape
       end
 
       def validate_param!(attr_name, params)
-        return if params.key? attr_name
         params[attr_name] = if @default.is_a? Proc
                               @default.call
                             elsif @default.frozen? || !duplicatable?(@default)

--- a/spec/grape/validations/validators/coerce_spec.rb
+++ b/spec/grape/validations/validators/coerce_spec.rb
@@ -424,6 +424,79 @@ describe Grape::Validations::CoerceValidator do
         expect(last_response.status).to eq(200)
         expect(last_response.body).to eq(integer_class_name)
       end
+
+      context 'nil values' do
+        context 'primitive types' do
+          Grape::Validations::Types::PRIMITIVES.each do |type|
+            it 'respects the nil value' do
+              subject.params do
+                requires :param, type: type
+              end
+              subject.get '/nil_value' do
+                params[:param].class
+              end
+
+              get '/nil_value', param: nil
+              expect(last_response.status).to eq(200)
+              expect(last_response.body).to eq('NilClass')
+            end
+          end
+        end
+
+        context 'structures types' do
+          Grape::Validations::Types::STRUCTURES.each do |type|
+            it 'respects the nil value' do
+              subject.params do
+                requires :param, type: type
+              end
+              subject.get '/nil_value' do
+                params[:param].class
+              end
+
+              get '/nil_value', param: nil
+              expect(last_response.status).to eq(200)
+              expect(last_response.body).to eq('NilClass')
+            end
+          end
+        end
+
+        context 'special types' do
+          Grape::Validations::Types::SPECIAL.each_key do |type|
+            it 'respects the nil value' do
+              subject.params do
+                requires :param, type: type
+              end
+              subject.get '/nil_value' do
+                params[:param].class
+              end
+
+              get '/nil_value', param: nil
+              expect(last_response.status).to eq(200)
+              expect(last_response.body).to eq('NilClass')
+            end
+          end
+
+          context 'variant-member-type collections' do
+            [
+              Array[Integer, String],
+              [Integer, String, Array[Integer, String]]
+            ].each do |type|
+              it 'respects the nil value' do
+                subject.params do
+                  requires :param, type: type
+                end
+                subject.get '/nil_value' do
+                  params[:param].class
+                end
+
+                get '/nil_value', param: nil
+                expect(last_response.status).to eq(200)
+                expect(last_response.body).to eq('NilClass')
+              end
+            end
+          end
+        end
+      end
     end
 
     context 'using coerce_with' do
@@ -750,19 +823,6 @@ describe Grape::Validations::CoerceValidator do
         get '/', a: 'anything else'
         expect(last_response.status).to eq(200)
         expect(last_response.body).to eq('String')
-      end
-
-      it 'respects nil values' do
-        subject.params do
-          optional :a, types: [File, String]
-        end
-        subject.get '/' do
-          params[:a].class.to_s
-        end
-
-        get '/', a: nil
-        expect(last_response.status).to eq(200)
-        expect(last_response.body).to eq('NilClass')
       end
 
       it 'fails when no coercion is possible' do

--- a/spec/grape/validations/validators/values_spec.rb
+++ b/spec/grape/validations/validators/values_spec.rb
@@ -319,7 +319,7 @@ describe Grape::Validations::ValuesValidator do
       expect(last_response.status).to eq 200
     end
 
-    it 'allows for an optional param with a list of values' do
+    it 'accepts for an optional param with a list of values' do
       put('/optional_with_array_of_string_values', optional: nil)
       expect(last_response.status).to eq 200
     end

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -574,7 +574,7 @@ describe Grape::Validations do
         # NOTE: with body parameters in json or XML or similar this
         # should actually fail with: children[parents][name] is missing.
         expect(last_response.status).to eq(400)
-        expect(last_response.body).to eq('children[1][parents] is missing')
+        expect(last_response.body).to eq('children[1][parents] is missing, children[0][parents][1][name] is missing, children[0][parents][1][name] is empty')
       end
 
       it 'errors when a parameter is not present in array within array' do
@@ -615,7 +615,7 @@ describe Grape::Validations do
 
         get '/within_array', children: [name: 'Jay']
         expect(last_response.status).to eq(400)
-        expect(last_response.body).to eq('children[0][parents] is missing')
+        expect(last_response.body).to eq('children[0][parents] is missing, children[0][parents][0][name] is missing, children[0][parents][0][name] is empty')
       end
 
       it 'errors when param is not an Array' do
@@ -763,7 +763,7 @@ describe Grape::Validations do
         expect(last_response.status).to eq(200)
         put_with_json '/within_array', children: [name: 'Jay']
         expect(last_response.status).to eq(400)
-        expect(last_response.body).to eq('children[0][parents] is missing')
+        expect(last_response.body).to eq('children[0][parents] is missing, children[0][parents][0][name] is missing')
       end
     end
 
@@ -838,7 +838,7 @@ describe Grape::Validations do
       it 'does internal validations if the outer group is present' do
         get '/nested_optional_group', items: [{ key: 'foo' }]
         expect(last_response.status).to eq(400)
-        expect(last_response.body).to eq('items[0][required_subitems] is missing')
+        expect(last_response.body).to eq('items[0][required_subitems] is missing, items[0][required_subitems][0][value] is missing')
 
         get '/nested_optional_group', items: [{ key: 'foo', required_subitems: [{ value: 'bar' }] }]
         expect(last_response.status).to eq(200)
@@ -858,7 +858,7 @@ describe Grape::Validations do
       it 'handles validation within arrays' do
         get '/nested_optional_group', items: [{ key: 'foo' }]
         expect(last_response.status).to eq(400)
-        expect(last_response.body).to eq('items[0][required_subitems] is missing')
+        expect(last_response.body).to eq('items[0][required_subitems] is missing, items[0][required_subitems][0][value] is missing')
 
         get '/nested_optional_group', items: [{ key: 'foo', required_subitems: [{ value: 'bar' }] }]
         expect(last_response.status).to eq(200)


### PR DESCRIPTION
Since #2019, I found a regression (our tests suite fails with 1.3.2) when params type is an `Array` of `Type` and the api is called with a `nil` value. It should return the default value which is `[]`.