### PR TITLE
Split CI matrix, extract edge.

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -1,0 +1,35 @@
+---
+name: edge
+on:
+  pull_request:
+    branches:
+      - "*"
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ruby: 2.7
+            gemfile: 'gemfiles/rails_edge.gemfile'
+          - ruby: 2.7
+            gemfile: 'gemfiles/rack_edge.gemfile'
+          - ruby: "ruby-head"
+          - ruby: "truffleruby-head"
+          - ruby: "jruby-head"
+    runs-on: ubuntu-20.04
+    continue-on-error: true
+    env:
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+
+    - name: Run tests
+      run: bundle exec rake spec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,49 +37,26 @@ jobs:
           - gemfiles/rails_5.gemfile
           - gemfiles/rails_6.gemfile
           - gemfiles/rails_6_1.gemfile
-        experimental: [false]
         include:
           - ruby: 3.1
             gemfile: 'gemfiles/multi_json.gemfile'
-            experimental: false
           - ruby: 3.1
             gemfile: 'gemfiles/multi_xml.gemfile'
-            experimental: false
           - ruby: 3.1
             gemfile: 'gemfiles/rails_7.gemfile'
-            experimental: false
           - ruby: "3.0"
             gemfile: 'gemfiles/multi_json.gemfile'
-            experimental: false
           - ruby: "3.0"
             gemfile: 'gemfiles/multi_xml.gemfile'
-            experimental: false
           - ruby: "3.0"
             gemfile: 'gemfiles/rails_7.gemfile'
-            experimental: false
           - ruby: 2.7
             gemfile: 'gemfiles/multi_json.gemfile'
-            experimental: false
           - ruby: 2.7
             gemfile: 'gemfiles/multi_xml.gemfile'
-            experimental: false
           - ruby: 2.7
             gemfile: 'gemfiles/rails_7.gemfile'
-            experimental: false
-          - ruby: 2.7
-            gemfile: 'gemfiles/rails_edge.gemfile'
-            experimental: true
-          - ruby: 2.7
-            gemfile: 'gemfiles/rack_edge.gemfile'
-            experimental: true
-          - ruby: "ruby-head"
-            experimental: true
-          - ruby: "truffleruby-head"
-            experimental: true
-          - ruby: "jruby-head"
-            experimental: true
     runs-on: ubuntu-20.04
-    continue-on-error: ${{ matrix.experimental }}
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#2233](https://github.com/ruby-grape/grape/pull/2233): A setting for disabling documentation to internal APIs - [@dnesteryuk](https://github.com/dnesteryuk).
 * [#2235](https://github.com/ruby-grape/grape/pull/2235): Add Ruby 3.1 to CI - [@petergoldstein](https://github.com/petergoldstein).
 * [#2248](https://github.com/ruby-grape/grape/pull/2248): Upgraded to rspec 3.11.0 - [@dblock](https://github.com/dblock).
+* [#2249](https://github.com/ruby-grape/grape/pull/2249): Split ci matrix, extract edge - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 #### Fixes


### PR DESCRIPTION
GitHub CI doesn't have a feature to ignore certain steps in CI, so it looks like Grape build is continuously broken. This isn't the case. This PR extracts edge CI into a separate workflow that only runs on pull requests.