### PR TITLE
Adjust test expectations to conform to rack 3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['2.7', '3.0', '3.1', '3.2']
-        gemfile: [rack_2_0, rails_6_0, rails_6_1, rails_7_0]
+        gemfile: [rack_2_0, rack_3_0, rails_6_0, rails_6_1, rails_7_0]
         include:
           - ruby: '2.6'
             gemfile: rails_5_2

--- a/Appraisals
+++ b/Appraisals
@@ -39,3 +39,7 @@ end
 appraise 'rack2' do
   gem 'rack', '~> 2.0.0'
 end
+
+appraise 'rack3' do
+  gem 'rack', '~> 3.0.0'
+end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#2339](https://github.com/ruby-grape/grape/pull/2339): Documentation and specs for remountable configuration in params - [@myxoh](https://github.com/myxoh).
 * [#2328](https://github.com/ruby-grape/grape/pull/2328): Don't cache Class.instance_methods - [@byroot](https://github.com/byroot).
 * [#2337](https://github.com/ruby-grape/grape/pull/2337): Fix: allow custom validators that do not end with _validator - [@ericproulx](https://github.com/ericproulx).
+* [#2346](https://github.com/ruby-grape/grape/pull/2346): Adjust test expectations to conform to rack 3 - [@kbarrette](https://github.com/kbarrette).
 * Your contribution here.
 
 ## 1.7.1 (2023/05/14)

--- a/grape.gemspec
+++ b/grape.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'builder'
   s.add_runtime_dependency 'dry-types', '>= 1.1'
   s.add_runtime_dependency 'mustermann-grape', '~> 1.0.0'
-  s.add_runtime_dependency 'rack', '>= 1.3.0', '< 3'
+  s.add_runtime_dependency 'rack', '>= 1.3.0'
   s.add_runtime_dependency 'rack-accept'
 
   s.files         = %w[CHANGELOG.md CONTRIBUTING.md README.md grape.png UPGRADING.md LICENSE]

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -138,10 +138,9 @@ describe Grape::Endpoint do
 
     it 'includes request headers' do
       get '/headers'
-      expect(JSON.parse(last_response.body)).to eq(
+      expect(JSON.parse(last_response.body)).to include(
         'Host' => 'example.org',
-        'Cookie' => '',
-        'Version' => 'HTTP/1.0'
+        'Cookie' => ''
       )
     end
 
@@ -174,7 +173,7 @@ describe Grape::Endpoint do
 
       get('/get/cookies')
 
-      expect(last_response.headers['Set-Cookie'].split("\n").sort).to eql [
+      expect(Array(last_response.headers['Set-Cookie']).flat_map { |h| h.split("\n") }.sort).to eql [
         'cookie3=symbol',
         'cookie4=secret+code+here',
         'my-awesome-cookie1=is+cool',
@@ -199,8 +198,9 @@ describe Grape::Endpoint do
       end
       get('/username', {}, 'HTTP_COOKIE' => 'username=user; sandbox=false')
       expect(last_response.body).to eq('user_test')
-      expect(last_response.headers['Set-Cookie']).to match(/username=user_test/)
-      expect(last_response.headers['Set-Cookie']).to match(/sandbox=true/)
+      cookies = Array(last_response.headers['Set-Cookie']).flat_map { |h| h.split("\n") }
+      expect(cookies.first).to match(/username=user_test/)
+      expect(cookies.second).to match(/sandbox=true/)
     end
 
     it 'deletes cookie' do
@@ -214,7 +214,7 @@ describe Grape::Endpoint do
       end
       get '/test', {}, 'HTTP_COOKIE' => 'delete_this_cookie=1; and_this=2'
       expect(last_response.body).to eq('3')
-      cookies = last_response.headers['Set-Cookie'].split("\n").to_h do |set_cookie|
+      cookies = Array(last_response.headers['Set-Cookie']).flat_map { |h| h.split("\n") }.to_h do |set_cookie|
         cookie = CookieJar::Cookie.from_set_cookie 'http://localhost/test', set_cookie
         [cookie.name, cookie]
       end
@@ -238,7 +238,7 @@ describe Grape::Endpoint do
       end
       get('/test', {}, 'HTTP_COOKIE' => 'delete_this_cookie=1; and_this=2')
       expect(last_response.body).to eq('3')
-      cookies = last_response.headers['Set-Cookie'].split("\n").to_h do |set_cookie|
+      cookies = Array(last_response.headers['Set-Cookie']).flat_map { |h| h.split("\n") }.to_h do |set_cookie|
         cookie = CookieJar::Cookie.from_set_cookie 'http://localhost/test', set_cookie
         [cookie.name, cookie]
       end

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -405,7 +405,7 @@ describe Grape::Middleware::Formatter do
       env = { 'PATH_INFO' => '/somewhere', 'HTTP_ACCEPT' => 'application/json' }
       status, headers, body = subject.call(env)
       expect(status).to be == 200
-      expect(headers).to be == { 'Content-Type' => 'application/json' }
+      expect(headers.transform_keys(&:downcase)).to be == { 'content-type' => 'application/json' }
       expect(read_chunks(body)).to be == ['data']
     end
   end


### PR DESCRIPTION
As suggested in https://github.com/ruby-grape/grape/issues/2298, here's a PR that adjusts test expectations to conform to rack 3