### PR TITLE
Use rubygems default instead of latest

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -12,9 +12,8 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2
+        ruby-version: 2.7
         bundler-cache: true
-        rubygems: latest
     - name: Run Danger
       run: |
         # the token is public, has public_repo scope and belongs to the grape-bot user owned by @dblock, this is ok

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: latest
         bundler-cache: true
         rubygems: latest
     - name: Run Danger

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: latest
+        ruby-version: 3.2
         bundler-cache: true
         rubygems: latest
     - name: Run Danger

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -20,7 +20,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-        rubygems: latest
 
     - name: Run tests
       run: bundle exec rake spec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: latest
+        ruby-version: 3.2
         bundler-cache: true
         rubygems: latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: latest
         bundler-cache: true
         rubygems: latest
 
@@ -45,7 +45,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-        rubygems: latest
 
     - name: Run tests
       run: bundle exec rake spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#2372](https://github.com/ruby-grape/grape/pull/2372): Fix `declared` method for hash params with overlapping names - [@jcagarcia](https://github.com/jcagarcia).
 * [#2373](https://github.com/ruby-grape/grape/pull/2373): Fix markdown files for following 1-line format - [@jcagarcia](https://github.com/jcagarcia).
 * [#2382](https://github.com/ruby-grape/grape/pull/2382): Fix values validator for params wrapped in `with` block - [@numbata](https://github.com/numbata).
+* [#2387](https://github.com/ruby-grape/grape/pull/2387): Fix rubygems version within workflows - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 2.0.0 (2023/11/11)


### PR DESCRIPTION
[rubygems-update 3.5.0](https://github.com/rubygems/rubygems/blob/master/CHANGELOG.md#350--2023-12-15) dropped support for ruby 2.6 and 2.7. This PR sets `rubygems` to its default version for the following workflows:
- danger
-  test

Also, this PR keeps rubygems to its latest version and sets `ruby-version` to 3.2 for `rubocop`