### PR TITLE
Refactor route public_send to AttributeTranslator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#2048](https://github.com/ruby-grape/grape/issues/2034): Grape Enterprise support is now available [via TideLift](https://tidelift.com/subscription/request-a-demo?utm_source=rubygems-grape&utm_medium=referral&utm_campaign=enterprise) - [@dblock](https://github.com/dblock).
 * [#2039](https://github.com/ruby-grape/grape/pull/2039): Travis - update rails versions - [@ericproulx](https://github.com/ericproulx).
 * [#2038](https://github.com/ruby-grape/grape/pull/2038): Travis - update ruby versions - [@ericproulx](https://github.com/ericproulx).
+* [#2050](https://github.com/ruby-grape/grape/pull/2050): Refactor route public_send to AttributeTranslator - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -7,15 +7,6 @@ module Grape
   class Router
     attr_reader :map, :compiled
 
-    class Any < AttributeTranslator
-      attr_reader :pattern, :index
-      def initialize(pattern, index, **attributes)
-        @pattern = pattern
-        @index = index
-        super(attributes)
-      end
-    end
-
     class NormalizePathCache < Grape::Util::Cache
       def initialize
         @cache = Hash.new do |h, path|
@@ -64,7 +55,7 @@ module Grape
 
     def associate_routes(pattern, **options)
       @neutral_regexes << Regexp.new("(?<_#{@neutral_map.length}>)#{pattern.to_regexp}")
-      @neutral_map << Any.new(pattern, @neutral_map.length, **options)
+      @neutral_map << Grape::Router::AttributeTranslator.new(options.merge(pattern: pattern, index: @neutral_map.length))
     end
 
     def call(env)

--- a/lib/grape/router/attribute_translator.rb
+++ b/lib/grape/router/attribute_translator.rb
@@ -6,10 +6,31 @@ module Grape
     class AttributeTranslator
       attr_reader :attributes, :request_method, :requirements
 
+      ROUTE_ATTRIBUTES = %i[
+        prefix
+        version
+        settings
+        format
+        description
+        http_codes
+        headers
+        entity
+        details
+        requirements
+        request_method
+        namespace
+      ].freeze
+
+      ROUTER_ATTRIBUTES = %i[pattern index].freeze
+
       def initialize(attributes = {})
         @attributes = attributes
-        @request_method = attributes[:request_method]
-        @requirements = attributes[:requirements]
+      end
+
+      (ROUTER_ATTRIBUTES + ROUTE_ATTRIBUTES).each do |attr|
+        define_method attr do
+          attributes[attr]
+        end
       end
 
       def to_h

--- a/lib/grape/router/route.rb
+++ b/lib/grape/router/route.rb
@@ -18,6 +18,7 @@ module Grape
 
       extend Forwardable
       def_delegators :pattern, :path, :origin
+      delegate Grape::Router::AttributeTranslator::ROUTE_ATTRIBUTES => :attributes
 
       def method_missing(method_id, *arguments)
         match = ROUTE_ATTRIBUTE_REGEXP.match(method_id.to_s)
@@ -32,25 +33,6 @@ module Grape
 
       def respond_to_missing?(method_id, _)
         ROUTE_ATTRIBUTE_REGEXP.match?(method_id.to_s)
-      end
-
-      %i[
-        prefix
-        version
-        settings
-        format
-        description
-        http_codes
-        headers
-        entity
-        details
-        requirements
-        request_method
-        namespace
-      ].each do |method_name|
-        define_method method_name do
-          attributes.public_send method_name
-        end
       end
 
       def route_method


### PR DESCRIPTION
Hi,

I transformed `route` public send to actual methods in `attribute_translator`.  Makes more sense than falling back on `method_missing`.

I also removed `Any` in router and use pure `AttributeTranslator`.
