### PR TITLE
Corrected a hash modification while iterating issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Your contribution here.
 
 * [#2161](https://github.com/ruby-grape/grape/pull/2157): Handle EOFError from Rack when given an empty multipart body - [@bschmeck](https://github.com/bschmeck).
+* [#2162](https://github.com/ruby-grape/grape/pull/2162): Corrected a hash modification while iterating issue - [@Jack12816](https://github.com/Jack12816).
 
 ### 1.5.2 (2021/02/06)
 

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -141,7 +141,7 @@ module Grape
       # Adds a new stage to the set up require to get a Grape::API up and running
       def add_setup(method, *args, &block)
         setup_step = { method: method, args: args, block: block }
-        @setup << setup_step
+        @setup += [setup_step]
         last_response = nil
         @instances.each do |instance|
           last_response = replay_step_on(instance, setup_step)


### PR DESCRIPTION
**- What is it good for**

There is a nasty bug on edge case usage of nested mounted APIs which use a shared class-helper method to abstract the creation of a route. With this fix in place, no errors are raised. Otherwise a `RuntimeError: can't add a new key into hash during iteration` is raised. This is caused by [an inline modification of the @setup set inside the Grape::API class](https://github.com/ruby-grape/grape/blob/v1.5.2/lib/grape/api.rb#L144). This error is caused by the definition of the helper method in a specific way. The following form causes the issue:

```ruby
def uniqe_id_route
  params do
    use :unique_id
  end
  route_param(:id) do
    yield
  end
end  
```

while this form works as expected:

```ruby
def uniqe_id_route(&block)
  params do
    use :unique_id
  end
  route_param(:id, &block)
end
```

**- What I did**

I just converted the inline set modification into a reassignment of a freshly built set and added a test that proves the bugfix.

**- A picture of a cute animal (not mandatory but encouraged)**

![images](https://user-images.githubusercontent.com/2496275/108552363-7e80ff00-72f1-11eb-9d0b-a091162ddd89.jpeg)
