### PR TITLE
Fix bug with handling array params.

### DIFF
--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -75,8 +75,7 @@ module Grape
 
               params_nested_path_dup = params_nested_path.dup
               params_nested_path_dup << declared_param.to_s
-
-              memo[memo_key] = handle_passed_param(params_nested_path_dup) do
+              memo[memo_key] = passed_param || handle_passed_param(params_nested_path_dup) do
                 passed_param
               end
             end

--- a/spec/grape/endpoint/declared_spec.rb
+++ b/spec/grape/endpoint/declared_spec.rb
@@ -135,6 +135,20 @@ describe Grape::Endpoint do
       expect(JSON.parse(last_response.body)['nested'].keys.size).to eq 9
     end
 
+    it 'builds arrays correctly' do
+      subject.params do
+        requires :first
+        optional :second, type: Array
+      end
+      subject.post('/declared') { declared(params) }
+
+      post '/declared', first: 'present', second: ['present']
+      expect(last_response.status).to eq(201)
+
+      body = JSON.parse(last_response.body)
+      expect(body['second']).to eq(['present'])
+    end
+
     it 'builds nested params when given array' do
       subject.get '/dummy' do
       end


### PR DESCRIPTION
Fixes an issue introduced in 7e432153f08d4985b0df625d11aef28a38beb4fe that results in Array leaf params being ignored.

For example, given the following API and Request:

```
class Api < Grape::API
  params do
    optional :array, type: Array
  end
  post 'example' do
    declared(params, include_missing: true)
  end
end

POST /example
{ "array": ["value"] }
```

Expected Response Body:

```
{ "array": ["value"] }
```

Observed Response Body:

```
{ "array": [] }
```