### PR TITLE
CI: Avoid YAML float 3.0 => "3"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
-          - 3.0
+          - "3.0"
         gemfile:
           - Gemfile
           - gemfiles/rack1.gemfile
@@ -40,10 +40,10 @@ jobs:
           - gemfiles/rails_6_1.gemfile
         experimental: [false]
         include:
-          - ruby: 3.0
+          - ruby: "3.0"
             gemfile: 'gemfiles/multi_json.gemfile'
             experimental: false
-          - ruby: 3.0
+          - ruby: "3.0"
             gemfile: 'gemfiles/multi_xml.gemfile'
             experimental: false
           - ruby: 2.7


### PR DESCRIPTION
This is a very small change, but which avoids a Float-to-String loss of characters.

You can see the effect of what it looks like before this change, in this picture:

<img width="376" alt="bild" src="https://user-images.githubusercontent.com/211/119782378-6ad6cd00-becc-11eb-9e13-9a425adaa054.png">

Read more details, if you like: https://github.com/actions/runner/issues/849