### PR TITLE
do not collect params in route settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * [#2222](https://github.com/ruby-grape/grape/pull/2222): Autoload types and validators - [@ericproulx](https://github.com/ericproulx).
 * [#2232](https://github.com/ruby-grape/grape/pull/2232): Fix kwargs support in shared params definition - [@dm1try](https://github.com/dm1try).
+* [#2229](https://github.com/ruby-grape/grape/pull/2229): Do not collect params in route settings - [@dnesteryuk](https://github.com/dnesteryuk).
 * Your contribution here.
 
 ### 1.6.2 (2021/12/30)

--- a/benchmark/nested_params.rb
+++ b/benchmark/nested_params.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'grape'
 require 'benchmark/ips'
 

--- a/lib/grape/dsl/desc.rb
+++ b/lib/grape/dsl/desc.rb
@@ -78,21 +78,6 @@ module Grape
         route_setting :description, options
       end
 
-      def description_field(field, value = nil)
-        description = route_setting(:description)
-        if value
-          description ||= route_setting(:description, {})
-          description[field] = value
-        elsif description
-          description[field]
-        end
-      end
-
-      def unset_description_field(field)
-        description = route_setting(:description)
-        description&.delete(field)
-      end
-
       # Returns an object which configures itself via an instance-context DSL.
       def desc_container(endpoint_configuration)
         Module.new do

--- a/lib/grape/dsl/validations.rb
+++ b/lib/grape/dsl/validations.rb
@@ -30,7 +30,6 @@ module Grape
           unset_namespace_stackable :declared_params
           unset_namespace_stackable :validations
           unset_namespace_stackable :params
-          unset_description_field :params
         end
 
         # Opens a root-level ParamsScope, defining parameter coercions and
@@ -41,14 +40,8 @@ module Grape
         end
 
         def document_attribute(names, opts)
-          setting = description_field(:params)
-          setting ||= description_field(:params, {})
           Array(names).each do |name|
-            full_name = name[:full_name].to_s
-            setting[full_name] ||= {}
-            setting[full_name].merge!(opts)
-
-            namespace_stackable(:params, full_name => opts)
+            namespace_stackable(:params, name[:full_name].to_s => opts)
           end
         end
       end

--- a/spec/grape/dsl/validations_spec.rb
+++ b/spec/grape/dsl/validations_spec.rb
@@ -36,10 +36,6 @@ module Grape
           expect(subject.namespace_stackable(:params)).to eq []
         end
 
-        it 'resets documentation params' do
-          expect(subject.route_setting(:description)[:params]).to be_nil
-        end
-
         it 'does not reset documentation description' do
           expect(subject.route_setting(:description)[:description]).to eq 'lol'
         end
@@ -62,7 +58,6 @@ module Grape
 
         it 'creates a param documentation' do
           expect(subject.namespace_stackable(:params)).to eq(['xxx' => { foo: 'bar' }])
-          expect(subject.route_setting(:description)).to eq(params: { 'xxx' => { foo: 'bar' } })
         end
       end
     end


### PR DESCRIPTION
While investigating another issue I discovered that params were documented twice then [merged there](https://github.com/ruby-grape/grape/blob/5053b797429279d91818e2116034ba40636338bb/lib/grape/dsl/routing.rb#L132-L134).

Params are stored in `namespace_stackable` there is no reason to keep them in `route_setting(:description)` too.

I checked this change against our app, it still works :wink: 
