### PR TITLE
Fix 2.7 deprecation warning in validator_factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#2121](https://github.com/ruby-grape/grape/pull/2121): Fix 2.7 deprecation warning in validator_factory - [@Legogris](https://github.com/Legogris).
 * [#2115](https://github.com/ruby-grape/grape/pull/2115): Fix declared_params regression with multiple allowed types - [@stanhu](https://github.com/stanhu).
 
 ### 1.5.0 (2020/10/05)

--- a/lib/grape/validations/validator_factory.rb
+++ b/lib/grape/validations/validator_factory.rb
@@ -8,7 +8,7 @@ module Grape
                                       options[:options],
                                       options[:required],
                                       options[:params_scope],
-                                      options[:opts])
+                                      **options[:opts])
       end
     end
   end


### PR DESCRIPTION
Addresses the following warnings:
```
/app/vendor/bundle/ruby/2.7.0/gems/grape-1.5.0/lib/grape/validations/validator_factory.rb:7: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/app/vendor/bundle/ruby/2.7.0/gems/grape-1.5.0/lib/grape/validations/validators/values.rb:6: warning: The called method `initialize' is defined here

```