### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1348,7 +1348,7 @@ class Color
   end
 
   def self.parse(value)
-    return new(value) if %w[blue red green]).include?(value)
+    return new(value) if %w[blue red green].include?(value)
 
     Grape::Types::InvalidValue.new('Unsupported color')
   end


### PR DESCRIPTION
Fixed typo error in [Custom Types and Coercions section](https://github.com/ruby-grape/grape?tab=readme-ov-file#custom-types-and-coercions)