### PR TITLE
Numeric is not a dry-types built-in type, fix coercion/validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#2248](https://github.com/ruby-grape/grape/pull/2248): Upgraded to rspec 3.11.0 - [@dblock](https://github.com/dblock).
 * [#2249](https://github.com/ruby-grape/grape/pull/2249): Split CI matrix, extract edge - [@dblock](https://github.com/dblock).
 * [#2249](https://github.com/ruby-grape/grape/pull/2251): Upgraded to RuboCop 1.25.1 - [@dblock](https://github.com/dblock).
+* [#2271](https://github.com/ruby-grape/grape/pull/2271): Fixed validation regression on Numeric type introduced in 1.3 - [@vasfed](https://github.com/Vasfed).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/validations/types/primitive_coercer.rb
+++ b/lib/grape/validations/types/primitive_coercer.rb
@@ -12,6 +12,7 @@ module Grape
         MAPPING = {
           Grape::API::Boolean => DryTypes::Params::Bool,
           BigDecimal => DryTypes::Params::Decimal,
+          Numeric => DryTypes::Params::Integer | DryTypes::Params::Float | DryTypes::Params::Decimal,
 
           # unfortunately, a +Params+ scope doesn't contain String
           String => DryTypes::Coercible::String
@@ -19,7 +20,8 @@ module Grape
 
         STRICT_MAPPING = {
           Grape::API::Boolean => DryTypes::Strict::Bool,
-          BigDecimal => DryTypes::Strict::Decimal
+          BigDecimal => DryTypes::Strict::Decimal,
+          Numeric => DryTypes::Strict::Integer | DryTypes::Strict::Float | DryTypes::Strict::Decimal
         }.freeze
 
         def initialize(type, strict = false)

--- a/spec/grape/validations/types/primitive_coercer_spec.rb
+++ b/spec/grape/validations/types/primitive_coercer_spec.rb
@@ -64,6 +64,10 @@ describe Grape::Validations::Types::PrimitiveCoercer do
       it 'coerces an empty string to nil' do
         expect(subject.call('')).to be_nil
       end
+
+      it 'accepts non-nil value' do
+        expect(subject.call(42)).to be_a(Integer)
+      end
     end
 
     context 'Numeric' do
@@ -71,6 +75,10 @@ describe Grape::Validations::Types::PrimitiveCoercer do
 
       it 'coerces an empty string to nil' do
         expect(subject.call('')).to be_nil
+      end
+
+      it 'accepts a non-nil value' do
+        expect(subject.call(42)).to be_a(Numeric) # in fact Integer
       end
     end
 


### PR DESCRIPTION
In 1.3+ if someone had a `Numeric` type parameter which worked in `<1.3` - any valid non-blank value will silently fail validation
```ruby
params { optional :price, type: Numeric }
```

This happens because dry-types does not contain built-in type for `DryTypes::SomeScope::Numeric` and `const_get` by default searches ancestors, thus finding `::Numeric`.
Runtime error ``undefined method `[]' for Numeric:Class`` is treated as a validation error and leads to unexpected behavior.

This PR adds mapping for Numeric that fixes it, also fallback to `const_get(.., false)` will make similar issues easier to debug.