### PR TITLE
fix(#2236): Stripping the internals of `Grape::Endpoint` when `NoMethodError` is raised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * [#2364](https://github.com/ruby-grape/grape/pull/2364): Add missing requires - [@ericproulx](https://github.com/ericproulx).
 * [#2366](https://github.com/ruby-grape/grape/pull/2366): Default quality to 1.0 in the `Accept` header when omitted - [@hiddewie](https://github.com/hiddewie).
+* [#2368](https://github.com/ruby-grape/grape/pull/2368): Stripping the internals of `Grape::Endpoint` when `NoMethodError` is raised - [@jcagarcia](https://github.com/jcagarcia).
 * Your contribution here.
 
 ### 1.8.0 (2023/08/30)

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -404,8 +404,12 @@ module Grape
         env[Grape::Http::Headers::REQUEST_METHOD] == Grape::Http::Headers::OPTIONS
     end
 
-    def method_missing(name, *args)
-      raise NoMethodError.new("undefined method `#{name}' for #{self.class} in `#{self.route.origin}' endpoint")
+    def method_missing(name, *_args)
+      raise NoMethodError.new("undefined method `#{name}' for #{self.class} in `#{route.origin}' endpoint")
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      super
     end
   end
 end

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -403,5 +403,9 @@ module Grape
       options[:options_route_enabled] &&
         env[Grape::Http::Headers::REQUEST_METHOD] == Grape::Http::Headers::OPTIONS
     end
+
+    def method_missing(name, *args)
+      raise NoMethodError.new("undefined method `#{name}` for #{self.class}")
+    end
   end
 end

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -405,7 +405,7 @@ module Grape
     end
 
     def method_missing(name, *args)
-      raise NoMethodError.new("undefined method `#{name}` for #{self.class}")
+      raise NoMethodError.new("undefined method `#{name}' for #{self.class} in `#{self.route.origin}' endpoint")
     end
   end
 end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -698,9 +698,9 @@ describe Grape::Endpoint do
         subject.get('/hey') do
           undefined_helper
         end
-        expect {
+        expect do
           get '/hey'
-        }.to raise_error(NoMethodError, /^undefined method `undefined_helper' for #<Class:0x[0-9a-fA-F]+> in `\/hey' endpoint/)
+        end.to raise_error(NoMethodError, %r{^undefined method `undefined_helper' for #<Class:0x[0-9a-fA-F]+> in `/hey' endpoint})
       end
     end
 
@@ -709,9 +709,9 @@ describe Grape::Endpoint do
         subject.get('/hey') do
           Object.new.x
         end
-        expect {
+        expect do
           get '/hey'
-        }.to raise_error(NoMethodError, /^undefined method `x' for #<Object:0x[0-9a-fA-F]+>$/)
+        end.to raise_error(NoMethodError, /^undefined method `x' for #<Object:0x[0-9a-fA-F]+>$/)
       end
     end
   end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -692,6 +692,17 @@ describe Grape::Endpoint do
     end
   end
 
+  describe '#method_missing' do
+    it 'raises NoMethodError but stripping the internals of the Grape::Endpoint class' do
+      subject.get('/hey') do
+        undefined_helper
+      end
+      expect {
+        get '/hey'
+      }.to raise_error(NoMethodError, /^undefined method `undefined_helper` for #<Class:0x[0-9a-fA-F]+>$/)
+    end
+  end
+
   it 'does not persist params between calls' do
     subject.post('/new') do
       params[:text]

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -693,13 +693,26 @@ describe Grape::Endpoint do
   end
 
   describe '#method_missing' do
-    it 'raises NoMethodError but stripping the internals of the Grape::Endpoint class' do
-      subject.get('/hey') do
-        undefined_helper
+    context 'when referencing an undefined local variable' do
+      it 'raises NoMethodError but stripping the internals of the Grape::Endpoint class and including the API route' do
+        subject.get('/hey') do
+          undefined_helper
+        end
+        expect {
+          get '/hey'
+        }.to raise_error(NoMethodError, /^undefined method `undefined_helper' for #<Class:0x[0-9a-fA-F]+> in `\/hey' endpoint/)
       end
-      expect {
-        get '/hey'
-      }.to raise_error(NoMethodError, /^undefined method `undefined_helper` for #<Class:0x[0-9a-fA-F]+>$/)
+    end
+
+    context 'when performing an undefined method of an instance inside the API' do
+      it 'raises NoMethodError but stripping the internals of the Object class' do
+        subject.get('/hey') do
+          Object.new.x
+        end
+        expect {
+          get '/hey'
+        }.to raise_error(NoMethodError, /^undefined method `x' for #<Object:0x[0-9a-fA-F]+>$/)
+      end
     end
   end
 


### PR DESCRIPTION
Hi all! 👋 

My first contribution to the Grape project. Let's see if this can help to solve the issue #2236 

With the fix, when referencing an undefined local variable within a grape controller, Grape is returning this error message.

(error trace updated after applying @dblock suggestions)
```shell
NoMethodError: undefined method `authenticate!' for #<Class:0x0000000103996728> in `/foo' endpoint
	/Users/Juancarlos.Garcia/code/grape/lib/grape/endpoint.rb:408:in `method_missing'
	/Users/Juancarlos.Garcia/code/grape-2236/api.rb:7:in `block in <class:MyAPI>'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/endpoint.rb:58:in `call'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/endpoint.rb:58:in `block (2 levels) in generate_api_method'
	/Users/Juancarlos.Garcia/.rvm/gems/ruby-3.2.2/gems/activesupport-7.0.8/lib/active_support/notifications.rb:208:in `instrument'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/endpoint.rb:57:in `block in generate_api_method'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/endpoint.rb:328:in `execute'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/endpoint.rb:260:in `block in run'
	/Users/Juancarlos.Garcia/.rvm/gems/ruby-3.2.2/gems/activesupport-7.0.8/lib/active_support/notifications.rb:208:in `instrument'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/endpoint.rb:240:in `run'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/endpoint.rb:316:in `block in build_stack'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/middleware/base.rb:36:in `call!'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/middleware/base.rb:29:in `call'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/middleware/error.rb:39:in `block in call!'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/middleware/error.rb:38:in `catch'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/middleware/error.rb:38:in `call!'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/middleware/base.rb:29:in `call'
	/Users/Juancarlos.Garcia/.rvm/gems/ruby-3.2.2/gems/rack-2.2.8/lib/rack/head.rb:12:in `call'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/endpoint.rb:224:in `call!'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/endpoint.rb:218:in `call'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/router/route.rb:58:in `exec'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/router.rb:120:in `process_route'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/router.rb:74:in `block in identity'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/router.rb:94:in `transaction'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/router.rb:72:in `identity'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/router.rb:56:in `block in call'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/router.rb:136:in `with_optimization'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/router.rb:55:in `call'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/api/instance.rb:165:in `call'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/api/instance.rb:70:in `call!'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/api/instance.rb:65:in `call'
	/Users/Juancarlos.Garcia/code/grape/lib/grape/api.rb:81:in `call'
	/Users/Juancarlos.Garcia/.rvm/gems/ruby-3.2.2/gems/rack-2.2.8/lib/rack/tempfile_reaper.rb:15:in `call'
	/Users/Juancarlos.Garcia/.rvm/gems/ruby-3.2.2/gems/rack-2.2.8/lib/rack/lint.rb:50:in `_call'
	/Users/Juancarlos.Garcia/.rvm/gems/ruby-3.2.2/gems/rack-2.2.8/lib/rack/lint.rb:38:in `call'
	/Users/Juancarlos.Garcia/.rvm/gems/ruby-3.2.2/gems/rack-2.2.8/lib/rack/show_exceptions.rb:23:in `call'
	/Users/Juancarlos.Garcia/.rvm/gems/ruby-3.2.2/gems/rack-2.2.8/lib/rack/common_logger.rb:38:in `call'
	/Users/Juancarlos.Garcia/.rvm/gems/ruby-3.2.2/gems/rack-2.2.8/lib/rack/content_length.rb:17:in `call'
	/Users/Juancarlos.Garcia/.rvm/gems/ruby-3.2.2/gems/puma-5.6.7/lib/puma/configuration.rb:252:in `call'
	/Users/Juancarlos.Garcia/.rvm/gems/ruby-3.2.2/gems/puma-5.6.7/lib/puma/request.rb:77:in `block in handle_request'
	/Users/Juancarlos.Garcia/.rvm/gems/ruby-3.2.2/gems/puma-5.6.7/lib/puma/thread_pool.rb:340:in `with_force_shutdown'
	/Users/Juancarlos.Garcia/.rvm/gems/ruby-3.2.2/gems/puma-5.6.7/lib/puma/request.rb:76:in `handle_request'
	/Users/Juancarlos.Garcia/.rvm/gems/ruby-3.2.2/gems/puma-5.6.7/lib/puma/server.rb:443:in `process_client'
	/Users/Juancarlos.Garcia/.rvm/gems/ruby-3.2.2/gems/puma-5.6.7/lib/puma/thread_pool.rb:147:in `block in spawn_thread'
127.0.0.1 - - [10/Nov/2023:10:14:40 +0100] "GET /foo HTTP/1.1" 500 154280 0.0466
```

Don't know the implications of overriding the `method_missing` for the `Grape::Endpoint` instance class. Also, don't know if you want to show more descriptive information a part of the anonymous class object. So suggestions, feedback or any kind of comment is really welcome :) 