### PR TITLE
Initialize error data using constructors directly

### DIFF
--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -255,7 +255,7 @@ module Grape
           run_filters befores, :before
 
           if (allowed_methods = env[Grape::Env::GRAPE_ALLOWED_METHODS])
-            raise Grape::Exceptions::MethodNotAllowed, header.merge('Allow' => allowed_methods) unless options?
+            raise Grape::Exceptions::MethodNotAllowed.new(header.merge('Allow' => allowed_methods)) unless options?
             header 'Allow', allowed_methods
             response_object = ''
             status 204

--- a/lib/grape/parser/json.rb
+++ b/lib/grape/parser/json.rb
@@ -8,7 +8,7 @@ module Grape
           ::Grape::Json.load(object)
         rescue ::Grape::Json::ParseError
           # handle JSON parsing errors via the rescue handlers or provide error message
-          raise Grape::Exceptions::InvalidMessageBody, 'application/json'
+          raise Grape::Exceptions::InvalidMessageBody.new('application/json')
         end
       end
     end

--- a/lib/grape/parser/xml.rb
+++ b/lib/grape/parser/xml.rb
@@ -8,7 +8,7 @@ module Grape
           ::Grape::Xml.parse(object)
         rescue ::Grape::Xml::ParseError
           # handle XML parsing errors via the rescue handlers or provide error message
-          raise Grape::Exceptions::InvalidMessageBody, 'application/xml'
+          raise Grape::Exceptions::InvalidMessageBody.new('application/xml')
         end
       end
     end

--- a/lib/grape/request.rb
+++ b/lib/grape/request.rb
@@ -16,7 +16,7 @@ module Grape
     def params
       @params ||= build_params
     rescue EOFError
-      raise Grape::Exceptions::EmptyMessageBody, content_type
+      raise Grape::Exceptions::EmptyMessageBody.new(content_type)
     end
 
     def headers

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -55,7 +55,7 @@ module Grape
           end
         end
 
-        raise Grape::Exceptions::ValidationArrayErrors, array_errors if array_errors.any?
+        raise Grape::Exceptions::ValidationArrayErrors.new(array_errors) if array_errors.any?
       end
 
       def self.convert_to_short_name(klass)

--- a/lib/grape/validations/validators/multiple_params_base.rb
+++ b/lib/grape/validations/validators/multiple_params_base.rb
@@ -16,7 +16,7 @@ module Grape
           end
         end
 
-        raise Grape::Exceptions::ValidationArrayErrors, array_errors if array_errors.any?
+        raise Grape::Exceptions::ValidationArrayErrors.new(array_errors) if array_errors.any?
       end
 
       private


### PR DESCRIPTION
This avoids using the `Kernel#raise` string message parameter to initialize custom data for errors in favor of initializing with the data directly as described here:
https://github.com/ruby-grape/grape/pull/2164#issuecomment-791597922

This is also consistent with other usages like:
https://github.com/ruby-grape/grape/blob/e0f412ca73f6188c233ac9c35661027d28f38a54/lib/grape/middleware/versioner.rb#L29
https://github.com/ruby-grape/grape/blob/e0f412ca73f6188c233ac9c35661027d28f38a54/lib/grape/endpoint.rb#L129