### PR TITLE
Lock rubocop-ast to < 0.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :development, :test do
   gem 'hashie'
   gem 'rake'
   gem 'rubocop', '0.84.0'
+  gem 'rubocop-ast', '< 0.7'
   gem 'rubocop-performance', require: false
 end
 

--- a/gemfiles/multi_json.gemfile
+++ b/gemfiles/multi_json.gemfile
@@ -11,6 +11,7 @@ group :development, :test do
   gem 'hashie'
   gem 'rake'
   gem 'rubocop', '0.84.0'
+  gem 'rubocop-ast', '< 0.7'
   gem 'rubocop-performance', require: false
 end
 

--- a/gemfiles/multi_xml.gemfile
+++ b/gemfiles/multi_xml.gemfile
@@ -11,6 +11,7 @@ group :development, :test do
   gem 'hashie'
   gem 'rake'
   gem 'rubocop', '0.84.0'
+  gem 'rubocop-ast', '< 0.7'
   gem 'rubocop-performance', require: false
 end
 

--- a/gemfiles/rack1.gemfile
+++ b/gemfiles/rack1.gemfile
@@ -11,6 +11,7 @@ group :development, :test do
   gem 'hashie'
   gem 'rake'
   gem 'rubocop', '0.84.0'
+  gem 'rubocop-ast', '< 0.7'
   gem 'rubocop-performance', require: false
 end
 

--- a/gemfiles/rack2.gemfile
+++ b/gemfiles/rack2.gemfile
@@ -11,6 +11,7 @@ group :development, :test do
   gem 'hashie'
   gem 'rake'
   gem 'rubocop', '0.84.0'
+  gem 'rubocop-ast', '< 0.7'
   gem 'rubocop-performance', require: false
 end
 

--- a/gemfiles/rack_edge.gemfile
+++ b/gemfiles/rack_edge.gemfile
@@ -11,6 +11,7 @@ group :development, :test do
   gem 'hashie'
   gem 'rake'
   gem 'rubocop', '0.84.0'
+  gem 'rubocop-ast', '< 0.7'
   gem 'rubocop-performance', require: false
 end
 

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -11,6 +11,7 @@ group :development, :test do
   gem 'hashie'
   gem 'rake'
   gem 'rubocop', '0.84.0'
+  gem 'rubocop-ast', '< 0.7'
   gem 'rubocop-performance', require: false
 end
 

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -11,6 +11,7 @@ group :development, :test do
   gem 'hashie'
   gem 'rake'
   gem 'rubocop', '0.84.0'
+  gem 'rubocop-ast', '< 0.7'
   gem 'rubocop-performance', require: false
 end
 

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -11,6 +11,7 @@ group :development, :test do
   gem 'hashie'
   gem 'rake'
   gem 'rubocop', '0.84.0'
+  gem 'rubocop-ast', '< 0.7'
   gem 'rubocop-performance', require: false
 end
 


### PR DESCRIPTION
The latest versions of rubocop-ast (>= 0.7) are incompatible with older versions of rubocop. Since grape currently use rubocop 0.84 we need to lock rubocop-ast to a compatible version