### PR TITLE
Remove non-UTF-8 characters from format before generating JSON error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#2222](https://github.com/ruby-grape/grape/pull/2222): Autoload types and validators - [@ericproulx](https://github.com/ericproulx).
 * [#2232](https://github.com/ruby-grape/grape/pull/2232): Fix kwargs support in shared params definition - [@dm1try](https://github.com/dm1try).
 * [#2229](https://github.com/ruby-grape/grape/pull/2229): Do not collect params in route settings - [@dnesteryuk](https://github.com/dnesteryuk).
+* [#2234](https://github.com/ruby-grape/grape/pull/2234): Remove non-utf-8 characters from format before generating JSON error - [@bschmeck](https://github.com/bschmeck).
 * Your contribution here.
 
 ### 1.6.2 (2021/12/30)

--- a/lib/grape/error_formatter/json.rb
+++ b/lib/grape/error_formatter/json.rb
@@ -21,8 +21,14 @@ module Grape
           if message.is_a?(Exceptions::ValidationErrors) || message.is_a?(Hash)
             message
           else
-            { error: message }
+            { error: ensure_utf8(message) }
           end
+        end
+
+        def ensure_utf8(message)
+          return message unless message.respond_to? :encode
+
+          message.encode('UTF-8', invalid: :replace, undef: :replace)
         end
       end
     end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -4157,6 +4157,20 @@ describe Grape::API do
     end
   end
 
+  context 'with non-UTF-8 characters in specified format' do
+    it 'converts the characters' do
+      subject.format :json
+      subject.content_type :json, 'application/json'
+      subject.get '/something' do
+        'foo'
+      end
+      get '/something?format=%0A%0B%BF'
+      expect(last_response.status).to eq(406)
+      message = "The requested format '\n\u000b\357\277\275' is not supported."
+      expect(last_response.body).to eq({ error: message }.to_json)
+    end
+  end
+
   context 'body' do
     context 'false' do
       before do


### PR DESCRIPTION
If we receive a request with an unsupported format, that user-provided format is included in the generated error message.  If the format includes non-UTF-8 characters and the app is configured to generate JSON error messages, a `JSON::GeneratorError` is raised.

To work around this error, this PR uses `String#encode`'s ability to replace invalid and undefined UTF-8 characters before calling `Grape::Json::dump`.