### PR TITLE
Treat Middleware::Base#initialize options as Hash.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 #### Fixes
 
 * Your contribution here.
-* [](): Fix Ruby 2.7 deprecation warning in `Grape::Middleware::Base#initialize` - [@skarger](https://github.com/skarger).
+* [2064](https://github.com/ruby-grape/grape/pull/2064): Fix Ruby 2.7 deprecation warning in `Grape::Middleware::Base#initialize` - [@skarger](https://github.com/skarger).
 
 ### 1.3.3 (2020/05/23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 #### Fixes
 
 * Your contribution here.
-* [2064](https://github.com/ruby-grape/grape/pull/2064): Fix Ruby 2.7 deprecation warning in `Grape::Middleware::Base#initialize` - [@skarger](https://github.com/skarger).
+* [#2064](https://github.com/ruby-grape/grape/pull/2064): Fix Ruby 2.7 deprecation warning in `Grape::Middleware::Base#initialize` - [@skarger](https://github.com/skarger).
 
 ### 1.3.3 (2020/05/23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Fixes
 
 * Your contribution here.
+* [](): Fix Ruby 2.7 deprecation warning in `Grape::Middleware::Base#initialize` - [@skarger](https://github.com/skarger).
 
 ### 1.3.3 (2020/05/23)
 

--- a/lib/grape/middleware/base.rb
+++ b/lib/grape/middleware/base.rb
@@ -14,9 +14,9 @@ module Grape
 
       # @param [Rack Application] app The standard argument for a Rack middleware.
       # @param [Hash] options A hash of options, simply stored for use by subclasses.
-      def initialize(app, **options)
+      def initialize(app, options = {})
         @app = app
-        @options = default_options.merge(**options)
+        @options = default_options.merge(options)
         @app_response = nil
       end
 


### PR DESCRIPTION
Addresses https://github.com/ruby-grape/grape/issues/1992.

Before this PR, `Grape::Middleware::Base` is treating the `options` param as keyword args, but it's actually meant as a `Hash` positional argument.

https://github.com/ruby-grape/grape/blob/536622a38ae5ed266477689cdd7afabd92046ed2/lib/grape/middleware/base.rb#L17

The former style, `**options`, prompts a deprecation warning in Ruby 2.7.

`gems/2.7.0/gems/rack-2.2.2/lib/rack/builder.rb:158: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call`
`gems/2.7.0/gems/grape-1.3.3/lib/grape/middleware/base.rb:17: warning: The called method 'initialize' is defined here`.

For a middleware subclass of `Grape::Middleware::Base`, Rack's `use` method will instantiate it with `middleware.new(app, *args, &block)`, passing the `options` parameter in `*args`:

https://github.com/rack/rack/blob/a5e80f01947954af76b14c1d1fdd8e79dd8337f3/lib/rack/builder.rb#L158

My assumption is that, contrary to the suggestion by the deprecation warning, it's not feasible to change Rack to add `**` to the call where it passes `*args`. Plus, Grape's code implies that `options` really is meant as a positional Hash argument, so I changed it to be one.

The tests pass after this change, including
https://github.com/ruby-grape/grape/blob/v1.3.3/spec/grape/middleware/base_spec.rb.

The main risk I see here is if there's some behavior or usage style that the `**options` version supported that will now break.