### PR TITLE
Fix Ruby 2.7 keyword deprecation warning in validators/coerce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#2131](https://github.com/ruby-grape/grape/pull/2131): Fix Ruby 2.7 keyword deprecation warning in validators/coerce - [@K0H205](https://github.com/K0H205).
 
 ### 1.5.1 (2020/11/15)
 

--- a/lib/grape/validations/validators/coerce.rb
+++ b/lib/grape/validations/validators/coerce.rb
@@ -17,7 +17,7 @@ module Grape
 
   module Validations
     class CoerceValidator < Base
-      def initialize(*_args)
+      def initialize(attrs, options, required, scope, **opts)
         super
 
         @converter = if type.is_a?(Grape::Validations::Types::VariantCollectionCoercer)


### PR DESCRIPTION
Fix these deprecation warnings
```
grape/lib/grape/validations/validators/coerce.rb:21: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
grape/lib/grape/validations/validators/base.rb:16: warning: The called method `initialize' is defined here
```


