### PR TITLE
Optimize AttributeTranslator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#2383](https://github.com/ruby-grape/grape/pull/2383): Use regex block instead of if - [@ericproulx](https://github.com/ericproulx).
 * [#2384](https://github.com/ruby-grape/grape/pull/2384): Allow to use `before/after/rescue_from` methods in any order when using `mount` - [@jcagarcia](https://github.com/jcagarcia).
 * [#2390](https://github.com/ruby-grape/grape/pull/2390): Drop support for Ruby 2.6 and Rails 5 - [@ericproulx](https://github.com/ericproulx).
+* [#2393](https://github.com/ruby-grape/grape/pull/2393): Optimize AttributeTranslator - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/dsl/desc.rb
+++ b/lib/grape/dsl/desc.rb
@@ -5,6 +5,27 @@ module Grape
     module Desc
       include Grape::DSL::Settings
 
+      ROUTE_ATTRIBUTES = %i[
+        body_name
+        consumes
+        default
+        deprecated
+        description
+        detail
+        entity
+        headers
+        hidden
+        http_codes
+        is_array
+        named
+        nickname
+        params
+        produces
+        security
+        summary
+        tags
+      ].freeze
+
       # Add a description to the next namespace or function.
       # @param description [String] descriptive string for this endpoint
       #   or namespace
@@ -81,26 +102,7 @@ module Grape
       # Returns an object which configures itself via an instance-context DSL.
       def desc_container(endpoint_configuration)
         Module.new do
-          include Grape::Util::StrictHashConfiguration.module(
-            :summary,
-            :description,
-            :detail,
-            :params,
-            :entity,
-            :http_codes,
-            :named,
-            :body_name,
-            :headers,
-            :hidden,
-            :deprecated,
-            :is_array,
-            :nickname,
-            :produces,
-            :consumes,
-            :security,
-            :tags,
-            :default
-          )
+          include Grape::Util::StrictHashConfiguration.module(*ROUTE_ATTRIBUTES)
           config_context.define_singleton_method(:configuration) do
             endpoint_configuration
           end

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -184,7 +184,7 @@ module Grape
         requirements: prepare_routes_requirements,
         prefix: namespace_inheritable(:root_prefix),
         anchor: options[:route_options].fetch(:anchor, true),
-        settings: inheritable_setting.route.except(:declared_params, :saved_validations),
+        settings: inheritable_setting.route.except(:declared_params, :saved_validations, :description),
         forward_match: options[:forward_match]
       }
     end

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -184,7 +184,7 @@ module Grape
         requirements: prepare_routes_requirements,
         prefix: namespace_inheritable(:root_prefix),
         anchor: options[:route_options].fetch(:anchor, true),
-        settings: inheritable_setting.route.except(:declared_params, :saved_validations, :description),
+        settings: inheritable_setting.route.except(:declared_params, :saved_validations),
         forward_match: options[:forward_match]
       }
     end

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'grape/router/route'
+require 'grape/router/greedy_route'
 require 'grape/util/cache'
 
 module Grape
@@ -48,7 +49,7 @@ module Grape
 
     def associate_routes(pattern, **options)
       @neutral_regexes << Regexp.new("(?<_#{@neutral_map.length}>)#{pattern.to_regexp}")
-      @neutral_map << Grape::Router::AttributeTranslator.new(**options, pattern: pattern, index: @neutral_map.length)
+      @neutral_map << Grape::Router::GreedyRoute.new(pattern: pattern, index: @neutral_map.length, **options)
     end
 
     def call(env)
@@ -122,7 +123,7 @@ module Grape
 
     def make_routing_args(default_args, route, input)
       args = default_args || { route_info: route }
-      args.merge(route.params(input) || {})
+      args.merge(route.params(input))
     end
 
     def extract_input_and_method(env)

--- a/lib/grape/router/attribute_translator.rb
+++ b/lib/grape/router/attribute_translator.rb
@@ -5,8 +5,6 @@ module Grape
     # this could be an OpenStruct, but doesn't work in Ruby 2.3.0, see https://bugs.ruby-lang.org/issues/12251
     # fixed >= 3.0
     class AttributeTranslator
-      attr_reader :attributes, :options
-
       ROUTE_ATTRIBUTES = (%i[
         allow_header
         anchor
@@ -26,28 +24,27 @@ module Grape
 
       def initialize(**attributes)
         @attributes = attributes
-        @options = attributes.delete(:options)
       end
 
       ROUTE_ATTRIBUTES.each do |attr|
         define_method attr do
-          attributes[attr]
+          @attributes[attr]
         end
 
         define_method("#{attr}=") do |val|
-          attributes[attr] = val
+          @attributes[attr] = val
         end
       end
 
       def to_h
-        attributes
+        @attributes
       end
 
       def method_missing(method_name, *args)
         if setter?(method_name)
-          attributes[method_name.to_s.chomp('=').to_sym] = args.first
+          @attributes[method_name.to_s.chomp('=').to_sym] = args.first
         else
-          attributes[method_name]
+          @attributes[method_name]
         end
       end
 

--- a/lib/grape/router/attribute_translator.rb
+++ b/lib/grape/router/attribute_translator.rb
@@ -8,7 +8,6 @@ module Grape
       ROUTE_ATTRIBUTES = (%i[
         allow_header
         anchor
-        details
         endpoint
         format
         forward_match

--- a/lib/grape/router/greedy_route.rb
+++ b/lib/grape/router/greedy_route.rb
@@ -3,22 +3,26 @@
 require 'grape/router/attribute_translator'
 require 'forwardable'
 
+# Act like a Grape::Router::Route but for greedy_match
+# see @neutral_map
+
 module Grape
   class Router
     class GreedyRoute
       extend Forwardable
 
-      attr_reader :index, :pattern, :options
+      attr_reader :index, :pattern, :options, :attributes
 
       delegate Grape::Router::AttributeTranslator::ROUTE_ATTRIBUTES => :@attributes
 
-      def initialize(index:, pattern:, **attributes)
+      def initialize(index:, pattern:, **options)
         @index = index
         @pattern = pattern
-        @options = attributes.delete(:options)
-        @attributes = Grape::Router::AttributeTranslator.new(**attributes)
+        @options = options
+        @attributes = Grape::Router::AttributeTranslator.new(**options)
       end
 
+      # Grape::Router:Route defines params as a function
       def params(_input = nil)
         @attributes.params || {}
       end

--- a/lib/grape/router/greedy_route.rb
+++ b/lib/grape/router/greedy_route.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'grape/router/attribute_translator'
+require 'forwardable'
+
+module Grape
+  class Router
+    class GreedyRoute
+      extend Forwardable
+
+      attr_reader :index, :pattern, :options
+
+      delegate Grape::Router::AttributeTranslator::ROUTE_ATTRIBUTES => :@attributes
+
+      def initialize(index:, pattern:, **attributes)
+        @index = index
+        @pattern = pattern
+        @options = attributes.delete(:options)
+        @attributes = Grape::Router::AttributeTranslator.new(**attributes)
+      end
+
+      def params(_input = nil)
+        @attributes.params || {}
+      end
+    end
+  end
+end
+
+

--- a/lib/grape/router/greedy_route.rb
+++ b/lib/grape/router/greedy_route.rb
@@ -29,5 +29,3 @@ module Grape
     end
   end
 end
-
-

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3100,13 +3100,13 @@ describe Grape::API do
       ]
     end
 
-    it 'includes details' do
-      subject.desc 'method', details: 'method details'
+    it 'includes detail' do
+      subject.desc 'method', detail: 'method details'
       subject.get 'method'
       expect(subject.routes.map do |route|
-        { description: route.description, details: route.details, params: route.params }
+        { description: route.description, detail: route.detail, params: route.params }
       end).to eq [
-        { description: 'method', details: 'method details', params: {} }
+        { description: 'method', detail: 'method details', params: {} }
       ]
     end
 

--- a/spec/grape/router/attribute_translator_spec.rb
+++ b/spec/grape/router/attribute_translator_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Grape::Router::AttributeTranslator do
-  (Grape::Router::AttributeTranslator::ROUTE_ATTRIBUTES + Grape::Router::AttributeTranslator::ROUTE_ATTRIBUTES).each do |attribute|
+  described_class::ROUTE_ATTRIBUTES.each do |attribute|
     describe "##{attribute}" do
       it "returns value from #{attribute} key if present" do
         translator = described_class.new(attribute => 'value')

--- a/spec/grape/router/greedy_route_spec.rb
+++ b/spec/grape/router/greedy_route_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe Grape::Router::GreedyRoute do
+  let(:instance) { described_class.new(index: index, pattern: pattern, **options) }
+  let(:index) { 0 }
+  let(:pattern) { :pattern }
+  let(:params) do
+    { a_param: 1 }.freeze
+  end
+  let(:options) do
+    {
+      params: params,
+      requirements: {}
+    }.freeze
+  end
+
+  describe '#index' do
+    subject { instance.index }
+    it { is_expected.to eq(index) }
+  end
+
+  describe '#pattern' do
+    subject { instance.pattern }
+    it { is_expected.to eq(pattern) }
+  end
+
+  describe '#options' do
+    subject { instance.options }
+    it { is_expected.to eq(options) }
+  end
+
+  describe '#params' do
+    subject { instance.params }
+    it { is_expected.to eq(params) }
+  end
+
+  describe '#attributes' do
+    subject { instance.attributes }
+    it { is_expected.to be_a(Grape::Router::AttributeTranslator) }
+  end
+end

--- a/spec/grape/router/greedy_route_spec.rb
+++ b/spec/grape/router/greedy_route_spec.rb
@@ -8,34 +8,36 @@ RSpec.describe Grape::Router::GreedyRoute do
     { a_param: 1 }.freeze
   end
   let(:options) do
-    {
-      params: params,
-      requirements: {}
-    }.freeze
+    { params: params }.freeze
   end
 
   describe '#index' do
     subject { instance.index }
+
     it { is_expected.to eq(index) }
   end
 
   describe '#pattern' do
     subject { instance.pattern }
+
     it { is_expected.to eq(pattern) }
   end
 
   describe '#options' do
     subject { instance.options }
+
     it { is_expected.to eq(options) }
   end
 
   describe '#params' do
     subject { instance.params }
+
     it { is_expected.to eq(params) }
   end
 
   describe '#attributes' do
     subject { instance.attributes }
+
     it { is_expected.to be_a(Grape::Router::AttributeTranslator) }
   end
 end

--- a/spec/integration/rack/v2/headers_spec.rb
+++ b/spec/integration/rack/v2/headers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Grape::Http::Headers do
+describe Grape::Http::Headers, if: Gem::Version.new(Rack.release) < Gem::Version.new('3.0.0') do
   it { expect(described_class::ALLOW).to eq('Allow') }
   it { expect(described_class::LOCATION).to eq('Location') }
   it { expect(described_class::TRANSFER_ENCODING).to eq('Transfer-Encoding') }


### PR DESCRIPTION
After #2375, I've spent some time understanding the `Grape::Router::AttributeTranslator` across the gem. I knew already what it did but I didn't know where it was used exactly. This PR is an effort to optimize the usage of the AttributeTranslator but also some refactoring across the `Grape::Router` classes.

Changes:
- Introducing `Grape::Router::GreedyRoute` to encapsulate `Grape::Router::AttributeTranslator` in the greedy match process.
- `Grape::Router::AttributeTranslator` defines more methods to not rely on `method_missing` internally.
- `Grape::Router::Pattern` and `Grape::Router::Route` have been refactored.



