### PR TITLE
Fix 2.7 deprecation warning in middleware/stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * Your contribution here.
 * [#2115](https://github.com/ruby-grape/grape/pull/2115): Fix declared_params regression with multiple allowed types - [@stanhu](https://github.com/stanhu).
+* [#2123](https://github.com/ruby-grape/grape/pull/2123): Fix 2.7 deprecation warning in middleware/stack - [@Legogris](https://github.com/Legogris).
 
 ### 1.5.0 (2020/10/05)
 

--- a/lib/grape/middleware/stack.rb
+++ b/lib/grape/middleware/stack.rb
@@ -70,9 +70,9 @@ module Grape
         middlewares[i]
       end
 
-      def insert(index, *args, &block)
+      def insert(index, *args, **kwargs, &block)
         index = assert_index(index, :before)
-        middleware = self.class::Middleware.new(*args, &block)
+        middleware = self.class::Middleware.new(*args, **kwargs, &block)
         middlewares.insert(index, middleware)
       end
 
@@ -83,8 +83,8 @@ module Grape
         insert(index + 1, *args, &block)
       end
 
-      def use(*args, &block)
-        middleware = self.class::Middleware.new(*args, &block)
+      def use(*args, **kwargs, &block)
+        middleware = self.class::Middleware.new(*args, **kwargs, &block)
         middlewares.push(middleware)
       end
 


### PR DESCRIPTION
Attempt at fixing #2122 

See https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/ (`Handling argument delegation`)