### PR TITLE
Add validators module to all validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 * [#2193](https://github.com/ruby-grape/grape/pull/2193): Fixed the broken ruby-head NoMethodError spec - [@Jack12816](https://github.com/Jack12816).
 * [#2192](https://github.com/ruby-grape/grape/pull/2192): Memoize the result of Grape::Middleware::Base#response - [@Jack12816](https://github.com/Jack12816).
+* [#2200](https://github.com/ruby-grape/grape/pull/2200): Add validators module to all validators - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 1.6.0 (2021/10/04)

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'test-prof', require: false
 end
 
 platforms :jruby do

--- a/gemfiles/multi_json.gemfile
+++ b/gemfiles/multi_json.gemfile
@@ -34,6 +34,7 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'test-prof', require: false
 end
 
 gemspec path: '../'

--- a/gemfiles/multi_xml.gemfile
+++ b/gemfiles/multi_xml.gemfile
@@ -34,6 +34,7 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'test-prof', require: false
 end
 
 gemspec path: '../'

--- a/gemfiles/rack1.gemfile
+++ b/gemfiles/rack1.gemfile
@@ -34,6 +34,7 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'test-prof', require: false
 end
 
 gemspec path: '../'

--- a/gemfiles/rack2.gemfile
+++ b/gemfiles/rack2.gemfile
@@ -34,6 +34,7 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'test-prof', require: false
 end
 
 gemspec path: '../'

--- a/gemfiles/rack2_2.gemfile
+++ b/gemfiles/rack2_2.gemfile
@@ -34,6 +34,7 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'test-prof', require: false
 end
 
 gemspec path: '../'

--- a/gemfiles/rack_edge.gemfile
+++ b/gemfiles/rack_edge.gemfile
@@ -34,6 +34,7 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'test-prof', require: false
 end
 
 gemspec path: '../'

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -34,6 +34,7 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'test-prof', require: false
 end
 
 gemspec path: '../'

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -34,6 +34,7 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'test-prof', require: false
 end
 
 gemspec path: '../'

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -34,6 +34,7 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'test-prof', require: false
 end
 
 gemspec path: '../'

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -34,6 +34,7 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'test-prof', require: false
 end
 
 gemspec path: '../'

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -10,6 +10,18 @@ module Grape
     # Class methods that we want to call on the API rather than on the API object
     NON_OVERRIDABLE = (Class.new.methods + %i[call call! configuration compile! inherited]).freeze
 
+    class Boolean
+      def self.build(val)
+        return nil if val != true && val != false
+
+        new
+      end
+    end
+
+    class Instance
+      Boolean = Grape::API::Boolean
+    end
+
     class << self
       attr_accessor :base_instance, :instances
 

--- a/lib/grape/validations.rb
+++ b/lib/grape/validations.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+require 'grape/validations/attributes_iterator'
+require 'grape/validations/single_attribute_iterator'
+require 'grape/validations/multiple_attributes_iterator'
+require 'grape/validations/params_scope'
+require 'grape/validations/types'
+
 module Grape
   # Registry to store and locate known Validators.
   module Validations

--- a/lib/grape/validations/validators/all_or_none.rb
+++ b/lib/grape/validations/validators/all_or_none.rb
@@ -4,12 +4,14 @@ require 'grape/validations/validators/multiple_params_base'
 
 module Grape
   module Validations
-    class AllOrNoneOfValidator < MultipleParamsBase
-      def validate_params!(params)
-        keys = keys_in_common(params)
-        return if keys.empty? || keys.length == all_keys.length
+    module Validators
+      class AllOrNoneOfValidator < MultipleParamsBase
+        def validate_params!(params)
+          keys = keys_in_common(params)
+          return if keys.empty? || keys.length == all_keys.length
 
-        raise Grape::Exceptions::Validation.new(params: all_keys, message: message(:all_or_none))
+          raise Grape::Exceptions::Validation.new(params: all_keys, message: message(:all_or_none))
+        end
       end
     end
   end

--- a/lib/grape/validations/validators/allow_blank.rb
+++ b/lib/grape/validations/validators/allow_blank.rb
@@ -2,16 +2,18 @@
 
 module Grape
   module Validations
-    class AllowBlankValidator < Base
-      def validate_param!(attr_name, params)
-        return if (options_key?(:value) ? @option[:value] : @option) || !params.is_a?(Hash)
+    module Validators
+      class AllowBlankValidator < Base
+        def validate_param!(attr_name, params)
+          return if (options_key?(:value) ? @option[:value] : @option) || !params.is_a?(Hash)
 
-        value = params[attr_name]
-        value = value.strip if value.respond_to?(:strip)
+          value = params[attr_name]
+          value = value.strip if value.respond_to?(:strip)
 
-        return if value == false || value.present?
+          return if value == false || value.present?
 
-        raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message(:blank))
+          raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message(:blank))
+        end
       end
     end
   end

--- a/lib/grape/validations/validators/as.rb
+++ b/lib/grape/validations/validators/as.rb
@@ -2,11 +2,13 @@
 
 module Grape
   module Validations
-    class AsValidator < Base
-      # We use a validator for renaming parameters. This is just a marker for
-      # the parameter scope to handle the renaming. No actual validation
-      # happens here.
-      def validate_param!(*); end
+    module Validators
+      class AsValidator < Base
+        # We use a validator for renaming parameters. This is just a marker for
+        # the parameter scope to handle the renaming. No actual validation
+        # happens here.
+        def validate_param!(*); end
+      end
     end
   end
 end

--- a/lib/grape/validations/validators/at_least_one_of.rb
+++ b/lib/grape/validations/validators/at_least_one_of.rb
@@ -4,11 +4,13 @@ require 'grape/validations/validators/multiple_params_base'
 
 module Grape
   module Validations
-    class AtLeastOneOfValidator < MultipleParamsBase
-      def validate_params!(params)
-        return unless keys_in_common(params).empty?
+    module Validators
+      class AtLeastOneOfValidator < MultipleParamsBase
+        def validate_params!(params)
+          return unless keys_in_common(params).empty?
 
-        raise Grape::Exceptions::Validation.new(params: all_keys, message: message(:at_least_one))
+          raise Grape::Exceptions::Validation.new(params: all_keys, message: message(:at_least_one))
+        end
       end
     end
   end

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -2,91 +2,93 @@
 
 module Grape
   module Validations
-    class Base
-      attr_reader :attrs
+    module Validators
+      class Base
+        attr_reader :attrs
 
-      # Creates a new Validator from options specified
-      # by a +requires+ or +optional+ directive during
-      # parameter definition.
-      # @param attrs [Array] names of attributes to which the Validator applies
-      # @param options [Object] implementation-dependent Validator options
-      # @param required [Boolean] attribute(s) are required or optional
-      # @param scope [ParamsScope] parent scope for this Validator
-      # @param opts [Array] additional validation options
-      def initialize(attrs, options, required, scope, *opts)
-        @attrs = Array(attrs)
-        @option = options
-        @required = required
-        @scope = scope
-        opts = opts.any? ? opts.shift : {}
-        @fail_fast = opts.fetch(:fail_fast, false)
-        @allow_blank = opts.fetch(:allow_blank, false)
-      end
-
-      # Validates a given request.
-      # @note Override #validate! unless you need to access the entire request.
-      # @param request [Grape::Request] the request currently being handled
-      # @raise [Grape::Exceptions::Validation] if validation failed
-      # @return [void]
-      def validate(request)
-        return unless @scope.should_validate?(request.params)
-
-        validate!(request.params)
-      end
-
-      # Validates a given parameter hash.
-      # @note Override #validate if you need to access the entire request.
-      # @param params [Hash] parameters to validate
-      # @raise [Grape::Exceptions::Validation] if validation failed
-      # @return [void]
-      def validate!(params)
-        attributes = SingleAttributeIterator.new(self, @scope, params)
-        # we collect errors inside array because
-        # there may be more than one error per field
-        array_errors = []
-
-        attributes.each do |val, attr_name, empty_val, skip_value|
-          next if skip_value
-          next if !@scope.required? && empty_val
-          next unless @scope.meets_dependency?(val, params)
-
-          begin
-            validate_param!(attr_name, val) if @required || (val.respond_to?(:key?) && val.key?(attr_name))
-          rescue Grape::Exceptions::Validation => e
-            array_errors << e
-          end
+        # Creates a new Validator from options specified
+        # by a +requires+ or +optional+ directive during
+        # parameter definition.
+        # @param attrs [Array] names of attributes to which the Validator applies
+        # @param options [Object] implementation-dependent Validator options
+        # @param required [Boolean] attribute(s) are required or optional
+        # @param scope [ParamsScope] parent scope for this Validator
+        # @param opts [Array] additional validation options
+        def initialize(attrs, options, required, scope, *opts)
+          @attrs = Array(attrs)
+          @option = options
+          @required = required
+          @scope = scope
+          opts = opts.any? ? opts.shift : {}
+          @fail_fast = opts.fetch(:fail_fast, false)
+          @allow_blank = opts.fetch(:allow_blank, false)
         end
 
-        raise Grape::Exceptions::ValidationArrayErrors.new(array_errors) if array_errors.any?
-      end
+        # Validates a given request.
+        # @note Override #validate! unless you need to access the entire request.
+        # @param request [Grape::Request] the request currently being handled
+        # @raise [Grape::Exceptions::Validation] if validation failed
+        # @return [void]
+        def validate(request)
+          return unless @scope.should_validate?(request.params)
 
-      def self.convert_to_short_name(klass)
-        ret = klass.name.gsub(/::/, '/')
-        ret.gsub!(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
-        ret.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
-        ret.tr!('-', '_')
-        ret.downcase!
-        File.basename(ret, '_validator')
-      end
+          validate!(request.params)
+        end
 
-      def self.inherited(klass)
-        return unless klass.name.present?
+        # Validates a given parameter hash.
+        # @note Override #validate if you need to access the entire request.
+        # @param params [Hash] parameters to validate
+        # @raise [Grape::Exceptions::Validation] if validation failed
+        # @return [void]
+        def validate!(params)
+          attributes = SingleAttributeIterator.new(self, @scope, params)
+          # we collect errors inside array because
+          # there may be more than one error per field
+          array_errors = []
 
-        Validations.register_validator(convert_to_short_name(klass), klass)
-      end
+          attributes.each do |val, attr_name, empty_val, skip_value|
+            next if skip_value
+            next if !@scope.required? && empty_val
+            next unless @scope.meets_dependency?(val, params)
 
-      def message(default_key = nil)
-        options = instance_variable_get(:@option)
-        options_key?(:message) ? options[:message] : default_key
-      end
+            begin
+              validate_param!(attr_name, val) if @required || (val.respond_to?(:key?) && val.key?(attr_name))
+            rescue Grape::Exceptions::Validation => e
+              array_errors << e
+            end
+          end
 
-      def options_key?(key, options = nil)
-        options = instance_variable_get(:@option) if options.nil?
-        options.respond_to?(:key?) && options.key?(key) && !options[key].nil?
-      end
+          raise Grape::Exceptions::ValidationArrayErrors.new(array_errors) if array_errors.any?
+        end
 
-      def fail_fast?
-        @fail_fast
+        def self.convert_to_short_name(klass)
+          ret = klass.name.gsub(/::/, '/')
+          ret.gsub!(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+          ret.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
+          ret.tr!('-', '_')
+          ret.downcase!
+          File.basename(ret, '_validator')
+        end
+
+        def self.inherited(klass)
+          return unless klass.name.present?
+
+          Validations.register_validator(convert_to_short_name(klass), klass)
+        end
+
+        def message(default_key = nil)
+          options = instance_variable_get(:@option)
+          options_key?(:message) ? options[:message] : default_key
+        end
+
+        def options_key?(key, options = nil)
+          options = instance_variable_get(:@option) if options.nil?
+          options.respond_to?(:key?) && options.key?(key) && !options[key].nil?
+        end
+
+        def fail_fast?
+          @fail_fast
+        end
       end
     end
   end

--- a/lib/grape/validations/validators/coerce.rb
+++ b/lib/grape/validations/validators/coerce.rb
@@ -1,86 +1,74 @@
 # frozen_string_literal: true
 
 module Grape
-  class API
-    class Boolean
-      def self.build(val)
-        return nil if val != true && val != false
-
-        new
-      end
-    end
-
-    class Instance
-      Boolean = Grape::API::Boolean
-    end
-  end
-
   module Validations
-    class CoerceValidator < Base
-      def initialize(attrs, options, required, scope, **opts)
-        super
+    module Validators
+      class CoerceValidator < Base
+        def initialize(attrs, options, required, scope, **opts)
+          super
 
-        @converter = if type.is_a?(Grape::Validations::Types::VariantCollectionCoercer)
-                       type
-                     else
-                       Types.build_coercer(type, method: @option[:method])
-                     end
-      end
+          @converter = if type.is_a?(Grape::Validations::Types::VariantCollectionCoercer)
+                         type
+                       else
+                         Types.build_coercer(type, method: @option[:method])
+                       end
+        end
 
-      def validate_param!(attr_name, params)
-        raise validation_exception(attr_name) unless params.is_a? Hash
+        def validate_param!(attr_name, params)
+          raise validation_exception(attr_name) unless params.is_a? Hash
 
-        new_value = coerce_value(params[attr_name])
+          new_value = coerce_value(params[attr_name])
 
-        raise validation_exception(attr_name, new_value.message) unless valid_type?(new_value)
+          raise validation_exception(attr_name, new_value.message) unless valid_type?(new_value)
 
-        # Don't assign a value if it is identical. It fixes a problem with Hashie::Mash
-        # which looses wrappers for hashes and arrays after reassigning values
+          # Don't assign a value if it is identical. It fixes a problem with Hashie::Mash
+          # which looses wrappers for hashes and arrays after reassigning values
+          #
+          #     h = Hashie::Mash.new(list: [1, 2, 3, 4])
+          #     => #<Hashie::Mash list=#<Hashie::Array [1, 2, 3, 4]>>
+          #     list = h.list
+          #     h[:list] = list
+          #     h
+          #     => #<Hashie::Mash list=[1, 2, 3, 4]>
+          return if params[attr_name].instance_of?(new_value.class) && params[attr_name] == new_value
+
+          params[attr_name] = new_value
+        end
+
+        private
+
+        # @!attribute [r] converter
+        # Object that will be used for parameter coercion and type checking.
         #
-        #     h = Hashie::Mash.new(list: [1, 2, 3, 4])
-        #     => #<Hashie::Mash list=#<Hashie::Array [1, 2, 3, 4]>>
-        #     list = h.list
-        #     h[:list] = list
-        #     h
-        #     => #<Hashie::Mash list=[1, 2, 3, 4]>
-        return if params[attr_name].instance_of?(new_value.class) && params[attr_name] == new_value
+        # See {Types.build_coercer}
+        #
+        # @return [Object]
+        attr_reader :converter
 
-        params[attr_name] = new_value
-      end
+        def valid_type?(val)
+          !val.is_a?(Types::InvalidValue)
+        end
 
-      private
+        def coerce_value(val)
+          converter.call(val)
+          # Some custom types might fail, so it should be treated as an invalid value
+        rescue StandardError
+          Types::InvalidValue.new
+        end
 
-      # @!attribute [r] converter
-      # Object that will be used for parameter coercion and type checking.
-      #
-      # See {Types.build_coercer}
-      #
-      # @return [Object]
-      attr_reader :converter
+        # Type to which the parameter will be coerced.
+        #
+        # @return [Class]
+        def type
+          @option[:type].is_a?(Hash) ? @option[:type][:value] : @option[:type]
+        end
 
-      def valid_type?(val)
-        !val.is_a?(Types::InvalidValue)
-      end
-
-      def coerce_value(val)
-        converter.call(val)
-      # Some custom types might fail, so it should be treated as an invalid value
-      rescue StandardError
-        Types::InvalidValue.new
-      end
-
-      # Type to which the parameter will be coerced.
-      #
-      # @return [Class]
-      def type
-        @option[:type].is_a?(Hash) ? @option[:type][:value] : @option[:type]
-      end
-
-      def validation_exception(attr_name, custom_msg = nil)
-        Grape::Exceptions::Validation.new(
-          params: [@scope.full_name(attr_name)],
-          message: custom_msg || message(:coerce)
-        )
+        def validation_exception(attr_name, custom_msg = nil)
+          Grape::Exceptions::Validation.new(
+            params: [@scope.full_name(attr_name)],
+            message: custom_msg || message(:coerce)
+          )
+        end
       end
     end
   end

--- a/lib/grape/validations/validators/default.rb
+++ b/lib/grape/validations/validators/default.rb
@@ -2,47 +2,49 @@
 
 module Grape
   module Validations
-    class DefaultValidator < Base
-      def initialize(attrs, options, required, scope, **opts)
-        @default = options
-        super
-      end
-
-      def validate_param!(attr_name, params)
-        params[attr_name] = if @default.is_a? Proc
-                              @default.call
-                            elsif @default.frozen? || !duplicatable?(@default)
-                              @default
-                            else
-                              duplicate(@default)
-                            end
-      end
-
-      def validate!(params)
-        attrs = SingleAttributeIterator.new(self, @scope, params)
-        attrs.each do |resource_params, attr_name|
-          next unless @scope.meets_dependency?(resource_params, params)
-
-          validate_param!(attr_name, resource_params) if resource_params.is_a?(Hash) && resource_params[attr_name].nil?
+    module Validators
+      class DefaultValidator < Base
+        def initialize(attrs, options, required, scope, **opts)
+          @default = options
+          super
         end
-      end
 
-      private
+        def validate_param!(attr_name, params)
+          params[attr_name] = if @default.is_a? Proc
+                                @default.call
+                              elsif @default.frozen? || !duplicatable?(@default)
+                                @default
+                              else
+                                duplicate(@default)
+                              end
+        end
 
-      # return true if we might be able to dup this object
-      def duplicatable?(obj)
-        !obj.nil? &&
-          obj != true &&
-          obj != false &&
-          !obj.is_a?(Symbol) &&
-          !obj.is_a?(Numeric)
-      end
+        def validate!(params)
+          attrs = SingleAttributeIterator.new(self, @scope, params)
+          attrs.each do |resource_params, attr_name|
+            next unless @scope.meets_dependency?(resource_params, params)
 
-      # make a best effort to dup the object
-      def duplicate(obj)
-        obj.dup
-      rescue TypeError
-        obj
+            validate_param!(attr_name, resource_params) if resource_params.is_a?(Hash) && resource_params[attr_name].nil?
+          end
+        end
+
+        private
+
+        # return true if we might be able to dup this object
+        def duplicatable?(obj)
+          !obj.nil? &&
+            obj != true &&
+            obj != false &&
+            !obj.is_a?(Symbol) &&
+            !obj.is_a?(Numeric)
+        end
+
+        # make a best effort to dup the object
+        def duplicate(obj)
+          obj.dup
+        rescue TypeError
+          obj
+        end
       end
     end
   end

--- a/lib/grape/validations/validators/exactly_one_of.rb
+++ b/lib/grape/validations/validators/exactly_one_of.rb
@@ -4,13 +4,15 @@ require 'grape/validations/validators/multiple_params_base'
 
 module Grape
   module Validations
-    class ExactlyOneOfValidator < MultipleParamsBase
-      def validate_params!(params)
-        keys = keys_in_common(params)
-        return if keys.length == 1
-        raise Grape::Exceptions::Validation.new(params: all_keys, message: message(:exactly_one)) if keys.length.zero?
+    module Validators
+      class ExactlyOneOfValidator < MultipleParamsBase
+        def validate_params!(params)
+          keys = keys_in_common(params)
+          return if keys.length == 1
+          raise Grape::Exceptions::Validation.new(params: all_keys, message: message(:exactly_one)) if keys.length.zero?
 
-        raise Grape::Exceptions::Validation.new(params: keys, message: message(:mutual_exclusion))
+          raise Grape::Exceptions::Validation.new(params: keys, message: message(:mutual_exclusion))
+        end
       end
     end
   end

--- a/lib/grape/validations/validators/except_values.rb
+++ b/lib/grape/validations/validators/except_values.rb
@@ -2,20 +2,22 @@
 
 module Grape
   module Validations
-    class ExceptValuesValidator < Base
-      def initialize(attrs, options, required, scope, **opts)
-        @except = options.is_a?(Hash) ? options[:value] : options
-        super
-      end
+    module Validators
+      class ExceptValuesValidator < Base
+        def initialize(attrs, options, required, scope, **opts)
+          @except = options.is_a?(Hash) ? options[:value] : options
+          super
+        end
 
-      def validate_param!(attr_name, params)
-        return unless params.respond_to?(:key?) && params.key?(attr_name)
+        def validate_param!(attr_name, params)
+          return unless params.respond_to?(:key?) && params.key?(attr_name)
 
-        excepts = @except.is_a?(Proc) ? @except.call : @except
-        return if excepts.nil?
+          excepts = @except.is_a?(Proc) ? @except.call : @except
+          return if excepts.nil?
 
-        param_array = params[attr_name].nil? ? [nil] : Array.wrap(params[attr_name])
-        raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message(:except_values)) if param_array.any? { |param| excepts.include?(param) }
+          param_array = params[attr_name].nil? ? [nil] : Array.wrap(params[attr_name])
+          raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message(:except_values)) if param_array.any? { |param| excepts.include?(param) }
+        end
       end
     end
   end

--- a/lib/grape/validations/validators/multiple_params_base.rb
+++ b/lib/grape/validations/validators/multiple_params_base.rb
@@ -2,34 +2,36 @@
 
 module Grape
   module Validations
-    class MultipleParamsBase < Base
-      def validate!(params)
-        attributes = MultipleAttributesIterator.new(self, @scope, params)
-        array_errors = []
+    module Validators
+      class MultipleParamsBase < Base
+        def validate!(params)
+          attributes = MultipleAttributesIterator.new(self, @scope, params)
+          array_errors = []
 
-        attributes.each do |resource_params, skip_value|
-          next if skip_value
+          attributes.each do |resource_params, skip_value|
+            next if skip_value
 
-          begin
-            validate_params!(resource_params)
-          rescue Grape::Exceptions::Validation => e
-            array_errors << e
+            begin
+              validate_params!(resource_params)
+            rescue Grape::Exceptions::Validation => e
+              array_errors << e
+            end
           end
+
+          raise Grape::Exceptions::ValidationArrayErrors.new(array_errors) if array_errors.any?
         end
 
-        raise Grape::Exceptions::ValidationArrayErrors.new(array_errors) if array_errors.any?
-      end
+        private
 
-      private
+        def keys_in_common(resource_params)
+          return [] unless resource_params.is_a?(Hash)
 
-      def keys_in_common(resource_params)
-        return [] unless resource_params.is_a?(Hash)
+          all_keys & resource_params.keys.map! { |attr| @scope.full_name(attr) }
+        end
 
-        all_keys & resource_params.keys.map! { |attr| @scope.full_name(attr) }
-      end
-
-      def all_keys
-        attrs.map { |attr| @scope.full_name(attr) }
+        def all_keys
+          attrs.map { |attr| @scope.full_name(attr) }
+        end
       end
     end
   end

--- a/lib/grape/validations/validators/mutual_exclusion.rb
+++ b/lib/grape/validations/validators/mutual_exclusion.rb
@@ -4,12 +4,14 @@ require 'grape/validations/validators/multiple_params_base'
 
 module Grape
   module Validations
-    class MutualExclusionValidator < MultipleParamsBase
-      def validate_params!(params)
-        keys = keys_in_common(params)
-        return if keys.length <= 1
+    module Validators
+      class MutualExclusionValidator < MultipleParamsBase
+        def validate_params!(params)
+          keys = keys_in_common(params)
+          return if keys.length <= 1
 
-        raise Grape::Exceptions::Validation.new(params: keys, message: message(:mutual_exclusion))
+          raise Grape::Exceptions::Validation.new(params: keys, message: message(:mutual_exclusion))
+        end
       end
     end
   end

--- a/lib/grape/validations/validators/presence.rb
+++ b/lib/grape/validations/validators/presence.rb
@@ -2,11 +2,13 @@
 
 module Grape
   module Validations
-    class PresenceValidator < Base
-      def validate_param!(attr_name, params)
-        return if params.respond_to?(:key?) && params.key?(attr_name)
+    module Validators
+      class PresenceValidator < Base
+        def validate_param!(attr_name, params)
+          return if params.respond_to?(:key?) && params.key?(attr_name)
 
-        raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message(:presence))
+          raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message(:presence))
+        end
       end
     end
   end

