### PR TITLE
📝  Update `README.md` with `rename`-ing notes for `params`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1450,7 +1450,7 @@ end
 
 The value passed to `as` will be the key when calling `params` or `declared(params)`.
 
-Note: If you are on 1.6+, then you'll need to use `declared(params)`. See [inspiration here](https://github.com/ruby-grape/grape/blob/master/UPGRADING.md#upgrading-to--160) as to why.
+Note: If you are on 1.6+, then you'll need to use `declared(params)` to access your renamed parameter. See [inspiration here](https://github.com/ruby-grape/grape/blob/master/UPGRADING.md#upgrading-to--160) as to why.
 
 ### Built-in Validators
 

--- a/README.md
+++ b/README.md
@@ -1450,6 +1450,8 @@ end
 
 The value passed to `as` will be the key when calling `params` or `declared(params)`.
 
+Note: If you are on 1.6+, then you'll need to use `declared(params)`. See [inspiration here](https://github.com/ruby-grape/grape/blob/master/UPGRADING.md#upgrading-to--160) as to why.
+
 ### Built-in Validators
 
 #### `allow_blank`

--- a/README.md
+++ b/README.md
@@ -1448,9 +1448,7 @@ resource :users do
 end
 ```
 
-The value passed to `as` will be the key when calling `params` or `declared(params)`.
-
-Note: If you are on 1.6+, then you'll need to use `declared(params)` to access your renamed parameter. See [inspiration here](https://github.com/ruby-grape/grape/blob/master/UPGRADING.md#upgrading-to--160) as to why.
+The value passed to `as` will be the key when calling `declared(params)`.
 
 ### Built-in Validators
 


### PR DESCRIPTION
### Context

As of 1.6+ Grape only allows you to use `declared(params)` when using `as` parameter for renaming parameters.

It's referenced in an issue: https://github.com/ruby-grape/grape/issues/2237 and also referenced [here](https://github.com/ruby-grape/grape/blob/master/UPGRADING.md#upgrading-to--160).

Was confused for a bit until I found the issue - so thought it could help save some future folks (e.g. me!) time. Decided to remove the legacy way of accessing renamed parameters and suggest only using `declared(params)` moving forward.