### PR TITLE
Modify declared for nested array and hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#2038](https://github.com/ruby-grape/grape/pull/2038): Travis - update ruby versions - [@ericproulx](https://github.com/ericproulx).
 
 #### Fixes
+* [#2043](https://github.com/ruby-grape/grape/pull/2043): Modify declared for nested array and hash - [@kadotami](https://github.com/kadotami).
 
 * Your contribution here.
 

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -296,9 +296,12 @@ describe Grape::Endpoint do
               optional :seventh
             end
           end
+          optional :nested_arr, type: Array do
+            optional :eighth
+          end
         end
-        optional :nested_arr, type: Array do
-          optional :eighth
+        optional :arr, type: Array do
+          optional :nineth
         end
       end
     end
@@ -390,7 +393,7 @@ describe Grape::Endpoint do
 
       get '/declared?first=present&nested[fourth]=1'
       expect(last_response.status).to eq(200)
-      expect(JSON.parse(last_response.body)['nested'].keys.size).to eq 3
+      expect(JSON.parse(last_response.body)['nested'].keys.size).to eq 4
     end
 
     it 'builds nested params when given array' do
@@ -421,7 +424,7 @@ describe Grape::Endpoint do
 
         get '/declared?first=present'
         expect(last_response.status).to eq(200)
-        expect(JSON.parse(last_response.body)['nested']).to be_a(Hash)
+        expect(JSON.parse(last_response.body)['nested']).to eq({})
       end
 
       it 'to be an array when include_missing is true' do
@@ -431,7 +434,17 @@ describe Grape::Endpoint do
 
         get '/declared?first=present'
         expect(last_response.status).to eq(200)
-        expect(JSON.parse(last_response.body)['nested_arr']).to be_a(Array)
+        expect(JSON.parse(last_response.body)['arr']).to be_a(Array)
+      end
+
+      it 'to be an array when nested and include_missing is true' do
+        subject.get '/declared' do
+          declared(params, include_missing: true)
+        end
+
+        get '/declared?first=present&nested[fourth]=1'
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)['nested']['nested_arr']).to be_a(Array)
       end
 
       it 'to be nil when include_missing is false' do


### PR DESCRIPTION
I fixed bugs of declared method.

key of options[:route_options][:params] is not considered for nested params.

I changed to these.
* if nested array is nil, declared method return [].
* if nested hash is nil, declared method return {}.