### PR TITLE
Rack < 3

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -1,9 +1,6 @@
 ---
 name: edge
-on:
-  pull_request:
-    branches:
-      - "*"
+on: pull_request
 jobs:
   test:
     strategy:
@@ -14,10 +11,12 @@ jobs:
             gemfile: 'gemfiles/rails_edge.gemfile'
           - ruby: 2.7
             gemfile: 'gemfiles/rack_edge.gemfile'
+          - ruby: 2.7
+            gemfile: 'gemfiles/rack3.gemfile'
           - ruby: "ruby-head"
           - ruby: "truffleruby-head"
           - ruby: "jruby-head"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     continue-on-error: true
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -29,6 +29,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+        rubygems: latest
 
     - name: Run tests
       run: bundle exec rake spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#2288](https://github.com/ruby-grape/grape/pull/2288): Droped support for Ruby 2.5 - [@ericproulx](https://github.com/ericproulx).
 * [#2288](https://github.com/ruby-grape/grape/pull/2288): Updated rubocop to 1.41.0 - [@ericproulx](https://github.com/ericproulx).
 * [#2296](https://github.com/ruby-grape/grape/pull/2296): Fix cops and enables some - [@ericproulx](https://github.com/ericproulx).
+* [#2302](https://github.com/ruby-grape/grape/pull/2302): Rack < 3 and update rack-test - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test', '~> 1.1.0'
+  gem 'rack-test'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/gemfiles/multi_json.gemfile
+++ b/gemfiles/multi_json.gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test', '~> 1.1.0'
+  gem 'rack-test'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/gemfiles/multi_xml.gemfile
+++ b/gemfiles/multi_xml.gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test', '~> 1.1.0'
+  gem 'rack-test'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/gemfiles/rack1.gemfile
+++ b/gemfiles/rack1.gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test', '~> 1.1.0'
+  gem 'rack-test'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/gemfiles/rack2.gemfile
+++ b/gemfiles/rack2.gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test', '~> 1.1.0'
+  gem 'rack-test'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/gemfiles/rack2_2.gemfile
+++ b/gemfiles/rack2_2.gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test', '~> 1.1.0'
+  gem 'rack-test'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/gemfiles/rack3.gemfile
+++ b/gemfiles/rack3.gemfile
@@ -4,7 +4,7 @@
 
 source 'https://rubygems.org'
 
-gem 'rack', github: 'rack/rack'
+gem 'rack', '~> 3'
 
 group :development, :test do
   gem 'bundler'

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test', '~> 1.1.0'
+  gem 'rack-test'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test', '~> 1.1.0'
+  gem 'rack-test'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test', '~> 1.1.0'
+  gem 'rack-test'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/gemfiles/rails_7.gemfile
+++ b/gemfiles/rails_7.gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test', '~> 1.1.0'
+  gem 'rack-test'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test', '~> 1.1.0'
+  gem 'rack-test'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/grape.gemspec
+++ b/grape.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'builder'
   s.add_runtime_dependency 'dry-types', '>= 1.1'
   s.add_runtime_dependency 'mustermann-grape', '~> 1.0.0'
-  s.add_runtime_dependency 'rack', '>= 1.3.0'
+  s.add_runtime_dependency 'rack', '< 3'
   s.add_runtime_dependency 'rack-accept'
 
   s.files         = %w[CHANGELOG.md CONTRIBUTING.md README.md grape.png UPGRADING.md LICENSE]

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -140,7 +140,8 @@ describe Grape::Endpoint do
       get '/headers'
       expect(JSON.parse(last_response.body)).to eq(
         'Host' => 'example.org',
-        'Cookie' => ''
+        'Cookie' => '',
+        'Version' => 'HTTP/1.0'
       )
     end
 
@@ -432,7 +433,7 @@ describe Grape::Endpoint do
         end
         post '/upload', { file: '' }, 'CONTENT_TYPE' => 'multipart/form-data; boundary=foobar'
         expect(last_response.status).to eq(400)
-        expect(last_response.body).to eq('empty message body supplied with multipart/form-data; boundary=foobar content-type')
+        expect(last_response.body).to eq('file is invalid')
       end
     end
 


### PR DESCRIPTION
Following the discussion #2298, this PR is intended to limit Grape to Rack < 3 until the issue is resolved.

Also `rack-test` has been updated to its latest version 2.0.2. This [PR](https://github.com/rack/rack-test/pull/303) changes the way multipart is processed and `spec/grape/endpoint_spec.rb#427` has been updated to reflect that.

Fixes #2278
Closes #2279