### PR TITLE
Reduce gem size by removing test_files (spec)

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,14 +10,6 @@
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: Severity, Include.
 # Include: **/*.gemspec
-Gemspec/DeprecatedAttributeAssignment:
-  Exclude:
-    - 'grape.gemspec'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: Severity, Include.
-# Include: **/*.gemspec
 Gemspec/RequireMFA:
   Exclude:
     - 'grape.gemspec'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * [#2353](https://github.com/ruby-grape/grape/pull/2353): Added Rails 7.1 support - [@ericproulx](https://github.com/ericproulx).
+* [#2360](https://github.com/ruby-grape/grape/pull/2360): Reduce gem size by removing specs - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/grape.gemspec
+++ b/grape.gemspec
@@ -27,10 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rack', '>= 1.3.0'
   s.add_runtime_dependency 'rack-accept'
 
-  s.files         = %w[CHANGELOG.md CONTRIBUTING.md README.md grape.png UPGRADING.md LICENSE]
-  s.files        += %w[grape.gemspec]
-  s.files        += Dir['lib/**/*']
-  s.test_files    = Dir['spec/**/*']
+  s.files = Dir['lib/**/*', 'CHANGELOG.md', 'CONTRIBUTING.md', 'README.md', 'grape.png', 'UPGRADING.md', 'LICENSE', 'grape.gemspec']
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.6.0'
 end


### PR DESCRIPTION
It occurred to me while installing the gem that spec files are included. It represents half the size of the gem. Nowadays, most  gem does not include them and I think Grape should do the same.