### PR TITLE
run_validators memory optmization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#2326](https://github.com/ruby-grape/grape/pull/2326): Use ActiveSupport extensions - [@ericproulx](https://github.com/ericproulx).
 * [#2327](https://github.com/ruby-grape/grape/pull/2327): Use ActiveSupport deprecation - [@ericproulx](https://github.com/ericproulx).
 * [#2330](https://github.com/ruby-grape/grape/pull/2330): Use ActiveSupport inflector - [@ericproulx](https://github.com/ericproulx).
+* [#2331](https://github.com/ruby-grape/grape/pull/2331): Memory optimization when running validators - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes


### PR DESCRIPTION
This PR change the way validator are created before calling `validate`. `run_validators` has always created all the validators before calling `validate`. In a case where an exception is raised and the validator `fail_fast?` returns true, the remaining validators won't be `validate`. Thus, we can optimize the validation process by yielding validator instead of creating all of them at first. It's a small memory optimization and maybe it will speed up a little bit any endpoint that has a validator with `fail_fast`

In the same file, I also replaced some `|| []` by `&.`