### PR TITLE
Added SECURITY.md.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+# Security Policy
+
+## Supported Versions
+
+Version 1.2.0 or newer is currently supported.
+
+## Reporting a Vulnerability
+
+Tidelift acts as the security contact for this open-source project. To make a report, please email the security team at security@tidelift.com. See [tidelift.com/security](https://tidelift.com/security) for details and more options.
+


### PR DESCRIPTION
Adding a security policy as part of onboarding in #2034. I think 1.2.0 is fine as oldest version we support for security vulnerabilities, given that we had 1-2 in the entire history of Grape.