### PR TITLE
Fix eager loading due to ServeStream rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ matrix:
     - rvm: 2.7.1
       gemfile: gemfiles/rails_6.gemfile
     - rvm: 2.7.1
+      gemfile: Gemfile
+      script:
+        - bundle exec rspec spec/integration/eager_load
+    - rvm: 2.7.1
       gemfile: gemfiles/multi_json.gemfile
       script:
         - bundle exec rake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features
 
+* [#2072](https://github.com/ruby-grape/grape/pull/2072): Fix eager loading due to ServeStream rename - [@stanhu](https://github.com/stanhu).
 * [#1520](https://github.com/ruby-grape/grape/pull/1520): Un-deprecate stream-like objects - [@urkle](https://github.com/urkle).
 * [#2060](https://github.com/ruby-grape/grape/pull/2060): Drop support for Ruby 2.4 - [@dblock](https://github.com/dblock).
 * [#2060](https://github.com/ruby-grape/grape/pull/2060): Upgraded Rubocop to 0.84.0 - [@dblock](https://github.com/dblock).

--- a/lib/grape/eager_load.rb
+++ b/lib/grape/eager_load.rb
@@ -16,5 +16,5 @@ Grape::Parser.eager_load!
 Grape::DSL.eager_load!
 Grape::API.eager_load!
 Grape::Presenters.eager_load!
-Grape::ServeFile.eager_load!
+Grape::ServeStream.eager_load!
 Rack::Head # AutoLoads the Rack::Head

--- a/spec/integration/eager_load/eager_load_spec.rb
+++ b/spec/integration/eager_load/eager_load_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..', 'lib'))
+require 'grape'
+require 'grape/eager_load'
+
+describe 'eager loading' do
+  class API < Grape::API
+  end
+
+  it 'loads successfully' do
+    expect { Grape.eager_load! }.to_not raise_error
+    expect { API.compile! }.to_not raise_error
+  end
+end


### PR DESCRIPTION
ServeFile was renamed to ServeStream in #1520. Calling Grape.eager_load!
would fail with:

```
uninitialized constant Grape::ServeFile (NameError)
```