### PR TITLE
ActiveSupport inflector methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#2326](https://github.com/ruby-grape/grape/pull/2326): Use ActiveSupport extensions - [@ericproulx](https://github.com/ericproulx).
 * [#2327](https://github.com/ruby-grape/grape/pull/2327): Use ActiveSupport deprecation - [@ericproulx](https://github.com/ericproulx).
+* [#2330](https://github.com/ruby-grape/grape/pull/2330): Use ActiveSupport inflector - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -27,6 +27,7 @@ require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/object/duplicable'
 require 'active_support/dependencies/autoload'
 require 'active_support/deprecation'
+require 'active_support/inflector'
 require 'active_support/notifications'
 require 'i18n'
 

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -64,7 +64,7 @@ module Grape
         def self.inherited(klass)
           return if klass.name.blank?
 
-          short_validator_name = klass.name.demodulize.underscore.delete_suffix('_validator')
+          short_validator_name = klass.name.demodulize.underscore.delete_suffix!('_validator')
           Validations.register_validator(short_validator_name, klass)
         end
 

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -61,19 +61,11 @@ module Grape
           raise Grape::Exceptions::ValidationArrayErrors.new(array_errors) if array_errors.any?
         end
 
-        def self.convert_to_short_name(klass)
-          ret = klass.name.gsub(/::/, '/')
-          ret.gsub!(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
-          ret.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
-          ret.tr!('-', '_')
-          ret.downcase!
-          File.basename(ret, '_validator')
-        end
-
         def self.inherited(klass)
           return if klass.name.blank?
 
-          Validations.register_validator(convert_to_short_name(klass), klass)
+          short_validator_name = klass.name.demodulize.underscore.delete_suffix('_validator')
+          Validations.register_validator(short_validator_name, klass)
         end
 
         def message(default_key = nil)


### PR DESCRIPTION
While looking at the Validator's registration process, I found that `convert_to_short_name` could be replaced by some ActiveSupport::Inflector methods like `demodulize`.