### PR TITLE
handle the changes in errors method in rails 6.1

### DIFF
--- a/lib/grape/error_formatter/json.rb
+++ b/lib/grape/error_formatter/json.rb
@@ -22,7 +22,7 @@ module Grape
         private
 
         def wrap_message(message)
-          if message.is_a?(Exceptions::ValidationErrors) || message.is_a?(Hash)
+          if message.is_a?(Exceptions::ValidationErrors) || message.is_a?(Hash) || message.is_a?(ActiveModel::DeprecationHandlingMessageHash)
             message
           else
             { error: message }

--- a/lib/grape/error_formatter/json.rb
+++ b/lib/grape/error_formatter/json.rb
@@ -22,7 +22,7 @@ module Grape
         private
 
         def wrap_message(message)
-          if message.is_a?(Exceptions::ValidationErrors) || message.is_a?(Hash) || message.is_a?(ActiveModel::DeprecationHandlingMessageHash)
+          if message.is_a?(Exceptions::ValidationErrors) || message.is_a?(Hash) || (defined?(ActiveModel::DeprecationHandlingMessageHash) && message.is_a?(ActiveModel::DeprecationHandlingMessageHash))
             message
           else
             { error: message }


### PR DESCRIPTION
solve #2168
as active_record_instance#errors metho is not returning a hash object anymore. as a part of rails 6.1 upgrade
the JSON error formatter should consider this change and check if the object type is `ActiveModel::DeprecationHandlingMessageHash`