### PR TITLE
Error middleware support using rack util's symbols as status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#2271](https://github.com/ruby-grape/grape/pull/2271): Fixed validation regression on Numeric type introduced in 1.3 - [@vasfed](https://github.com/Vasfed).
 * [#2267](https://github.com/ruby-grape/grape/pull/2267): Standardized English error messages - [@dblock](https://github.com/dblock).
 * [#2272](https://github.com/ruby-grape/grape/pull/2272): Added error on param init when provided type does not have `[]` coercion method, previously validation silently failed for any value - [@vasfed](https://github.com/Vasfed).
+* [#2274](https://github.com/ruby-grape/grape/pull/2274): Error middleware support using rack util's symbols as status - [@dhruvCW](https://github.com/dhruvCW).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -72,7 +72,7 @@ module Grape
 
       def rack_response(message, status = options[:default_status], headers = { Grape::Http::Headers::CONTENT_TYPE => content_type })
         message = ERB::Util.html_escape(message) if headers[Grape::Http::Headers::CONTENT_TYPE] == TEXT_HTML
-        Rack::Response.new([message], status, headers)
+        Rack::Response.new([message], Rack::Utils.status_code(status), headers)
       end
 
       def format_message(message, backtrace, original_exception = nil)

--- a/spec/grape/middleware/error_spec.rb
+++ b/spec/grape/middleware/error_spec.rb
@@ -41,6 +41,12 @@ describe Grape::Middleware::Error do
     expect(last_response.status).to eq(410)
   end
 
+  it 'sets the status code based on the rack util status code symbol' do
+    ErrorSpec::ErrApp.error = { status: :gone }
+    get '/'
+    expect(last_response.status).to eq(410)
+  end
+
   it 'sets the error message appropriately' do
     ErrorSpec::ErrApp.error = { message: 'Awesome stuff.' }
     get '/'


### PR DESCRIPTION
support the ability to use the Rack::Utils's status_code symbols instead of integers.