### PR TITLE
Shared parameters are not inherited

### DIFF
--- a/spec/grape/api/shared_helpers_spec.rb
+++ b/spec/grape/api/shared_helpers_spec.rb
@@ -13,6 +13,15 @@ describe Grape::API::Helpers do
       end
     end
 
+    nested = Class.new(Grape::API) do
+      params do
+        use :pagination
+      end
+      get '/child' do
+        declared(params, include_missing: true)
+      end
+    end
+
     Class.new(Grape::API) do
       helpers shared_params
       format :json
@@ -23,6 +32,8 @@ describe Grape::API::Helpers do
       get do
         declared(params, include_missing: true)
       end
+
+      mount nested
     end
   end
 
@@ -32,6 +43,12 @@ describe Grape::API::Helpers do
 
   it 'defines parameters' do
     get '/'
+    expect(last_response.status).to eq 200
+    expect(last_response.body).to eq({ page: nil, size: nil }.to_json)
+  end
+
+  it 'inherits parameters' do
+    get '/child'
     expect(last_response.status).to eq 200
     expect(last_response.body).to eq({ page: nil, size: nil }.to_json)
   end


### PR DESCRIPTION
In relation to https://github.com/ruby-grape/grape/issues/2113