### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#2137](https://github.com/ruby-grape/grape/pull/2137): Fix typos - [@johnny-miyake](https://github.com/johnny-miyake).
 * [#2131](https://github.com/ruby-grape/grape/pull/2131): Fix Ruby 2.7 keyword deprecation warning in validators/coerce - [@K0H205](https://github.com/K0H205).
 * [#2132](https://github.com/ruby-grape/grape/pull/2132): Use #ruby2_keywords for correct delegation on Ruby <= 2.6, 2.7 and 3 - [@eregon](https://github.com/eregon).
 

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -921,7 +921,7 @@ describe Grape::Validations do
           expect(last_response.status).to eq(200)
         end
 
-        it "simplest example using Arry -> Array -> Hash -> String" do
+        it "simplest example using Array -> Array -> Hash -> String" do
           subject.params do
             requires :orders, type: Array do
               requires :id, type: Integer
@@ -947,7 +947,7 @@ describe Grape::Validations do
           expect(last_response.status).to eq(200)
         end
 
-        it "simplest example using Arry -> Hash -> String" do
+        it "simplest example using Array -> Hash -> String" do
           subject.params do
             requires :orders, type: Array do
               requires :id, type: Integer


### PR DESCRIPTION
Fixed typos in some comments
`Arry` → `Array`