--- a/lib/grape/validations/validators/regexp.rb
+++ b/lib/grape/validations/validators/regexp.rb
@@ -2,12 +2,14 @@
 
 module Grape
   module Validations
-    class RegexpValidator < Base
-      def validate_param!(attr_name, params)
-        return unless params.respond_to?(:key?) && params.key?(attr_name)
-        return if Array.wrap(params[attr_name]).all? { |param| param.nil? || param.to_s.match?((options_key?(:value) ? @option[:value] : @option)) }
+    module Validators
+      class RegexpValidator < Base
+        def validate_param!(attr_name, params)
+          return unless params.respond_to?(:key?) && params.key?(attr_name)
+          return if Array.wrap(params[attr_name]).all? { |param| param.nil? || param.to_s.match?((options_key?(:value) ? @option[:value] : @option)) }
 
-        raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message(:regexp))
+          raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message(:regexp))
+        end
       end
     end
   end

--- a/lib/grape/validations/validators/same_as.rb
+++ b/lib/grape/validations/validators/same_as.rb
@@ -2,24 +2,26 @@
 
 module Grape
   module Validations
-    class SameAsValidator < Base
-      def validate_param!(attr_name, params)
-        confirmation = options_key?(:value) ? @option[:value] : @option
-        return if params[attr_name] == params[confirmation]
+    module Validators
+      class SameAsValidator < Base
+        def validate_param!(attr_name, params)
+          confirmation = options_key?(:value) ? @option[:value] : @option
+          return if params[attr_name] == params[confirmation]
 
