### PR TITLE
[ISSUE-2350] recognize_path incorrectly incorrectly recognizes path

### DIFF
--- a/spec/grape/api/recognize_path_spec.rb
+++ b/spec/grape/api/recognize_path_spec.rb
@@ -17,5 +17,32 @@ describe Grape::API do
       subject.get {}
       expect(subject.recognize_path('/bar/1234')).to be_nil
     end
+
+    context 'given parametrized route and static route' do
+      subject do
+        Class.new(described_class) do
+          resource :books do
+            route_param :id, type: Integer do
+              # GET /books/:id
+              get do
+                'book by id'
+              end
+            end
+
+            resource :share do
+              # POST /books/share
+              post do
+                'books share'
+              end
+            end
+          end
+        end
+      end
+
+      it 'recognizes it as static' do
+        actual = subject.recognize_path('/books/share').routes[0].origin
+        expect(actual).to eq('/books/share')
+      end
+    end
   end
 end


### PR DESCRIPTION
This is a failing test implementation that reproduces an issue with `recognize_path`described in https://github.com/ruby-grape/grape/issues/2350

