### PR TITLE
Skip to set default value unless `meets_dependency?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#2083](https://github.com/ruby-grape/grape/pull/2083): Set `Cache-Control` header only for streamed responses - [@stanhu](https://github.com/stanhu).
 * [#2092](https://github.com/ruby-grape/grape/pull/2092): Correct an example params in Include Missing doc - [@huyvohcmc](https://github.com/huyvohcmc).
 * [#2091](https://github.com/ruby-grape/grape/pull/2091): Fix ruby 2.7 keyword deprecations - [@dim](https://github.com/dim).
+* [#2097](https://github.com/ruby-grape/grape/pull/2097): Skip to set default value unless `meets_dependency?` - [@wanabe](https://github.com/wanabe).
 
 ### 1.4.0 (2020/07/10)
 

--- a/lib/grape/validations/validators/default.rb
+++ b/lib/grape/validations/validators/default.rb
@@ -21,6 +21,7 @@ module Grape
       def validate!(params)
         attrs = SingleAttributeIterator.new(self, @scope, params)
         attrs.each do |resource_params, attr_name|
+          next unless @scope.meets_dependency?(resource_params, params)
           validate_param!(attr_name, resource_params) if resource_params.is_a?(Hash) && resource_params[attr_name].nil?
         end
       end


### PR DESCRIPTION
Hello,

`Grape::Validations::Base#validate!` calls `#validate_param!` only if `@scope.meets_dependency?(val, params)` is truthy.
But `Grape::Validations::DefaultValidator#validate!` ignores the cope dependency now.

It doesn't matter in most cases because of `@scope.should_validate?`, but this is not the case for an array that contains both matching and non-matching conditions.
So I guess `Grape::Validations::DefaultValidator#validate!` should the check scope dependency as same as `Grape::Validations::Base#validate!`.

How about it?