-        raise Grape::Exceptions::Validation.new(
-          params: [@scope.full_name(attr_name)],
-          message: build_message
-        )
-      end
+          raise Grape::Exceptions::Validation.new(
+            params: [@scope.full_name(attr_name)],
+            message: build_message
+          )
+        end
 
-      private
+        private
 
-      def build_message
-        if options_key?(:message)
-          @option[:message]
-        else
-          format I18n.t(:same_as, scope: 'grape.errors.messages'), parameter: @option
+        def build_message
+          if options_key?(:message)
+            @option[:message]
+          else
+            format I18n.t(:same_as, scope: 'grape.errors.messages'), parameter: @option
+          end
         end
       end
     end

--- a/lib/grape/validations/validators/values.rb
+++ b/lib/grape/validations/validators/values.rb
@@ -2,84 +2,86 @@
 
 module Grape
   module Validations
-    class ValuesValidator < Base
-      def initialize(attrs, options, required, scope, **opts)
-        if options.is_a?(Hash)
-          @excepts = options[:except]
-          @values = options[:value]
-          @proc = options[:proc]
+    module Validators
+      class ValuesValidator < Base
+        def initialize(attrs, options, required, scope, **opts)
+          if options.is_a?(Hash)
+            @excepts = options[:except]
+            @values = options[:value]
+            @proc = options[:proc]
 
