### PR TITLE
Mention rack 2.1.0 support in UPGRADING.md

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -189,6 +189,8 @@ end
 
 ### Upgrading to >= 1.3.0
 
+#### Added Rack 2.1.0 support
+
 #### Ruby
 
 After adding dry-types, Ruby 2.4 or newer is required.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -189,7 +189,7 @@ end
 
 ### Upgrading to >= 1.3.0
 
-#### Added Rack 2.1.0 support
+You will need to upgrade to this version if you depend on `rack >= 2.1.0`
 
 #### Ruby
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -189,7 +189,7 @@ end
 
 ### Upgrading to >= 1.3.0
 
-You will need to upgrade to this version if you depend on `rack >= 2.1.0`
+You will need to upgrade to this version if you depend on `rack >= 2.1.0`.
 
 #### Ruby
 


### PR DESCRIPTION
I'm currently upgrading a fairly big rails app I did not write myself which uses grape. Since I unfortunately never used grape before (I want to though :wink:), I was in unknown territory and it took me quite I while to figure out that grape added support for rack >= 2.1.0 first on 1.3.0.

First thing I did when running into [https://github.com/ruby-grape/grape/issues/1966](this error) was checking the Upgrade.md file for any signs of rack incompatibility, but I did not find any. I wish I did, since it took me a few hours to find the mentioned issue. (I really have to up my google-fu, I know :see_no_evil:)

But for any poor soul in the future, who is just as bad as googling as I am, it might be helpful to mention this in the Upgrade guide :)