### PR TITLE
Remove outdated XML formatter documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3100,7 +3100,7 @@ end
 Built-in formatters are the following.
 
 * `:json`: use object's `to_json` when available, otherwise call `MultiJson.dump`
-* `:xml`: use object's `to_xml` when available, usually via `MultiXml`, otherwise call `to_s`
+* `:xml`: use object's `to_xml` when available, usually via `MultiXml`
 * `:txt`: use object's `to_txt` when available, otherwise `to_s`
 * `:serializable_hash`: use object's `serializable_hash` when available, otherwise fallback to `:json`
 * `:binary`: data will be returned "as is"


### PR DESCRIPTION
Since commit https://github.com/ruby-grape/grape/commit/11576c8b97d33439a555c7bd0f9146916874dc20, the built in `Grape::Formatter::Xml` does no longer fall back to calling the object's `#to_s` method if it does not respond to `#to_xml`. This pull request updates the documentation to match the behavior of the current version.