### PR TITLE
Fix validation error for nested array when  `requires` => `optional` => `requires`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#2128](https://github.com/ruby-grape/grape/pull/2128): Fix validation error when Required Array nested inside an optional array - [@dwhenry](https://github.com/dwhenry).
 * [#2127](https://github.com/ruby-grape/grape/pull/2127): Fix a performance issue with dependent params - [@dnesteryuk](https://github.com/dnesteryuk).
 * [#2126](https://github.com/ruby-grape/grape/pull/2126): Fix warnings about redefined attribute accessors in `AttributeTranslator` - [@samsonjs](https://github.com/samsonjs).
 * [#2121](https://github.com/ruby-grape/grape/pull/2121): Fix 2.7 deprecation warning in validator_factory - [@Legogris](https://github.com/Legogris).

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -227,13 +227,17 @@ module Grape
 
       alias group requires
 
-      def map_params(params, element)
+      class EmptyOptionalValue; end
+
+      def map_params(params, element, is_array = false)
         if params.is_a?(Array)
           params.map do |el|
-            map_params(el, element)
+            map_params(el, element, true)
           end
         elsif params.is_a?(Hash)
-          params[element] || {}
+          params[element] || (@optional && is_array ? EmptyOptionalValue : {})
+        elsif params == EmptyOptionalValue
+          EmptyOptionalValue
         else
           {}
         end

--- a/lib/grape/validations/single_attribute_iterator.rb
+++ b/lib/grape/validations/single_attribute_iterator.rb
@@ -17,7 +17,6 @@ module Grape
       # are the parameter parsing stage as they are required to ensure
       # the correct indexing is maintained
       def skip?(val)
-        # return false
         val == Grape::DSL::Parameters::EmptyOptionalValue
       end
 

--- a/lib/grape/validations/single_attribute_iterator.rb
+++ b/lib/grape/validations/single_attribute_iterator.rb
@@ -7,8 +7,18 @@ module Grape
 
       def yield_attributes(val, attrs)
         attrs.each do |attr_name|
-          yield val, attr_name, empty?(val)
+          yield val, attr_name, empty?(val), skip?(val)
         end
+      end
+
+
+      # This is a special case so that we can ignore tree's where option
+      # values are missing lower down. Unfortunately we can remove this
+      # are the parameter parsing stage as they are required to ensure
+      # the correct indexing is maintained
+      def skip?(val)
+        # return false
+        val == Grape::DSL::Parameters::EmptyOptionalValue
       end
 
       # Primitives like Integers and Booleans don't respond to +empty?+.

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -43,7 +43,8 @@ module Grape
         # there may be more than one error per field
         array_errors = []
 
-        attributes.each do |val, attr_name, empty_val|
+        attributes.each do |val, attr_name, empty_val, skip_value|
+          next if skip_value
           next if !@scope.required? && empty_val
           next unless @scope.meets_dependency?(val, params)
           begin

--- a/spec/grape/validations/single_attribute_iterator_spec.rb
+++ b/spec/grape/validations/single_attribute_iterator_spec.rb
@@ -15,7 +15,7 @@ describe Grape::Validations::SingleAttributeIterator do
 
       it 'yields params and every single attribute from the list' do
         expect { |b| iterator.each(&b) }
-          .to yield_successive_args([params, :first, false], [params, :second, false])
+          .to yield_successive_args([params, :first, false, false], [params, :second, false, false])
       end
     end
 
@@ -26,8 +26,8 @@ describe Grape::Validations::SingleAttributeIterator do
 
       it 'yields every single attribute from the list for each of the array elements' do
         expect { |b| iterator.each(&b) }.to yield_successive_args(
-          [params[0], :first, false], [params[0], :second, false],
-          [params[1], :first, false], [params[1], :second, false]
+          [params[0], :first, false, false], [params[0], :second, false, false],
+          [params[1], :first, false, false], [params[1], :second, false, false]
         )
       end
 
@@ -36,9 +36,20 @@ describe Grape::Validations::SingleAttributeIterator do
 
         it 'marks params with empty values' do
           expect { |b| iterator.each(&b) }.to yield_successive_args(
-            [params[0], :first, true], [params[0], :second, true],
-            [params[1], :first, true], [params[1], :second, true],
-            [params[2], :first, false], [params[2], :second, false]
+            [params[0], :first, true, false], [params[0], :second, true, false],
+            [params[1], :first, true, false], [params[1], :second, true, false],
+            [params[2], :first, false, false], [params[2], :second, false, false]
+          )
+        end
+      end
+
+      context 'when missing optional value' do
+        let(:params) { [Grape::DSL::Parameters::EmptyOptionalValue, 10] }
+
+        it 'marks params with skipped values' do
+          expect { |b| iterator.each(&b) }.to yield_successive_args(
+            [params[0], :first, false, true], [params[0], :second, false, true],
+            [params[1], :first, false, false], [params[1], :second, false, false],
           )
         end
       end

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -883,6 +883,34 @@ describe Grape::Validations do
         end
         expect(declared_params).to eq([items: [:key, { optional_subitems: [:value] }, { required_subitems: [:value] }]])
       end
+
+      it "does not report errors when required array inside missing optional array" do
+        subject.params do
+          requires :orders, type: Array do
+            requires :id, type: Integer
+            optional :drugs, type: Array do
+              requires :batches, type: Array do
+                requires :batch_no, type: String
+              end
+            end
+          end
+        end
+
+        subject.get '/validate_required_arrays_under_optional_arrays' do
+          'validate_required_arrays_under_optional_arrays works!'
+        end
+
+        data = {
+          orders: [
+            { id: 77, drugs: [{batches: [{batch_no: "A1234567"}]}]},
+            { id: 70 }
+          ]
+        }
+
+        get '/validate_required_arrays_under_optional_arrays', data
+        expect(last_response.body).to eq("validate_required_arrays_under_optional_arrays works!")
+        expect(last_response.status).to eq(200)
+      end
     end
 
     context 'multiple validation errors' do


### PR DESCRIPTION
This bug is due to the params parsing code return `{}` when the value is not found.
This is fine in most cases, however in the instance that the value was optional
and has nested required values.

I was not able to find a way to confine the changes to just the parameter parsing
as this resulted in the indexing being incorrect if any of the other array objects
had an error.

I have used a class to indicate that an Optional Value was missing as this avoid issues
with the value actually being in the response.