### PR TITLE
Fix retaining setup blocks when remounting APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#2097](https://github.com/ruby-grape/grape/pull/2097): Skip to set default value unless `meets_dependency?` - [@wanabe](https://github.com/wanabe).
 * [#2096](https://github.com/ruby-grape/grape/pull/2096): Fix redundant dependency check - [@braktar](https://github.com/braktar).
 * [#2096](https://github.com/ruby-grape/grape/pull/2098): Fix nested coercion - [@braktar](https://github.com/braktar).
+* [#2102](https://github.com/ruby-grape/grape/pull/2102): Fix retaining setup blocks when remounting APIs - [@jylamont](https://github.com/jylamont).
 
 ### 1.4.0 (2020/07/10)
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ end
 group :development do
   gem 'appraisal'
   gem 'benchmark-ips'
+  gem 'benchmark-memory'
   gem 'guard'
   gem 'guard-rspec'
   gem 'guard-rubocop'

--- a/benchmark/remounting.rb
+++ b/benchmark/remounting.rb
@@ -1,0 +1,47 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'grape'
+require 'benchmark/memory'
+
+class VotingApi < Grape::API
+  logger Logger.new(STDOUT)
+
+  helpers do
+    def logger
+      VotingApi.logger
+    end
+  end
+
+  namespace 'votes' do
+    get do
+      logger
+    end
+  end
+end
+
+class PostApi < Grape::API
+  mount VotingApi
+end
+
+class CommentAPI < Grape::API
+  mount VotingApi
+end
+
+env = Rack::MockRequest.env_for('/votes', method: 'GET')
+
+Benchmark.memory do |api|
+  calls = 1000
+
+  api.report('using Array') do
+    VotingApi.instance_variable_set(:@setup, [])
+    calls.times { PostApi.call(env) }
+    puts " setup size: #{VotingApi.instance_variable_get(:@setup).size}"
+  end
+
+  api.report('using Set') do
+    VotingApi.instance_variable_set(:@setup, Set.new)
+    calls.times { PostApi.call(env) }
+    puts " setup size: #{VotingApi.instance_variable_get(:@setup).size}"
+  end
+
+  api.compare!
+end

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -30,7 +30,7 @@ module Grape
       # an instance that will be used to create the set up but will not be mounted
       def initial_setup(base_instance_parent)
         @instances = []
-        @setup = []
+        @setup = Set.new
         @base_parent = base_instance_parent
         @base_instance = mount_instance
       end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1600,6 +1600,11 @@ XML
       expect(subject.io).to receive(:write).with(message)
       subject.logger.info 'this will be logged'
     end
+
+    it 'does not unnecessarily retain duplicate setup blocks' do
+      subject.logger
+      expect { subject.logger }.to_not change(subject.instance_variable_get(:@setup), :size)
+    end
   end
 
   describe '.helpers' do


### PR DESCRIPTION
This is a simple fix for #2071. 

`Grape::API` class methods that are not referenced in the `NON_OVERRIDABLE` constant are overridden to call `add_setup` when invoked. Unfortunately there is a memory leak with `add_setup` where a hash describing the class method call is added to `@setup` on every call (not just the first). This PR changes the data structure of `@setup` from an `Array` to a `Set` therefore only allowing a single hash per combination of method name and arguments.

This bug is causing pain for us as we call `Grape::API.logger` in every API request 📈 In our case `Grape::API.logger` with no arguments is sorted by moving to a `Set`, but I am not too familiar with the inner workings of Grape so I will ask for some guidance of whether this doesn't meet a particular edge case or breaks some other functionality. Also the spec I have added was for our specific issue, so I ask for guidance if you guys would prefer a more generic spec somewhere else.