### PR TITLE
Update README.md (changes Grape::Validations::Base into Grape::Validations::Validators::Base)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1743,7 +1743,7 @@ end
 ### Custom Validators
 
 ```ruby
-class AlphaNumeric < Grape::Validations::Base
+class AlphaNumeric < Grape::Validations::Validators::Base
   def validate_param!(attr_name, params)
     unless params[attr_name] =~ /\A[[:alnum:]]+\z/
       fail Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: 'must consist of alpha-numeric characters'
@@ -1761,7 +1761,7 @@ end
 You can also create custom classes that take parameters.
 
 ```ruby
-class Length < Grape::Validations::Base
+class Length < Grape::Validations::Validators::Base
   def validate_param!(attr_name, params)
     unless params[attr_name].length <= @option
       fail Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: "must be at the most #{@option} characters long"
@@ -1779,7 +1779,7 @@ end
 You can also create custom validation that use request to validate the attribute. For example if you want to have parameters that are available to only admins, you can do the following.
 
 ```ruby
-class Admin < Grape::Validations::Base
+class Admin < Grape::Validations::Validators::Base
   def validate(request)
     # return if the param we are checking was not in request
     # @attrs is a list containing the attribute we are currently validating


### PR DESCRIPTION
Hello.
https://github.com/ruby-grape/grape/pull/2200 changes `Grape::Validations::Base` into `Grape::Validations::Validators::Base`
The readme needs to be updated.