### PR TITLE
Add ddtrace gem to monitoring products list

### DIFF
--- a/README.md
+++ b/README.md
@@ -3954,6 +3954,7 @@ Grape integrates with following third-party tools:
 * **[Skylight](https://www.skylight.io/)** - [skylight](https://github.com/skylightio/skylight-ruby) gem, [documentation](https://docs.skylight.io/grape/)
 * **[AppSignal](https://www.appsignal.com)** - [appsignal-ruby](https://github.com/appsignal/appsignal-ruby) gem, [documentation](http://docs.appsignal.com/getting-started/supported-frameworks.html#grape)
 * **[ElasticAPM](https://www.elastic.co/products/apm)** - [elastic-apm](https://github.com/elastic/apm-agent-ruby) gem, [documentation](https://www.elastic.co/guide/en/apm/agent/ruby/3.x/getting-started-rack.html#getting-started-grape)
+* **[Datadog APM](https://docs.datadoghq.com/tracing/)** - [ddtrace](https://github.com/datadog/dd-trace-rb) gem, [documentation](https://docs.datadoghq.com/tracing/setup_overview/setup/ruby/#grape)
 
 ## Contributing to Grape
 


### PR DESCRIPTION
Howdy 👋 

I'm a member of Datadog's ddtrace gem team and I noticed we were missing from the Monitoring Products list. Would it be acceptable to add a link to our gem there?

Thanks!

(P.s.: I'm not sure if this would be changelog-worthy so I didn't touch it, but let me know if you'd still like me to update it)