### PR TITLE
Fixed the broken ruby-head NoMethodError spec.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#2193](https://github.com/ruby-grape/grape/pull/2193): Fixed the broken ruby-head NoMethodError spec - [@Jack12816](https://github.com/Jack12816).
 * Your contribution here.
 
 ### 1.6.0 (2021/10/04)

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -2272,7 +2272,7 @@ describe Grape::API do
       subject.rescue_from :all, with: :not_exist_method
       subject.get('/rescue_method') { raise StandardError }
 
-      expect { get '/rescue_method' }.to raise_error(NoMethodError, 'undefined method `not_exist_method\'')
+      expect { get '/rescue_method' }.to raise_error(NoMethodError, /^undefined method `not_exist_method'/)
     end
 
     it 'correctly chooses exception handler if :all handler is specified' do


### PR DESCRIPTION
**- What is it good for**

Fix the broken ruby-head continuous integration build ([latest master](https://github.com/ruby-grape/grape/runs/3790202051)). 

**- What I did**

Looks like ruby 3.1.0-dev adds a more verbose exception message with the raising line as a suffix. 

```ruby
# Before 3.1.0-dev
pp e.message
"undefined method `not_exist_method'"

# After/With 3.1.0-dev
pp e.message
"undefined method `not_exist_method'\n" +
"\n" +
"          raise NoMethodError, \"undefined method `\#{handler}'\" unless respond_to?(handler)\n" +
"          ^^^^^"
```

So I just converted the `raise_error` message from a string to a regexp to ignore the new suffix.

**- A picture of a cute animal (not mandatory but encouraged)**

![images (1)](https://user-images.githubusercontent.com/2496275/135878701-da7c7f2b-f037-4ab9-9c1a-a6ecf11e4d97.jpeg)