### PR TITLE
Expand test coverage of undocumented functionality

### DIFF
--- a/lib/grape/dsl/headers.rb
+++ b/lib/grape/dsl/headers.rb
@@ -3,8 +3,11 @@
 module Grape
   module DSL
     module Headers
-      # Set an individual header or retrieve
-      # all headers that have been set.
+      # This method has four responsibilities:
+      # 1. Set a specifc header value by key
+      # 2. Retrieve a specifc header value by key
+      # 3. Retrieve all headers that have been set
+      # 4. Delete a specifc header key-value pair
       def header(key = nil, val = nil)
         if key
           val ? header[key.to_s] = val : header.delete(key.to_s)

--- a/spec/grape/dsl/headers_spec.rb
+++ b/spec/grape/dsl/headers_spec.rb
@@ -11,22 +11,48 @@ module Grape
     end
     describe Headers do
       subject { HeadersSpec::Dummy.new }
+      let(:header_data) do
+        { 'First Key' => 'First Value',
+          'Second Key' => 'Second Value' }
+      end
 
-      describe '#header' do
-        describe 'set' do
+      context 'when headers are set' do
+        describe '#header' do
           before do
-            subject.header 'Name', 'Value'
+            header_data.each { |k, v| subject.header(k, v) }
           end
+          describe 'get' do
+            it 'returns a specifc value' do
+              expect(subject.header['First Key']).to eq 'First Value'
+              expect(subject.header['Second Key']).to eq 'Second Value'
+            end
 
-          it 'returns value' do
-            expect(subject.header['Name']).to eq 'Value'
-            expect(subject.header('Name')).to eq 'Value'
+            it 'returns all set headers' do
+              expect(subject.header).to eq header_data
+              expect(subject.headers).to eq header_data
+            end
+          end
+          describe 'set' do
+            it 'returns value' do
+              expect(subject.header('Third Key', 'Third Value'))
+              expect(subject.header['Third Key']).to eq 'Third Value'
+            end
+          end
+          describe 'delete' do
+            it 'deletes a header key-value pair' do
+              expect(subject.header('First Key')).to eq header_data['First Key']
+              expect(subject.header).not_to have_key('First Key')
+            end
           end
         end
+      end
 
-        it 'returns nil' do
-          expect(subject.header['Name']).to be nil
-          expect(subject.header('Name')).to be nil
+      context 'when no headers are set' do
+        describe '#header' do
+          it 'returns nil' do
+            expect(subject.header['First Key']).to be nil
+            expect(subject.header('First Key')).to be nil
+          end
         end
       end
     end


### PR DESCRIPTION
In an interview recently, I was given the Grape repository sans the
content of this method as a technical screening question. The task was
to discover what had been removed from the project and re-implement the
missing code using only the test suite.

It was actually fairly difficult to re-implement this method because
there are a couple of untested responsibilities. I think this is a
fairly integral component of the framework, so it makes sense to fully
test its functionality.