### PR TITLE
Update rspec version from `3.11.0` to `< 4`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 * [#2299](https://github.com/ruby-grape/grape/pull/2299): Fix, do not use kwargs for empty args  - [@dm1try](https://github.com/dm1try).
 * [#2307](https://github.com/ruby-grape/grape/pull/2307): Fixed autoloading of InvalidValue - [@fixlr](https://github.com/fixlr).
+* [#23015](https://github.com/ruby-grape/grape/pull/2315): Update rspec - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 1.7.0 (2022/12/20)

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
-  gem 'rspec', '~> 3.11.0'
+  gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'
   gem 'simplecov-lcov', '~> 0.8.0'

--- a/gemfiles/multi_json.gemfile
+++ b/gemfiles/multi_json.gemfile
@@ -32,7 +32,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
-  gem 'rspec', '~> 3.11.0'
+  gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'
   gem 'simplecov-lcov', '~> 0.8.0'

--- a/gemfiles/multi_xml.gemfile
+++ b/gemfiles/multi_xml.gemfile
@@ -32,7 +32,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
-  gem 'rspec', '~> 3.11.0'
+  gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'
   gem 'simplecov-lcov', '~> 0.8.0'

--- a/gemfiles/rack_1_0.gemfile
+++ b/gemfiles/rack_1_0.gemfile
@@ -32,7 +32,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
-  gem 'rspec', '~> 3.11.0'
+  gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'
   gem 'simplecov-lcov', '~> 0.8.0'

--- a/gemfiles/rack_2_0.gemfile
+++ b/gemfiles/rack_2_0.gemfile
@@ -32,7 +32,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
-  gem 'rspec', '~> 3.11.0'
+  gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'
   gem 'simplecov-lcov', '~> 0.8.0'

--- a/gemfiles/rack_3_0.gemfile
+++ b/gemfiles/rack_3_0.gemfile
@@ -32,7 +32,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
-  gem 'rspec', '~> 3.11.0'
+  gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'
   gem 'simplecov-lcov', '~> 0.8.0'

--- a/gemfiles/rack_edge.gemfile
+++ b/gemfiles/rack_edge.gemfile
@@ -32,7 +32,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
-  gem 'rspec', '~> 3.11.0'
+  gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'
   gem 'simplecov-lcov', '~> 0.8.0'

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -32,7 +32,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
-  gem 'rspec', '~> 3.11.0'
+  gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'
   gem 'simplecov-lcov', '~> 0.8.0'

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -32,7 +32,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
-  gem 'rspec', '~> 3.11.0'
+  gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'
   gem 'simplecov-lcov', '~> 0.8.0'

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -32,7 +32,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
-  gem 'rspec', '~> 3.11.0'
+  gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'
   gem 'simplecov-lcov', '~> 0.8.0'

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -32,7 +32,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
-  gem 'rspec', '~> 3.11.0'
+  gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'
   gem 'simplecov-lcov', '~> 0.8.0'

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -32,7 +32,7 @@ group :test do
   gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
-  gem 'rspec', '~> 3.11.0'
+  gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', '~> 0.21.2'
   gem 'simplecov-lcov', '~> 0.8.0'


### PR DESCRIPTION
This PR updates `rspec` to its latest version and relax its expected version to `< 4'
Fix #2314 