### PR TITLE
Lowercase content-type and x-cascade headers

### DIFF
--- a/lib/grape/http/headers.rb
+++ b/lib/grape/http/headers.rb
@@ -10,7 +10,7 @@ module Grape
       PATH_INFO       = 'PATH_INFO'
       REQUEST_METHOD  = 'REQUEST_METHOD'
       QUERY_STRING    = 'QUERY_STRING'
-      CONTENT_TYPE    = 'Content-Type'
+      CONTENT_TYPE    = 'content-type'
 
       GET     = 'GET'
       POST    = 'POST'
@@ -24,7 +24,7 @@ module Grape
       SUPPORTED_METHODS_WITHOUT_OPTIONS = Grape::Util::LazyObject.new { [GET, POST, PUT, PATCH, DELETE, HEAD].freeze }
 
       HTTP_ACCEPT_VERSION    = 'HTTP_ACCEPT_VERSION'
-      X_CASCADE              = 'X-Cascade'
+      X_CASCADE              = 'x-cascade'
       HTTP_TRANSFER_ENCODING = 'HTTP_TRANSFER_ENCODING'
       HTTP_ACCEPT            = 'HTTP_ACCEPT'
 

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -681,7 +681,7 @@ describe Grape::API do
       expect(last_response.headers['Allow']).to eql 'OPTIONS, GET, POST, HEAD'
     end
 
-    specify '405 responses includes an Content-Type header' do
+    specify '405 responses includes an content-type header' do
       subject.get 'example' do
         'example'
       end
@@ -689,7 +689,7 @@ describe Grape::API do
         'example'
       end
       put '/example'
-      expect(last_response.headers['Content-Type']).to eql 'text/plain'
+      expect(last_response.headers['content-type']).to eql 'text/plain'
     end
 
     describe 'adds an OPTIONS route that' do
@@ -1196,7 +1196,7 @@ describe Grape::API do
 
     it 'sets content type for txt format' do
       get '/foo'
-      expect(last_response.headers['Content-Type']).to eq('text/plain')
+      expect(last_response.headers['content-type']).to eq('text/plain')
     end
 
     it 'does not set Cache-Control' do
@@ -1206,22 +1206,22 @@ describe Grape::API do
 
     it 'sets content type for xml' do
       get '/foo.xml'
-      expect(last_response.headers['Content-Type']).to eq('application/xml')
+      expect(last_response.headers['content-type']).to eq('application/xml')
     end
 
     it 'sets content type for json' do
       get '/foo.json'
-      expect(last_response.headers['Content-Type']).to eq('application/json')
+      expect(last_response.headers['content-type']).to eq('application/json')
     end
 
     it 'sets content type for serializable hash format' do
       get '/foo.serializable_hash'
-      expect(last_response.headers['Content-Type']).to eq('application/json')
+      expect(last_response.headers['content-type']).to eq('application/json')
     end
 
     it 'sets content type for binary format' do
       get '/foo.binary'
-      expect(last_response.headers['Content-Type']).to eq('application/octet-stream')
+      expect(last_response.headers['content-type']).to eq('application/octet-stream')
     end
 
     it 'returns raw data when content type binary' do
@@ -1230,7 +1230,7 @@ describe Grape::API do
       subject.format :binary
       subject.get('/binary_file') { File.binread(image_filename) }
       get '/binary_file'
-      expect(last_response.headers['Content-Type']).to eq('application/octet-stream')
+      expect(last_response.headers['content-type']).to eq('application/octet-stream')
       expect(last_response.body).to eq(file)
     end
 
@@ -1243,7 +1243,7 @@ describe Grape::API do
       subject.get('/file') { file test_file }
       get '/file'
       expect(last_response.headers['Content-Length']).to eq('25')
-      expect(last_response.headers['Content-Type']).to eq('text/plain')
+      expect(last_response.headers['content-type']).to eq('text/plain')
       expect(last_response.body).to eq(file_content)
     end
 
@@ -1257,7 +1257,7 @@ describe Grape::API do
       subject.get('/stream') { stream test_stream }
       get '/stream', {}, 'HTTP_VERSION' => 'HTTP/1.1', 'SERVER_PROTOCOL' => 'HTTP/1.1'
 
-      expect(last_response.headers['Content-Type']).to eq('text/plain')
+      expect(last_response.headers['content-type']).to eq('text/plain')
       expect(last_response.headers['Content-Length']).to be_nil
       expect(last_response.headers['Cache-Control']).to eq('no-cache')
       expect(last_response.headers['Transfer-Encoding']).to eq('chunked')
@@ -1268,7 +1268,7 @@ describe Grape::API do
     it 'sets content type for error' do
       subject.get('/error') { error!('error in plain text', 500) }
       get '/error'
-      expect(last_response.headers['Content-Type']).to eql 'text/plain'
+      expect(last_response.headers['content-type']).to eql 'text/plain'
     end
 
     it 'sets content type for json error' do
