### PR TITLE
Use `rack-contrib` JSONP instead of rack-jsonp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#2410](https://github.com/ruby-grape/grape/pull/2410): Gem deprecations will raise a DeprecationWarning in specs - [@ericproulx](https://github.com/ericproulx).
 * [#2389](https://github.com/ruby-grape/grape/pull/2389): Remove rack-accept dependency - [@ericproulx](https://github.com/ericproulx).
 * [#2426](https://github.com/ruby-grape/grape/pull/2426): Drop support for rack 1.x series - [@ericproulx](https://github.com/ericproulx).
+* [#2427](https://github.com/ruby-grape/grape/pull/2427): Use `rack-contrib` jsonp instead of rack-jsonp - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-contrib', require: 'rack/contrib/jsonp'
+  gem 'rack-contrib', require: false
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-jsonp', require: 'rack/jsonp'
+  gem 'rack-contrib', require: 'rack/contrib/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/gemfiles/multi_json.gemfile
+++ b/gemfiles/multi_json.gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-contrib', require: 'rack/contrib/jsonp'
+  gem 'rack-contrib', require: false
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/gemfiles/multi_json.gemfile
+++ b/gemfiles/multi_json.gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-jsonp', require: 'rack/jsonp'
+  gem 'rack-contrib', require: 'rack/contrib/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/gemfiles/multi_xml.gemfile
+++ b/gemfiles/multi_xml.gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-contrib', require: 'rack/contrib/jsonp'
+  gem 'rack-contrib', require: false
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/gemfiles/multi_xml.gemfile
+++ b/gemfiles/multi_xml.gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-jsonp', require: 'rack/jsonp'
+  gem 'rack-contrib', require: 'rack/contrib/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/gemfiles/no_dry_validation.gemfile
+++ b/gemfiles/no_dry_validation.gemfile
@@ -24,7 +24,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-jsonp', require: 'rack/jsonp'
+  gem 'rack-contrib', require: 'rack/contrib/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/gemfiles/no_dry_validation.gemfile
+++ b/gemfiles/no_dry_validation.gemfile
@@ -24,7 +24,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-contrib', require: 'rack/contrib/jsonp'
+  gem 'rack-contrib', require: false
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/gemfiles/rack_2_0.gemfile
+++ b/gemfiles/rack_2_0.gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-contrib', require: 'rack/contrib/jsonp'
+  gem 'rack-contrib', require: false
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/gemfiles/rack_2_0.gemfile
+++ b/gemfiles/rack_2_0.gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-jsonp', require: 'rack/jsonp'
+  gem 'rack-contrib', require: 'rack/contrib/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/gemfiles/rack_3_0.gemfile
+++ b/gemfiles/rack_3_0.gemfile
@@ -6,4 +6,38 @@ source 'https://rubygems.org'
 
 gem 'rack', '~> 3.0.0'
 
-eval_gemfile '../Gemfile'
+group :development, :test do
+  gem 'bundler'
+  gem 'dry-validation'
+  gem 'hashie'
+  gem 'rake'
+  gem 'rubocop', '1.59.0', require: false
+  gem 'rubocop-performance', '1.20.1', require: false
+  gem 'rubocop-rspec', '2.25.0', require: false
+end
+
+group :development do
+  gem 'appraisal'
+  gem 'benchmark-ips'
+  gem 'benchmark-memory'
+  gem 'guard'
+  gem 'guard-rspec'
+  gem 'guard-rubocop'
+end
+
+group :test do
+  gem 'grape-entity', '~> 0.6', require: false
+  gem 'rack-contrib', require: false
+  gem 'rack-test', '< 2.1'
+  gem 'rspec', '< 4'
+  gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'simplecov', '~> 0.21.2'
+  gem 'simplecov-lcov', '~> 0.8.0'
+  gem 'test-prof', require: false
+end
+
+platforms :jruby do
+  gem 'racc'
+end
+
+gemspec path: '../'

--- a/gemfiles/rack_3_0.gemfile
+++ b/gemfiles/rack_3_0.gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-jsonp', require: 'rack/jsonp'
+  gem 'rack-contrib', require: 'rack/contrib/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/gemfiles/rack_3_0.gemfile
+++ b/gemfiles/rack_3_0.gemfile
@@ -6,38 +6,4 @@ source 'https://rubygems.org'
 
 gem 'rack', '~> 3.0.0'
 
-group :development, :test do
-  gem 'bundler'
-  gem 'dry-validation'
-  gem 'hashie'
-  gem 'rake'
-  gem 'rubocop', '1.59.0', require: false
-  gem 'rubocop-performance', '1.20.1', require: false
-  gem 'rubocop-rspec', '2.25.0', require: false
-end
-
-group :development do
-  gem 'appraisal'
-  gem 'benchmark-ips'
-  gem 'benchmark-memory'
-  gem 'guard'
-  gem 'guard-rspec'
-  gem 'guard-rubocop'
-end
-
-group :test do
-  gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-contrib', require: 'rack/contrib/jsonp'
-  gem 'rack-test', '< 2.1'
-  gem 'rspec', '< 4'
-  gem 'ruby-grape-danger', '~> 0.2.0', require: false
-  gem 'simplecov', '~> 0.21.2'
-  gem 'simplecov-lcov', '~> 0.8.0'
-  gem 'test-prof', require: false
-end
-
-platforms :jruby do
-  gem 'racc'
-end
-
-gemspec path: '../'
+eval_gemfile '../Gemfile'

--- a/gemfiles/rack_edge.gemfile
+++ b/gemfiles/rack_edge.gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-contrib', require: 'rack/contrib/jsonp'
+  gem 'rack-contrib', require: false
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/gemfiles/rack_edge.gemfile
+++ b/gemfiles/rack_edge.gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-jsonp', require: 'rack/jsonp'
+  gem 'rack-contrib', require: 'rack/contrib/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-contrib', require: 'rack/contrib/jsonp'
+  gem 'rack-contrib', require: false
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-jsonp', require: 'rack/jsonp'
+  gem 'rack-contrib', require: 'rack/contrib/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-contrib', require: 'rack/contrib/jsonp'
+  gem 'rack-contrib', require: false
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-jsonp', require: 'rack/jsonp'
+  gem 'rack-contrib', require: 'rack/contrib/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-contrib', require: 'rack/contrib/jsonp'
+  gem 'rack-contrib', require: false
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-jsonp', require: 'rack/jsonp'
+  gem 'rack-contrib', require: 'rack/contrib/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-contrib', require: 'rack/contrib/jsonp'
+  gem 'rack-contrib', require: false
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-jsonp', require: 'rack/jsonp'
+  gem 'rack-contrib', require: 'rack/contrib/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-contrib', require: 'rack/contrib/jsonp'
+  gem 'rack-contrib', require: false
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'grape-entity', '~> 0.6', require: false
-  gem 'rack-jsonp', require: 'rack/jsonp'
+  gem 'rack-contrib', require: 'rack/contrib/jsonp'
   gem 'rack-test', '< 2.1'
   gem 'rspec', '< 4'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false

--- a/spec/grape/entity_spec.rb
+++ b/spec/grape/entity_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'grape_entity'
+require 'rack/contrib/jsonp'
 
 describe Grape::Entity do
   subject { Class.new(Grape::API) }


### PR DESCRIPTION
I thought it would be great to use the same JSONP gem in our test suite like we recommend in our README.