### PR TITLE
Quality arguments to `Accept` header should default to 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 #### Fixes
 
 * [#2364](https://github.com/ruby-grape/grape/pull/2364): Add missing requires - [@ericproulx](https://github.com/ericproulx).
+* [#2366](https://github.com/ruby-grape/grape/pull/2366): Quality arguments to `accept` header should default to 1.0 - [@hiddewie](https://github.com/hiddewie).
 * Your contribution here.
 
 ### 1.8.0 (2023/08/30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@
 * [#2360](https://github.com/ruby-grape/grape/pull/2360): Reduce gem size by removing specs - [@ericproulx](https://github.com/ericproulx).
 * [#2361](https://github.com/ruby-grape/grape/pull/2361): Remove `Rack::Auth::Digest` - [@ninoseki](https://github.com/ninoseki).
 * Your contribution here.
-  
+
 #### Fixes
 
 * [#2364](https://github.com/ruby-grape/grape/pull/2364): Add missing requires - [@ericproulx](https://github.com/ericproulx).
-* [#2366](https://github.com/ruby-grape/grape/pull/2366): Quality arguments to `accept` header should default to 1.0 - [@hiddewie](https://github.com/hiddewie).
+* [#2366](https://github.com/ruby-grape/grape/pull/2366): Default quality to 1.0 in the `Accept` header when omitted - [@hiddewie](https://github.com/hiddewie).
 * Your contribution here.
 
 ### 1.8.0 (2023/08/30)

--- a/README.md
+++ b/README.md
@@ -596,6 +596,10 @@ When an invalid `Accept` header is supplied, a `406 Not Acceptable` error is ret
 option is set to `false`. Otherwise a `404 Not Found` error is returned by Rack if no other route
 matches.
 
+Grape will evaluate the relative quality preference included in Accept headers and default to a quality of 1.0 when omitted. In the following example a Grape API that supports XML and JSON in that order will return JSON:
+
+    curl -H "Accept: text/xml;q=0.8, application/json;q=0.9" localhost:1234/resource
+
 ### Accept-Version Header
 
 ```ruby
@@ -1600,7 +1604,7 @@ Note endless ranges are also supported with ActiveSupport >= 6.0, but they requi
 ```ruby
 params do
   requires :minimum, type: Integer, values: 10..
-  optional :maximum, type: Integer, values: ..10 
+  optional :maximum, type: Integer, values: ..10
 end
 ```
 

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -172,6 +172,7 @@ module Grape
 
         accept.scan(accept_into_mime_and_quality)
               .sort_by { |_, quality_preference| -quality_preference.to_f }
+              .sort_by { |_, quality_preference| -(quality_preference || '1.0').to_f }
               .flat_map { |mime, _| [mime, mime.sub(vendor_prefix_pattern, '')] }
       end
     end

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -171,7 +171,6 @@ module Grape
         vendor_prefix_pattern = /vnd\.[^+]+\+/
 
         accept.scan(accept_into_mime_and_quality)
-              .sort_by { |_, quality_preference| -quality_preference.to_f }
               .sort_by { |_, quality_preference| -(quality_preference || '1.0').to_f }
               .flat_map { |mime, _| [mime, mime.sub(vendor_prefix_pattern, '')] }
       end

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -164,14 +164,14 @@ module Grape
             \w+/[\w+.-]+)     # eg application/vnd.example.myformat+xml
           (?:
            (?:;[^,]*?)?       # optionally multiple formats in a row
-           ;\s*q=([\d.]+)     # optional "quality" preference (eg q=0.5)
+           ;\s*q=([\w.]+)     # optional "quality" preference (eg q=0.5)
           )?
         }x
 
         vendor_prefix_pattern = /vnd\.[^+]+\+/
 
         accept.scan(accept_into_mime_and_quality)
-              .sort_by { |_, quality_preference| -(quality_preference || '1.0').to_f }
+              .sort_by { |_, quality_preference| -(quality_preference ? quality_preference.to_f : 1.0) }
               .flat_map { |mime, _| [mime, mime.sub(vendor_prefix_pattern, '')] }
       end
     end

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -132,7 +132,7 @@ describe Grape::Middleware::Formatter do
 
     it 'handles quality rankings mixed with nothing' do
       subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/json,application/xml; q=1.0')
-      expect(subject.env['api.format']).to eq(:json)
+      expect(subject.env['api.format']).to eq(:xml)
 
       subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/xml; q=1.0,application/json')
       expect(subject.env['api.format']).to eq(:xml)

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -132,7 +132,7 @@ describe Grape::Middleware::Formatter do
 
     it 'handles quality rankings mixed with nothing' do
       subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/json,application/xml; q=1.0')
-      expect(subject.env['api.format']).to eq(:xml)
+      expect(subject.env['api.format']).to eq(:json)
 
       subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/xml; q=1.0,application/json')
       expect(subject.env['api.format']).to eq(:xml)

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -131,7 +131,16 @@ describe Grape::Middleware::Formatter do
 
     it 'handles quality rankings mixed with nothing' do
       subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/json,application/xml; q=1.0')
+      expect(subject.env['api.format']).to eq(:json)
+      subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/xml; q=1.0,application/json')
       expect(subject.env['api.format']).to eq(:xml)
+    end
+
+    it 'handles quality rankings that have a default 1.0 value' do
+      subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/json,application/xml;q=0.5')
+      expect(subject.env['api.format']).to eq(:json)
+      subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/xml;q=0.5,application/json')
+      expect(subject.env['api.format']).to eq(:json)
     end
 
     it 'parses headers with other attributes' do

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -125,6 +125,7 @@ describe Grape::Middleware::Formatter do
     it 'uses quality rankings to determine formats' do
       subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/json; q=0.3,application/xml; q=1.0')
       expect(subject.env['api.format']).to eq(:xml)
+
       subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/json; q=1.0,application/xml; q=0.3')
       expect(subject.env['api.format']).to eq(:json)
     end
@@ -132,6 +133,7 @@ describe Grape::Middleware::Formatter do
     it 'handles quality rankings mixed with nothing' do
       subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/json,application/xml; q=1.0')
       expect(subject.env['api.format']).to eq(:json)
+
       subject.call('PATH_INFO' => '/info', 'HTTP_ACCEPT' => 'application/xml; q=1.0,application/json')
       expect(subject.env['api.format']).to eq(:xml)
     end


### PR DESCRIPTION
This PR ensures that Accept headers with mime types without a given quality value, are parsed as having a quality value of `1.0`.

The current value for mime types without a quality value is 0.0 (`nil.to_f`).

From the HTTP specification (RFC 9110), https://www.rfc-editor.org/rfc/rfc9110.html#name-accept and https://www.rfc-editor.org/rfc/rfc9110.html#name-quality-values:

> The weight is normalized to a real number in the range 0 through 1, where 0.001 is the least preferred and 1 is the most preferred; a value of 0 means "not acceptable". If no "q" parameter is present, the default weight is 1.