### PR TITLE
Fix warnings about redefined methods on AttributeTranslator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#2126](https://github.com/ruby-grape/grape/pull/2126): Fix warnings about redefined attribute accessors in `AttributeTranslator` - [@samsonjs](https://github.com/samsonjs).
 * [#2121](https://github.com/ruby-grape/grape/pull/2121): Fix 2.7 deprecation warning in validator_factory - [@Legogris](https://github.com/Legogris).
 * [#2115](https://github.com/ruby-grape/grape/pull/2115): Fix declared_params regression with multiple allowed types - [@stanhu](https://github.com/stanhu).
 * [#2123](https://github.com/ruby-grape/grape/pull/2123): Fix 2.7 deprecation warning in middleware/stack - [@Legogris](https://github.com/Legogris).

--- a/lib/grape/router/attribute_translator.rb
+++ b/lib/grape/router/attribute_translator.rb
@@ -4,7 +4,7 @@ module Grape
   class Router
     # this could be an OpenStruct, but doesn't work in Ruby 2.3.0, see https://bugs.ruby-lang.org/issues/12251
     class AttributeTranslator
-      attr_reader :attributes, :request_method, :requirements
+      attr_reader :attributes
 
       ROUTE_ATTRIBUTES = %i[
         prefix


### PR DESCRIPTION
This fixes warnings about redefined attribute readers for `AttributeTranslator#requirements` and `#request_method`. The `attr_reader` call is redundant because those accessors are defined dynamically below that.

```
/Users/samsonjs/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/grape-1.5.0/lib/grape/router/attribute_translator.rb:31: warning: method redefined; discarding old requirements
/Users/samsonjs/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/grape-1.5.0/lib/grape/router/attribute_translator.rb:31: warning: method redefined; discarding old request_method
```