### PR TITLE
Memoize the result of Grape::Middleware::Base#response.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#2192](https://github.com/ruby-grape/grape/pull/2192): Memoize the result of Grape::Middleware::Base#response - [@Jack12816](https://github.com/Jack12816).
 * Your contribution here.
 
 ### 1.6.0 (2021/10/04)

--- a/lib/grape/middleware/base.rb
+++ b/lib/grape/middleware/base.rb
@@ -60,7 +60,7 @@ module Grape
       def response
         return @app_response if @app_response.is_a?(Rack::Response)
 
-        Rack::Response.new(@app_response[2], @app_response[0], @app_response[1])
+        @app_response = Rack::Response.new(@app_response[2], @app_response[0], @app_response[1])
       end
 
       def content_type_for(format)

--- a/spec/grape/middleware/base_spec.rb
+++ b/spec/grape/middleware/base_spec.rb
@@ -77,22 +77,25 @@ describe Grape::Middleware::Base do
   describe '#response' do
     subject { Grape::Middleware::Base.new(response) }
 
+    before { subject.call({}) }
+
     context Array do
       let(:response) { ->(_) { [204, { abc: 1 }, 'test'] } }
 
       it 'status' do
-        subject.call({})
         expect(subject.response.status).to eq(204)
       end
 
       it 'body' do
-        subject.call({})
         expect(subject.response.body).to eq(['test'])
       end
 
       it 'header' do
-        subject.call({})
         expect(subject.response.header).to have_key(:abc)
+      end
+
+      it 'returns the memoized Rack::Response instance' do
+        expect(subject.response).to be(subject.response)
       end
     end
 
@@ -100,18 +103,19 @@ describe Grape::Middleware::Base do
       let(:response) { ->(_) { Rack::Response.new('test', 204, abc: 1) } }
 
       it 'status' do
-        subject.call({})
         expect(subject.response.status).to eq(204)
       end
 
       it 'body' do
-        subject.call({})
         expect(subject.response.body).to eq(['test'])
       end
 
       it 'header' do
-        subject.call({})
         expect(subject.response.header).to have_key(:abc)
+      end
+
+      it 'returns the memoized Rack::Response instance' do
+        expect(subject.response).to be(subject.response)
       end
     end
   end


### PR DESCRIPTION
**- What is it good for**

When using the `Grape::Middleware::Base#response` method multiple times from within a custom middleware, the method generates a `Rack::Response` instance each (multiple) time.

[Do not convert Rack::Response to Rack::Response](https://github.com/ruby-grape/grape/commit/7ad647a873b666ad90ebd512c58d037db2f6148e) was missing the memoization I think, because [Don't create Grape::Request multiple times](https://github.com/ruby-grape/grape/commit/22b3aefda6ef31cda2379b3d80ab8299adddd27a#diff-0575f1465bc0e57934dfcda6d3c6b81846e771a1bfce6774b1302787a8e68468) already added memoization for `#request`.

**- What I did**

While writing a simple middleware that should append a response header I hit an unexpected behavior while using the `Grape::Middleware::Base#response` helper. Example time:

```ruby
class ResponseRoute < Grape::Middleware::Base
  # (1) Works with a Grape generated response,
  #     but not with a Rails generated response (looks like they aren't
  #     sharing the Rack::Utils::HeaderHash instance)
  def after
    response['X-Debug'] = 'true'
    response
  end

  # (2) Works with a Grape and Rails generated response 
  def after
    response.tap do |res|
      res['X-Debug'] = 'true'
    end
  end
end
```

After my fix, both versions will work as expected.

**- A picture of a cute animal (not mandatory but encouraged)**

![images](https://user-images.githubusercontent.com/2496275/135865509-238957a6-dee9-4b37-be79-e778634c9837.jpeg)