-          warn '[DEPRECATION] The values validator except option is deprecated. ' \
-               'Use the except validator instead.' if @excepts
+            warn '[DEPRECATION] The values validator except option is deprecated. ' \
+                 'Use the except validator instead.' if @excepts
 
-          raise ArgumentError, 'proc must be a Proc' if @proc && !@proc.is_a?(Proc)
+            raise ArgumentError, 'proc must be a Proc' if @proc && !@proc.is_a?(Proc)
 
-          warn '[DEPRECATION] The values validator proc option is deprecated. ' \
-               'The lambda expression can now be assigned directly to values.' if @proc
-        else
-          @excepts = nil
-          @values = nil
-          @proc = nil
-          @values = options
+            warn '[DEPRECATION] The values validator proc option is deprecated. ' \
+                 'The lambda expression can now be assigned directly to values.' if @proc
+          else
+            @excepts = nil
+            @values = nil
+            @proc = nil
+            @values = options
+          end
+          super
         end
-        super
-      end
 
-      def validate_param!(attr_name, params)
-        return unless params.is_a?(Hash)
+        def validate_param!(attr_name, params)
+          return unless params.is_a?(Hash)
 
-        val = params[attr_name]
+          val = params[attr_name]
 
-        return if val.nil? && !required_for_root_scope?
+          return if val.nil? && !required_for_root_scope?
 
-        # don't forget that +false.blank?+ is true
-        return if val != false && val.blank? && @allow_blank
+          # don't forget that +false.blank?+ is true
+          return if val != false && val.blank? && @allow_blank
 
-        param_array = val.nil? ? [nil] : Array.wrap(val)
+          param_array = val.nil? ? [nil] : Array.wrap(val)
 
-        raise validation_exception(attr_name, except_message) \
+          raise validation_exception(attr_name, except_message) \
           unless check_excepts(param_array)
 
-        raise validation_exception(attr_name, message(:values)) \
+          raise validation_exception(attr_name, message(:values)) \
           unless check_values(param_array, attr_name)
 
-        raise validation_exception(attr_name, message(:values)) \
+          raise validation_exception(attr_name, message(:values)) \
           if @proc && !param_array.all? { |param| @proc.call(param) }
-      end
-
-      private
-
-      def check_values(param_array, attr_name)
-        values = @values.is_a?(Proc) && @values.arity.zero? ? @values.call : @values
-        return true if values.nil?
-
-        begin
-          return param_array.all? { |param| values.call(param) } if values.is_a? Proc
-        rescue StandardError => e
-          warn "Error '#{e}' raised while validating attribute '#{attr_name}'"
-          return false
         end
-        param_array.all? { |param| values.include?(param) }
-      end
 
-      def check_excepts(param_array)
-        excepts = @excepts.is_a?(Proc) ? @excepts.call : @excepts
-        return true if excepts.nil?
+        private
 
-        param_array.none? { |param| excepts.include?(param) }
-      end
+        def check_values(param_array, attr_name)
+          values = @values.is_a?(Proc) && @values.arity.zero? ? @values.call : @values
+          return true if values.nil?
 
-      def except_message
-        options = instance_variable_get(:@option)
-        options_key?(:except_message) ? options[:except_message] : message(:except_values)
-      end
+          begin
+            return param_array.all? { |param| values.call(param) } if values.is_a? Proc
+          rescue StandardError => e
+            warn "Error '#{e}' raised while validating attribute '#{attr_name}'"
+            return false
+          end
+          param_array.all? { |param| values.include?(param) }
+        end
 
-      def required_for_root_scope?
-        @required && @scope.root?
-      end
+        def check_excepts(param_array)
+          excepts = @excepts.is_a?(Proc) ? @excepts.call : @excepts
+          return true if excepts.nil?
 
-      def validation_exception(attr_name, message)
-        Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message)
+          param_array.none? { |param| excepts.include?(param) }
+        end
+
+        def except_message
+          options = instance_variable_get(:@option)
+          options_key?(:except_message) ? options[:except_message] : message(:except_values)
+        end
+
+        def required_for_root_scope?
+          @required && @scope.root?
+        end
+
+        def validation_exception(attr_name, message)
+          Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message)
+        end
       end
     end
   end

--- a/spec/grape/validations/instance_behaivour_spec.rb
+++ b/spec/grape/validations/instance_behaivour_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'Validator with instance variables' do
   let(:validator_type) do
