### PR TITLE
Add a benchmark for API.compile!

### DIFF
--- a/benchmark/compile_many_routes.rb
+++ b/benchmark/compile_many_routes.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'grape'
+require 'benchmark/ips'
+require 'grape/eager_load'
+
+Grape.eager_load!
+
+class API < Grape::API
+  prefix :api
+  version 'v1', using: :path
+
+  2000.times do |index|
+    get "/test#{index}/" do
+      'hello'
+    end
+  end
+end
+
+Benchmark.ips do |ips|
+  ips.report('Compiling 2000 routes') do
+    API.compile!
+  end
+end


### PR DESCRIPTION
This replicates the slowness in compiling routes via Mustermann for 2000
routes.

Part of https://github.com/ruby-grape/grape/issues/1736

```
$ ruby compile_many_routes.rb
Warming up --------------------------------------
Compiling 2000 routes
                         1.000  i/100ms
Calculating -------------------------------------
Compiling 2000 routes
                          4.541k (±16.0%) i/s -     20.871k in   4.989357s
```

ruby-prof output:

![image](https://user-images.githubusercontent.com/963826/84006448-98c1ab00-a923-11ea-9d1d-f3715b2bd711.png)
