### PR TITLE
Fix ValuesValidator for Params Wrapped in with Block in Grape

### DIFF
--- a/lib/grape/validations/validators/values_validator.rb
+++ b/lib/grape/validations/validators/values_validator.rb
@@ -85,7 +85,12 @@ module Grape
         end
 
         def required_for_root_scope?
-          @required && @scope.root?
+          return false unless @required
+
+          scope = @scope
+          scope = scope.parent while scope.lateral?
+
+          scope.root?
         end
 
         def validation_exception(attr_name, message)

--- a/spec/grape/validations/validators/values_spec.rb
+++ b/spec/grape/validations/validators/values_spec.rb
@@ -261,6 +261,13 @@ describe Grape::Validations::Validators::ValuesValidator do
         optional :name, type: String, values: %w[a b], allow_blank: true
       end
       get '/allow_blank'
+
+      params do
+        with(type: String) do
+          requires :type, values: ValuesModel.values
+        end
+      end
+      get 'values_wrapped_by_with_block'
     end
   end
 
@@ -728,6 +735,15 @@ describe Grape::Validations::Validators::ValuesValidator do
         get '/proc/arity2', input_one: 2, input_two: 3
         expect(last_response.status).to eq 400
       end
+    end
+  end
+
+  context 'when wrapped by with block' do
+    it 'rejects an invalid value' do
+      get 'values_wrapped_by_with_block'
+
+      expect(last_response.status).to eq 400
+      expect(last_response.body).to eq({ error: 'type is missing, type does not have a valid value' }.to_json)
     end
   end
 end


### PR DESCRIPTION
This PR fixes a bug [#2376](https://github.com/ruby-grape/grape/issues/2376) in Grape's `ValuesValidator`, specifically when parameters are nested within a `with` block. Previously, the validator did not correctly handle the required validation for nested parameters in this context.

## Changes:
- The `required_for_root_scope?` method in `ValuesValidator` has been modified to correctly detect if a parameter is required when it's nested inside a `with` block. The fix involves checking the parent scope of the parameter until a non-lateral (non-`with` block) scope is found, and then determining if it's the root scope.
- A test case has been added to `values_spec.rb` to cover the scenario where a parameter nested within a `with` block doesn't meet the validation criteria, ensuring that the correct error response is generated.

## Impact:
This fix ensures more accurate validation of parameters nested within `with` blocks, and aligns the behavior with the expected norms of Grape's parameter validation. It's an important fix for Grape users who use nested parameter structures, improving the reliability and correctness of the validation logic.

I welcome any feedback or suggestions on this fix and look forward to your reviews!