### PR TITLE
Move require 'active_support/concern' in grape.rb

### DIFF
--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -8,6 +8,7 @@ require 'rack/auth/basic'
 require 'rack/auth/digest/md5'
 require 'set'
 require 'active_support'
+require 'active_support/concern'
 require 'active_support/version'
 require 'active_support/isolated_execution_state' if ActiveSupport::VERSION::MAJOR > 6
 require 'active_support/core_ext/array/conversions'

--- a/lib/grape/dsl/api.rb
+++ b/lib/grape/dsl/api.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'active_support/concern'
-
 module Grape
   module DSL
     module API

--- a/lib/grape/dsl/callbacks.rb
+++ b/lib/grape/dsl/callbacks.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'active_support/concern'
-
 module Grape
   module DSL
     # Blocks can be executed before or after every API call, using `before`, `after`,

--- a/lib/grape/dsl/configuration.rb
+++ b/lib/grape/dsl/configuration.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'active_support/concern'
-
 module Grape
   module DSL
     module Configuration

--- a/lib/grape/dsl/helpers.rb
+++ b/lib/grape/dsl/helpers.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'active_support/concern'
-
 module Grape
   module DSL
     module Helpers

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'active_support/concern'
 require 'grape/dsl/headers'
 
 module Grape

--- a/lib/grape/dsl/middleware.rb
+++ b/lib/grape/dsl/middleware.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'active_support/concern'
-
 module Grape
   module DSL
     module Middleware

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'active_support/concern'
-
 module Grape
   module DSL
     # Defines DSL methods, meant to be applied to a ParamsScope, which define

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'active_support/concern'
-
 module Grape
   module DSL
     module RequestResponse

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'active_support/concern'
-
 module Grape
   module DSL
     module Routing

--- a/lib/grape/dsl/settings.rb
+++ b/lib/grape/dsl/settings.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'active_support/concern'
-
 module Grape
   module DSL
     # Keeps track of settings (implemented as key-value pairs, grouped by

--- a/lib/grape/dsl/validations.rb
+++ b/lib/grape/dsl/validations.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'active_support/concern'
-
 module Grape
   module DSL
     module Validations

--- a/lib/grape/middleware/auth/dsl.rb
+++ b/lib/grape/middleware/auth/dsl.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rack/auth/basic'
-require 'active_support/concern'
 
 module Grape
   module Middleware


### PR DESCRIPTION
Since `active_support/concern` is required more than once,  I thought it would be better to require it once instead of multiple times.