@@ -1276,7 +1276,7 @@ describe Grape::API do
       subject.get('/error') { error!('error in json', 500) }
       get '/error.json'
       expect(last_response.status).to be 500
-      expect(last_response.headers['Content-Type']).to eql 'application/json'
+      expect(last_response.headers['content-type']).to eql 'application/json'
     end
 
     it 'sets content type for xml error' do
@@ -1284,7 +1284,7 @@ describe Grape::API do
       subject.get('/error') { error!('error in xml', 500) }
       get '/error'
       expect(last_response.status).to be 500
-      expect(last_response.headers['Content-Type']).to eql 'application/xml'
+      expect(last_response.headers['content-type']).to eql 'application/xml'
     end
 
     it 'includes extension in format' do
@@ -1314,12 +1314,12 @@ describe Grape::API do
 
       it 'sets content type' do
         get '/custom.custom'
-        expect(last_response.headers['Content-Type']).to eql 'application/custom'
+        expect(last_response.headers['content-type']).to eql 'application/custom'
       end
 
       it 'sets content type for error' do
         get '/error.custom'
-        expect(last_response.headers['Content-Type']).to eql 'application/custom'
+        expect(last_response.headers['content-type']).to eql 'application/custom'
       end
     end
 
@@ -1339,7 +1339,7 @@ describe Grape::API do
           image_filename = 'grape.png'
           post url, file: Rack::Test::UploadedFile.new(image_filename, 'image/png', true)
           expect(last_response.status).to eq(201)
-          expect(last_response.headers['Content-Type']).to eq('image/png')
+          expect(last_response.headers['content-type']).to eq('image/png')
           expect(last_response.headers['Content-Disposition']).to eq("attachment; filename*=UTF-8''grape.png")
           File.open(image_filename, 'rb') do |io|
             expect(last_response.body).to eq io.read
@@ -1351,7 +1351,7 @@ describe Grape::API do
         filename = __FILE__
         post '/attachment.rb', file: Rack::Test::UploadedFile.new(filename, 'application/x-ruby', true)
         expect(last_response.status).to eq(201)
-        expect(last_response.headers['Content-Type']).to eq('application/x-ruby')
+        expect(last_response.headers['content-type']).to eq('application/x-ruby')
         expect(last_response.headers['Content-Disposition']).to eq("attachment; filename*=UTF-8''api_spec.rb")
         File.open(filename, 'rb') do |io|
           expect(last_response.body).to eq io.read
@@ -3311,7 +3311,7 @@ describe Grape::API do
       it 'is able to cascade' do
         subject.mount lambda { |env|
           headers = {}
-          headers['X-Cascade'] == 'pass' if env['PATH_INFO'].exclude?('boo')
+          headers['x-cascade'] == 'pass' if env['PATH_INFO'].exclude?('boo')
           [200, headers, ['Farfegnugen']]
         } => '/'
 
@@ -4081,14 +4081,14 @@ describe Grape::API do
         subject.version 'v1', using: :path, cascade: true
         get '/v1/hello'
         expect(last_response.status).to eq(404)
-        expect(last_response.headers['X-Cascade']).to eq('pass')
+        expect(last_response.headers['x-cascade']).to eq('pass')
       end
 
       it 'does not cascade' do
         subject.version 'v2', using: :path, cascade: false
         get '/v2/hello'
         expect(last_response.status).to eq(404)
-        expect(last_response.headers.keys).not_to include 'X-Cascade'
+        expect(last_response.headers.keys).not_to include 'x-cascade'
       end
     end
 
@@ -4097,14 +4097,14 @@ describe Grape::API do
         subject.cascade true
         get '/hello'
         expect(last_response.status).to eq(404)
-        expect(last_response.headers['X-Cascade']).to eq('pass')
+        expect(last_response.headers['x-cascade']).to eq('pass')
       end
 
       it 'does not cascade' do
         subject.cascade false
         get '/hello'
         expect(last_response.status).to eq(404)
-        expect(last_response.headers.keys).not_to include 'X-Cascade'
+        expect(last_response.headers.keys).not_to include 'x-cascade'
       end
     end
   end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -497,7 +497,7 @@ describe Grape::Endpoint do
       end
 
       it 'responses with given content type in headers' do
-        expect(last_response.headers['Content-Type']).to eq 'application/json; charset=utf-8'
+        expect(last_response.headers['content-type']).to eq 'application/json; charset=utf-8'
       end
     end
 

--- a/spec/grape/exceptions/invalid_accept_header_spec.rb
+++ b/spec/grape/exceptions/invalid_accept_header_spec.rb
@@ -19,7 +19,7 @@ describe Grape::Exceptions::InvalidAcceptHeader do
 
   shared_examples_for 'a not-cascaded request' do
     it 'does not include the X-Cascade=pass header' do
-      expect(last_response.headers['X-Cascade']).to be_nil
+      expect(last_response.headers['x-cascade']).to be_nil
     end
 
     it 'does not accept the request' do
