### PR TITLE
Remove mime-types dependency in specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#2397](https://github.com/ruby-grape/grape/pull/2397): Add support for ruby 3.3 - [@ericproulx](https://github.com/ericproulx).
 * [#2399](https://github.com/ruby-grape/grape/pull/2399): Update `rubocop` to 1.59.0, `rubocop-performance` to 1.20.1 and `rubocop-rspec` to 2.25.0 - [@ericproulx](https://github.com/ericproulx).
 * [#2402](https://github.com/ruby-grape/grape/pull/2402): Grape::Deprecations will be raised when running specs  - [@ericproulx](https://github.com/ericproulx).
+* [#2406](https://github.com/ruby-grape/grape/pull/2406): Remove mime-types dependency in specs - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'

--- a/gemfiles/multi_json.gemfile
+++ b/gemfiles/multi_json.gemfile
@@ -26,7 +26,6 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'

--- a/gemfiles/multi_xml.gemfile
+++ b/gemfiles/multi_xml.gemfile
@@ -26,7 +26,6 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'

--- a/gemfiles/rack_1_0.gemfile
+++ b/gemfiles/rack_1_0.gemfile
@@ -26,7 +26,6 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'

--- a/gemfiles/rack_2_0.gemfile
+++ b/gemfiles/rack_2_0.gemfile
@@ -26,7 +26,6 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'

--- a/gemfiles/rack_3_0.gemfile
+++ b/gemfiles/rack_3_0.gemfile
@@ -26,7 +26,6 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'

--- a/gemfiles/rack_edge.gemfile
+++ b/gemfiles/rack_edge.gemfile
@@ -26,7 +26,6 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -26,7 +26,6 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -26,7 +26,6 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -26,7 +26,6 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -27,7 +27,6 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -26,7 +26,6 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'mime-types'
   gem 'rack-jsonp', require: 'rack/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'


### PR DESCRIPTION
This PR removes `mime-types` has a dependency when testing. It was only used in 3 specs.