### PR TITLE
introduce a finalize! method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features
 
+* [#2082](https://github.com/ruby-grape/grape/pull/2082): Introduce a finalize! method - [@dnesteryuk](https://github.com/dnesteryuk).
 * Your contribution here.
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@
   - [Grape Middleware](#grape-middleware)
   - [Rails Middleware](#rails-middleware)
   - [Remote IP](#remote-ip)
+- [Finalizing API](#finalizing-api)
 - [Writing Tests](#writing-tests)
   - [Writing Tests with Rack](#writing-tests-with-rack)
     - [RSpec](#rspec)
@@ -3605,6 +3606,16 @@ class API < Grape::API
   end
 end
 ```
+
+## Finalizing API
+
+Grape initializes lots of objects during setup, later they aren't needed. So, you might add a following line to a file that loads your server (for example, `config.ru`) to clean up those objects and free RAM:
+
+```ruby
+Grape::API.finalize!
+```
+
+**It must be called exactly this way, calls on inheritors of `Grape::API` won't have the effect.**
 
 ## Writing Tests
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,13 @@
 Upgrading Grape
 ===============
 
+### Upgrading to >= 1.4.1
+
+#### Cleaning up setup-related objects
+
+Grape initializes lots of objects which aren't needed at runtime. To clean them up and free RAM, `Grape::API.finalize!` was introduced.
+See [README.md](#finalizing-api) for more details.
+
 ### Upgrading to >= 1.4.0
 
 #### Reworking stream and file and un-deprecating stream like-objects
@@ -28,17 +35,17 @@ class API < Grape::API
 end
 ```
 
-Or use `stream` to stream other kinds of content. In the following example a streamer class 
+Or use `stream` to stream other kinds of content. In the following example a streamer class
 streams paginated data from a database.
 
 ```ruby
-class MyObject     
+class MyObject
   attr_accessor :result
 
   def initialize(query)
     @result = query
   end
-  
+
   def each
     yield '['
     # Do paginated DB fetches and return each page formatted
@@ -47,7 +54,7 @@ class MyObject
       yield process_records(records, first)
       first = false
     end
-    yield ']'  
+    yield ']'
   end
 
   def process_records(records, first)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,7 +6,7 @@ Upgrading Grape
 #### Cleaning up setup-related objects
 
 Grape initializes lots of objects which aren't needed at runtime. To clean them up and free RAM, `Grape::API.finalize!` was introduced.
-See [README.md](#finalizing-api) for more details.
+See [README.md](https://github.com/ruby-grape/grape/README.md#finalizing-api) for more details.
 
 ### Upgrading to >= 1.4.0
 

--- a/lib/grape/api/instance.rb
+++ b/lib/grape/api/instance.rb
@@ -91,6 +91,15 @@ module Grape
           instance.router.recognize_path(path)
         end
 
+        # Cleans up settings which are only need during setup
+        def finalize!
+          # named params get evaluated right away after embedding them into the params block,
+          # see Grape::DSL::Parameters#use for more details
+          unset_namespace_stackable(:named_params)
+
+          endpoints.each(&:finalize!)
+        end
+
         protected
 
         def prepare_routes

--- a/lib/grape/dsl/settings.rb
+++ b/lib/grape/dsl/settings.rb
@@ -24,7 +24,8 @@ module Grape
         @inheritable_setting ||= Grape::Util::InheritableSetting.new.tap { |new_settings| new_settings.inherit_from top_level_setting }
       end
 
-      # @param type [Symbol]
+      # Returns a value for the given type and key then deletes the value from settings.
+      # @param type [Symbol] One of: :namespace,  :inheritable, :stackable, :reverse_stackable.
       # @param key [Symbol]
       def unset(type, key)
         setting = inheritable_setting.send(type)
@@ -71,7 +72,7 @@ module Grape
         get_or_set :namespace, key, value
       end
 
-      # (see #unset_global_setting)
+      # (see #unset)
       def unset_namespace_setting(key)
         unset :namespace, key
       end
@@ -81,7 +82,7 @@ module Grape
         get_or_set :namespace_inheritable, key, value
       end
 
-      # (see #unset_global_setting)
+      # (see #unset)
       def unset_namespace_inheritable(key)
         unset :namespace_inheritable, key
       end

--- a/lib/grape/util/base_inheritable.rb
+++ b/lib/grape/util/base_inheritable.rb
@@ -14,6 +14,7 @@ module Grape
         @new_values = {}
       end
 
+      # Returns a current value for the given key then deletes it.
       def delete(key)
         new_values.delete key
       end

--- a/lib/grape/version.rb
+++ b/lib/grape/version.rb
@@ -2,5 +2,5 @@
 
 module Grape
   # The current version of Grape.
-  VERSION = '1.4.1'
+  VERSION = '1.3.4'
 end

--- a/spec/grape/dsl/helpers_spec.rb
+++ b/spec/grape/dsl/helpers_spec.rb
@@ -2,99 +2,117 @@
 
 require 'spec_helper'
 
-module Grape
-  module DSL
-    module HelpersSpec
-      class Dummy
-        include Grape::DSL::Helpers
-
-        def self.mods
-          namespace_stackable(:helpers)
-        end
-
-        def self.first_mod
-          mods.first
-        end
-      end
-    end
-
-    module BooleanParam
+describe Grape::DSL::Helpers do
+  let!(:shared_param) do
+    Module.new do
       extend Grape::API::Helpers
 
       params :requires_toggle_prm do
-        requires :toggle_prm, type: Boolean
+        requires :toggle_prm, type: Grape::API::Boolean
+      end
+    end
+  end
+
+  let(:dummy) do
+    Class.new do
+      include Grape::DSL::Helpers
+
+      def self.mods
+        namespace_stackable(:helpers)
+      end
+
+      def self.first_mod
+        mods.first
+      end
+    end
+  end
+
+  let(:base) do
+    boolean_param = shared_param
+
+    Class.new(Grape::API) do
+      helpers boolean_param
+    end
+  end
+
+  subject { Class.new(dummy) }
+  let(:proc) do
+    lambda do |*|
+      def test
+        :test
+      end
+    end
+  end
+
+  describe '.helpers' do
+    it 'adds a module with the given block' do
+      expect(subject).to(
+        receive(:namespace_stackable).with(:helpers, kind_of(Grape::DSL::Helpers::BaseHelper))
+                                     .and_call_original
+      )
+
+      expect(subject).to receive(:namespace_stackable).with(:helpers).and_call_original
+      subject.helpers(&proc)
+
+      expect(subject.first_mod.instance_methods).to include(:test)
+    end
+
+    it 'uses provided modules' do
+      mod = Module.new
+
+      expect(subject).to(
+        receive(:namespace_stackable).with(:helpers, kind_of(Grape::DSL::Helpers::BaseHelper))
+                                     .and_call_original
+                                     .exactly(2)
+                                     .times
+      )
+      expect(subject).to receive(:namespace_stackable).with(:helpers).and_call_original
+      subject.helpers(mod, &proc)
+
+      expect(subject.first_mod).to eq mod
+    end
+
+    it 'uses many provided modules' do
+      mod  = Module.new
+      mod2 = Module.new
+      mod3 = Module.new
+
+      expect(subject).to(
+        receive(:namespace_stackable).with(:helpers, kind_of(Grape::DSL::Helpers::BaseHelper))
+                                     .and_call_original
+                                     .exactly(4)
+                                     .times
+      )
+      expect(subject).to(
+        receive(:namespace_stackable).with(:helpers)
+                                     .and_call_original
+                                     .exactly(3)
+                                     .times
+      )
+
+      subject.helpers(mod, mod2, mod3, &proc)
+
+      expect(subject.mods).to include(mod)
+      expect(subject.mods).to include(mod2)
+      expect(subject.mods).to include(mod3)
+    end
+
+    context 'with an external file' do
+      it 'sets Boolean as a Grape::API::Boolean' do
+        subject.helpers shared_param
+        expect(subject.first_mod::Boolean).to eq Grape::API::Boolean
       end
     end
 
-    class Base < Grape::API
-      helpers BooleanParam
-    end
-
-    class Child < Base; end
-
-    describe Helpers do
-      subject { Class.new(HelpersSpec::Dummy) }
-      let(:proc) do
-        lambda do |*|
-          def test
-            :test
+    context 'in child classes' do
+      it 'is available' do
+        expect do
+          Class.new(base) do
+            params do
+              use :requires_toggle_prm
+            end
           end
-        end
-      end
-
-      describe '.helpers' do
-        it 'adds a module with the given block' do
-          expect(subject).to receive(:namespace_stackable).with(:helpers, kind_of(Grape::DSL::Helpers::BaseHelper)).and_call_original
-          expect(subject).to receive(:namespace_stackable).with(:helpers).and_call_original
-          subject.helpers(&proc)
-
-          expect(subject.first_mod.instance_methods).to include(:test)
-        end
-
-        it 'uses provided modules' do
-          mod = Module.new
-
-          expect(subject).to receive(:namespace_stackable).with(:helpers, kind_of(Grape::DSL::Helpers::BaseHelper)).and_call_original.exactly(2).times
-          expect(subject).to receive(:namespace_stackable).with(:helpers).and_call_original
-          subject.helpers(mod, &proc)
-
-          expect(subject.first_mod).to eq mod
-        end
-
-        it 'uses many provided modules' do
-          mod  = Module.new
-          mod2 = Module.new
-          mod3 = Module.new
-
-          expect(subject).to receive(:namespace_stackable).with(:helpers, kind_of(Grape::DSL::Helpers::BaseHelper)).and_call_original.exactly(4).times
-          expect(subject).to receive(:namespace_stackable).with(:helpers).and_call_original.exactly(3).times
-
-          subject.helpers(mod, mod2, mod3, &proc)
-
-          expect(subject.mods).to include(mod)
-          expect(subject.mods).to include(mod2)
-          expect(subject.mods).to include(mod3)
-        end
-
-        context 'with an external file' do
-          it 'sets Boolean as a Grape::API::Boolean' do
-            subject.helpers BooleanParam
-            expect(subject.first_mod::Boolean).to eq Grape::API::Boolean
-          end
-        end
-
-        context 'in child classes' do
-          it 'is available' do
-            klass = Child
-            expect do
-              klass.instance_eval do
-                params do
-                  use :requires_toggle_prm
-                end
-              end
-            end.to_not raise_exception
-          end
-        end
+        end.to_not raise_exception
       end
     end
   end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper'
 
 describe Grape::Endpoint do
+  let(:settings) { Grape::Util::InheritableSetting.new }
+
   subject { Class.new(Grape::API) }
 
   def app
@@ -66,10 +68,7 @@ describe Grape::Endpoint do
     it 'takes a settings stack, options, and a block' do
       p = proc {}
       expect do
-        Grape::Endpoint.new(Grape::Util::InheritableSetting.new, {
-                              path: '/',
-                              method: :get
-                            }, &p)
+        Grape::Endpoint.new(settings, { path: '/', method: :get }, &p)
       end.not_to raise_error
     end
   end
@@ -1185,6 +1184,25 @@ describe Grape::Endpoint do
       end
       get '/hey'
       expect(last_response.body).to eq 'test body'
+    end
+  end
+
+  describe '#finalize!' do
+    subject { described_class.new(settings, { path: '/', method: :get }) }
+
+    before do
+      settings.namespace_stackable[:named_params] = 'Some named params'
+      settings.namespace_stackable[:validations] = 'Some validations'
+
+      subject.finalize!
+    end
+
+    it 'removes named params' do
+      expect(subject.namespace_stackable(:named_params)).to eq([])
+    end
+
+    it 'removes validations' do
+      expect(subject.namespace_stackable(:validations)).to eq([])
     end
   end
 

--- a/spec/grape/util/inheritable_values_spec.rb
+++ b/spec/grape/util/inheritable_values_spec.rb
@@ -8,15 +8,19 @@ module Grape
       subject { InheritableValues.new(parent) }
 
       describe '#delete' do
+        before { subject[:some_thing] = :new_foo_bar }
+
         it 'deletes a key' do
-          subject[:some_thing] = :new_foo_bar
           subject.delete :some_thing
           expect(subject[:some_thing]).to be_nil
         end
 
+        it 'returns a value for the given key' do
+          expect(subject.delete(:some_thing)).to eq(:new_foo_bar)
+        end
+
         it 'does not delete parent values' do
           parent[:some_thing] = :foo
-          subject[:some_thing] = :new_foo_bar
           subject.delete :some_thing
           expect(subject[:some_thing]).to eq :foo
         end

--- a/spec/grape/util/stackable_values_spec.rb
+++ b/spec/grape/util/stackable_values_spec.rb
@@ -26,15 +26,19 @@ module Grape
       end
 
       describe '#delete' do
+        before { subject[:some_thing] = :new_foo_bar }
+
         it 'deletes a key' do
-          subject[:some_thing] = :new_foo_bar
           subject.delete :some_thing
           expect(subject[:some_thing]).to eq []
         end
 
+        it 'returns a value for the given key' do
+          expect(subject.delete(:some_thing)).to eq([:new_foo_bar])
+        end
+
         it 'does not delete parent values' do
           parent[:some_thing] = :foo
-          subject[:some_thing] = :new_foo_bar
           subject.delete :some_thing
           expect(subject[:some_thing]).to eq [:foo]
         end


### PR DESCRIPTION
There are a few variables (settings) which are only needed while defining API, once everything is set up those variables
could be cleaned up to save memory.

So, the `finalize!` method was added to the API and Instance classes, I found only few variables which might be cleaned up, over time there might be more.

The `finalize!` method could be a part of the `compile!` method, however, `compile!` must be called on a child level (for example, `Twitter::API.compile!`) while `finalize!` must be called on `Grape::API` to find all inheritors and clean them up.

This PR isn't finished, I would like to get early feedback before going deeper.

## TODO:
 - [ ] better tests
 - [ ] document this feature in README.md
 - [ ] add a section to UPGRADING.md
 - [x] update changelog