### PR TITLE
Use #ruby2_keywords for correct delegation on Ruby <= 2.6, 2.7 and 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * Your contribution here.
 * [#2131](https://github.com/ruby-grape/grape/pull/2131): Fix Ruby 2.7 keyword deprecation warning in validators/coerce - [@K0H205](https://github.com/K0H205).
+* [#2132](https://github.com/ruby-grape/grape/pull/2132): Use #ruby2_keywords for correct delegation on Ruby <= 2.6, 2.7 and 3 - [@eregon](https://github.com/eregon).
 
 ### 1.5.1 (2020/11/15)
 

--- a/spec/grape/middleware/stack_spec.rb
+++ b/spec/grape/middleware/stack_spec.rb
@@ -35,8 +35,7 @@ describe Grape::Middleware::Stack do
       expect { subject.use StackSpec::BarMiddleware, false, my_arg: 42 }
         .to change { subject.size }.by(1)
       expect(subject.last).to eq(StackSpec::BarMiddleware)
-      expect(subject.last.args).to eq([false])
-      expect(subject.last.opts).to eq(my_arg: 42)
+      expect(subject.last.args).to eq([false, { my_arg: 42 }])
     end
 
     it 'pushes a middleware class with block arguments onto the stack' do


### PR DESCRIPTION
* See https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/#a-compatible-delegation

More context on https://github.com/ruby-grape/grape/pull/2123#issuecomment-728384065

This also happens to fix the CI on `truffleruby-head`.