### PR TITLE
Reproducible spec to showcase `API.inherited` issue

### DIFF
--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -4081,6 +4081,49 @@ XML
     end
   end
 
+  describe '.inherited' do
+    context 'overriding within class' do
+      let(:root_api) do
+        Class.new(Grape::API) do
+          @bar = 'Hello, world'
+
+          def self.inherited(child_api)
+            super
+            child_api.instance_variable_set(:@foo, @bar.dup)
+          end
+        end
+      end
+
+      let(:child_api) { Class.new(root_api) }
+
+      it 'allows overriding the hook' do
+        expect(child_api.instance_variable_get(:@foo)).to eq('Hello, world')
+      end
+    end
+
+    context 'overriding via composition' do
+      module Inherited
+        def inherited(api)
+          super
+          api.instance_variable_set(:@foo, @bar.dup)
+        end
+      end
+
+      let(:root_api) do
+        Class.new(Grape::API) do
+          @bar = 'Hello, world'
+          extend Inherited
+        end
+      end
+
+      let(:child_api) { Class.new(root_api) }
+
+      it 'allows overriding the hook' do
+        expect(child_api.instance_variable_get(:@foo)).to eq('Hello, world')
+      end
+    end
+  end
+
   describe 'const_missing' do
     subject(:grape_api) { Class.new(Grape::API) }
     let(:mounted) do


### PR DESCRIPTION
We're trying to extend the `Grape::API` in one of our gem and found one issue where `Grape::API.inherited` hook doesn't get called when overridden via module composition. It only works when overridden in class itself.

For example,

```ruby
module Inherited
  # This doesn't get called when extended in `API` specific classes
  def inherited(api)
    super
    # ...
  end
end

class RootAPI < Grape::API
  extend Inherited
end

class ChildAPI < RootAPI
end
```

We identified this happens because `inherited` isn't calling `super`. I'm creating this PR in order to showcase reproducible spec. I can create another PR with the fix.