### PR TITLE
Update documentation to use raise instead of fail for custom validation exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -1740,7 +1740,7 @@ end
 class AlphaNumeric < Grape::Validations::Validators::Base
   def validate_param!(attr_name, params)
     unless params[attr_name] =~ /\A[[:alnum:]]+\z/
-      fail Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: 'must consist of alpha-numeric characters'
+      raise Grape::Exceptions::Validation.new params: [@scope.full_name(attr_name)], message: 'must consist of alpha-numeric characters'
     end
   end
 end
@@ -1758,7 +1758,7 @@ You can also create custom classes that take parameters.
 class Length < Grape::Validations::Validators::Base
   def validate_param!(attr_name, params)
     unless params[attr_name].length <= @option
-      fail Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: "must be at the most #{@option} characters long"
+      raise Grape::Exceptions::Validation.new params: [@scope.full_name(attr_name)], message: "must be at the most #{@option} characters long"
     end
   end
 end
@@ -1784,7 +1784,7 @@ class Admin < Grape::Validations::Validators::Base
     return unless @option
     # check if user is admin or not
     # as an example get a token from request and check if it's admin or not
-    fail Grape::Exceptions::Validation, params: @attrs, message: 'Can not set admin-only field.' unless request.headers['X-Access-Token'] == 'admin'
+    raise Grape::Exceptions::Validation.new params: @attrs, message: 'Can not set admin-only field.' unless request.headers['X-Access-Token'] == 'admin'
   end
 end
 ```


### PR DESCRIPTION
This updates the documentation to raise instead of fail during custom validator exceptions as noted in #2188. The tests already use raise instead of fail as here so no change is needed there: https://github.com/ruby-grape/grape/blob/5cc3226a77a3dd294b26b0c09c2707c36d50cf99/spec/grape/validations_spec.rb#L1195

Closes #2188