### PR TITLE
Grape::Exceptions::Base#initialize: call super earlier

### DIFF
--- a/lib/grape/exceptions/base.rb
+++ b/lib/grape/exceptions/base.rb
@@ -10,9 +10,10 @@ module Grape
       attr_reader :status, :headers
 
       def initialize(status: nil, message: nil, headers: nil, **_options)
+        super(message)
+
         @status  = status
         @headers = headers
-        super(message)
       end
 
       def [](index)


### PR DESCRIPTION
It's better to call `super` as soon as possible as it is a parent :)