-    Class.new(Grape::Validations::Base) do
+    Class.new(Grape::Validations::Validators::Base) do
       def validate_param!(_attr_name, _params)
         if instance_variable_defined?(:@instance_variable) && @instance_variable
           raise Grape::Exceptions::Validation.new(params: ['params'],

--- a/spec/grape/validations/validators/allow_blank_spec.rb
+++ b/spec/grape/validations/validators/allow_blank_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Grape::Validations::Validators::AllowBlankValidator do
   let_it_be(:app) do
-    @app = Class.new(Grape::API) do
+    Class.new(Grape::API) do
       default_format :json
 
       params do

--- a/spec/grape/validations/validators/allow_blank_spec.rb
+++ b/spec/grape/validations/validators/allow_blank_spec.rb
@@ -2,24 +2,139 @@
 
 require 'spec_helper'
 
-describe Grape::Validations::AllowBlankValidator do
-  module ValidationsSpec
-    module AllowBlankValidatorSpec
-      class API < Grape::API
-        default_format :json
+describe Grape::Validations::Validators::AllowBlankValidator do
+  let_it_be(:app) do
+    @app = Class.new(Grape::API) do
+      default_format :json
 
-        params do
+      params do
+        requires :name, allow_blank: false
+      end
+      get '/disallow_blank'
+
+      params do
+        optional :name, type: String, allow_blank: false
+      end
+      get '/opt_disallow_string_blank'
+
+      params do
+        optional :name, allow_blank: false
+      end
+      get '/disallow_blank_optional_param'
+
+      params do
+        requires :name, allow_blank: true
+      end
+      get '/allow_blank'
+
+      params do
+        requires :val, type: DateTime, allow_blank: true
+      end
+      get '/allow_datetime_blank'
+
+      params do
+        requires :val, type: DateTime, allow_blank: false
+      end
+      get '/disallow_datetime_blank'
+
+      params do
+        requires :val, type: DateTime
+      end
+      get '/default_allow_datetime_blank'
+
+      params do
+        requires :val, type: Date, allow_blank: true
+      end
+      get '/allow_date_blank'
+
+      params do
+        requires :val, type: Integer, allow_blank: true
+      end
+      get '/allow_integer_blank'
+
+      params do
+        requires :val, type: Float, allow_blank: true
+      end
+      get '/allow_float_blank'
+
+      params do
+        requires :val, type: Integer, allow_blank: true
+      end
+      get '/allow_integer_blank'
+
+      params do
+        requires :val, type: Symbol, allow_blank: true
+      end
+      get '/allow_symbol_blank'
+
+      params do
+        requires :val, type: Grape::API::Boolean, allow_blank: true
+      end
+      get '/allow_boolean_blank'
+
+      params do
+        requires :val, type: Grape::API::Boolean, allow_blank: false
+      end
+      get '/disallow_boolean_blank'
+
+      params do
+        optional :user, type: Hash do
           requires :name, allow_blank: false
         end
-        get '/disallow_blank'
+      end
+      get '/disallow_blank_required_param_in_an_optional_group'
 
-        params do
-          optional :name, type: String, allow_blank: false
+      params do
+        optional :user, type: Hash do
+          requires :name, type: Date, allow_blank: true
         end
-        get '/opt_disallow_string_blank'
+      end
+      get '/allow_blank_date_param_in_an_optional_group'
+
+      params do
+        optional :user, type: Hash do
+          optional :name, allow_blank: false
+          requires :age
+        end
+      end
+      get '/disallow_blank_optional_param_in_an_optional_group'
+
+      params do
+        requires :user, type: Hash do
+          requires :name, allow_blank: false
+        end
+      end
+      get '/disallow_blank_required_param_in_a_required_group'
+
+      params do
+        requires :user, type: Hash do
+          requires :name, allow_blank: false
+        end
+      end
+      get '/disallow_string_value_in_a_required_hash_group'
+
+      params do
+        requires :user, type: Hash do
+          optional :name, allow_blank: false
+        end
+      end
+      get '/disallow_blank_optional_param_in_a_required_group'
+
+      params do
+        optional :user, type: Hash do
+          optional :name, allow_blank: false
+        end
+      end
+      get '/disallow_string_value_in_an_optional_hash_group'
+
+      resources :custom_message do
+        params do
+          requires :name, allow_blank: { value: false, message: 'has no value' }
+        end
+        get
 
         params do
-          optional :name, allow_blank: false
+          optional :name, allow_blank: { value: false, message: 'has no value' }
         end
         get '/disallow_blank_optional_param'
 
@@ -34,7 +149,7 @@ describe Grape::Validations::AllowBlankValidator do
         get '/allow_datetime_blank'
 
         params do
-          requires :val, type: DateTime, allow_blank: false
+          requires :val, type: DateTime, allow_blank: { value: false, message: 'has no value' }
         end
         get '/disallow_datetime_blank'
 
@@ -69,18 +184,18 @@ describe Grape::Validations::AllowBlankValidator do
         get '/allow_symbol_blank'
 
         params do
-          requires :val, type: Boolean, allow_blank: true
+          requires :val, type: Grape::API::Boolean, allow_blank: true
         end
         get '/allow_boolean_blank'
 
         params do
-          requires :val, type: Boolean, allow_blank: false
+          requires :val, type: Grape::API::Boolean, allow_blank: { value: false, message: 'has no value' }
         end
         get '/disallow_boolean_blank'
 
         params do
           optional :user, type: Hash do
-            requires :name, allow_blank: false
+            requires :name, allow_blank: { value: false, message: 'has no value' }
           end
         end
         get '/disallow_blank_required_param_in_an_optional_group'
@@ -94,7 +209,7 @@ describe Grape::Validations::AllowBlankValidator do
 
         params do
           optional :user, type: Hash do
-            optional :name, allow_blank: false
+            optional :name, allow_blank: { value: false, message: 'has no value' }
             requires :age
           end
         end
@@ -102,154 +217,33 @@ describe Grape::Validations::AllowBlankValidator do
 
         params do
           requires :user, type: Hash do
-            requires :name, allow_blank: false
+            requires :name, allow_blank: { value: false, message: 'has no value' }
           end
         end
         get '/disallow_blank_required_param_in_a_required_group'
 
         params do
           requires :user, type: Hash do
-            requires :name, allow_blank: false
+            requires :name, allow_blank: { value: false, message: 'has no value' }
           end
         end
         get '/disallow_string_value_in_a_required_hash_group'
 
         params do
           requires :user, type: Hash do
-            optional :name, allow_blank: false
+            optional :name, allow_blank: { value: false, message: 'has no value' }
           end
         end
         get '/disallow_blank_optional_param_in_a_required_group'
 
         params do
           optional :user, type: Hash do
-            optional :name, allow_blank: false
+            optional :name, allow_blank: { value: false, message: 'has no value' }
           end
         end
         get '/disallow_string_value_in_an_optional_hash_group'
-
-        resources :custom_message do
-          params do
-            requires :name, allow_blank: { value: false, message: 'has no value' }
-          end
-          get
-
-          params do
-            optional :name, allow_blank: { value: false, message: 'has no value' }
-          end
-          get '/disallow_blank_optional_param'
-
-          params do
-            requires :name, allow_blank: true
-          end
-          get '/allow_blank'
-
-          params do
-            requires :val, type: DateTime, allow_blank: true
-          end
-          get '/allow_datetime_blank'
-
-          params do
-            requires :val, type: DateTime, allow_blank: { value: false, message: 'has no value' }
-          end
-          get '/disallow_datetime_blank'
-
-          params do
-            requires :val, type: DateTime
-          end
-          get '/default_allow_datetime_blank'
-
-          params do
-            requires :val, type: Date, allow_blank: true
-          end
-          get '/allow_date_blank'
-
-          params do
-            requires :val, type: Integer, allow_blank: true
-          end
-          get '/allow_integer_blank'
-
-          params do
-            requires :val, type: Float, allow_blank: true
-          end
-          get '/allow_float_blank'
-
-          params do
-            requires :val, type: Integer, allow_blank: true
-          end
-          get '/allow_integer_blank'
-
-          params do
-            requires :val, type: Symbol, allow_blank: true
-          end
-          get '/allow_symbol_blank'
-
-          params do
-            requires :val, type: Boolean, allow_blank: true
-          end
-          get '/allow_boolean_blank'
-
-          params do
-            requires :val, type: Boolean, allow_blank: { value: false, message: 'has no value' }
-          end
-          get '/disallow_boolean_blank'
-
-          params do
-            optional :user, type: Hash do
-              requires :name, allow_blank: { value: false, message: 'has no value' }
-            end
-          end
-          get '/disallow_blank_required_param_in_an_optional_group'
-
-          params do
-            optional :user, type: Hash do
-              requires :name, type: Date, allow_blank: true
-            end
-          end
-          get '/allow_blank_date_param_in_an_optional_group'
-
-          params do
-            optional :user, type: Hash do
-              optional :name, allow_blank: { value: false, message: 'has no value' }
-              requires :age
-            end
-          end
-          get '/disallow_blank_optional_param_in_an_optional_group'
-
-          params do
-            requires :user, type: Hash do
-              requires :name, allow_blank: { value: false, message: 'has no value' }
-            end
-          end
-          get '/disallow_blank_required_param_in_a_required_group'
-
-          params do
-            requires :user, type: Hash do
-              requires :name, allow_blank: { value: false, message: 'has no value' }
-            end
-          end
-          get '/disallow_string_value_in_a_required_hash_group'
-
-          params do
-            requires :user, type: Hash do
-              optional :name, allow_blank: { value: false, message: 'has no value' }
-            end
-          end
-          get '/disallow_blank_optional_param_in_a_required_group'
-
-          params do
-            optional :user, type: Hash do
-              optional :name, allow_blank: { value: false, message: 'has no value' }
-            end
-          end
-          get '/disallow_string_value_in_an_optional_hash_group'
-        end
       end
     end
-  end
-
-  def app
-    ValidationsSpec::AllowBlankValidatorSpec::API
   end
 
   context 'invalid input' do

--- a/spec/grape/validations/validators/at_least_one_of_spec.rb
+++ b/spec/grape/validations/validators/at_least_one_of_spec.rb
@@ -2,73 +2,67 @@
 
 require 'spec_helper'
 
-describe Grape::Validations::AtLeastOneOfValidator do
-  describe '#validate!' do
-    subject(:validate) { post path, params }
+describe Grape::Validations::Validators::AtLeastOneOfValidator do
+  let_it_be(:app) do
+    Class.new(Grape::API) do
+      rescue_from Grape::Exceptions::ValidationErrors do |e|
+        error!(e.errors.transform_keys! { |key| key.join(',') }, 400)
+      end
 
-    module ValidationsSpec
-      module AtLeastOneOfValidatorSpec
-        class API < Grape::API
-          rescue_from Grape::Exceptions::ValidationErrors do |e|
-            error!(e.errors.transform_keys! { |key| key.join(',') }, 400)
-          end
+      params do
+        optional :beer, :wine, :grapefruit
+        at_least_one_of :beer, :wine, :grapefruit
+      end
+      post do
+      end
 
-          params do
+      params do
+        optional :beer, :wine, :grapefruit, :other
+        at_least_one_of :beer, :wine, :grapefruit
+      end
+      post 'mixed-params' do
+      end
+
+      params do
+        optional :beer, :wine, :grapefruit
+        at_least_one_of :beer, :wine, :grapefruit, message: 'you should choose something'
+      end
+      post '/custom-message' do
+      end
+
+      params do
+        requires :item, type: Hash do
+          optional :beer, :wine, :grapefruit
+          at_least_one_of :beer, :wine, :grapefruit, message: 'fail'
+        end
+      end
+      post '/nested-hash' do
+      end
+
+      params do
+        requires :items, type: Array do
+          optional :beer, :wine, :grapefruit
+          at_least_one_of :beer, :wine, :grapefruit, message: 'fail'
+        end
+      end
+      post '/nested-array' do
+      end
+
+      params do
+        requires :items, type: Array do
+          requires :nested_items, type: Array do
             optional :beer, :wine, :grapefruit
-            at_least_one_of :beer, :wine, :grapefruit
-          end
-          post do
-          end
-
-          params do
-            optional :beer, :wine, :grapefruit, :other
-            at_least_one_of :beer, :wine, :grapefruit
-          end
-          post 'mixed-params' do
-          end
-
-          params do
-            optional :beer, :wine, :grapefruit
-            at_least_one_of :beer, :wine, :grapefruit, message: 'you should choose something'
-          end
-          post '/custom-message' do
-          end
-
-          params do
-            requires :item, type: Hash do
-              optional :beer, :wine, :grapefruit
-              at_least_one_of :beer, :wine, :grapefruit, message: 'fail'
-            end
-          end
-          post '/nested-hash' do
-          end
-
-          params do
-            requires :items, type: Array do
-              optional :beer, :wine, :grapefruit
-              at_least_one_of :beer, :wine, :grapefruit, message: 'fail'
-            end
-          end
-          post '/nested-array' do
-          end
-
-          params do
-            requires :items, type: Array do
-              requires :nested_items, type: Array do
-                optional :beer, :wine, :grapefruit
-                at_least_one_of :beer, :wine, :grapefruit, message: 'fail'
-              end
-            end
-          end
-          post '/deeply-nested-array' do
+            at_least_one_of :beer, :wine, :grapefruit, message: 'fail'
           end
         end
       end
+      post '/deeply-nested-array' do
+      end
     end
+  end
 
-    def app
-      ValidationsSpec::AtLeastOneOfValidatorSpec::API
-    end
+  describe '#validate!' do
+    subject(:validate) { post path, params }
 
     context 'when all restricted params are present' do
       let(:path) { '/' }

--- a/spec/grape/validations/validators/coerce_spec.rb
+++ b/spec/grape/validations/validators/coerce_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe Grape::Validations::CoerceValidator do
+describe Grape::Validations::Validators::CoerceValidator do
   subject do
     Class.new(Grape::API)
   end
@@ -83,7 +83,7 @@ describe Grape::Validations::CoerceValidator do
       context 'on custom coercion rules' do
         before do
           subject.params do
-            requires :a, types: { value: [Boolean, String], message: 'type cast is invalid' }, coerce_with: (lambda do |val|
+            requires :a, types: { value: [Grape::API::Boolean, String], message: 'type cast is invalid' }, coerce_with: (lambda do |val|
               case val
               when 'yup'
                 true
@@ -171,9 +171,9 @@ describe Grape::Validations::CoerceValidator do
           expect(last_response.body).to eq('BigDecimal 45.1')
         end
 
-        it 'Boolean' do
+        it 'Grape::API::Boolean' do
           subject.params do
-            requires :boolean, type: Boolean
+            requires :boolean, type: Grape::API::Boolean
           end
           subject.post '/boolean' do
             params[:boolean]
@@ -370,9 +370,9 @@ describe Grape::Validations::CoerceValidator do
         end
       end
 
-      it 'Boolean' do
+      it 'Grape::API::Boolean' do
         subject.params do
-          requires :boolean, type: Boolean
+          requires :boolean, type: Grape::API::Boolean
         end
         subject.get '/boolean' do
           params[:boolean].class
@@ -1018,11 +1018,9 @@ describe Grape::Validations::CoerceValidator do
     end
 
     context 'multiple types' do
-      Boolean = Grape::API::Boolean
-
       it 'coerces to first possible type' do
         subject.params do
-          requires :a, types: [Boolean, Integer, String]
+          requires :a, types: [Grape::API::Boolean, Integer, String]
         end
         subject.get '/' do
           params[:a].class.to_s
@@ -1043,7 +1041,7 @@ describe Grape::Validations::CoerceValidator do
 
       it 'fails when no coercion is possible' do
         subject.params do
-          requires :a, types: [Boolean, Integer]
+          requires :a, types: [Grape::API::Boolean, Integer]
         end
         subject.get '/' do
           params[:a].class.to_s
@@ -1202,7 +1200,7 @@ describe Grape::Validations::CoerceValidator do
       context 'custom coercion rules' do
         before do
           subject.params do
-            requires :a, types: [Boolean, String], coerce_with: (lambda do |val|
+            requires :a, types: [Grape::API::Boolean, String], coerce_with: (lambda do |val|
               case val
               when 'yup'
                 true

--- a/spec/grape/validations/validators/default_spec.rb
+++ b/spec/grape/validations/validators/default_spec.rb
@@ -2,102 +2,96 @@
 
 require 'spec_helper'
 
-describe Grape::Validations::DefaultValidator do
-  module ValidationsSpec
-    module DefaultValidatorSpec
-      class API < Grape::API
-        default_format :json
+describe Grape::Validations::Validators::DefaultValidator do
+  let_it_be(:app) do
+    Class.new(Grape::API) do
+      default_format :json
 
-        params do
-          optional :id
-          optional :type, default: 'default-type'
-        end
-        get '/' do
-          { id: params[:id], type: params[:type] }
-        end
+      params do
+        optional :id
+        optional :type, default: 'default-type'
+      end
+      get '/' do
+        { id: params[:id], type: params[:type] }
+      end
 
-        params do
-          optional :type1, default: 'default-type1'
-          optional :type2, default: 'default-type2'
-        end
-        get '/user' do
-          { type1: params[:type1], type2: params[:type2] }
-        end
+      params do
+        optional :type1, default: 'default-type1'
+        optional :type2, default: 'default-type2'
+      end
+      get '/user' do
+        { type1: params[:type1], type2: params[:type2] }
+      end
 
-        params do
-          requires :id
-          optional :type1, default: 'default-type1'
-          optional :type2, default: 'default-type2'
-        end
+      params do
+        requires :id
+        optional :type1, default: 'default-type1'
+        optional :type2, default: 'default-type2'
+      end
 
-        get '/message' do
-          { id: params[:id], type1: params[:type1], type2: params[:type2] }
-        end
+      get '/message' do
+        { id: params[:id], type1: params[:type1], type2: params[:type2] }
+      end
 
-        params do
-          optional :random, default: -> { Random.rand }
-          optional :not_random, default: Random.rand
-        end
-        get '/numbers' do
-          { random_number: params[:random], non_random_number: params[:non_random_number] }
-        end
+      params do
+        optional :random, default: -> { Random.rand }
+        optional :not_random, default: Random.rand
+      end
+      get '/numbers' do
+        { random_number: params[:random], non_random_number: params[:non_random_number] }
+      end
 
-        params do
-          optional :array, type: Array do
-            requires :name
-            optional :with_default, default: 'default'
-          end
-        end
-        get '/array' do
-          { array: params[:array] }
-        end
-
-        params do
-          requires :thing1
-          optional :more_things, type: Array do
-            requires :nested_thing
-            requires :other_thing, default: 1
-          end
-        end
-        get '/optional_array' do
-          { thing1: params[:thing1] }
-        end
-
-        params do
-          requires :root, type: Hash do
-            optional :some_things, type: Array do
-              requires :foo
-              optional :options, type: Array do
-                requires :name, type: String
-                requires :value, type: String
-              end
-            end
-          end
-        end
-        get '/nested_optional_array' do
-          { root: params[:root] }
-        end
-
-        params do
-          requires :root, type: Hash do
-            optional :some_things, type: Array do
-              requires :foo
-              optional :options, type: Array do
-                optional :name, type: String
-                optional :value, type: String
-              end
-            end
-          end
-        end
-        get '/another_nested_optional_array' do
-          { root: params[:root] }
+      params do
+        optional :array, type: Array do
+          requires :name
+          optional :with_default, default: 'default'
         end
       end
-    end
-  end
+      get '/array' do
+        { array: params[:array] }
+      end
 
-  def app
-    ValidationsSpec::DefaultValidatorSpec::API
+      params do
+        requires :thing1
+        optional :more_things, type: Array do
+          requires :nested_thing
+          requires :other_thing, default: 1
+        end
+      end
+      get '/optional_array' do
+        { thing1: params[:thing1] }
+      end
+
+      params do
+        requires :root, type: Hash do
+          optional :some_things, type: Array do
+            requires :foo
+            optional :options, type: Array do
+              requires :name, type: String
+              requires :value, type: String
+            end
+          end
+        end
+      end
+      get '/nested_optional_array' do
+        { root: params[:root] }
+      end
+
+      params do
+        requires :root, type: Hash do
+          optional :some_things, type: Array do
+            requires :foo
+            optional :options, type: Array do
+              optional :name, type: String
+              optional :value, type: String
+            end
+          end
+        end
+      end
+      get '/another_nested_optional_array' do
+        { root: params[:root] }
+      end
+    end
   end
 
   it 'lets you leave required values nested inside an optional blank' do

--- a/spec/grape/validations/validators/exactly_one_of_spec.rb
+++ b/spec/grape/validations/validators/exactly_one_of_spec.rb
@@ -2,95 +2,89 @@
 
 require 'spec_helper'
 
-describe Grape::Validations::ExactlyOneOfValidator do
-  describe '#validate!' do
-    subject(:validate) { post path, params }
+describe Grape::Validations::Validators::ExactlyOneOfValidator do
+  let_it_be(:app) do
+    Class.new(Grape::API) do
+      rescue_from Grape::Exceptions::ValidationErrors do |e|
+        error!(e.errors.transform_keys! { |key| key.join(',') }, 400)
+      end
 
-    module ValidationsSpec
-      module ExactlyOneOfValidatorSpec
-        class API < Grape::API
-          rescue_from Grape::Exceptions::ValidationErrors do |e|
-            error!(e.errors.transform_keys! { |key| key.join(',') }, 400)
-          end
+      params do
+        optional :beer
+        optional :wine
+        optional :grapefruit
+        exactly_one_of :beer, :wine, :grapefruit
+      end
+      post do
+      end
 
-          params do
-            optional :beer
-            optional :wine
-            optional :grapefruit
+      params do
+        optional :beer
+        optional :wine
+        optional :grapefruit
+        optional :other
+        exactly_one_of :beer, :wine, :grapefruit
+      end
+      post 'mixed-params' do
+      end
+
+      params do
+        optional :beer
+        optional :wine
+        optional :grapefruit
+        exactly_one_of :beer, :wine, :grapefruit, message: 'you should choose one'
+      end
+      post '/custom-message' do
+      end
+
+      params do
+        requires :item, type: Hash do
+          optional :beer
+          optional :wine
+          optional :grapefruit
+          exactly_one_of :beer, :wine, :grapefruit
+        end
+      end
+      post '/nested-hash' do
+      end
+
+      params do
+        optional :item, type: Hash do
+          optional :beer
+          optional :wine
+          optional :grapefruit
+          exactly_one_of :beer, :wine, :grapefruit
+        end
+      end
+      post '/nested-optional-hash' do
+      end
+
+      params do
+        requires :items, type: Array do
+          optional :beer
+          optional :wine
+          optional :grapefruit
+          exactly_one_of :beer, :wine, :grapefruit
+        end
+      end
+      post '/nested-array' do
+      end
+
+      params do
+        requires :items, type: Array do
+          requires :nested_items, type: Array do
+            optional :beer, :wine, :grapefruit, type: Grape::API::Boolean
             exactly_one_of :beer, :wine, :grapefruit
-          end
-          post do
-          end
-
-          params do
-            optional :beer
-            optional :wine
-            optional :grapefruit
-            optional :other
-            exactly_one_of :beer, :wine, :grapefruit
-          end
-          post 'mixed-params' do
-          end
-
-          params do
-            optional :beer
-            optional :wine
-            optional :grapefruit
-            exactly_one_of :beer, :wine, :grapefruit, message: 'you should choose one'
-          end
-          post '/custom-message' do
-          end
-
-          params do
-            requires :item, type: Hash do
-              optional :beer
-              optional :wine
-              optional :grapefruit
-              exactly_one_of :beer, :wine, :grapefruit
-            end
-          end
-          post '/nested-hash' do
-          end
-
-          params do
-            optional :item, type: Hash do
-              optional :beer
-              optional :wine
-              optional :grapefruit
-              exactly_one_of :beer, :wine, :grapefruit
-            end
-          end
-          post '/nested-optional-hash' do
-          end
-
-          params do
-            requires :items, type: Array do
-              optional :beer
-              optional :wine
-              optional :grapefruit
-              exactly_one_of :beer, :wine, :grapefruit
-            end
-          end
-          post '/nested-array' do
-          end
-
-          params do
-            requires :items, type: Array do
-              requires :nested_items, type: Array do
-                optional :beer, :wine, :grapefruit, type: Boolean
-                exactly_one_of :beer, :wine, :grapefruit
-              end
-            end
-          end
-          post '/deeply-nested-array' do
           end
         end
       end
+      post '/deeply-nested-array' do
+      end
     end
+  end
 
-    def app
-      ValidationsSpec::ExactlyOneOfValidatorSpec::API
-    end
+  describe '#validate!' do
+    subject(:validate) { post path, params }
 
     context 'when all params are present' do
       let(:path) { '/' }

--- a/spec/grape/validations/validators/except_values_spec.rb
+++ b/spec/grape/validations/validators/except_values_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe Grape::Validations::ExceptValuesValidator do
+describe Grape::Validations::Validators::ExceptValuesValidator do
   module ValidationsSpec
     class ExceptValuesModel
       DEFAULT_EXCEPTS = %w[invalid-type1 invalid-type2 invalid-type3].freeze

--- a/spec/grape/validations/validators/presence_spec.rb
+++ b/spec/grape/validations/validators/presence_spec.rb
@@ -2,12 +2,13 @@
 
 require 'spec_helper'
 
-describe Grape::Validations::PresenceValidator do
+describe Grape::Validations::Validators::PresenceValidator do
   subject do
     Class.new(Grape::API) do
       format :json
     end
   end
+
   def app
     subject
   end

--- a/spec/grape/validations/validators/regexp_spec.rb
+++ b/spec/grape/validations/validators/regexp_spec.rb
@@ -2,51 +2,45 @@
 
 require 'spec_helper'
 
-describe Grape::Validations::RegexpValidator do
-  module ValidationsSpec
-    module RegexpValidatorSpec
-      class API < Grape::API
-        default_format :json
+describe Grape::Validations::Validators::RegexpValidator do
+  let_it_be(:app) do
+    Class.new(Grape::API) do
+      default_format :json
 
-        resources :custom_message do
-          params do
-            requires :name, regexp: { value: /^[a-z]+$/, message: 'format is invalid' }
-          end
-          get do
-          end
-
-          params do
-            requires :names, type: { value: Array[String], message: 'can\'t be nil' }, regexp: { value: /^[a-z]+$/, message: 'format is invalid' }
-          end
-          get 'regexp_with_array' do
-          end
-        end
-
+      resources :custom_message do
         params do
-          requires :name, regexp: /^[a-z]+$/
+          requires :name, regexp: { value: /^[a-z]+$/, message: 'format is invalid' }
         end
         get do
         end
 
         params do
-          requires :names, type: Array[String], regexp: /^[a-z]+$/
+          requires :names, type: { value: Array[String], message: 'can\'t be nil' }, regexp: { value: /^[a-z]+$/, message: 'format is invalid' }
         end
         get 'regexp_with_array' do
         end
+      end
 
-        params do
-          requires :people, type: Hash do
-            requires :names, type: Array[String], regexp: /^[a-z]+$/
-          end
-        end
-        get 'nested_regexp_with_array' do
+      params do
+        requires :name, regexp: /^[a-z]+$/
+      end
+      get do
+      end
+
+      params do
+        requires :names, type: Array[String], regexp: /^[a-z]+$/
+      end
+      get 'regexp_with_array' do
+      end
+
+      params do
+        requires :people, type: Hash do
+          requires :names, type: Array[String], regexp: /^[a-z]+$/
         end
       end
+      get 'nested_regexp_with_array' do
+      end
     end
-  end
-
-  def app
-    ValidationsSpec::RegexpValidatorSpec::API
   end
 
   context 'custom validation message' do

--- a/spec/grape/validations/validators/same_as_spec.rb
+++ b/spec/grape/validations/validators/same_as_spec.rb
@@ -2,29 +2,23 @@
 
 require 'spec_helper'
 
-describe Grape::Validations::SameAsValidator do
-  module ValidationsSpec
-    module SameAsValidatorSpec
-      class API < Grape::API
-        params do
-          requires :password
-          requires :password_confirmation, same_as: :password
-        end
-        post do
-        end
+describe Grape::Validations::Validators::SameAsValidator do
+  let_it_be(:app) do
+    Class.new(Grape::API) do
+      params do
+        requires :password
+        requires :password_confirmation, same_as: :password
+      end
+      post do
+      end
 
-        params do
-          requires :password
-          requires :password_confirmation, same_as: { value: :password, message: 'not match' }
-        end
-        post '/custom-message' do
-        end
+      params do
+        requires :password
+        requires :password_confirmation, same_as: { value: :password, message: 'not match' }
+      end
+      post '/custom-message' do
       end
     end
-  end
-
-  def app
-    ValidationsSpec::SameAsValidatorSpec::API
   end
 
   describe '/' do

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -489,16 +489,22 @@ describe Grape::Validations do
     end
 
     context 'custom validator for a Hash' do
-      module ValuesSpec
-        module DateRangeValidations
-          class DateRangeValidator < Grape::Validations::Base
-            def validate_param!(attr_name, params)
-              return if params[attr_name][:from] <= params[attr_name][:to]
+      let(:date_range_validator) do
+        Class.new(Grape::Validations::Validators::Base) do
+          def validate_param!(attr_name, params)
+            return if params[attr_name][:from] <= params[attr_name][:to]
 
-              raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: "'from' must be lower or equal to 'to'")
-            end
+            raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: "'from' must be lower or equal to 'to'")
           end
         end
+      end
+
+      before do
+        Grape::Validations.register_validator('date_range', date_range_validator)
+      end
+
+      after do
+        Grape::Validations.deregister_validator('date_range')
       end
 
       before do
@@ -1183,14 +1189,22 @@ describe Grape::Validations do
     end
 
     context 'custom validation' do
-      module CustomValidations
-        class Customvalidator < Grape::Validations::Base
+      let(:custom_validator) do
+        Class.new(Grape::Validations::Validators::Base) do
           def validate_param!(attr_name, params)
             return if params[attr_name] == 'im custom'
 
             raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: 'is not custom!')
           end
         end
+      end
+
+      before do
+        Grape::Validations.register_validator('customvalidator', custom_validator)
+      end
+
+      after do
+        Grape::Validations.deregister_validator('customvalidator')
       end
 
       context 'when using optional with a custom validator' do
@@ -1332,14 +1346,22 @@ describe Grape::Validations do
       end
 
       context 'when using options on param' do
-        module CustomValidations
-          class CustomvalidatorWithOptions < Grape::Validations::Base
+        let(:custom_validator_with_options) do
+          Class.new(Grape::Validations::Validators::Base) do
             def validate_param!(attr_name, params)
               return if params[attr_name] == @option[:text]
 
               raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message)
             end
           end
+        end
+
+        before do
+          Grape::Validations.register_validator('customvalidator_with_options', custom_validator_with_options)
+        end
+
+        after do
+          Grape::Validations.deregister_validator('customvalidator_with_options')
         end
 
         before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,15 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), 'support'))
 
 require 'grape'
+require 'test_prof/recipes/rspec/let_it_be'
+
+class NullAdapter
+  def begin_transaction; end
+
+  def rollback_transaction; end
+end
+
+TestProf::BeforeAll.adapter = NullAdapter.new
 
 require 'rubygems'
 require 'bundler'


### PR DESCRIPTION
Hello,

While looking at the "validations/validators" folder, I found that 'validators" is not a declared module and I was wondering why. I looked at the "validations/types" and "types" is a declared module. Anyway, I thought that for consistency, it had to be done.

There were also a lot of [LeakyConstantDeclaration](https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LeakyConstantDeclaration) inside validators specs. I figured it would be better to use AnonymousClasses instead. Unfortunately, declaring an anonymous Grape::API for every single test was slowing down everything and I thought using `let_it_be` from [test-prof](https://github.com/test-prof/test-prof/blob/master/lib/test_prof/recipes/rspec/let_it_be.rb) would be ideal.

I think rubocop-rspec could be a great addition for the spec. I could open a PR if you want.


