### PR TITLE
Fix random mock spec error

### DIFF
--- a/spec/grape/dsl/logger_spec.rb
+++ b/spec/grape/dsl/logger_spec.rb
@@ -2,27 +2,25 @@
 
 require 'spec_helper'
 
-module Grape
-  module DSL
-    module LoggerSpec
-      class Dummy
-        extend Grape::DSL::Logger
-      end
+describe Grape::DSL::Logger do
+  subject { Class.new(dummy_logger) }
+
+  let(:dummy_logger) do
+    Class.new do
+      extend Grape::DSL::Logger
     end
-    describe Logger do
-      subject { Class.new(LoggerSpec::Dummy) }
-      let(:logger) { double(:logger) }
+  end
 
-      describe '.logger' do
-        it 'sets a logger' do
-          subject.logger logger
-          expect(subject.logger).to eq logger
-        end
+  let(:logger) { instance_double(::Logger) }
 
-        it 'returns a logger' do
-          expect(subject.logger(logger)).to eq logger
-        end
-      end
+  describe '.logger' do
+    it 'sets a logger' do
+      subject.logger logger
+      expect(subject.logger).to eq logger
+    end
+
+    it 'returns a logger' do
+      expect(subject.logger(logger)).to eq logger
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,7 @@ RSpec.configure do |config|
   config.filter_run_when_matching :focus
   config.warnings = true
 
+  config.before(:all) { Grape::Util::InheritableSetting.reset_global! }
   config.before(:each) { Grape::Util::InheritableSetting.reset_global! }
 
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Hi,

This is a fix for  https://github.com/ruby-grape/grape/runs/4422845217?check_suite_focus=true

Since using let_it_be, we need to `reset_global!` also on `before :all`