### PR TITLE
[WIP] Fix same custom route_setting value ignoreing problem

### DIFF
--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -30,7 +30,7 @@ module Grape
       # an instance that will be used to create the set up but will not be mounted
       def initial_setup(base_instance_parent)
         @instances = []
-        @setup = Set.new
+        @setup = []
         @base_parent = base_instance_parent
         @base_instance = mount_instance
       end

--- a/spec/grape/api/describing_and_inspecting_spec.rb
+++ b/spec/grape/api/describing_and_inspecting_spec.rb
@@ -6,7 +6,6 @@ require 'spec_helper'
 #
 # @see https://github.com/ruby-grape/grape/issues/2173
 module DescribingAndInspectingSpec
-
   class CustomKeyExample < Grape::API
     desc 'Includes custom settings.'
     route_setting :custom, key: 'value'
@@ -21,22 +20,45 @@ module DescribingAndInspectingSpec
     end
   end
 
-  class Main < Grape::API
-    mount CustomKeyExample
+  class CustomKeyExampleMount < Grape::API
+    desc 'Includes custom settings.'
+    route_setting :custom, key: 'value'
+    get '/api1' do
+      status 200
+    end
+
+    desc 'Includes custom settings.'
+    route_setting :custom, key: 'value'
+    get '/api2' do
+      status 200
+    end
   end
 
+  class Main < Grape::API
+    mount CustomKeyExampleMount
+  end
 end
 
 describe Grape::API do
-  subject { DescribingAndInspectingSpec::Main.routes.map(&:settings) }
-
   let(:description) { 'Includes custom settings.' }
   let(:custom) { { key: 'value' } }
 
-  it 'can have same custom key and value' do
-    subject.each do |settings|
-      expect(settings[:description]).to eq({ description: 'Includes custom settings.' })
-      expect(settings[:custom]).to eq({ key: 'value' })
+  shared_examples 'same_custom_key_and_value' do
+    it 'can have same custom key and value' do
+      subject.each do |settings|
+        expect(settings[:description]).to eq({ description: 'Includes custom settings.' })
+        expect(settings[:custom]).to eq({ key: 'value' })
+      end
     end
+  end
+
+  context 'independent' do
+    subject { DescribingAndInspectingSpec::CustomKeyExample.routes.map(&:settings) }
+    include_examples 'same_custom_key_and_value'
+  end
+
+  context 'on mount' do
+    subject { DescribingAndInspectingSpec::Main.routes.map(&:settings) }
+    include_examples 'same_custom_key_and_value'
   end
 end

--- a/spec/grape/api/describing_and_inspecting_spec.rb
+++ b/spec/grape/api/describing_and_inspecting_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# @see https://github.com/ruby-grape/grape#describing-and-inspecting-an-api
+#
+# @see https://github.com/ruby-grape/grape/issues/2173
+module DescribingAndInspectingSpec
+
+  class CustomKeyExample < Grape::API
+    desc 'Includes custom settings.'
+    route_setting :custom, key: 'value'
+    get '/api1' do
+      status 200
+    end
+
+    desc 'Includes custom settings.'
+    route_setting :custom, key: 'value'
+    get '/api2' do
+      status 200
+    end
+  end
+
+  class Main < Grape::API
+    mount CustomKeyExample
+  end
+
+end
+
+describe Grape::API do
+  subject { DescribingAndInspectingSpec::Main.routes.map(&:settings) }
+
+  let(:description) { 'Includes custom settings.' }
+  let(:custom) { { key: 'value' } }
+
+  it 'can have same custom key and value' do
+    subject.each do |settings|
+      expect(settings[:description]).to eq({ description: 'Includes custom settings.' })
+      expect(settings[:custom]).to eq({ key: 'value' })
+    end
+  end
+end


### PR DESCRIPTION
#2173 After 1.5.0 , 'route_setting :custom , key: :value' is broken with 'mount'.

check plz. @dblock 

ps. I always thank you for grape.