### PR TITLE
coercing of nested arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#2049](https://github.com/ruby-grape/grape/pull/2049): Coerce an empty string to nil in case of the bool type - [@dnesteryuk](https://github.com/dnesteryuk).
 * [#2043](https://github.com/ruby-grape/grape/pull/2043): Modify declared for nested array and hash - [@kadotami](https://github.com/kadotami).
 * [#2040](https://github.com/ruby-grape/grape/pull/2040): Fix a regression with Array of type nil - [@ericproulx](https://github.com/ericproulx).
+* [#2054](https://github.com/ruby-grape/grape/pull/2054): Coercing of nested arrays - [@dnesteryuk](https://github.com/dnesteryuk).
 * Your contribution here.
 
 ### 1.3.2 (2020/04/12)

--- a/lib/grape/validations/types/array_coercer.rb
+++ b/lib/grape/validations/types/array_coercer.rb
@@ -20,7 +20,7 @@ module Grape
           super
 
           @coercer = scope::Array
-          @subtype = type.first.class
+          @subtype = type.first
         end
 
         def call(_val)
@@ -57,10 +57,7 @@ module Grape
         end
 
         def elem_coercer
-          @elem_coercer ||= begin
-            klass = DryTypeCoercer.collection_coercer_for(subtype) || PrimitiveCoercer
-            klass.new(type.first, strict)
-          end
+          @elem_coercer ||= DryTypeCoercer.coercer_instance_for(subtype, strict)
         end
       end
     end

--- a/lib/grape/validations/types/array_coercer.rb
+++ b/lib/grape/validations/types/array_coercer.rb
@@ -14,11 +14,13 @@ module Grape
       # behavior of Virtus which was used earlier, a `Grape::Validations::Types::PrimitiveCoercer`
       # maintains Virtus behavior in coercing.
       class ArrayCoercer < DryTypeCoercer
+        register_collection Array
+
         def initialize(type, strict = false)
           super
 
           @coercer = scope::Array
-          @nested = type.first.is_a?(Array)
+          @subtype = type.first.class
         end
 
         def call(_val)
@@ -30,7 +32,7 @@ module Grape
 
         protected
 
-        attr_reader :nested
+        attr_reader :subtype
 
         def coerce_elements(collection)
           return if collection.nil?
@@ -48,7 +50,7 @@ module Grape
           collection
         end
 
-        # This method maintaine logic which was defined by Virtus for arrays.
+        # This method maintains logic which was defined by Virtus for arrays.
         # Virtus doesn't allow nil in arrays.
         def reject?(val)
           val.nil?
@@ -56,7 +58,7 @@ module Grape
 
         def elem_coercer
           @elem_coercer ||= begin
-            klass = nested ? ArrayCoercer : PrimitiveCoercer
+            klass = DryTypeCoercer.collection_coercer_for(subtype) || PrimitiveCoercer
             klass.new(type.first, strict)
           end
         end

--- a/lib/grape/validations/types/build_coercer.rb
+++ b/lib/grape/validations/types/build_coercer.rb
@@ -60,12 +60,8 @@ module Grape
           Types::CustomTypeCollectionCoercer.new(
             Types.map_special(type.first), type.is_a?(Set)
           )
-        elsif type.is_a?(Array)
-          ArrayCoercer.new type, strict
-        elsif type.is_a?(Set)
-          SetCoercer.new type, strict
         else
-          PrimitiveCoercer.new type, strict
+          DryTypeCoercer.coercer_instance_for(type, strict)
         end
       end
 

--- a/lib/grape/validations/types/dry_type_coercer.rb
+++ b/lib/grape/validations/types/dry_type_coercer.rb
@@ -19,6 +19,7 @@ module Grape
       class DryTypeCoercer
         def initialize(type, strict = false)
           @type = type
+          @strict = strict
           @scope = strict ? DryTypes::Strict : DryTypes::Params
         end
 
@@ -36,7 +37,7 @@ module Grape
 
         protected
 
-        attr_reader :scope, :type
+        attr_reader :scope, :type, :strict
       end
     end
   end

--- a/lib/grape/validations/types/dry_type_coercer.rb
+++ b/lib/grape/validations/types/dry_type_coercer.rb
@@ -17,6 +17,34 @@ module Grape
       # but check its type. More information there
       # https://dry-rb.org/gems/dry-types/1.2/built-in-types/
       class DryTypeCoercer
+        class << self
+          def inherited(klass)
+            # share the hash with classes, so inheritors could will it
+            klass.instance_variable_set(:@collection_coercers, collection_coercers)
+          end
+
+          # Registers a collection coercer which could be found by a type,
+          # see +collection_coercer_for+ method below.
+          def register_collection(type)
+            collection_coercers[type] = self
+          end
+
+          # Returns a collection coercer which corresponds to a given type.
+          # Example:
+          #
+          #    collection_coercer_for(Array)
+          #    #=> Grape::Validations::Types::ArrayCoercer
+          def collection_coercer_for(type)
+            collection_coercers[type]
+          end
+
+          protected
+
+          def collection_coercers
+            @collection_coercers ||= {}
+          end
+        end
+
         def initialize(type, strict = false)
           @type = type
           @strict = strict

--- a/lib/grape/validations/types/set_coercer.rb
+++ b/lib/grape/validations/types/set_coercer.rb
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
 
 require 'set'
-require_relative 'dry_type_coercer'
+require_relative 'array_coercer'
 
 module Grape
   module Validations
     module Types
       # Takes the given array and converts it to a set. Every element of the set
       # is also coerced.
-      class SetCoercer < DryTypeCoercer
+      class SetCoercer < ArrayCoercer
+        register_collection Set
+
         def initialize(type, strict = false)
           super
 
-          @elem_coercer = PrimitiveCoercer.new(type.first, strict)
+          @coercer = nil
         end
 
         def call(value)
@@ -25,7 +27,7 @@ module Grape
 
         def coerce_elements(collection)
           collection.each_with_object(Set.new) do |elem, memo|
-            coerced_elem = @elem_coercer.call(elem)
+            coerced_elem = elem_coercer.call(elem)
 
             return coerced_elem if coerced_elem.is_a?(InvalidValue)
 

--- a/spec/grape/validations/types/array_coercer_spec.rb
+++ b/spec/grape/validations/types/array_coercer_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Grape::Validations::Types::ArrayCoercer do
+  subject { described_class.new(type) }
+
+  describe '#call' do
+    context 'an array of primitives' do
+      let(:type) { Array[String] }
+
+      it 'coerces elements in the array' do
+        expect(subject.call([10, 20])).to eq(['10', '20'])
+      end
+    end
+
+    context 'an array of arrays' do
+      let(:type) { Array[Array[Integer]] }
+
+      it 'coerces elements in the nested array' do
+        expect(subject.call([['10', '20']])).to eq([[10, 20]])
+        expect(subject.call([['10'], ['20']])).to eq([[10], [20]])
+      end
+    end
+  end
+end

--- a/spec/grape/validations/types/array_coercer_spec.rb
+++ b/spec/grape/validations/types/array_coercer_spec.rb
@@ -10,7 +10,7 @@ describe Grape::Validations::Types::ArrayCoercer do
       let(:type) { Array[String] }
 
       it 'coerces elements in the array' do
-        expect(subject.call([10, 20])).to eq(['10', '20'])
+        expect(subject.call([10, 20])).to eq(%w[10 20])
       end
     end
 
@@ -18,8 +18,17 @@ describe Grape::Validations::Types::ArrayCoercer do
       let(:type) { Array[Array[Integer]] }
 
       it 'coerces elements in the nested array' do
-        expect(subject.call([['10', '20']])).to eq([[10, 20]])
+        expect(subject.call([%w[10 20]])).to eq([[10, 20]])
         expect(subject.call([['10'], ['20']])).to eq([[10], [20]])
+      end
+    end
+
+    context 'an array of sets' do
+      let(:type) { Array[Set[Integer]] }
+
+      it 'coerces elements in the nested set' do
+        expect(subject.call([%w[10 20]])).to eq([Set[10, 20]])
+        expect(subject.call([['10'], ['20']])).to eq([Set[10], Set[20]])
       end
     end
   end

--- a/spec/grape/validations/types/primitive_coercer_spec.rb
+++ b/spec/grape/validations/types/primitive_coercer_spec.rb
@@ -7,7 +7,7 @@ describe Grape::Validations::Types::PrimitiveCoercer do
 
   subject { described_class.new(type, strict) }
 
-  describe '.call' do
+  describe '#call' do
     context 'Boolean' do
       let(:type) { Grape::API::Boolean }
 

--- a/spec/grape/validations/types/set_coercer_spec.rb
+++ b/spec/grape/validations/types/set_coercer_spec.rb
@@ -14,12 +14,20 @@ describe Grape::Validations::Types::SetCoercer do
       end
     end
 
-    context 'an set of sets' do
+    context 'a set of sets' do
       let(:type) { Set[Set[Integer]] }
 
       it 'coerces elements in the nested set' do
         expect(subject.call([%w[10 20]])).to eq(Set[Set[10, 20]])
         expect(subject.call([['10'], ['20']])).to eq(Set[Set[10], Set[20]])
+      end
+    end
+
+    context 'a set of sets of arrays' do
+      let(:type) { Set[Set[Array[Integer]]] }
+
+      it 'coerces elements in the nested set' do
+        expect(subject.call([[['10'], ['20']]])).to eq(Set[Set[Array[10], Array[20]]])
       end
     end
   end

--- a/spec/grape/validations/types/set_coercer_spec.rb
+++ b/spec/grape/validations/types/set_coercer_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Grape::Validations::Types::SetCoercer do
+  subject { described_class.new(type) }
+
+  describe '#call' do
+    context 'a set of primitives' do
+      let(:type) { Set[String] }
+
+      it 'coerces elements to the set' do
+        expect(subject.call([10, 20])).to eq(Set['10', '20'])
+      end
+    end
+
+    context 'an set of sets' do
+      let(:type) { Set[Set[Integer]] }
+
+      it 'coerces elements in the nested set' do
+        expect(subject.call([%w[10 20]])).to eq(Set[Set[10, 20]])
+        expect(subject.call([['10'], ['20']])).to eq(Set[Set[10], Set[20]])
+      end
+    end
+  end
+end


### PR DESCRIPTION
It is a regression which was introduced after migrating to DryTypes. Now, it is again possible to define an array of arrays as a type.

```ruby
params do
  requires :skills, type: Array[[String]]
end
```

Fixes #2041