### PR TITLE
Fix declared_params regression with multiple allowed types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#2115](https://github.com/ruby-grape/grape/pull/2115): Fix declared_params regression with multiple allowed types - [@stanhu](https://github.com/stanhu).
 
 ### 1.5.0 (2020/10/05)
 

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -94,7 +94,7 @@ module Grape
 
           if type == 'Hash' && !has_children
             {}
-          elsif type == 'Array' || type&.start_with?('[')
+          elsif type == 'Array' || type&.start_with?('[') && !type&.include?(',')
             []
           elsif type == 'Set' || type&.start_with?('#<Set')
             Set.new

--- a/spec/grape/endpoint/declared_spec.rb
+++ b/spec/grape/endpoint/declared_spec.rb
@@ -16,6 +16,7 @@ describe Grape::Endpoint do
         requires :first
         optional :second
         optional :third, default: 'third-default'
+        optional :multiple_types, types: [Integer, String]
         optional :nested, type: Hash do
           optional :fourth
           optional :fifth
@@ -96,6 +97,16 @@ describe Grape::Endpoint do
       expect(JSON.parse(last_response.body)['nested']['fourth']).to be_nil
     end
 
+    it 'should show nil for multiple allowed types if include_missing is true' do
+      subject.get '/declared' do
+        declared(params, include_missing: true)
+      end
+
+      get '/declared?first=present'
+      expect(last_response.status).to eq(200)
+      expect(JSON.parse(last_response.body)['multiple_types']).to be_nil
+    end
+
     it 'does not work in a before filter' do
       subject.before do
         declared(params)
@@ -113,7 +124,7 @@ describe Grape::Endpoint do
       end
       get '/declared?first=present'
       expect(last_response.status).to eq(200)
-      expect(JSON.parse(last_response.body).keys.size).to eq(10)
+      expect(JSON.parse(last_response.body).keys.size).to eq(11)
     end
 
     it 'has a optional param with default value all the time' do


### PR DESCRIPTION
Prior to Grape v1.5.0 and https://github.com/ruby-grape/grape/pull/2103, the following
would return `nil`:

```ruby
params do
  optional :status_code, types: [Integer, String]
end
get '/' do
  declared_params
end
```

However, now it turns an empty `Array`.

We restore the previous behavior by not returning an empty `Array` if multiple
types are used.

Closes https://github.com/ruby-grape/grape/issues/2115