### PR TITLE
method missing to_ary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#2370](https://github.com/ruby-grape/grape/pull/2370): Stop method_missing to_ary - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 2.0.0 (2023/11/11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 2.0.0 (Next)
+### 2.0.0 (2023/11/11)
 
 #### Features
 
@@ -6,14 +6,12 @@
 * [#2355](https://github.com/ruby-grape/grape/pull/2355): Set response headers based on Rack version - [@schinery](https://github.com/schinery).
 * [#2360](https://github.com/ruby-grape/grape/pull/2360): Reduce gem size by removing specs - [@ericproulx](https://github.com/ericproulx).
 * [#2361](https://github.com/ruby-grape/grape/pull/2361): Remove `Rack::Auth::Digest` - [@ninoseki](https://github.com/ninoseki).
-* Your contribution here.
 
 #### Fixes
 
 * [#2364](https://github.com/ruby-grape/grape/pull/2364): Add missing requires - [@ericproulx](https://github.com/ericproulx).
 * [#2366](https://github.com/ruby-grape/grape/pull/2366): Default quality to 1.0 in the `Accept` header when omitted - [@hiddewie](https://github.com/hiddewie).
 * [#2368](https://github.com/ruby-grape/grape/pull/2368): Stripping the internals of `Grape::Endpoint` when `NoMethodError` is raised - [@jcagarcia](https://github.com/jcagarcia).
-* Your contribution here.
 
 ### 1.8.0 (2023/08/30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+### 2.0.1 (Next)
+
+#### Features
+
+* Your contribution here.
+
+#### Fixes
+
+* Your contribution here.
+
 ### 2.0.0 (2023/11/11)
 
 #### Features

--- a/README.md
+++ b/README.md
@@ -160,8 +160,9 @@ content negotiation, versioning and much more.
 
 ## Stable Release
 
-You're reading the documentation for the stable release of Grape, **2.0.0**.
+You're reading the documentation for the next release of Grape, which should be **2.0.1**.
 Please read [UPGRADING](UPGRADING.md) when upgrading from a previous version.
+The current stable release is [2.0.0](https://github.com/ruby-grape/grape/blob/v2.0.0/README.md).
 
 
 ## Project Resources

--- a/README.md
+++ b/README.md
@@ -3506,7 +3506,7 @@ TwitterAPI::routes[0].description # => 'Includes custom settings.'
 TwitterAPI::routes[0].settings[:custom] # => { key: 'value' }
 ```
 
-Note that `Route#route_xyz` methods have been deprecated since 0.15.0 and removed since 2.0.1
+Note that `Route#route_xyz` methods have been deprecated since 0.15.0 and removed since 2.0.1.
 
 Please use `Route#xyz` instead.
 

--- a/README.md
+++ b/README.md
@@ -3483,7 +3483,7 @@ You can access the controller params, headers, and helpers through the context w
 
 Grape routes can be reflected at runtime. This can notably be useful for generating documentation.
 
-Grape exposes arrays of API versions and compiled routes. Each route contains a `route_prefix`, `route_version`, `route_namespace`, `route_method`, `route_path` and `route_params`. You can add custom route settings to the route metadata with `route_setting`.
+Grape exposes arrays of API versions and compiled routes. Each route contains a `prefix`, `version`, `namespace`, `method` and `params`. You can add custom route settings to the route metadata with `route_setting`.
 
 ```ruby
 class TwitterAPI < Grape::API
@@ -3506,7 +3506,7 @@ TwitterAPI::routes[0].description # => 'Includes custom settings.'
 TwitterAPI::routes[0].settings[:custom] # => { key: 'value' }
 ```
 
-Note that `Route#route_xyz` methods have been deprecated since 0.15.0.
+Note that `Route#route_xyz` methods have been deprecated since 0.15.0 and removed since 2.0.1
 
 Please use `Route#xyz` instead.
 
@@ -3526,7 +3526,7 @@ class MyAPI < Grape::API
     requires :id, type: Integer, desc: 'Identity.'
   end
   get 'params/:id' do
-    route.route_params[params[:id]] # yields the parameter description
+    route.params[params[:id]] # yields the parameter description
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -160,9 +160,8 @@ content negotiation, versioning and much more.
 
 ## Stable Release
 
-You're reading the documentation for the next release of Grape, which should be **2.0.0**.
+You're reading the documentation for the stable release of Grape, **2.0.0**.
 Please read [UPGRADING](UPGRADING.md) when upgrading from a previous version.
-The current stable release is [1.8.0](https://github.com/ruby-grape/grape/blob/v1.8.0/README.md).
 
 
 ## Project Resources

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,14 @@
 Upgrading Grape
 ===============
 
+### Upgrading to >= 2.0.1
+
+#### Grape::Router::Route.route_xxx methods have been removed
+
+- `route_method` is accessible through `request_method`
+- `route_path` is accessible through `path`
+- Any other `route_xyz` are accessible through `options[xyz]`
+
 ### Upgrading to >= 2.0.0
 
 #### Headers

--- a/lib/grape/router/route.rb
+++ b/lib/grape/router/route.rb
@@ -86,6 +86,10 @@ module Grape
         expected ||= name
         Grape.deprecator.warn("#{path}:#{line}: The route_xxx methods such as route_#{name} have been deprecated, please use #{expected}.")
       end
+
+      def to_ary
+        nil
+      end
     end
   end
 end

--- a/lib/grape/router/route.rb
+++ b/lib/grape/router/route.rb
@@ -3,13 +3,10 @@
 require 'grape/router/pattern'
 require 'grape/router/attribute_translator'
 require 'forwardable'
-require 'pathname'
 
 module Grape
   class Router
     class Route
-      ROUTE_ATTRIBUTE_REGEXP = /route_([_a-zA-Z]\w*)/.freeze
-      SOURCE_LOCATION_REGEXP = /^(.*?):(\d+?)(?::in `.+?')?$/.freeze
       FIXED_NAMED_CAPTURES = %w[format version].freeze
 
       attr_accessor :pattern, :translator, :app, :index, :options
@@ -19,31 +16,6 @@ module Grape
       extend Forwardable
       def_delegators :pattern, :path, :origin
       delegate Grape::Router::AttributeTranslator::ROUTE_ATTRIBUTES => :attributes
-
-      def method_missing(method_id, *arguments)
-        match = ROUTE_ATTRIBUTE_REGEXP.match(method_id.to_s)
-        if match
-          method_name = match.captures.last.to_sym
-          warn_route_methods(method_name, caller(1).shift)
-          @options[method_name]
-        else
-          super
-        end
-      end
-
-      def respond_to_missing?(method_id, _)
-        ROUTE_ATTRIBUTE_REGEXP.match?(method_id.to_s)
-      end
-
-      def route_method
-        warn_route_methods(:method, caller(1).shift, :request_method)
-        request_method
-      end
-
-      def route_path
-        warn_route_methods(:path, caller(1).shift)
-        pattern.path
-      end
 
       def initialize(method, pattern, **options)
         method_s = method.to_s
@@ -76,19 +48,6 @@ module Grape
           parsed = pattern.params(input)
           parsed ? parsed.delete_if { |_, value| value.nil? }.symbolize_keys : {}
         end
-      end
-
-      private
-
-      def warn_route_methods(name, location, expected = nil)
-        path, line = *location.scan(SOURCE_LOCATION_REGEXP).first
-        path = File.realpath(path) if Pathname.new(path).relative?
-        expected ||= name
-        Grape.deprecator.warn("#{path}:#{line}: The route_xxx methods such as route_#{name} have been deprecated, please use #{expected}.")
-      end
-
-      def to_ary
-        nil
       end
     end
   end

--- a/lib/grape/version.rb
+++ b/lib/grape/version.rb
@@ -2,5 +2,5 @@
 
 module Grape
   # The current version of Grape.
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3050,7 +3050,6 @@ describe Grape::API do
       expect(subject.routes.length).to eq(1)
       route = subject.routes.first
       expect(route.description).to eq('first method')
-      expect(route.route_foo).to be_nil
       expect(route.params).to eq({})
       expect(route.options).to be_a(Hash)
     end
@@ -3095,7 +3094,7 @@ describe Grape::API do
         get 'second'
       end
       expect(subject.routes.map do |route|
-        { description: route.description, foo: route.route_foo, params: route.params }
+        { description: route.description, foo: route.options[:foo], params: route.params }
       end).to eq [
         { description: 'ns second', foo: 'bar', params: {} }
       ]


### PR DESCRIPTION
While profiling #2363, I found that `to_ary` is leaking as `Allocated String Report`.
It has been fixed in by #466 but lost since.