### PR TITLE
Fix ordering issues between as: and default: validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 #### Fixes
 
-* [#2176](https://github.com/ruby-grape/grape/pull/2176): Fixes issue-2175 - options call failing if matching all routes - [@myxoh](https://github.com/myxoh).
+* [#2176](https://github.com/ruby-grape/grape/pull/2176): Fix: OPTIONS fails if matching all routes - [@myxoh](https://github.com/myxoh).
+* [#2177](https://github.com/ruby-grape/grape/pull/2177): Fix: `default` validator fails if preceded by `as` validator - [@Catsuko](https://github.com/Catsuko).
 * Your contribution here.
 ### 1.5.3 (2021/03/07)
 

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -300,9 +300,15 @@ module Grape
         # type casted values
         coerce_type validations, attrs, doc_attrs, opts
 
+        as = validations.delete(:as)
+
         validations.each do |type, options|
           validate(type, options, attrs, doc_attrs, opts)
         end
+
+        # Validate as last so other validations are applied to
+        # renamed param
+        validate(:as, as, attrs, doc_attrs, opts) if as
       end
 
       # Validate and comprehend the +:type+, +:types+, and +:coerce_with+

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -289,11 +289,7 @@ module Grape
         opts = derive_validator_options(validations)
 
         # Validate for presence before any other validators
-        if validations.key?(:presence) && validations[:presence]
-          validate('presence', validations[:presence], attrs, doc_attrs, opts)
-          validations.delete(:presence)
-          validations.delete(:message) if validations.key?(:message)
-        end
+        validates_presence(validations, attrs, doc_attrs, opts)
 
         # Before we run the rest of the validators, let's handle
         # whatever coercion so that we are working with correctly
@@ -469,6 +465,13 @@ module Grape
           allow_blank: allow_blank.is_a?(Hash) ? allow_blank[:value] : allow_blank,
           fail_fast:   validations.delete(:fail_fast) || false
         }
+      end
+
+      def validates_presence(validations, attrs, doc_attrs, opts)
+        return unless validations.key?(:presence) && validations[:presence]
+        validate(:presence, validations[:presence], attrs, doc_attrs, opts)
+        validations.delete(:presence)
+        validations.delete(:message) if validations.key?(:message)
       end
     end
   end

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -180,6 +180,28 @@ describe Grape::Validations::ParamsScope do
       expect(last_response.status).to eq(200)
       expect(last_response.body).to eq('{"baz":{"qux":"any"}}')
     end
+
+    it 'renaming can be defined before default' do
+      subject.params do
+        optional :foo, as: :bar, default: 'before'
+      end
+      subject.get('/rename-before-default') { params[:bar] }
+      get '/rename-before-default'
+
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq('before')
+    end
+
+    it 'renaming can be defined after default' do
+      subject.params do
+        optional :foo, default: 'after', as: :bar
+      end
+      subject.get('/rename-after-default') { params[:bar] }
+      get '/rename-after-default'
+
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq('after')
+    end
   end
 
   context 'array without coerce type explicitly given' do


### PR DESCRIPTION
Fixes #2094 where it was found that defining `as:` before `default:` would fail to add the default whereas `as:` after `default:` would work fine.

