### PR TITLE
Use Coveralls GitHub Action

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,1 @@
-service_name: github-actions
+service_name: github

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -21,7 +21,6 @@ jobs:
     continue-on-error: true
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
-      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
     steps:
     - uses: actions/checkout@v2
@@ -34,3 +33,20 @@ jobs:
 
     - name: Run tests
       run: bundle exec rake spec
+
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        flag-name: run-${{ matrix.ruby }}-${{ matrix.gemfile }}
+        parallel: true
+
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.github_token }}
+        parallel-finished: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,6 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
-      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
     steps:
     - uses: actions/checkout@v2
@@ -84,3 +83,20 @@ jobs:
     - name: Run tests (spec/integration/multi_xml)
       if: ${{ matrix.gemfile == 'gemfiles/multi_xml.gemfile' }}
       run: bundle exec rspec spec/integration/multi_xml
+
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        flag-name: run-${{ matrix.ruby }}-${{ matrix.gemfile }}
+        parallel: true
+
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.github_token }}
+        parallel-finished: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * [#2244](https://github.com/ruby-grape/grape/pull/2244): Fix a breaking change in `Grape::Validations` provided in 1.6.1 - [@dm1try](https://github.com/dm1try).
 * [#2250](https://github.com/ruby-grape/grape/pull/2250): Add deprecation warning for `UnsupportedGroupTypeError` and `MissingGroupTypeError` - [@ericproulx](https://github.com/ericproulx).
 * [#2256](https://github.com/ruby-grape/grape/pull/2256): Raise `Grape::Exceptions::MultipartPartLimitError` from Rack when too many files are uploaded - [@bschmeck](https://github.com/bschmeck).
-* [#2264](https://github.com/ruby-grape/grape/pull/2264): Fix coveralls code coverage - [@duffn](https://github.com/duffn).
+* [#2266](https://github.com/ruby-grape/grape/pull/2266): Fix code coverage - [@duffn](https://github.com/duffn).
 * Your contribution here.
 
 ### 1.6.2 (2021/12/30)

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,6 @@ end
 
 group :test do
   gem 'cookiejar'
-  gem 'coveralls_reborn'
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
   gem 'mime-types'
@@ -35,6 +34,8 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'simplecov', '~> 0.21.2'
+  gem 'simplecov-lcov', '~> 0.8.0'
   gem 'test-prof', require: false
 end
 

--- a/gemfiles/multi_json.gemfile
+++ b/gemfiles/multi_json.gemfile
@@ -27,7 +27,6 @@ end
 
 group :test do
   gem 'cookiejar'
-  gem 'coveralls_reborn'
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
   gem 'mime-types'
@@ -35,6 +34,8 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'simplecov', '~> 0.21.2'
+  gem 'simplecov-lcov', '~> 0.8.0'
   gem 'test-prof', require: false
 end
 

--- a/gemfiles/multi_xml.gemfile
+++ b/gemfiles/multi_xml.gemfile
@@ -27,7 +27,6 @@ end
 
 group :test do
   gem 'cookiejar'
-  gem 'coveralls_reborn'
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
   gem 'mime-types'
@@ -35,6 +34,8 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'simplecov', '~> 0.21.2'
+  gem 'simplecov-lcov', '~> 0.8.0'
   gem 'test-prof', require: false
 end
 

--- a/gemfiles/rack1.gemfile
+++ b/gemfiles/rack1.gemfile
@@ -27,7 +27,6 @@ end
 
 group :test do
   gem 'cookiejar'
-  gem 'coveralls_reborn'
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
   gem 'mime-types'
@@ -35,6 +34,8 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'simplecov', '~> 0.21.2'
+  gem 'simplecov-lcov', '~> 0.8.0'
   gem 'test-prof', require: false
 end
 

--- a/gemfiles/rack2.gemfile
+++ b/gemfiles/rack2.gemfile
@@ -27,7 +27,6 @@ end
 
 group :test do
   gem 'cookiejar'
-  gem 'coveralls_reborn'
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
   gem 'mime-types'
@@ -35,6 +34,8 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'simplecov', '~> 0.21.2'
+  gem 'simplecov-lcov', '~> 0.8.0'
   gem 'test-prof', require: false
 end
 

--- a/gemfiles/rack2_2.gemfile
+++ b/gemfiles/rack2_2.gemfile
@@ -27,7 +27,6 @@ end
 
 group :test do
   gem 'cookiejar'
-  gem 'coveralls_reborn'
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
   gem 'mime-types'
@@ -35,6 +34,8 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'simplecov', '~> 0.21.2'
+  gem 'simplecov-lcov', '~> 0.8.0'
   gem 'test-prof', require: false
 end
 

--- a/gemfiles/rack_edge.gemfile
+++ b/gemfiles/rack_edge.gemfile
@@ -27,7 +27,6 @@ end
 
 group :test do
   gem 'cookiejar'
-  gem 'coveralls_reborn'
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
   gem 'mime-types'
@@ -35,6 +34,8 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'simplecov', '~> 0.21.2'
+  gem 'simplecov-lcov', '~> 0.8.0'
   gem 'test-prof', require: false
 end
 

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -27,7 +27,6 @@ end
 
 group :test do
   gem 'cookiejar'
-  gem 'coveralls_reborn'
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
   gem 'mime-types'
@@ -35,6 +34,8 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'simplecov', '~> 0.21.2'
+  gem 'simplecov-lcov', '~> 0.8.0'
   gem 'test-prof', require: false
 end
 

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -27,7 +27,6 @@ end
 
 group :test do
   gem 'cookiejar'
-  gem 'coveralls_reborn'
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
   gem 'mime-types'
@@ -35,6 +34,8 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'simplecov', '~> 0.21.2'
+  gem 'simplecov-lcov', '~> 0.8.0'
   gem 'test-prof', require: false
 end
 

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -27,7 +27,6 @@ end
 
 group :test do
   gem 'cookiejar'
-  gem 'coveralls_reborn'
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
   gem 'mime-types'
@@ -35,6 +34,8 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'simplecov', '~> 0.21.2'
+  gem 'simplecov-lcov', '~> 0.8.0'
   gem 'test-prof', require: false
 end
 

--- a/gemfiles/rails_7.gemfile
+++ b/gemfiles/rails_7.gemfile
@@ -27,7 +27,6 @@ end
 
 group :test do
   gem 'cookiejar'
-  gem 'coveralls_reborn'
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
   gem 'mime-types'
@@ -35,6 +34,8 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'simplecov', '~> 0.21.2'
+  gem 'simplecov-lcov', '~> 0.8.0'
   gem 'test-prof', require: false
 end
 

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -27,7 +27,6 @@ end
 
 group :test do
   gem 'cookiejar'
-  gem 'coveralls_reborn'
   gem 'grape-entity', '~> 0.6'
   gem 'maruku'
   gem 'mime-types'
@@ -35,6 +34,8 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'simplecov', '~> 0.21.2'
+  gem 'simplecov-lcov', '~> 0.8.0'
   gem 'test-prof', require: false
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,5 +41,12 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = '.rspec_status'
 end
 
-require 'coveralls'
-Coveralls.wear!
+require 'simplecov'
+require 'simplecov-lcov'
+SimpleCov::Formatter::LcovFormatter.config do |c|
+  c.report_with_single_file = true
+  c.single_report_path = 'coverage/lcov.info'
+end
+
+SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+SimpleCov.start


### PR DESCRIPTION
This uses the Coveralls GitHub Action in place of `coveralls-reborn` as recommended in the gem README https://github.com/tagliala/coveralls-ruby-reborn#github-actions and as discussed here https://github.com/ruby-grape/grape/pull/2265. The parallel test steps are taken from the Action README https://github.com/coverallsapp/github-action

Examples on my fork: 
- Job for a merge showing individual Ruby version & Gemfile matrix https://coveralls.io/builds/50032540
- Master after a merge https://coveralls.io/github/duffn/grape


