### PR TITLE
Fix tests by pinning rack-test to < 2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test'
+  gem 'rack-test', '< 2.1'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/gemfiles/multi_json.gemfile
+++ b/gemfiles/multi_json.gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test'
+  gem 'rack-test', '< 2.1'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/gemfiles/multi_xml.gemfile
+++ b/gemfiles/multi_xml.gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test'
+  gem 'rack-test', '< 2.1'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/gemfiles/rack_1_0.gemfile
+++ b/gemfiles/rack_1_0.gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test'
+  gem 'rack-test', '< 2.1'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/gemfiles/rack_2_0.gemfile
+++ b/gemfiles/rack_2_0.gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test'
+  gem 'rack-test', '< 2.1'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/gemfiles/rack_3_0.gemfile
+++ b/gemfiles/rack_3_0.gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test'
+  gem 'rack-test', '< 2.1'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/gemfiles/rack_edge.gemfile
+++ b/gemfiles/rack_edge.gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test'
+  gem 'rack-test', '< 2.1'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test'
+  gem 'rack-test', '< 2.1'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test'
+  gem 'rack-test', '< 2.1'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test'
+  gem 'rack-test', '< 2.1'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test'
+  gem 'rack-test', '< 2.1'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'maruku'
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
-  gem 'rack-test'
+  gem 'rack-test', '< 2.1'
   gem 'rspec', '~> 3.11.0'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -1071,12 +1071,12 @@ describe Grape::Validations do
             }
             # debugger
             get '/multi_level', data
-            expect(last_response.body.split(', ')).to match_array([
-                                                                    'top[3][top_id] is empty',
-                                                                    'top[2][middle_1][0][middle_1_id] is empty',
-                                                                    'top[1][middle_1][1][middle_2][0][middle_2_id] is empty',
-                                                                    'top[0][middle_1][1][middle_2][1][bottom][0][bottom_id] is empty'
-                                                                  ])
+            expect(last_response.body.split(', ')).to contain_exactly(
+              'top[3][top_id] is empty',
+              'top[2][middle_1][0][middle_1_id] is empty',
+              'top[1][middle_1][1][middle_2][0][middle_2_id] is empty',
+              'top[0][middle_1][1][middle_2][1][bottom][0][bottom_id] is empty'
+            )
             expect(last_response.status).to eq(400)
           end
         end


### PR DESCRIPTION
Discovered here: https://github.com/ruby-grape/grape/pull/2310#issuecomment-1475459509

`rack-test` has removed digest authentication support in a minor version, 2.1.0. 

This pins `rack-test` to under 2.1. Removing digest support has been discussed here https://github.com/ruby-grape/grape/issues/2294 as a breaking change, but in the meantime, should continue to be tested.