### PR TITLE
Add failing test for multiple nested params error indices

### DIFF
--- a/lib/grape/exceptions/validation_errors.rb
+++ b/lib/grape/exceptions/validation_errors.rb
@@ -23,6 +23,7 @@ module Grape
       end
 
       def each
+        puts "errors: #{errors}"
         errors.each_pair do |attribute, errors|
           errors.each do |error|
             yield attribute, error

--- a/lib/grape/validations/attributes_iterator.rb
+++ b/lib/grape/validations/attributes_iterator.rb
@@ -15,6 +15,7 @@ module Grape
       end
 
       def each(&block)
+        puts "@params #{@params}"
         do_each(@params, &block) # because we need recursion for nested arrays
       end
 
@@ -38,6 +39,9 @@ module Grape
               parent_scope.index = parent_index
               parent_scope = parent_scope.parent
             end
+            puts "........\n"
+            puts "@scope.index = #{index}"
+            puts "........\n"
             @scope.index = index
           end
 

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -48,6 +48,7 @@ module Grape
           next unless @scope.meets_dependency?(val, params)
           begin
             if @required || val.respond_to?(:key?) && val.key?(attr_name)
+              puts "validating #{attr_name}"
               validate_param!(attr_name, val)
             end
           rescue Grape::Exceptions::Validation => e


### PR DESCRIPTION
This reproduces the issue described in #1998. The `AttributesIterator` seems to control what the a given scopes index is set to. I believe this bug is due to index not iterating in sync with each param being validating in an array.

You can see here that the scope is set to 2 before we even start validating the `value` param:
![image](https://user-images.githubusercontent.com/1127238/82482318-8aead980-9a8b-11ea-981a-0156e65c6c5c.png)


