### PR TITLE
allow set passwords_hashed option for digest auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features
 
+* [#2196](https://github.com/ruby-grape/grape/pull/2196): Add support for `passwords_hashed` param for `digest_auth` - [@lHydra](https://github.com/lhydra).
 * Your contribution here.
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -3297,9 +3297,17 @@ http_basic do |username, password|
 end
 ```
 
+Digest auth supports clear-text passwords and password hashes.
+
 ```ruby
 http_digest({ realm: 'Test Api', opaque: 'app secret' }) do |username|
   # lookup the user's password here
+end
+```
+
+```ruby
+http_digest(realm: { realm: 'Test Api', opaque: 'app secret', passwords_hashed: true }) do |username|
+  # lookup the user's password hash here
 end
 ```
 

--- a/lib/grape/middleware/auth/dsl.rb
+++ b/lib/grape/middleware/auth/dsl.rb
@@ -32,7 +32,13 @@ module Grape
 
           def http_digest(options = {}, &block)
             options[:realm] ||= 'API Authorization'
-            options[:opaque] ||= 'secret'
+
+            if options[:realm].respond_to?(:values_at)
+              options[:realm][:opaque] ||= 'secret'
+            else
+              options[:opaque] ||= 'secret'
+            end
+
             auth :http_digest, options, &block
           end
         end

--- a/spec/grape/middleware/auth/dsl_spec.rb
+++ b/spec/grape/middleware/auth/dsl_spec.rb
@@ -16,7 +16,7 @@ describe Grape::Middleware::Auth::DSL do
   end
 
   describe '.auth' do
-    it 'stets auth parameters' do
+    it 'sets auth parameters' do
       expect(subject.base_instance).to receive(:use).with(Grape::Middleware::Auth::Base, settings)
 
       subject.auth :http_digest, realm: settings[:realm], opaque: settings[:opaque], &settings[:proc]
@@ -38,16 +38,25 @@ describe Grape::Middleware::Auth::DSL do
   end
 
   describe '.http_basic' do
-    it 'stets auth parameters' do
+    it 'sets auth parameters' do
       subject.http_basic realm: 'my_realm', &settings[:proc]
       expect(subject.auth).to eq(realm: 'my_realm', type: :http_basic, proc: block)
     end
   end
 
   describe '.http_digest' do
-    it 'stets auth parameters' do
-      subject.http_digest realm: 'my_realm', opaque: 'my_opaque', &settings[:proc]
-      expect(subject.auth).to eq(realm: 'my_realm', type: :http_digest, proc: block, opaque: 'my_opaque')
+    context 'when realm is a hash' do
+      it 'sets auth parameters' do
+        subject.http_digest realm: { realm: 'my_realm', opaque: 'my_opaque' }, &settings[:proc]
+        expect(subject.auth).to eq(realm: { realm: 'my_realm', opaque: 'my_opaque' }, type: :http_digest, proc: block)
+      end
+    end
+
+    context 'when realm is not hash' do
+      it 'sets auth parameters' do
+        subject.http_digest realm: 'my_realm', opaque: 'my_opaque', &settings[:proc]
+        expect(subject.auth).to eq(realm: 'my_realm', type: :http_digest, proc: block, opaque: 'my_opaque')
+      end
     end
   end
 end


### PR DESCRIPTION
Rack Digest Auth [allows](https://github.com/rack/rack/blob/e0993d47096d36535dbe725091963a7e0f5aab52/lib/rack/auth/digest/md5.rb#L123) to check the user's credentials with ha1 digest hash instead of check with a plain password. But at the moment this functionality is not available because the condition from `Rack::Auth::Digest::MD5` is always false

```ruby
if opaque.nil? and realm.respond_to? :values_at
  realm, opaque, @passwords_hashed = realm.values_at :realm, :opaque, :passwords_hashed
end
```
(in the grape auth dsl we constantly set the option `opaque` - `options[:opaque] ||= 'secret'`)