### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,6 @@ jobs:
           - gemfiles/rack1.gemfile
           - gemfiles/rack2.gemfile
           - gemfiles/rack2_2.gemfile
-          - gemfiles/rack_edge.gemfile
           - gemfiles/rails_5.gemfile
           - gemfiles/rails_6.gemfile
           - gemfiles/rails_6_1.gemfile
@@ -69,7 +68,10 @@ jobs:
             experimental: false
           - ruby: 2.7
             gemfile: 'gemfiles/rails_edge.gemfile'
-            experimental: false
+            experimental: true
+          - ruby: 2.7
+            gemfile: 'gemfiles/rack_edge.gemfile'
+            experimental: true
           - ruby: "ruby-head"
             experimental: true
           - ruby: "truffleruby-head"

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '~> 1.1.0'
-  gem 'rspec', '~> 3.0'
+  gem 'rspec', '~> 3.9.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'test-prof', require: false
 end

--- a/gemfiles/multi_json.gemfile
+++ b/gemfiles/multi_json.gemfile
@@ -33,7 +33,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '~> 1.1.0'
-  gem 'rspec', '~> 3.0'
+  gem 'rspec', '~> 3.9.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'test-prof', require: false
 end

--- a/gemfiles/multi_xml.gemfile
+++ b/gemfiles/multi_xml.gemfile
@@ -33,7 +33,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '~> 1.1.0'
-  gem 'rspec', '~> 3.0'
+  gem 'rspec', '~> 3.9.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'test-prof', require: false
 end

--- a/gemfiles/rack1.gemfile
+++ b/gemfiles/rack1.gemfile
@@ -33,7 +33,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '~> 1.1.0'
-  gem 'rspec', '~> 3.0'
+  gem 'rspec', '~> 3.9.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'test-prof', require: false
 end

--- a/gemfiles/rack2.gemfile
+++ b/gemfiles/rack2.gemfile
@@ -33,7 +33,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '~> 1.1.0'
-  gem 'rspec', '~> 3.0'
+  gem 'rspec', '~> 3.9.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'test-prof', require: false
 end

--- a/gemfiles/rack2_2.gemfile
+++ b/gemfiles/rack2_2.gemfile
@@ -33,7 +33,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '~> 1.1.0'
-  gem 'rspec', '~> 3.0'
+  gem 'rspec', '~> 3.9.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'test-prof', require: false
 end

--- a/gemfiles/rack_edge.gemfile
+++ b/gemfiles/rack_edge.gemfile
@@ -33,7 +33,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '~> 1.1.0'
-  gem 'rspec', '~> 3.0'
+  gem 'rspec', '~> 3.9.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'test-prof', require: false
 end

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -33,7 +33,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '~> 1.1.0'
-  gem 'rspec', '~> 3.0'
+  gem 'rspec', '~> 3.9.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'test-prof', require: false
 end

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -33,7 +33,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '~> 1.1.0'
-  gem 'rspec', '~> 3.0'
+  gem 'rspec', '~> 3.9.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'test-prof', require: false
 end

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -33,7 +33,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '~> 1.1.0'
-  gem 'rspec', '~> 3.0'
+  gem 'rspec', '~> 3.9.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'test-prof', require: false
 end

--- a/gemfiles/rails_7.gemfile
+++ b/gemfiles/rails_7.gemfile
@@ -33,7 +33,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '~> 1.1.0'
-  gem 'rspec', '~> 3.0'
+  gem 'rspec', '~> 3.9.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'test-prof', require: false
 end

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -33,7 +33,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '~> 1.1.0'
-  gem 'rspec', '~> 3.0'
+  gem 'rspec', '~> 3.9.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'test-prof', require: false
 end


### PR DESCRIPTION
- On rack.edge `nil` arguments are now empty String
- rspec 3.10 seems to have a broken `expect(subject).to receive(:method).with(hash)`