### PR TITLE
Populate the env route information when calling the automatically added endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#2067](https://github.com/ruby-grape/grape/pull/2067): Coerce empty string to nil for all primitive types except String - [@petekinnecom](https://github.com/petekinnecom).
 * [#2064](https://github.com/ruby-grape/grape/pull/2064): Fix Ruby 2.7 deprecation warning in `Grape::Middleware::Base#initialize` - [@skarger](https://github.com/skarger).
 * [#2072](https://github.com/ruby-grape/grape/pull/2072): Fix `Grape.eager_load!` and `compile!` - [@stanhu](https://github.com/stanhu).
+* [#2076](https://github.com/ruby-grape/grape/pull/2076): Make route information available for hooks when the automatically generated endpoints are invoked - [@anakinj](https://github.com/anakinj).
 * Your contribution here.
 
 ### 1.3.3 (2020/05/23)


### PR DESCRIPTION
Noticed that calling the `route` method in a `before` hook causes an `NoMethodError` when the hook is invoked for the automatically generated Method Not Allowed endpoints. The reason seems to be that the route information dictionary is not populated in these cases.

These changes will populate the route information before calling the method not allowed endpoint. Also included some minor refactoring for the methods involved in all this.

