### PR TITLE
fix, do not use kwargs for empty args 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 #### Fixes
 
+* [#2299](https://github.com/ruby-grape/grape/pull/2299): Fix, do not use kwargs for empty args  - [@dm1try](https://github.com/dm1try).
 * Your contribution here.
 
 ### 1.7.0 (2022/12/20)

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -62,7 +62,12 @@ module Grape
           params_block = named_params.fetch(name) do
             raise "Params :#{name} not found!"
           end
-          instance_exec(**options, &params_block)
+
+          if options.empty?
+            instance_exec(options, &params_block)
+          else
+            instance_exec(**options, &params_block)
+          end
         end
       end
       alias use_scope use

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -1509,6 +1509,29 @@ describe Grape::Validations do
       end
     end
 
+    context 'with block and empty args' do
+      before do
+        subject.helpers do
+          params :shared_params do |empty_args|
+            optional :param, default: empty_args[:some]
+          end
+        end
+        subject.format :json
+        subject.params do
+          use :shared_params
+        end
+        subject.get '/shared_params' do
+          :ok
+        end
+      end
+
+      it 'works' do
+        get '/shared_params'
+
+        expect(last_response.status).to eq(200)
+      end
+    end
+
     context 'all or none' do
       context 'optional params' do
         before do


### PR DESCRIPTION
for backward compatibility with the previous implemention
where options param behaves as an empty hash by default

see #2295