### PR TITLE
Check for dry-types type existence and prevent unexpected top level const lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#2249](https://github.com/ruby-grape/grape/pull/2251): Upgraded to RuboCop 1.25.1 - [@dblock](https://github.com/dblock).
 * [#2271](https://github.com/ruby-grape/grape/pull/2271): Fixed validation regression on Numeric type introduced in 1.3 - [@vasfed](https://github.com/Vasfed).
 * [#2267](https://github.com/ruby-grape/grape/pull/2267): Standardized English error messages - [@dblock](https://github.com/dblock).
+* [#2272](https://github.com/ruby-grape/grape/pull/2272): Added error on param init when provided type does not have `[]` coercion method, previously validation silently failed for any value - [@vasfed](https://github.com/Vasfed).
 * Your contribution here.
 
 #### Fixes

--- a/spec/grape/validations/types/primitive_coercer_spec.rb
+++ b/spec/grape/validations/types/primitive_coercer_spec.rb
@@ -110,6 +110,15 @@ describe Grape::Validations::Types::PrimitiveCoercer do
       end
     end
 
+    context 'a type unknown in Dry-types' do
+      let(:type) { Complex }
+
+      it 'raises error on init' do
+        expect(DryTypes::Params.constants).not_to include(type.name.to_sym)
+        expect { subject }.to raise_error(/type Complex should support coercion/)
+      end
+    end
+
     context 'the strict mode' do
       let(:strict) { true }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/ruby-grape/grape/pull/2271 - prevent silent validation fails for types not built-in in dry-types.
Instead of validation fail - check for `[]` method presence in provided class at init time.