### PR TITLE
Fix YARD docs markdown rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ dist
 Gemfile.lock
 gemfiles/*.lock
 tmp
+.yardoc
 
 ## Rubinius
 .rbx

--- a/.yardopts
+++ b/.yardopts
@@ -1,1 +1,2 @@
 --asset grape.png
+--markup markdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#2302](https://github.com/ruby-grape/grape/pull/2302): Rack < 3 and update rack-test - [@ericproulx](https://github.com/ericproulx).
 * [#2303](https://github.com/ruby-grape/grape/pull/2302): Rack >= 1.3.0 - [@ericproulx](https://github.com/ericproulx).
 * [#2301](https://github.com/ruby-grape/grape/pull/2301): Revisit GH workflows - [@ericproulx](https://github.com/ericproulx).
+* [#2310](https://github.com/ruby-grape/grape/pull/2310): Fix YARD docs markdown rendering - [@duffn](https://github.com/duffn).
 * Your contribution here.
 
 #### Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,8 @@ Make sure that `bundle exec rake` completes without errors.
 
 Document any external behavior in the [README](README.md).
 
+You should also document code as necessary, using current code as examples. This project uses [YARD](https://yardoc.org/). You can run and preview the docs locally by [installing `yard`](https://yardoc.org/), running `yard server --reload` and view the docs at http://localhost:8808.
+
 #### Update Changelog
 
 Add a line to [CHANGELOG](CHANGELOG.md) under *Next Release*. Make it look like every other line, including your name and link to your Github account.

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -1071,12 +1071,12 @@ describe Grape::Validations do
             }
             # debugger
             get '/multi_level', data
-            expect(last_response.body.split(', ')).to match_array([
-                                                                    'top[3][top_id] is empty',
-                                                                    'top[2][middle_1][0][middle_1_id] is empty',
-                                                                    'top[1][middle_1][1][middle_2][0][middle_2_id] is empty',
-                                                                    'top[0][middle_1][1][middle_2][1][bottom][0][bottom_id] is empty'
-                                                                  ])
+            expect(last_response.body.split(', ')).to contain_exactly([
+                                                                        'top[3][top_id] is empty',
+                                                                        'top[2][middle_1][0][middle_1_id] is empty',
+                                                                        'top[1][middle_1][1][middle_2][0][middle_2_id] is empty',
+                                                                        'top[0][middle_1][1][middle_2][1][bottom][0][bottom_id] is empty'
+                                                                      ])
             expect(last_response.status).to eq(400)
           end
         end

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -1071,12 +1071,12 @@ describe Grape::Validations do
             }
             # debugger
             get '/multi_level', data
-            expect(last_response.body.split(', ')).to contain_exactly([
-                                                                        'top[3][top_id] is empty',
-                                                                        'top[2][middle_1][0][middle_1_id] is empty',
-                                                                        'top[1][middle_1][1][middle_2][0][middle_2_id] is empty',
-                                                                        'top[0][middle_1][1][middle_2][1][bottom][0][bottom_id] is empty'
-                                                                      ])
+            expect(last_response.body.split(', ')).to contain_exactly(
+              'top[3][top_id] is empty',
+              'top[2][middle_1][0][middle_1_id] is empty',
+              'top[1][middle_1][1][middle_2][0][middle_2_id] is empty',
+              'top[0][middle_1][1][middle_2][1][bottom][0][bottom_id] is empty'
+            )
             expect(last_response.status).to eq(400)
           end
         end


### PR DESCRIPTION
This fixes the rendering of the YARD docs in markdown. RudyDoc reads `.yardopts` so this will work there too.

As one small example:

Before

<img width="236" alt="Screen Shot 2023-03-18 at 6 57 36 PM" src="https://user-images.githubusercontent.com/3457341/226148030-83612a58-0a60-42f8-9e74-8d71dfc2fda3.png">

After

<img width="262" alt="Screen Shot 2023-03-18 at 6 58 56 PM" src="https://user-images.githubusercontent.com/3457341/226148050-fc09108e-8222-48d5-affd-ce61359a90da.png">

