### PR TITLE
Add deprecation warning for UnsupportedGroupTypeError And MissingGroupTypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#2234](https://github.com/ruby-grape/grape/pull/2234): Remove non-utf-8 characters from format before generating JSON error - [@bschmeck](https://github.com/bschmeck).
 * [#2227](https://github.com/ruby-grape/grape/pull/2222): Rename "MissingGroupType" and "UnsupportedGroupType" exceptions - [@ericproulx](https://github.com/ericproulx).
 * [#2244](https://github.com/ruby-grape/grape/pull/2244): Fix a breaking change in `Grape::Validations` provided in 1.6.1 - [@dm1try](https://github.com/dm1try).
+* [#2250](https://github.com/ruby-grape/grape/pull/2250): Add deprecation warning for unsupportedgrouptypeerror and missinggrouptypeerror - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 1.6.2 (2021/12/30)

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -81,6 +81,8 @@ module Grape
       autoload :MethodNotAllowed
       autoload :InvalidResponse
       autoload :EmptyMessageBody
+      autoload :MissingGroupTypeError, 'grape/exceptions/missing_group_type'
+      autoload :UnsupportedGroupTypeError, 'grape/exceptions/unsupported_group_type'
     end
   end
 

--- a/lib/grape/exceptions/missing_group_type.rb
+++ b/lib/grape/exceptions/missing_group_type.rb
@@ -10,4 +10,9 @@ module Grape
   end
 end
 
-Grape::Exceptions::MissingGroupTypeError = Grape::Exceptions::MissingGroupType
+Grape::Exceptions::MissingGroupTypeError = Class.new(Grape::Exceptions::MissingGroupType) do
+  def initialize(*)
+    super
+    warn '[DEPRECATION] `Grape::Exceptions::MissingGroupTypeError` is deprecated. Use `Grape::Exceptions::MissingGroupType` instead.'
+  end
+end

--- a/lib/grape/exceptions/unsupported_group_type.rb
+++ b/lib/grape/exceptions/unsupported_group_type.rb
@@ -10,4 +10,9 @@ module Grape
   end
 end
 
-Grape::Exceptions::UnsupportedGroupTypeError = Grape::Exceptions::UnsupportedGroupType
+Grape::Exceptions::UnsupportedGroupTypeError = Class.new(Grape::Exceptions::UnsupportedGroupType) do
+  def initialize(*)
+    super
+    warn '[DEPRECATION] `Grape::Exceptions::UnsupportedGroupTypeError` is deprecated. Use `Grape::Exceptions::UnsupportedGroupType` instead.'
+  end
+end

--- a/spec/grape/exceptions/missing_group_type_spec.rb
+++ b/spec/grape/exceptions/missing_group_type_spec.rb
@@ -7,9 +7,15 @@ RSpec.describe Grape::Exceptions::MissingGroupType do
     it { is_expected.to include 'group type is required' }
   end
 
-  describe '#alias' do
-    subject { described_class }
+  describe 'deprecated Grape::Exceptions::MissingGroupTypeError' do
+    subject { Grape::Exceptions::MissingGroupTypeError.new }
 
-    it { is_expected.to eq(Grape::Exceptions::MissingGroupTypeError) }
+    it 'puts a deprecation warning' do
+      expect(Warning).to receive(:warn) do |message|
+        expect(message).to include('`Grape::Exceptions::MissingGroupTypeError` is deprecated')
+      end
+
+      subject
+    end
   end
 end

--- a/spec/grape/exceptions/unsupported_group_type_spec.rb
+++ b/spec/grape/exceptions/unsupported_group_type_spec.rb
@@ -9,9 +9,15 @@ RSpec.describe Grape::Exceptions::UnsupportedGroupType do
     it { is_expected.to include 'group type must be Array, Hash, JSON or Array[JSON]' }
   end
 
-  describe '#alias' do
-    subject { described_class }
+  describe 'deprecated Grape::Exceptions::UnsupportedGroupTypeError' do
+    subject { Grape::Exceptions::UnsupportedGroupTypeError.new }
 
-    it { is_expected.to eq(Grape::Exceptions::UnsupportedGroupTypeError) }
+    it 'puts a deprecation warning' do
+      expect(Warning).to receive(:warn) do |message|
+        expect(message).to include('`Grape::Exceptions::UnsupportedGroupTypeError` is deprecated')
+      end
+
+      subject
+    end
   end
 end


### PR DESCRIPTION
Since #2227 there'a an alias for `MissingGroupTypeError` and `UnsupportedGroupTypeError` but there's no deprecation warnings. This PR adds the deprecation warnings inspired by #2244