### PR TITLE
Fix response headers from lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [#2382](https://github.com/ruby-grape/grape/pull/2382): Fix values validator for params wrapped in `with` block - [@numbata](https://github.com/numbata).
 * [#2387](https://github.com/ruby-grape/grape/pull/2387): Fix rubygems version within workflows - [@ericproulx](https://github.com/ericproulx).
 * [#2405](https://github.com/ruby-grape/grape/pull/2405): Fix edge workflow - [@ericproulx](https://github.com/ericproulx).
+* [#2414](https://github.com/ruby-grape/grape/pull/2414): Fix Rack::Lint missing content-type - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 2.0.0 (2023/11/11)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,7 +4,10 @@ Upgrading Grape
 ### Upgrading to >= 2.1.0
 
 #### Changes in rescue_from
-`rack_response` has been deprecated and `error_response` has been removed. Use `error!` instead.
+
+The `rack_response` method has been deprecated and the `error_response` method has been removed. Use `error!` instead.
+
+See [#2414](https://github.com/ruby-grape/grape/pull/2414) for more information.
 
 #### Grape::Router::Route.route_xxx methods have been removed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,9 @@ Upgrading Grape
 
 ### Upgrading to >= 2.1.0
 
+#### Changes in rescue_from
+`rack_response` has been deprecated and `error_response` has been removed. Use `error!` instead.
+
 #### Grape::Router::Route.route_xxx methods have been removed
 
 - `route_method` is accessible through `request_method`

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -180,7 +180,7 @@ module Grape
       # A Rack::Response object containing the specified message, status, and headers.
       #
       def rack_response(message, status = 200, headers = { Rack::CONTENT_TYPE => content_type })
-        Grape.deprecator.warn('Use error! instead of rack_response')
+        Grape.deprecator.warn('The rack_response method has been deprecated, use error! instead.')
         message = Rack::Utils.escape_html(message) if headers[Rack::CONTENT_TYPE] == 'text/html'
         Rack::Response.new(Array.wrap(message), Rack::Utils.status_code(status), headers)
       end

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -167,6 +167,24 @@ module Grape
         throw :error, message: message, status: status, headers: headers
       end
 
+      # Creates a Rack response based on the provided message, status, and headers.
+      # The content type in the headers is set to the default content type unless provided.
+      # The message is HTML-escaped if the content type is 'text/html'.
+      #
+      # @param message [String] The content of the response.
+      # @param status [Integer] The HTTP status code.
+      # @params headers [Hash] (optional) Headers for the response
+      #                      (default: {Rack::CONTENT_TYPE => content_type}).
+      #
+      # Returns:
+      # A Rack::Response object containing the specified message, status, and headers.
+      #
+      def rack_response(message, status = 200, headers = { Rack::CONTENT_TYPE => content_type })
+        Grape.deprecator.warn('Use error! instead of rack_response')
+        message = Rack::Utils::escape_html(message) if headers[Rack::CONTENT_TYPE] == 'text/html'
+        Rack::Response.new(Array.wrap(message), Rack::Utils.status_code(status), headers)
+      end
+
       # Redirect to a new url.
       #
       # @param url [String] The url to be redirect.

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -162,9 +162,9 @@ module Grape
       # @param status [Integer] the HTTP Status Code. Defaults to default_error_status, 500 if not set.
       # @param additional_headers [Hash] Addtional headers for the response.
       def error!(message, status = nil, additional_headers = nil)
-        self.status(status || namespace_inheritable(:default_error_status))
+        status = self.status(status || namespace_inheritable(:default_error_status))
         headers = additional_headers.present? ? header.merge(additional_headers) : header
-        throw :error, message: message, status: self.status, headers: headers
+        throw :error, message: message, status: status, headers: headers
       end
 
       # Redirect to a new url.

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -181,7 +181,7 @@ module Grape
       #
       def rack_response(message, status = 200, headers = { Rack::CONTENT_TYPE => content_type })
         Grape.deprecator.warn('Use error! instead of rack_response')
-        message = Rack::Utils::escape_html(message) if headers[Rack::CONTENT_TYPE] == 'text/html'
+        message = Rack::Utils.escape_html(message) if headers[Rack::CONTENT_TYPE] == 'text/html'
         Rack::Response.new(Array.wrap(message), Rack::Utils.status_code(status), headers)
       end
 

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -167,23 +167,6 @@ module Grape
         throw :error, message: message, status: self.status, headers: headers
       end
 
-      # Creates a Rack response based on the provided message, status, and headers.
-      # The content type in the headers is set to the default content type unless provided.
-      # The message is HTML-escaped if the content type is 'text/html'.
-      #
-      # @param message [String] The content of the response.
-      # @param status [Integer] The HTTP status code.
-      # @params headers [Hash] (optional) Headers for the response
-      #                      (default: {Rack::CONTENT_TYPE => content_type}).
-      #
-      # Returns:
-      # A Rack::Response object containing the specified message, status, and headers.
-      #
-      def rack_response(message, status = 200, headers = { Rack::CONTENT_TYPE => content_type })
-        message = ERB::Util.html_escape(message) if headers[Rack::CONTENT_TYPE] == 'text/html'
-        Rack::Response.new([message], Rack::Utils.status_code(status), headers)
-      end
-
       # Redirect to a new url.
       #
       # @param url [String] The url to be redirect.

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -138,7 +138,6 @@ module Grape
         )
       end
 
-
       def error?(response)
         response.is_a?(Hash) && response[:message] && response[:status] && response[:headers]
       end

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -38,13 +38,6 @@ module Grape
         run_rescue_handler(find_handler(e.class), e, @env[Grape::Env::API_ENDPOINT])
       end
 
-      def error!(message, status = options[:default_status], headers = {}, backtrace = [], original_exception = nil)
-        rack_response(
-          status, headers.reverse_merge(Rack::CONTENT_TYPE => content_type),
-          format_message(message, backtrace, original_exception)
-        )
-      end
-
       private
 
       def rack_response(status, headers, message)
@@ -137,6 +130,14 @@ module Grape
           run_rescue_handler(:default_rescue_handler, Grape::Exceptions::InvalidResponse.new, endpoint)
         end
       end
+
+      def error!(message, status = options[:default_status], headers = {}, backtrace = [], original_exception = nil)
+        rack_response(
+          status, headers.reverse_merge(Rack::CONTENT_TYPE => content_type),
+          format_message(message, backtrace, original_exception)
+        )
+      end
+
 
       def error?(response)
         response.is_a?(Hash) && response[:message] && response[:status] && response[:headers]

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -4437,8 +4437,9 @@ describe Grape::API do
     end
 
     it 'raises a deprecation' do
-      expect(Grape.deprecator).to receive(:warn).with('Use error! instead of rack_response')
+      expect(Grape.deprecator).to receive(:warn).with('The rack_response method has been deprecated, use error! instead.')
       get 'test'
+      expect(last_response.body).to eq('deprecated')
     end
   end
 end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -2102,7 +2102,7 @@ describe Grape::API do
 
       it 'rescues custom grape exceptions' do
         subject.rescue_from ApiSpec::CustomError do |e|
-          rack_response('New Error', e.status)
+          error!('New Error', e.status)
         end
         subject.get '/custom_error' do
           raise ApiSpec::CustomError.new(status: 400, message: 'Custom Error')
@@ -2120,7 +2120,7 @@ describe Grape::API do
       allow(Grape::Formatter).to receive(:formatter_for) { formatter }
 
       subject.rescue_from :all do |_e|
-        rack_response('Formatter Error', 500)
+        error!('Formatter Error', 500)
       end
       subject.get('/formatter_exception') { 'Hello world' }
 
@@ -2143,7 +2143,7 @@ describe Grape::API do
   describe '.rescue_from klass, block' do
     it 'rescues Exception' do
       subject.rescue_from RuntimeError do |e|
-        rack_response("rescued from #{e.message}", 202)
+        error!("rescued from #{e.message}", 202)
       end
       subject.get '/exception' do
         raise 'rain!'
@@ -2164,7 +2164,7 @@ describe Grape::API do
 
       it 'rescues an error via rescue_from :all' do
         subject.rescue_from :all do |e|
-          rack_response("rescued from #{e.class.name}", 500)
+          error!("rescued from #{e.class.name}", 500)
         end
         subject.get '/exception' do
           raise ConnectionError
@@ -2176,7 +2176,7 @@ describe Grape::API do
 
       it 'rescues a specific error' do
         subject.rescue_from ConnectionError do |e|
-          rack_response("rescued from #{e.class.name}", 500)
+          error!("rescued from #{e.class.name}", 500)
         end
         subject.get '/exception' do
           raise ConnectionError
@@ -2188,7 +2188,7 @@ describe Grape::API do
 
       it 'rescues a subclass of an error by default' do
         subject.rescue_from RuntimeError do |e|
-          rack_response("rescued from #{e.class.name}", 500)
+          error!("rescued from #{e.class.name}", 500)
         end
         subject.get '/exception' do
           raise ConnectionError
@@ -2200,10 +2200,10 @@ describe Grape::API do
 
       it 'rescues multiple specific errors' do
         subject.rescue_from ConnectionError do |e|
-          rack_response("rescued from #{e.class.name}", 500)
+          error!("rescued from #{e.class.name}", 500)
         end
         subject.rescue_from DatabaseError do |e|
-          rack_response("rescued from #{e.class.name}", 500)
+          error!("rescued from #{e.class.name}", 500)
         end
         subject.get '/connection' do
           raise ConnectionError
@@ -2221,7 +2221,7 @@ describe Grape::API do
 
       it 'does not rescue a different error' do
         subject.rescue_from RuntimeError do |e|
-          rack_response("rescued from #{e.class.name}", 500)
+          error!("rescued from #{e.class.name}", 500)
         end
         subject.get '/uncaught' do
           raise CommunicationError
@@ -2234,7 +2234,7 @@ describe Grape::API do
   describe '.rescue_from klass, lambda' do
     it 'rescues an error with the lambda' do
       subject.rescue_from ArgumentError, lambda {
-        rack_response('rescued with a lambda', 400)
+        error!('rescued with a lambda', 400)
       }
       subject.get('/rescue_lambda') { raise ArgumentError }
 
@@ -2245,7 +2245,7 @@ describe Grape::API do
 
     it 'can execute the lambda with an argument' do
       subject.rescue_from ArgumentError, lambda { |e|
-        rack_response(e.message, 400)
+        error!(e.message, 400)
       }
       subject.get('/rescue_lambda') { raise ArgumentError, 'lambda takes an argument' }
 
@@ -2326,7 +2326,7 @@ describe Grape::API do
 
     it 'rescues error as well as subclass errors with rescue_subclasses option set' do
       subject.rescue_from ApiSpec::APIErrors::ParentError, rescue_subclasses: true do |e|
-        rack_response("rescued from #{e.class.name}", 500)
+        error!("rescued from #{e.class.name}", 500)
       end
       subject.get '/caught_child' do
         raise ApiSpec::APIErrors::ChildError
@@ -2347,7 +2347,7 @@ describe Grape::API do
 
     it 'sets rescue_subclasses to true by default' do
       subject.rescue_from ApiSpec::APIErrors::ParentError do |e|
-        rack_response("rescued from #{e.class.name}", 500)
+        error!("rescued from #{e.class.name}", 500)
       end
       subject.get '/caught_child' do
         raise ApiSpec::APIErrors::ChildError
@@ -2359,7 +2359,7 @@ describe Grape::API do
 
     it 'does not rescue child errors if rescue_subclasses is false' do
       subject.rescue_from ApiSpec::APIErrors::ParentError, rescue_subclasses: false do |e|
-        rack_response("rescued from #{e.class.name}", 500)
+        error!("rescued from #{e.class.name}", 500)
       end
       subject.get '/uncaught' do
         raise ApiSpec::APIErrors::ChildError
@@ -2389,7 +2389,7 @@ describe Grape::API do
 
     it 'rescues grape exceptions with a user-defined handler' do
       subject.rescue_from grape_exception.class do |_error|
-        rack_response('Redefined Error', 403)
+        error!('Redefined Error', 403)
       end
 
       exception = grape_exception
@@ -2572,11 +2572,7 @@ describe Grape::API do
       end
       get '/excel.json'
       expect(last_response.status).to eq(406)
-      if ActiveSupport::VERSION::MAJOR == 3
-        expect(last_response.body).to eq('The requested format &#x27;txt&#x27; is not supported.')
-      else
-        expect(last_response.body).to eq('The requested format &#39;txt&#39; is not supported.')
-      end
+      expect(last_response.body).to eq(Rack::Utils.escape_html("The requested format 'txt' is not supported."))
     end
   end
 
@@ -3375,7 +3371,7 @@ describe Grape::API do
       context 'when some rescues are defined by mounted' do
         it 'inherits parent rescues' do
           subject.rescue_from :all do |e|
-            rack_response("rescued from #{e.message}", 202)
+            error!("rescued from #{e.message}", 202)
           end
 
           app = Class.new(described_class)
@@ -3393,14 +3389,14 @@ describe Grape::API do
 
         it 'prefers rescues defined by mounted if they rescue similar error class' do
           subject.rescue_from StandardError do
-            rack_response('outer rescue')
+            error!('outer rescue')
           end
 
           app = Class.new(described_class)
 
           subject.namespace :mounted do
             rescue_from StandardError do
-              rack_response('inner rescue')
+              error!('inner rescue')
             end
             app.get('/fail') { raise 'doh!' }
             mount app
@@ -3412,14 +3408,14 @@ describe Grape::API do
 
         it 'prefers rescues defined by mounted even if outer is more specific' do
           subject.rescue_from ArgumentError do
-            rack_response('outer rescue')
+            error!('outer rescue')
           end
 
           app = Class.new(described_class)
 
           subject.namespace :mounted do
             rescue_from StandardError do
-              rack_response('inner rescue')
+              error!('inner rescue')
             end
             app.get('/fail') { raise ArgumentError.new }
             mount app
@@ -3431,14 +3427,14 @@ describe Grape::API do
 
         it 'prefers more specific rescues defined by mounted' do
           subject.rescue_from StandardError do
-            rack_response('outer rescue')
+            error!('outer rescue')
           end
 
           app = Class.new(described_class)
 
           subject.namespace :mounted do
             rescue_from ArgumentError do
-              rack_response('inner rescue')
+              error!('inner rescue')
             end
             app.get('/fail') { raise ArgumentError.new }
             mount app
@@ -4125,11 +4121,7 @@ describe Grape::API do
       end
       get '/something'
       expect(last_response.status).to eq(406)
-      if ActiveSupport::VERSION::MAJOR == 3
-        expect(last_response.body).to eq('{&quot;error&quot;:&quot;The requested format &#x27;txt&#x27; is not supported.&quot;}')
-      else
-        expect(last_response.body).to eq('{&quot;error&quot;:&quot;The requested format &#39;txt&#39; is not supported.&quot;}')
-      end
+      expect(last_response.body).to eq(Rack::Utils.escape_html({ error: "The requested format 'txt' is not supported." }.to_json))
     end
   end
 
@@ -4141,11 +4133,7 @@ describe Grape::API do
       end
       get '/something?format=<script>blah</script>'
       expect(last_response.status).to eq(406)
-      if ActiveSupport::VERSION::MAJOR == 3
-        expect(last_response.body).to eq('The requested format &#x27;&lt;script&gt;blah&lt;/script&gt;&#x27; is not supported.')
-      else
-        expect(last_response.body).to eq('The requested format &#39;&lt;script&gt;blah&lt;/script&gt;&#39; is not supported.')
-      end
+      expect(last_response.body).to eq(Rack::Utils.escape_html("The requested format '<script>blah</script>' is not supported."))
     end
   end
 

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -4422,4 +4422,23 @@ describe Grape::API do
       end
     end
   end
+
+  context 'rack_response deprecated' do
+    let(:app) do
+      Class.new(described_class) do
+        rescue_from :all do
+          rack_response('deprecated', 500)
+        end
+
+        get 'test' do
+          raise ArgumentError
+        end
+      end
+    end
+
+    it 'raises a deprecation' do
+      expect(Grape.deprecator).to receive(:warn).with('Use error! instead of rack_response')
+      get 'test'
+    end
+  end
 end

--- a/spec/grape/exceptions/body_parse_errors_spec.rb
+++ b/spec/grape/exceptions/body_parse_errors_spec.rb
@@ -6,7 +6,7 @@ describe Grape::Exceptions::ValidationErrors do
 
     before do
       subject.rescue_from :all do |_e|
-        rack_response 'message was processed', 400
+        error! 'message was processed', 400
       end
       subject.params do
         requires :beer
@@ -58,7 +58,7 @@ describe Grape::Exceptions::ValidationErrors do
 
     before do
       subject.rescue_from :all do |_e|
-        rack_response 'message was processed', 400
+        error! 'message was processed', 400
       end
       subject.rescue_from :grape_exceptions
 
@@ -96,7 +96,7 @@ describe Grape::Exceptions::ValidationErrors do
 
     before do
       subject.rescue_from :grape_exceptions do |e|
-        rack_response "Custom Error Contents, Original Message: #{e.message}", 400
+        error! "Custom Error Contents, Original Message: #{e.message}", 400
       end
 
       subject.params do

--- a/spec/grape/exceptions/invalid_accept_header_spec.rb
+++ b/spec/grape/exceptions/invalid_accept_header_spec.rb
@@ -44,7 +44,7 @@ describe Grape::Exceptions::InvalidAcceptHeader do
     before do
       subject.version 'v99', using: :header, vendor: 'vendorname', format: :json, cascade: false
       subject.rescue_from :all do |e|
-        rack_response 'message was processed', 400, e[:headers]
+        error! 'message was processed', 400, e[:headers]
       end
       subject.get '/beer' do
         'beer received'
@@ -114,7 +114,7 @@ describe Grape::Exceptions::InvalidAcceptHeader do
     before do
       subject.version 'v99', using: :header, vendor: 'vendorname', format: :json, cascade: false
       subject.rescue_from :all do |e|
-        rack_response 'message was processed', 400, e[:headers]
+        error! 'message was processed', 400, e[:headers]
       end
       subject.desc 'Get beer' do
         failure [[400, 'Bad Request'], [401, 'Unauthorized'], [403, 'Forbidden'],
@@ -194,7 +194,7 @@ describe Grape::Exceptions::InvalidAcceptHeader do
     before do
       subject.version 'v99', using: :header, vendor: 'vendorname', format: :json, cascade: true
       subject.rescue_from :all do |e|
-        rack_response 'message was processed', 400, e[:headers]
+        error! 'message was processed', 400, e[:headers]
       end
       subject.get '/beer' do
         'beer received'
@@ -273,7 +273,7 @@ describe Grape::Exceptions::InvalidAcceptHeader do
     before do
       subject.version 'v99', using: :header, vendor: 'vendorname', format: :json, cascade: true
       subject.rescue_from :all do |e|
-        rack_response 'message was processed', 400, e[:headers]
+        error! 'message was processed', 400, e[:headers]
       end
       subject.desc 'Get beer' do
         failure [[400, 'Bad Request'], [401, 'Unauthorized'], [403, 'Forbidden'],

--- a/spec/grape/validations/validators/values_spec.rb
+++ b/spec/grape/validations/validators/values_spec.rb
@@ -404,13 +404,13 @@ describe Grape::Validations::Validators::ValuesValidator do
     expect(last_response.body).to eq({ error: 'type does not have a valid value' }.to_json)
   end
 
-  it 'validates against values in an endless range', if: ActiveSupport::VERSION::MAJOR >= 6 do
+  it 'validates against values in an endless range' do
     get('/endless', type: 10)
     expect(last_response.status).to eq 200
     expect(last_response.body).to eq({ type: 10 }.to_json)
   end
 
-  it 'does not allow an invalid value for a parameter using an endless range', if: ActiveSupport::VERSION::MAJOR >= 6 do
+  it 'does not allow an invalid value for a parameter using an endless range' do
     get('/endless', type: 0)
     expect(last_response.status).to eq 400
     expect(last_response.body).to eq({ error: 'type does not have a valid value' }.to_json)


### PR DESCRIPTION
Fix #2411 

Changes:
- Use `Rack::Utils.escape_html` instead of `ERB::Util.escape_html`
- Some refactor in error middleware.
- Remove `rack_response` from `inside_route`
- Remove some irrelevant `if: ActiveSupport::VERSION::MAJOR >= ?` in specs