### PR TITLE
Use regex block instead of if

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * [#2371](https://github.com/ruby-grape/grape/pull/2371): Use a param value as the `default` value of other param - [@jcagarcia](https://github.com/jcagarcia).
+* [#2383](https://github.com/ruby-grape/grape/pull/2383): Use regex block instead of if - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -141,18 +141,11 @@ module Grape
     end
 
     def match?(input, method)
-      current_regexp = @optimized_map[method]
-      return unless current_regexp.match(input)
-
-      last_match = Regexp.last_match
-      @map[method].detect { |route| last_match["_#{route.index}"] }
+      @optimized_map[method].match(input) { |m| @map[method].detect { |route| m["_#{route.index}"] } }
     end
 
     def greedy_match?(input)
-      return unless @union.match(input)
-
-      last_match = Regexp.last_match
-      @neutral_map.detect { |route| last_match["_#{route.index}"] }
+      @union.match(input) { |m|  @neutral_map.detect { |route| m["_#{route.index}"] } }
     end
 
     def call_with_allow_headers(env, route)

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -145,7 +145,7 @@ module Grape
     end
 
     def greedy_match?(input)
-      @union.match(input) { |m|  @neutral_map.detect { |route| m["_#{route.index}"] } }
+      @union.match(input) { |m| @neutral_map.detect { |route| m["_#{route.index}"] } }
     end
 
     def call_with_allow_headers(env, route)


### PR DESCRIPTION
Since ruby 2.6, the Regex's `match` function comes with a [block](https://ruby-doc.org/core-2.6/Regexp.html#method-i-match) that will be executed only if match succeed. This PR is just a small refactor