### PR TITLE
Make edge workflows only run on demand.

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -1,6 +1,6 @@
 ---
 name: edge
-on: pull_request
+on: workflow_dispatch
 jobs:
   test:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#2310](https://github.com/ruby-grape/grape/pull/2310): Fix YARD docs markdown rendering - [@duffn](https://github.com/duffn).
 * [#2317](https://github.com/ruby-grape/grape/pull/2317): Remove maruku and rubocop-ast as direct development/testing dependencies - [@ericproulx](https://github.com/ericproulx).
 * [#2292](https://github.com/ruby-grape/grape/pull/2292): Introduce Docker to local development - [@ericproulx](https://github.com/ericproulx).
+* [#2325](https://github.com/ruby-grape/grape/pull/2325): Change edge test workflows only run on demand - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -1587,7 +1587,7 @@ params do
 end
 ```
 
-Note endless ranges are also supported but they require that the type be provided.
+Note endless ranges are also supported with ActiveSupport >= 6.0, but they require that the type be provided.
 
 ```ruby
 params do

--- a/spec/grape/validations/validators/values_spec.rb
+++ b/spec/grape/validations/validators/values_spec.rb
@@ -381,13 +381,13 @@ describe Grape::Validations::Validators::ValuesValidator do
     expect(last_response.body).to eq({ error: 'type does not have a valid value' }.to_json)
   end
 
-  it 'validates against values in an endless range' do
+  it 'validates against values in an endless range', if: ActiveSupport::VERSION::MAJOR >= 6 do
     get('/endless', type: 10)
     expect(last_response.status).to eq 200
     expect(last_response.body).to eq({ type: 10 }.to_json)
   end
 
-  it 'does not allow an invalid value for a parameter using an endless range' do
+  it 'does not allow an invalid value for a parameter using an endless range', if: ActiveSupport::VERSION::MAJOR >= 6 do
     get('/endless', type: 0)
     expect(last_response.status).to eq 400
     expect(last_response.body).to eq({ error: 'type does not have a valid value' }.to_json)


### PR DESCRIPTION
In https://github.com/ruby-grape/grape/pull/2323 a real failure was drowed in edge failures. 

Changing the edge workflow to only run on demand, nobody is paying attention until someone says otherwise.