### PR TITLE
fix using endless ranges for values parameter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#2307](https://github.com/ruby-grape/grape/pull/2307): Fixed autoloading of InvalidValue - [@fixlr](https://github.com/fixlr).
 * [#2315](https://github.com/ruby-grape/grape/pull/2315): Update rspec - [@ericproulx](https://github.com/ericproulx).
 * [#2319](https://github.com/ruby-grape/grape/pull/2319): Update rubocop - [@ericproulx](https://github.com/ericproulx).
+* [#2323](https://github.com/ruby-grape/grape/pull/2323): Fix using endless ranges for values parameter - [@dhruvCW](https://github.com/dhruvCW).
 * Your contribution here.
 
 ### 1.7.0 (2022/12/20)

--- a/README.md
+++ b/README.md
@@ -1587,6 +1587,15 @@ params do
 end
 ```
 
+Note endless ranges are also supported but they require that the type be provided.
+
+```ruby
+params do
+  requires :minimum, type: Integer, values: 10..
+  optional :maximum, type: Integer, values: ..10 
+end
+```
+
 Note that *both* range endpoints have to be a `#kind_of?` your `:type` option (if you don't supply the `:type` option, it will be guessed to be equal to the class of the range's first endpoint). So the following is invalid:
 
 ```ruby

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -485,7 +485,7 @@ module Grape
         values_list.each do |values|
           next if !values || values.is_a?(Proc)
 
-          value_types = values.is_a?(Range) ? [values.begin, values.end] : values
+          value_types = values.is_a?(Range) ? [values.begin, values.end].compact : values
           value_types = value_types.map { |type| Grape::API::Boolean.build(type) } if coerce_type == Grape::API::Boolean
           raise Grape::Exceptions::IncompatibleOptionValues.new(:type, coerce_type, :values, values) unless value_types.all?(coerce_type)
         end

--- a/spec/grape/validations/validators/values_spec.rb
+++ b/spec/grape/validations/validators/values_spec.rb
@@ -115,6 +115,13 @@ describe Grape::Validations::Validators::ValuesValidator do
       end
 
       params do
+        optional :type, type: Integer, values: 1..
+      end
+      get '/endless' do
+        { type: params[:type] }
+      end
+
+      params do
         requires :type, values: ->(v) { ValuesModel.include? v }
       end
       get '/lambda_val' do
@@ -370,6 +377,18 @@ describe Grape::Validations::Validators::ValuesValidator do
 
   it 'does not allow an invalid value for a parameter using lambda' do
     get('/lambda', type: 'invalid-type')
+    expect(last_response.status).to eq 400
+    expect(last_response.body).to eq({ error: 'type does not have a valid value' }.to_json)
+  end
+
+  it 'validates against values in an endless range' do
+    get('/endless', type: 10)
+    expect(last_response.status).to eq 200
+    expect(last_response.body).to eq({ type: 10 }.to_json)
+  end
+
+  it 'does not allow an invalid value for a parameter using an endless range' do
+    get('/endless', type: 0)
     expect(last_response.status).to eq 400
     expect(last_response.body).to eq({ error: 'type does not have a valid value' }.to_json)
   end


### PR DESCRIPTION
allows using endless range for values validator.

e.g.

```ruby
params do
  requires :minimum, type: Integer, values: 10..
  optional :maximum, type: Integer, values: ..10 
end
```