### PR TITLE
Move convenience class into new file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 #### Fixes
 
 * [#2299](https://github.com/ruby-grape/grape/pull/2299): Fix, do not use kwargs for empty args  - [@dm1try](https://github.com/dm1try).
+* [#2307](https://github.com/ruby-grape/grape/pull/2307): Fixed autoloading of InvalidValue - [@fixlr](https://github.com/fixlr).
 * Your contribution here.
 
 ### 1.7.0 (2022/12/20)

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -277,6 +277,14 @@ module Grape
       end
     end
   end
+
+  module Types
+    extend ::ActiveSupport::Autoload
+
+    eager_autoload do
+      autoload :InvalidValue
+    end
+  end
 end
 
 require 'grape/config'

--- a/lib/grape/types/invalid_value.rb
+++ b/lib/grape/types/invalid_value.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# only exists to make it shorter for external use
+module Grape
+  module Types
+    InvalidValue = Class.new(Grape::Validations::Types::InvalidValue)
+  end
+end

--- a/lib/grape/validations/types/invalid_value.rb
+++ b/lib/grape/validations/types/invalid_value.rb
@@ -15,10 +15,3 @@ module Grape
     end
   end
 end
-
-# only exists to make it shorter for external use
-module Grape
-  module Types
-    InvalidValue = Class.new(Grape::Validations::Types::InvalidValue)
-  end
-end


### PR DESCRIPTION
This PR moves the `Grape::Types::InvalidValue` class definition into a separate file so that it can be lazy loaded in projects that use zeitwerk file structure conventions.

In environments that do not eager load, referencing the `Grape::Validations::Types::InvalidValue` class before `Grape::Types::InvalidValue` causes a load error due to the fact that both classes were defined in the same file.

---

**Testing?! Yes! Kind of...**

I haven't come up with a good way to write a _new_ rspec example for this change, but one test did fail on my branch before I updated `lib/grape.rb`. This failure occurred in [`coerce_spec.rb:271`](https://github.com/ruby-grape/grape/blob/master/spec/grape/validations/validators/coerce_spec.rb#L271) because  [`Grape::Types::InvalidValue`](https://github.com/ruby-grape/grape/blob/master/spec/grape/validations/validators/coerce_spec.rb#L253) was no longer being autoloaded. (It raised the same `uninitialized constant Grape::Types` exception that you'll see in my example below.)

For now, in lieu of tests, I created [a simple gist](https://gist.github.com/fixlr/3b140722aaa56944b1bbccc41a95eb32) that demonstrates the issue I'm seeing in a private Rails application. Here are the results on both my branch and master:

```
> git checkout master
> ruby grape_autoload_bug_sample.rb
grape_autoload_bug_sample.rb:15:in `<main>': uninitialized constant Grape::Types (NameError)

puts "Loaded #{Grape::Types::InvalidValue.name}"
                           ^^^^^^^^^^^^^^ 

> ruby grape_autoload_bug_sample_reversed.rb
Loaded Grape::Validations::Types::InvalidValue
Loaded Grape::Types::InvalidValue

> git checkout extract-grape-types-invalid_type
> ruby grape_autoload_bug_sample.rb
Loaded Grape::Types::InvalidValue
Loaded Grape::Validations::Types::InvalidValue
```