### PR TITLE
Fix memory leak caused by caching all unique paths seen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#2060](https://github.com/ruby-grape/grape/pull/2060): Drop support for Ruby 2.4 - [@dblock](https://github.com/dblock).
 * [#2060](https://github.com/ruby-grape/grape/pull/2060): Upgraded Rubocop to 0.84.0 - [@dblock](https://github.com/dblock).
 * [#2077](https://github.com/ruby-grape/grape/pull/2077): Simplify logic for defining declared params - [@dnesteryuk](https://github.com/dnesteryuk).
+* [#2084](https://github.com/ruby-grape/grape/pull/2084): Fix memory leak in path normalization - [@fcheung](https://github.com/fcheung).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -7,20 +7,12 @@ module Grape
   class Router
     attr_reader :map, :compiled
 
-    class NormalizePathCache < Grape::Util::Cache
-      def initialize
-        @cache = Hash.new do |h, path|
-          normalized_path = +"/#{path}"
-          normalized_path.squeeze!('/')
-          normalized_path.sub!(%r{/+\Z}, '')
-          normalized_path = '/' if normalized_path.empty?
-          h[path] = -normalized_path
-        end
-      end
-    end
-
     def self.normalize_path(path)
-      NormalizePathCache[path]
+      path = +"/#{path}"
+      path.squeeze!('/')
+      path.sub!(%r{/+\Z}, '')
+      path = '/' if path == ''
+      path
     end
 
     def self.supported_methods


### PR DESCRIPTION
I recently updated one of our apps from grape 1.2.5 to 1.3.3 and have observed a memory leak. After analysing some heap dumps taken from our app I believe I have tracked this back to part of the changes in #2002 

The change to router.rb caches normalized paths here: https://github.com/ruby-grape/grape/blob/master/lib/grape/router.rb#L10

This retains indefinitely every path that flows through grape. We have a number of apis where the path is of the form `foo/bar/id/action` where id is the id of the object the api call is acting on, so this grows in a more or less unbounded way.

Since this was just a memory optimization, I would suggest just reverting that part of the changes in #2002 which is what this PR does

