### PR TITLE
Added Rack version specs to ensure the correct version is loaded.

### DIFF
--- a/spec/integration/rack_3_0/headers_spec.rb
+++ b/spec/integration/rack_3_0/headers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Grape::Http::Headers, if: Gem::Version.new(Rack.release) >= Gem::Version.new('3') do
+describe Grape::Http::Headers do
   subject { last_response.headers }
 
   describe 'returned headers should all be in lowercase' do

--- a/spec/integration/rack_3_0/version_spec.rb
+++ b/spec/integration/rack_3_0/version_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+describe Rack do
+  it { expect(Gem::Version.new(described_class.release).segments.first).to eq 3 }
+end


### PR DESCRIPTION
A followup for https://github.com/ruby-grape/grape/pull/2431.