@@ -29,7 +29,7 @@ describe Grape::Exceptions::InvalidAcceptHeader do
 
   shared_examples_for 'a rescued request' do
     it 'does not include the X-Cascade=pass header' do
-      expect(last_response.headers['X-Cascade']).to be_nil
+      expect(last_response.headers['x-cascade']).to be_nil
     end
 
     it 'does show rescue handler processing' do

--- a/spec/grape/middleware/versioner/accept_version_header_spec.rb
+++ b/spec/grape/middleware/versioner/accept_version_header_spec.rb
@@ -36,7 +36,7 @@ describe Grape::Middleware::Versioner::AcceptVersionHeader do
       end.to throw_symbol(
         :error,
         status: 406,
-        headers: { 'X-Cascade' => 'pass' },
+        headers: { 'x-cascade' => 'pass' },
         message: 'The requested version is not supported.'
       )
     end
@@ -65,7 +65,7 @@ describe Grape::Middleware::Versioner::AcceptVersionHeader do
       end.to throw_symbol(
         :error,
         status: 406,
-        headers: { 'X-Cascade' => 'pass' },
+        headers: { 'x-cascade' => 'pass' },
         message: 'Accept-Version header must be set.'
       )
     end
@@ -76,7 +76,7 @@ describe Grape::Middleware::Versioner::AcceptVersionHeader do
       end.to throw_symbol(
         :error,
         status: 406,
-        headers: { 'X-Cascade' => 'pass' },
+        headers: { 'x-cascade' => 'pass' },
         message: 'Accept-Version header must be set.'
       )
     end

--- a/spec/grape/middleware/versioner/header_spec.rb
+++ b/spec/grape/middleware/versioner/header_spec.rb
@@ -88,7 +88,7 @@ describe Grape::Middleware::Versioner::Header do
       expect { subject.call('HTTP_ACCEPT' => 'application/vnd.othervendor+json').last }
         .to raise_exception do |exception|
           expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
-          expect(exception.headers).to eql('X-Cascade' => 'pass')
+          expect(exception.headers).to eql('x-cascade' => 'pass')
           expect(exception.status).to be 406
           expect(exception.message).to include 'API vendor not found'
         end
@@ -115,7 +115,7 @@ describe Grape::Middleware::Versioner::Header do
         expect { subject.call('HTTP_ACCEPT' => 'application/vnd.othervendor-v1+json').last }
           .to raise_exception do |exception|
             expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
-            expect(exception.headers).to eql('X-Cascade' => 'pass')
+            expect(exception.headers).to eql('x-cascade' => 'pass')
             expect(exception.status).to be 406
             expect(exception.message).to include('API vendor not found')
           end
@@ -143,7 +143,7 @@ describe Grape::Middleware::Versioner::Header do
     it 'fails with 406 Not Acceptable if version is invalid' do
       expect { subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v2+json').last }.to raise_exception do |exception|
         expect(exception).to be_a(Grape::Exceptions::InvalidVersionHeader)
-        expect(exception.headers).to eql('X-Cascade' => 'pass')
+        expect(exception.headers).to eql('x-cascade' => 'pass')
         expect(exception.status).to be 406
         expect(exception.message).to include('API version not found')
       end
@@ -176,7 +176,7 @@ describe Grape::Middleware::Versioner::Header do
     it 'fails with 406 Not Acceptable if header is not set' do
       expect { subject.call({}).last }.to raise_exception do |exception|
         expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
-        expect(exception.headers).to eql('X-Cascade' => 'pass')
+        expect(exception.headers).to eql('x-cascade' => 'pass')
         expect(exception.status).to be 406
         expect(exception.message).to include('Accept header must be set.')
       end
@@ -185,7 +185,7 @@ describe Grape::Middleware::Versioner::Header do
     it 'fails with 406 Not Acceptable if header is empty' do
       expect { subject.call('HTTP_ACCEPT' => '').last }.to raise_exception do |exception|
         expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
-        expect(exception.headers).to eql('X-Cascade' => 'pass')
+        expect(exception.headers).to eql('x-cascade' => 'pass')
         expect(exception.status).to be 406
         expect(exception.message).to include('Accept header must be set.')
       end
@@ -262,7 +262,7 @@ describe Grape::Middleware::Versioner::Header do
     it 'fails with another version' do
       expect { subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v3+json') }.to raise_exception do |exception|
         expect(exception).to be_a(Grape::Exceptions::InvalidVersionHeader)
-        expect(exception.headers).to eql('X-Cascade' => 'pass')
+        expect(exception.headers).to eql('x-cascade' => 'pass')
         expect(exception.status).to be 406
         expect(exception.message).to include('API version not found')
       end


### PR DESCRIPTION
Questions:

* The files `spec/grape/entity_spec.rb` and `spec/grape/middleware/formatter_spec.rb` has specs testing for `Content-type`, should these be lower case?