### PR TITLE
Implement nested `with` support in parameter DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [#2431](https://github.com/ruby-grape/grape/pull/2431): Drop appraisals in favor of eval_gemfile - [@ericproulx](https://github.com/ericproulx).
 * [#2435](https://github.com/ruby-grape/grape/pull/2435): Use rack constants - [@ericproulx](https://github.com/ericproulx).
 * [#2436](https://github.com/ruby-grape/grape/pull/2436): Update coverallsapp github-action - [@ericproulx](https://github.com/ericproulx).
+* [#2434](https://github.com/ruby-grape/grape/pull/2434): Implement nested `with` support in parameter dsl - [@numbata](https://github.com/numbata).
 * Your contribution here.
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -1567,6 +1567,20 @@ params do
 end
 ```
 
+You can organize settings into layers using nested `with' blocks. Each layer can use, add to, or change the settings of the layer above it. This helps to keep complex parameters organized and consistent, while still allowing for specific customizations to be made.
+
+```ruby
+params do
+  with(documentation: { in: 'body' }) do  # Applies documentation to all nested parameters
+    with(type: String, regexp: /\w+/) do  # Applies type and validation to names
+      requires :first_name, desc: 'First name'
+      requires :last_name, desc: 'Last name'
+    end
+    optional :age, type: Integer, desc: 'Age', documentation: { x: { nullable: true } }  # Specific settings for 'age'
+  end
+end
+```
+
 ### Renaming
 
 You can rename parameters using `as`, which can be useful when refactoring existing APIs:

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -170,7 +170,8 @@ module Grape
       # @param (see #requires)
       # @option (see #requires)
       def with(*attrs, &block)
-        new_group_scope(attrs.clone, &block)
+        new_group_attrs = [@group, attrs.clone.first].compact.reduce(&:deep_merge)
+        new_group_scope([new_group_attrs], &block)
       end
 
       # Disallow the given parameters to be present in the same request.

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -264,6 +264,7 @@ module Grape
           parent: self,
           optional: optional,
           type: type || Array,
+          group: @group,
           &block
         )
       end

--- a/spec/grape/dsl/parameters_spec.rb
+++ b/spec/grape/dsl/parameters_spec.rb
@@ -35,6 +35,12 @@ module Grape
           @validates
         end
 
+        def new_scope(args, _, &block)
+          nested_scope = self.class.new
+          nested_scope.new_group_scope(args, &block)
+          nested_scope
+        end
+
         def new_group_scope(args)
           @group = args.clone.first
           yield
@@ -166,6 +172,37 @@ module Grape
           expect(subject.validate_attributes_reader).to eq(
             [
               [:vault], { documentation: { details: { in: 'body', hidden: false, desc: 'The vault number' } } }
+            ]
+          )
+        end
+
+        it "supports nested 'with' calls" do
+          subject.with(type: Integer, documentation: { in: 'body' }) do
+            subject.optional :pipboy_id
+            subject.with(documentation: { default: 33 }) do
+              subject.optional :vault
+            end
+          end
+
+          expect(subject.validate_attributes_reader).to eq(
+            [
+              [:pipboy_id], { type: Integer, documentation: { in: 'body' } },
+              [:vault], { type: Integer, documentation: { in: 'body', default: 33 } }
+            ]
+          )
+        end
+
+        it "supports Hash parameter inside the 'with' calls" do
+          subject.with(documentation: { in: 'body' }) do
+            subject.optional :info, type: Hash, documentation: { x: { nullable: true }, desc: 'The info' } do
+              subject.optional :vault, type: Integer, documentation: { default: 33, desc: 'The vault number' }
+            end
+          end
+
+          expect(subject.validate_attributes_reader).to eq(
+            [
+              [:info], { type: Hash, documentation: { in: 'body', desc: 'The info', x: { nullable: true } } },
+              [:vault], { type: Integer, documentation: { in: 'body', default: 33, desc: 'The vault number' } }
             ]
           )
         end

--- a/spec/grape/dsl/parameters_spec.rb
+++ b/spec/grape/dsl/parameters_spec.rb
@@ -42,8 +42,10 @@ module Grape
         end
 
         def new_group_scope(args)
+          prev_group = @group
           @group = args.clone.first
           yield
+          @group = prev_group
         end
 
         def extract_message_option(attrs)
@@ -181,13 +183,21 @@ module Grape
             subject.optional :pipboy_id
             subject.with(documentation: { default: 33 }) do
               subject.optional :vault
+              subject.with(type: String) do
+                subject.with(documentation: { default: 'resident' }) do
+                  subject.optional :role
+                end
+              end
+              subject.optional :age, documentation: { default: 42 }
             end
           end
 
           expect(subject.validate_attributes_reader).to eq(
             [
               [:pipboy_id], { type: Integer, documentation: { in: 'body' } },
-              [:vault], { type: Integer, documentation: { in: 'body', default: 33 } }
+              [:vault], { type: Integer, documentation: { in: 'body', default: 33 } },
+              [:role], { type: String, documentation: { in: 'body', default: 'resident' } },
+              [:age], { type: Integer, documentation: { in: 'body', default: 42 } }
             ]
           )
         end


### PR DESCRIPTION
## Motivation
Previously, the `with`' method in the Parameter DSL did not support nested structures. This forced to redefine the entire attribute set for each nested scope, which was cumbersome and prone to errors, especially in complex parameter structures.

## Solution
This PR introduces enhanced functionality to the `with` method that allows nested scopes to inherit and extend the attributes defined in parent scopes. By merging attributes from the current group with the new attributes, it simplifies parameter declarations and ensures a clean, DRY approach to specifying shared attributes in nested parameter contexts.