### PR TITLE
Change Grape::Deprecator's Behavior in test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#2395](https://github.com/ruby-grape/grape/pull/2395): Set `max-age` to 0 when `cookies.delete` - [@ericproulx](https://github.com/ericproulx).
 * [#2397](https://github.com/ruby-grape/grape/pull/2397): Add support for ruby 3.3 - [@ericproulx](https://github.com/ericproulx).
 * [#2399](https://github.com/ruby-grape/grape/pull/2399): Update `rubocop` to 1.59.0, `rubocop-performance` to 1.20.1 and `rubocop-rspec` to 2.25.0 - [@ericproulx](https://github.com/ericproulx).
+* [#2402](https://github.com/ruby-grape/grape/pull/2402): Grape::Deprecations will be raised when running specs  - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
         - RUBY_VERSION=${RUBY_VERSION:-3}
     stdin_open: true
     tty: true
-    platform: linux/amd64
     volumes:
       - .:/var/grape
       - gems:/usr/local/bundle

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
         - RUBY_VERSION=${RUBY_VERSION:-3}
     stdin_open: true
     tty: true
+    platform: linux/amd64
     volumes:
       - .:/var/grape
       - gems:/usr/local/bundle

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1239,7 +1239,7 @@ describe Grape::API do
       test_file.write file_content
       test_file.rewind
 
-      subject.get('/file') { file test_file }
+      subject.get('/file') { stream test_file }
       get '/file'
       expect(last_response.headers[Rack::CONTENT_LENGTH]).to eq('25')
       expect(last_response.headers[Rack::CONTENT_TYPE]).to eq('text/plain')

--- a/spec/grape/dsl/inside_route_spec.rb
+++ b/spec/grape/dsl/inside_route_spec.rb
@@ -209,13 +209,7 @@ describe Grape::Endpoint do
 
         it 'emits a warning that this method is deprecated' do
           expect(Grape.deprecator).to receive(:warn).with(/Use sendfile or stream/)
-
-          subject.file file_path
-        end
-
-        it 'forwards the call to sendfile' do
           expect(subject).to receive(:sendfile).with(file_path)
-
           subject.file file_path
         end
       end
@@ -225,13 +219,7 @@ describe Grape::Endpoint do
 
         it 'emits a warning that this method is deprecated' do
           expect(Grape.deprecator).to receive(:warn).with(/Use stream to use a Stream object/)
-
-          subject.file file_object
-        end
-
-        it 'forwards the call to stream' do
           expect(subject).to receive(:stream).with(file_object)
-
           subject.file file_object
         end
       end
@@ -240,13 +228,7 @@ describe Grape::Endpoint do
     describe 'get' do
       it 'emits a warning that this method is deprecated' do
         expect(Grape.deprecator).to receive(:warn).with(/Use sendfile or stream/)
-
-        subject.file
-      end
-
-      it 'fowards call to sendfile' do
         expect(subject).to receive(:sendfile)
-
         subject.file
       end
     end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -979,7 +979,7 @@ describe Grape::Endpoint do
   context 'binary' do
     before do
       subject.get do
-        file FileStreamer.new(__FILE__)
+        stream FileStreamer.new(__FILE__)
       end
     end
 

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -179,7 +179,7 @@ describe Grape::Validations::ParamsScope do
     end
 
     it 'allows the proc to pass validation without checking in except' do
-      subject.params { requires :numbers, type: Integer, values: { except: -> { [0, 1, 2] } } }
+      subject.params { requires :numbers, type: Integer, except_values: -> { [0, 1, 2] } }
 
       subject.post('/required') { 'coercion with proc works' }
       post '/required', numbers: '10'

--- a/spec/grape/validations/validators/values_spec.rb
+++ b/spec/grape/validations/validators/values_spec.rb
@@ -63,17 +63,17 @@ describe Grape::Validations::Validators::ValuesValidator do
         end
 
         params do
-          requires :type, values: { except: ValuesModel.excepts, except_message: 'value is on exclusions list', message: 'default exclude message' }
+          requires :type, except_values: { value: ValuesModel.excepts, message: 'value is on exclusions list' }, default: 'default exclude message'
         end
         get '/exclude/exclude_message'
 
         params do
-          requires :type, values: { except: -> { ValuesModel.excepts }, except_message: 'value is on exclusions list' }
+          requires :type, except_values: { value: -> { ValuesModel.excepts }, message: 'value is on exclusions list' }
         end
         get '/exclude/lambda/exclude_message'
 
         params do
-          requires :type, values: { except: ValuesModel.excepts, message: 'default exclude message' }
+          requires :type, except_values: { value: ValuesModel.excepts, message: 'default exclude message' }
         end
         get '/exclude/fallback_message'
       end
@@ -105,7 +105,7 @@ describe Grape::Validations::Validators::ValuesValidator do
       end
 
       params do
-        optional :type, values: { except: ValuesModel.excepts }, default: 'valid-type2'
+        optional :type, except_values: ValuesModel.excepts, default: 'valid-type2'
       end
       get '/default/except' do
         { type: params[:type] }
@@ -187,42 +187,42 @@ describe Grape::Validations::Validators::ValuesValidator do
       get '/optional_with_required_values'
 
       params do
-        requires :type, values: { except: ValuesModel.excepts }
+        requires :type, except_values: ValuesModel.excepts
       end
       get '/except/exclusive' do
         { type: params[:type] }
       end
 
       params do
-        requires :type, type: String, values: { except: ValuesModel.excepts }
+        requires :type, type: String, except_values: ValuesModel.excepts
       end
       get '/except/exclusive/type' do
         { type: params[:type] }
       end
 
       params do
-        requires :type, values: { except: -> { ValuesModel.excepts } }
+        requires :type, except_values: ValuesModel.excepts
       end
       get '/except/exclusive/lambda' do
         { type: params[:type] }
       end
 
       params do
-        requires :type, type: String, values: { except: -> { ValuesModel.excepts } }
+        requires :type, type: String, except_values: -> { ValuesModel.excepts }
       end
       get '/except/exclusive/lambda/type' do
         { type: params[:type] }
       end
 
       params do
-        requires :type, type: Integer, values: { except: -> { [3, 4, 5] } }
+        requires :type, type: Integer, except_values: -> { [3, 4, 5] }
       end
       get '/except/exclusive/lambda/coercion' do
         { type: params[:type] }
       end
 
       params do
-        requires :type, type: Integer, values: { value: 1..5, except: [3] }
+        requires :type, type: Integer, values: 1..5, except_values: [3]
       end
       get '/mixed/value/except' do
         { type: params[:type] }
@@ -234,14 +234,14 @@ describe Grape::Validations::Validators::ValuesValidator do
       put '/optional_with_array_of_string_values'
 
       params do
-        requires :type, values: { proc: ->(v) { ValuesModel.include? v } }
+        requires :type, values: ->(v) { ValuesModel.include? v }
       end
       get '/proc' do
         { type: params[:type] }
       end
 
       params do
-        requires :type, values: { proc: ->(v) { ValuesModel.include? v }, message: 'failed check' }
+        requires :type, values: { value: ->(v) { ValuesModel.include? v }, message: 'failed check' }
       end
       get '/proc/message'
 
@@ -520,7 +520,7 @@ describe Grape::Validations::Validators::ValuesValidator do
   it 'raises IncompatibleOptionValues when except contains a value that is not a kind of the type' do
     subject = Class.new(Grape::API)
     expect do
-      subject.params { requires :type, values: { except: [10.5, 11] }, type: Integer }
+      subject.params { requires :type, except_values: [10.5, 11], type: Integer }
     end.to raise_error Grape::Exceptions::IncompatibleOptionValues
   end
 

--- a/spec/integration/multi_xml/xml_spec.rb
+++ b/spec/integration/multi_xml/xml_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Grape::Xml do
+describe Grape::Xml, if: defined?(MultiXml) do
   it 'uses multi_xml' do
     expect(described_class).to eq(::MultiXml)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,8 @@ Bundler.require :default, :test
 
 require 'grape'
 
+Grape.deprecator.behavior = :raise
+
 %w[config support].each do |dir|
   Dir["#{File.dirname(__FILE__)}/#{dir}/**/*.rb"].sort.each do |file|
     require file


### PR DESCRIPTION
This PR will set Grape::Deprecator's Behavior to `raise` when running specs. Our spec suite should not pass through our own deprecations unless its expected.