### PR TITLE
fix(#2195): Fix `declared` method for hash params with overlapping names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#2372](https://github.com/ruby-grape/grape/pull/2372): Fix `declared` method for hash params with overlapping names - [@jcagarcia](https://github.com/jcagarcia).
 * Your contribution here.
 
 ### 2.0.0 (2023/11/11)

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -99,7 +99,7 @@ module Grape
 
           route_options_params = options[:route_options][:params] || {}
           type = route_options_params.dig(key, :type)
-          has_children = route_options_params.keys.any? { |k| k != key && k.start_with?(key) }
+          has_children = route_options_params.keys.any? { |k| k != key && k.start_with?("#{key}[") }
 
           if type == 'Hash' && !has_children
             {}

--- a/spec/grape/endpoint/declared_spec.rb
+++ b/spec/grape/endpoint/declared_spec.rb
@@ -39,6 +39,7 @@ describe Grape::Endpoint do
         optional :empty_arr, type: Array
         optional :empty_typed_arr, type: Array[String]
         optional :empty_hash, type: Hash
+        optional :empty_hash_two, type: Hash
         optional :empty_set, type: Set
         optional :empty_typed_set, type: Set[String]
       end
@@ -122,7 +123,7 @@ describe Grape::Endpoint do
       end
       get '/declared?first=present'
       expect(last_response.status).to eq(200)
-      expect(JSON.parse(last_response.body).keys.size).to eq(11)
+      expect(JSON.parse(last_response.body).keys.size).to eq(12)
     end
 
     it 'has a optional param with default value all the time' do
@@ -201,6 +202,7 @@ describe Grape::Endpoint do
 
         body = JSON.parse(last_response.body)
         expect(body['empty_hash']).to eq({})
+        expect(body['empty_hash_two']).to eq({})
         expect(body['nested']).to be_a(Hash)
         expect(body['nested']['empty_hash']).to eq({})
         expect(body['nested']['nested_two']).to be_a(Hash)


### PR DESCRIPTION
Hi 👋 

I was taking a look to the issue #2195 .

Seems the error is because the logic inside the `handle_passed_param` method is using the `start_with?(key)` method. So, if we have two params like `:empty_hash` and `:empty_hash_two`, as both of them share part of the key, it detects that the `:empty_hash` parameter has children, and it behaves in a different way and it ends returning a `nil` value.

For solving it, I'm checking that for having children the key of the children should start with the same key name + a `[`. Maybe not the better solution for checking this 🤔 so open to discussion.