### PR TITLE
fix(#1922): Allow to use instance variables defined in the endpoints inside rescue_from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 #### Features
 
 * [#2371](https://github.com/ruby-grape/grape/pull/2371): Use a param value as the `default` value of other param - [@jcagarcia](https://github.com/jcagarcia).
-* [#2377](https://github.com/ruby-grape/grape/pull/2377): Allow to use instance variables values inside rescue_from - [@jcagarcia](https://github.com/jcagarcia).
+* [#2377](https://github.com/ruby-grape/grape/pull/2377): Allow to use instance variables values inside `rescue_from` - [@jcagarcia](https://github.com/jcagarcia).
 * Your contribution here.
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * [#2371](https://github.com/ruby-grape/grape/pull/2371): Use a param value as the `default` value of other param - [@jcagarcia](https://github.com/jcagarcia).
+* [#2377](https://github.com/ruby-grape/grape/pull/2377): Allow to use instance variables values inside rescue_from - [@jcagarcia](https://github.com/jcagarcia).
 * Your contribution here.
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@
 - [Current Route and Endpoint](#current-route-and-endpoint)
 - [Before, After and Finally](#before-after-and-finally)
 - [Anchoring](#anchoring)
+- [Instance Variables](#instance-variables)
 - [Using Custom Middleware](#using-custom-middleware)
   - [Grape Middleware](#grape-middleware)
   - [Rails Middleware](#rails-middleware)
@@ -3594,6 +3595,42 @@ end
 
 This will match all paths starting with '/statuses/'. There is one caveat though: the `params[:status]` parameter only holds the first part of the request url.
 Luckily this can be circumvented by using the described above syntax for path specification and using the `PATH_INFO` Rack environment variable, using `env['PATH_INFO']`. This will hold everything that comes after the '/statuses/' part.
+
+## Instance Variables
+
+You can use instance variables to pass information across the various stages of a request. An instance variable set within a `before` validator is accessible within the endpoint's code and can also be utilized within the `rescue_from` handler.
+
+```ruby
+class TwitterAPI < Grape::API
+  before do
+    @var = 1
+  end
+
+  get '/' do
+    puts @var # => 1
+    raise
+  end
+
+  rescue_from :all do
+    puts @var # => 1
+  end
+end
+```
+
+The values of instance variables cannot be shared among various endpoints within the same API. This limitation arises due to Grape generating a new instance for each request made. Consequently, instance variables set within an endpoint during one request differ from those set during a subsequent request, as they exist within separate instances.
+
+```ruby
+class TwitterAPI < Grape::API
+  get '/first' do
+    @var = 1
+    puts @var # => 1
+  end
+
+  get '/second' do
+    puts @var # => nil
+  end
+end
+```
 
 ## Using Custom Middleware
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -11,9 +11,45 @@ Upgrading Grape
 
 #### Instance variables scope
 
-Due to the changes done in [#2377](https://github.com/ruby-grape/grape/pull/2377), the instance variables defined inside each of the endpoints (or inside a `before` validator) are now accessible inside the `rescue_from`. This means the scope of the instance variables has changed.
+Due to the changes done in [#2377](https://github.com/ruby-grape/grape/pull/2377), the instance variables defined inside each of the endpoints (or inside a `before` validator) are now accessible inside the `rescue_from`. The behavior of the instance variables was undefined until `2.1.0`.
 
 If you were using the same variable name defined inside an endpoint or `before` validator inside a `rescue_from` handler, you need to take in mind that you can start getting different values or you can be overriding values.
+
+Before:
+```ruby
+class TwitterAPI < Grape::API
+  before do
+    @var = 1
+  end
+
+  get '/' do
+    puts @var # => 1
+    raise
+  end
+
+  rescue_from :all do
+    puts @var # => nil
+  end
+end
+```
+
+After:
+```ruby
+class TwitterAPI < Grape::API
+  before do
+    @var = 1
+  end
+
+  get '/' do
+    puts @var # => 1
+    raise
+  end
+
+  rescue_from :all do
+    puts @var # => 1
+  end
+end
+```
 
 ### Upgrading to >= 2.0.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,13 +1,19 @@
 Upgrading Grape
 ===============
 
-### Upgrading to >= 2.0.1
+### Upgrading to >= 2.1.0
 
 #### Grape::Router::Route.route_xxx methods have been removed
 
 - `route_method` is accessible through `request_method`
 - `route_path` is accessible through `path`
 - Any other `route_xyz` are accessible through `options[xyz]`
+
+#### Instance variables scope
+
+Due to the changes done in [#2377](https://github.com/ruby-grape/grape/pull/2377), the instance variables defined inside each of the endpoints (or inside a `before` validator) are now accessible inside the `rescue_from`. This means the scope of the instance variables has changed.
+
+If you were using the same variable name defined inside an endpoint or `before` validator inside a `rescue_from` handler, you need to take in mind that you can start getting different values or you can be overriding values.
 
 ### Upgrading to >= 2.0.0
 

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -167,6 +167,23 @@ module Grape
         throw :error, message: message, status: self.status, headers: headers
       end
 
+      # Creates a Rack response based on the provided message, status, and headers.
+      # The content type in the headers is set to the default content type unless provided.
+      # The message is HTML-escaped if the content type is 'text/html'.
+      #
+      # @param message [String] The content of the response.
+      # @param status [Integer] The HTTP status code.
+      # @params headers [Hash] (optional) Headers for the response
+      #                      (default: {Rack::CONTENT_TYPE => content_type}).
+      #
+      # Returns:
+      # A Rack::Response object containing the specified message, status, and headers.
+      #
+      def rack_response(message, status, headers = { Rack::CONTENT_TYPE => content_type })
+        message = ERB::Util.html_escape(message) if headers[Rack::CONTENT_TYPE] == 'text/html'
+        Rack::Response.new([message], Rack::Utils.status_code(status), headers)
+      end
+
       # Redirect to a new url.
       #
       # @param url [String] The url to be redirect.

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -179,7 +179,7 @@ module Grape
       # Returns:
       # A Rack::Response object containing the specified message, status, and headers.
       #
-      def rack_response(message, status, headers = { Rack::CONTENT_TYPE => content_type })
+      def rack_response(message, status = 200, headers = { Rack::CONTENT_TYPE => content_type })
         message = ERB::Util.html_escape(message) if headers[Rack::CONTENT_TYPE] == 'text/html'
         Rack::Response.new([message], Rack::Utils.status_code(status), headers)
       end

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -46,7 +46,7 @@ module Grape
             rescue_handler_for_any_class(e.class) ||
             raise
 
-          run_rescue_handler(@env[Grape::Env::API_ENDPOINT], handler, e)
+          run_rescue_handler(handler, e, @env[Grape::Env::API_ENDPOINT])
         end
       end
 
@@ -119,7 +119,7 @@ module Grape
         options[:all_rescue_handler] || :default_rescue_handler
       end
 
-      def run_rescue_handler(endpoint, handler, error)
+      def run_rescue_handler(handler, error, endpoint)
         if handler.instance_of?(Symbol)
           raise NoMethodError, "undefined method '#{handler}'" unless respond_to?(handler)
 
@@ -135,7 +135,7 @@ module Grape
         if response.is_a?(Rack::Response)
           response
         else
-          run_rescue_handler(endpoint, :default_rescue_handler, Grape::Exceptions::InvalidResponse.new)
+          run_rescue_handler(:default_rescue_handler, Grape::Exceptions::InvalidResponse.new, endpoint)
         end
       end
 

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -130,9 +130,7 @@ module Grape
           handler.arity.zero? ? endpoint.instance_exec(&handler) : endpoint.instance_exec(error, &handler)
         end)
 
-        if error?(response)
-          response = error!(response[:message], response[:status], response[:headers])
-        end
+        response = error!(response[:message], response[:status], response[:headers]) if error?(response)
 
         if response.is_a?(Rack::Response)
           response
@@ -142,7 +140,7 @@ module Grape
       end
 
       def error?(response)
-        response && response.is_a?(Hash) && response[:message] && response[:status] && response[:headers]
+        response.is_a?(Hash) && response[:message] && response[:status] && response[:headers]
       end
     end
   end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -2130,6 +2130,25 @@ describe Grape::API do
       expect(last_response.status).to be 500
       expect(last_response.body).to eql 'Invalid response'
     end
+
+    context 'when using instance variables inside the rescue_from' do
+      it 'is able to access the values' do
+        expected_instance_variable_value = 'wadus'
+
+        subject.rescue_from(:all) do
+          body = { my_var: @my_var }
+          error!(body, 400)
+        end
+        subject.get('/') do
+          @my_var = expected_instance_variable_value
+          raise
+        end
+
+        get '/'
+        expect(last_response.status).to be 400
+        expect(last_response.body).to eq({ my_var: expected_instance_variable_value }.to_json)
+      end
+    end
   end
 
   describe '.rescue_from klass, block' do

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -2130,25 +2130,6 @@ describe Grape::API do
       expect(last_response.status).to be 500
       expect(last_response.body).to eql 'Invalid response'
     end
-
-    context 'when using instance variables inside the rescue_from' do
-      it 'is able to access the values' do
-        expected_instance_variable_value = 'wadus'
-
-        subject.rescue_from(:all) do
-          body = { my_var: @my_var }
-          error!(body, 400)
-        end
-        subject.get('/') do
-          @my_var = expected_instance_variable_value
-          raise
-        end
-
-        get '/'
-        expect(last_response.status).to be 400
-        expect(last_response.body).to eq({ my_var: expected_instance_variable_value }.to_json)
-      end
-    end
   end
 
   describe '.rescue_from klass, block' do
@@ -4369,6 +4350,63 @@ describe Grape::API do
     it 'returns the given id when it is valid' do
       get '/v1/orders/1-2'
       expect(last_response.body).to be_eql('1-2')
+    end
+  end
+
+  context 'instance variables' do
+    context 'when setting instance variables in a before validation' do
+      it 'is accessible inside the endpoint' do
+        expected_instance_variable_value = 'wadus'
+
+        subject.before do
+          @my_var = expected_instance_variable_value
+        end
+
+        subject.get('/') do
+          { my_var: @my_var }.to_json
+        end
+
+        get '/'
+        expect(last_response.body).to eq({ my_var: expected_instance_variable_value }.to_json)
+      end
+    end
+
+    context 'when setting instance variables inside the endpoint code' do
+      it 'is accessible inside the rescue_from handler' do
+        expected_instance_variable_value = 'wadus'
+
+        subject.rescue_from(:all) do
+          body = { my_var: @my_var }
+          error!(body, 400)
+        end
+
+        subject.get('/') do
+          @my_var = expected_instance_variable_value
+          raise
+        end
+
+        get '/'
+        expect(last_response.status).to be 400
+        expect(last_response.body).to eq({ my_var: expected_instance_variable_value }.to_json)
+      end
+
+      it 'is NOT available in other endpoints of the same api' do
+        expected_instance_variable_value = 'wadus'
+
+        subject.get('/first') do
+          @my_var = expected_instance_variable_value
+          { my_var: @my_var }.to_json
+        end
+
+        subject.get('/second') do
+          { my_var: @my_var }.to_json
+        end
+
+        get '/first'
+        expect(last_response.body).to eq({ my_var: expected_instance_variable_value }.to_json)
+        get '/second'
+        expect(last_response.body).to eq({ my_var: nil }.to_json)
+      end
     end
   end
 end


### PR DESCRIPTION
Hey 👋 

I was taking a look at #1922 and after some checks I can see that we are in a different instance when we are inside the `rescue_from` method.

```ruby
require 'grape'

class MyAPI < Grape::API
  class MyError < StandardError; end

  before do
    puts "self => #{self.class}"
    @my_var = 328
  end

  rescue_from MyError do |e|
    puts "self => #{self.class}"
    puts "my var value => #{@my_var}"
    error!({ my_var: @my_var }, 401)
  end

  get '/wadus' do
    puts "my var value => #{@my_var}"
    puts "self => #{self.class}"
    raise MyError.new
  end
end
```

The current output of the previous code is:

```shell
self =>#<Class:0x0000000107c79d88>
my var value => 328
self => #<Class:0x0000000107c79d88>
self => ##<Class:0x0000000104c77950>
my var value =>
```

This means that we cannot have access to the same instance variables declared in the `before` because we are not in the same instance.

For solving it, I'm adding the scope of the endpoint when performing the handler. So now I'm performing `endpoint.instance_exec(&handler)` instead of `instance_exec(&handler)` where the `endpoint` is the instance obtained from `@env["api.endpoint"]` [here](https://github.com/ruby-grape/grape/blob/master/lib/grape/middleware/error.rb#L36-L49). 

Doing it in that way, we are executing the handler under the endpoint instance scope and we have the variables accessible. 

```shell
self => #<Class:0x000000010448a148>
my var value => 328
self => #<Class:0x000000010448a148>
self => #<Class:0x000000010448a148>
my var value => 328
```

However, there are some trade-offs that we need to fix in this issue in order to pass all the tests.

As now we are performing the handler under the `endpoint` instance, the methods called inside the `rescue_from` should be defined in the `inside_route.rb` file. I've experienced problems with two of those methods:

* The `error!` method. Is defined both times in `inside_routes.rb` and in the `error.rb`. However, the one defined in the `inside_routes.rb` is throwing an error and the one defined in the `error.rb` is just returning a rack response. 
  * **Proposed Solution**: Catch the thrown error when performing the handler and if an error appears because someone calls the `error!` method, call the `error!` method from the `error.rb` again for returning the rack response. Check [this](https://github.com/ruby-grape/grape/compare/master...jcagarcia:issue-1922?expand=1#diff-4dd2d3b9eb97044b27af6778457a4fb2d0991647867f4a6a728919038d3d06c2R134)
* The `rack_response` method is used in several tests inside the `rescue_from`. However, this method is not defined in the `inside_route.rb` file, what causes that a `NoMethodError` is raised.
  * **Proposed Solution**: Define the `rack_response` method in the `inside_route.rb` file, so now endpoints can also perform this method for building a rack response. 