### PR TITLE
Fix Coveralls code coverage

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,1 @@
-service_name: travis-ci
+service_name: github-actions

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -21,6 +21,7 @@ jobs:
     continue-on-error: true
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#2244](https://github.com/ruby-grape/grape/pull/2244): Fix a breaking change in `Grape::Validations` provided in 1.6.1 - [@dm1try](https://github.com/dm1try).
 * [#2250](https://github.com/ruby-grape/grape/pull/2250): Add deprecation warning for `UnsupportedGroupTypeError` and `MissingGroupTypeError` - [@ericproulx](https://github.com/ericproulx).
 * [#2256](https://github.com/ruby-grape/grape/pull/2256): Raise `Grape::Exceptions::MultipartPartLimitError` from Rack when too many files are uploaded - [@bschmeck](https://github.com/bschmeck).
+* [#2264](https://github.com/ruby-grape/grape/pull/2264): Fix coveralls code coverage - [@duffn](https://github.com/duffn).
 * Your contribution here.
 
 ### 1.6.2 (2021/12/30)


### PR DESCRIPTION
Currently
```
Randomized with seed 1113
[Coveralls] Submitting to https://coveralls.io/api/v1
[Coveralls] Couldn't find a repository matching this job.
Coverage is at 98.94%.
Coverage report sent to Coveralls.
```

On my fork after adding the Coveralls token
```
Randomized with seed 57600
[Coveralls] Submitting to https://coveralls.io/api/v1
[Coveralls] Job ##8.1
[Coveralls] https://coveralls.io/jobs/101153293
Coverage is at 98.94%.
Coverage report sent to Coveralls.
```

- Reference a good comment: https://github.com/lemurheavy/coveralls-public/issues/1613#issuecomment-1028302521
- `coveralls-reborn` using `COVERALLS_REPO_TOKEN` https://github.com/tagliala/coveralls-ruby-reborn/blob/e17e7c4c7776fb2f74a225905d421f01382f3f2b/lib/coveralls/configuration.rb#L22
- The service name in `.coveralls.yml` must be something, though in this case it doesn't have any special meaning https://docs.coveralls.io/api-reference
- _NOTE_: The repo token here (https://coveralls.io/github/ruby-grape/grape/settings) must be set as a secret in this repository for this to work

Closes #2061. 