### PR TITLE
Use Rack's Constants

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,6 @@ jobs:
             gemfile: gemfiles/multi_xml.gemfile
             specs: 'spec/integration/multi_xml'
           - ruby: '2.7'
-            gemfile: gemfiles/rack_2_0.gemfile
-            specs: 'spec/integration/rack_2_0'
-          - ruby: '2.7'
             gemfile: gemfiles/rack_3_0.gemfile
             specs: 'spec/integration/rack_3_0'
           - ruby: '3.3'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#2425](https://github.com/ruby-grape/grape/pull/2425): Replace `{}` with `Rack::Header` or `Rack::Utils::HeaderHash` - [@dhruvCW](https://github.com/dhruvCW).
 * [#2430](https://github.com/ruby-grape/grape/pull/2430): Isolate extensions within specific gemfile - [@ericproulx](https://github.com/ericproulx).
 * [#2431](https://github.com/ruby-grape/grape/pull/2431): Drop appraisals in favor of eval_gemfile - [@ericproulx](https://github.com/ericproulx).
+* [#2435](https://github.com/ruby-grape/grape/pull/2435): Use rack constants - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/benchmark/large_model.rb
+++ b/benchmark/large_model.rb
@@ -233,7 +233,7 @@ end
 puts Grape::VERSION
 
 options = {
-  method: 'POST',
+  method: Rack::POST,
   params: JSON.parse(File.read('benchmark/resource/vrp_example.json'))
 }
 

--- a/benchmark/nested_params.rb
+++ b/benchmark/nested_params.rb
@@ -21,7 +21,7 @@ class API < Grape::API
 end
 
 options = {
-  method: 'POST',
+  method: Rack::POST,
   params: {
     address: {
       street: 'Alexis Pl.',

--- a/benchmark/remounting.rb
+++ b/benchmark/remounting.rb
@@ -28,7 +28,7 @@ class CommentAPI < Grape::API
   mount VotingApi
 end
 
-env = Rack::MockRequest.env_for('/votes', method: 'GET')
+env = Rack::MockRequest.env_for('/votes', method: Rack::GET)
 
 Benchmark.memory do |api|
   calls = 1000

--- a/benchmark/simple.rb
+++ b/benchmark/simple.rb
@@ -13,7 +13,7 @@ class API < Grape::API
 end
 
 options = {
-  method: 'GET'
+  method: Rack::GET
 }
 
 env = Rack::MockRequest.env_for('/api/v1', options)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,5 +15,3 @@ services:
     volumes:
       - .:/var/grape
       - gems:/usr/local/bundle
-    environment:
-      GEMFILE: multi_xml

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -280,7 +280,6 @@ module Grape
       stack = Grape::Middleware::Stack.new
 
       stack.use Rack::Head
-      stack.use Rack::Lint
       stack.use Class.new(Grape::Middleware::Error),
                 helpers: helpers,
                 format: namespace_inheritable(:format),

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -151,7 +151,7 @@ module Grape
         reset_routes!
         routes.each do |route|
           methods = [route.request_method]
-          methods << Grape::Http::Headers::HEAD if !namespace_inheritable(:do_not_route_head) && route.request_method == Grape::Http::Headers::GET
+          methods << Rack::HEAD if !namespace_inheritable(:do_not_route_head) && route.request_method == Rack::GET
           methods.each do |method|
             route = Grape::Router::Route.new(method, route.origin, **route.attributes.to_h) unless route.request_method == method
             router.append(route.apply(self))
@@ -280,6 +280,7 @@ module Grape
       stack = Grape::Middleware::Stack.new
 
       stack.use Rack::Head
+      stack.use Rack::Lint
       stack.use Class.new(Grape::Middleware::Error),
                 helpers: helpers,
                 format: namespace_inheritable(:format),
@@ -401,7 +402,7 @@ module Grape
 
     def options?
       options[:options_route_enabled] &&
-        env[Grape::Http::Headers::REQUEST_METHOD] == Grape::Http::Headers::OPTIONS
+        env[Rack::REQUEST_METHOD] == Rack::OPTIONS
     end
 
     def method_missing(name, *_args)

--- a/lib/grape/env.rb
+++ b/lib/grape/env.rb
@@ -11,11 +11,6 @@ module Grape
     API_VENDOR = 'api.vendor'
     API_FORMAT = 'api.format'
 
-    RACK_INPUT = 'rack.input'
-    RACK_REQUEST_QUERY_HASH = 'rack.request.query_hash'
-    RACK_REQUEST_FORM_HASH = 'rack.request.form_hash'
-    RACK_REQUEST_FORM_INPUT = 'rack.request.form_input'
-
     GRAPE_REQUEST = 'grape.request'
     GRAPE_REQUEST_HEADERS = 'grape.request.headers'
     GRAPE_REQUEST_PARAMS = 'grape.request.params'

--- a/lib/grape/http/headers.rb
+++ b/lib/grape/http/headers.rb
@@ -3,44 +3,25 @@
 module Grape
   module Http
     module Headers
-      # https://github.com/rack/rack/blob/master/lib/rack.rb
-      HTTP_VERSION    = 'HTTP_VERSION'
-      PATH_INFO       = 'PATH_INFO'
-      REQUEST_METHOD  = 'REQUEST_METHOD'
-      QUERY_STRING    = 'QUERY_STRING'
-
-      def self.lowercase?
-        Rack::CONTENT_TYPE == 'content-type'
-      end
-
-      if lowercase?
-        ALLOW             = 'allow'
-        LOCATION          = 'location'
-        TRANSFER_ENCODING = 'transfer-encoding'
-        X_CASCADE         = 'x-cascade'
-      else
-        ALLOW             = 'Allow'
-        LOCATION          = 'Location'
-        TRANSFER_ENCODING = 'Transfer-Encoding'
-        X_CASCADE         = 'X-Cascade'
-      end
-
-      GET     = 'GET'
-      POST    = 'POST'
-      PUT     = 'PUT'
-      PATCH   = 'PATCH'
-      DELETE  = 'DELETE'
-      HEAD    = 'HEAD'
-      OPTIONS = 'OPTIONS'
-
-      SUPPORTED_METHODS = [GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS].freeze
-      SUPPORTED_METHODS_WITHOUT_OPTIONS = Grape::Util::Lazy::Object.new { [GET, POST, PUT, PATCH, DELETE, HEAD].freeze }
-
-      HTTP_ACCEPT_VERSION    = 'HTTP_ACCEPT_VERSION'
+      HTTP_ACCEPT_VERSION = 'HTTP_ACCEPT_VERSION'
+      HTTP_ACCEPT = 'HTTP_ACCEPT'
       HTTP_TRANSFER_ENCODING = 'HTTP_TRANSFER_ENCODING'
-      HTTP_ACCEPT            = 'HTTP_ACCEPT'
 
-      FORMAT                 = 'format'
+      ALLOW = 'Allow'
+      LOCATION = 'Location'
+      X_CASCADE = 'X-Cascade'
+
+      SUPPORTED_METHODS = [
+        Rack::GET,
+        Rack::POST,
+        Rack::PUT,
+        Rack::PATCH,
+        Rack::DELETE,
+        Rack::HEAD,
+        Rack::OPTIONS
+      ].freeze
+
+      SUPPORTED_METHODS_WITHOUT_OPTIONS = (SUPPORTED_METHODS - [Rack::OPTIONS]).freeze
 
       HTTP_HEADERS = Grape::Util::Lazy::Object.new do
         common_http_headers = %w[

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -40,7 +40,7 @@ module Grape
 
       def rack_response(status, headers, message)
         message = Rack::Utils.escape_html(message) if headers[Rack::CONTENT_TYPE] == TEXT_HTML
-        Rack::Response.new(Array.wrap(message), Rack::Utils.status_code(status), headers)
+        Rack::Response.new(Array.wrap(message), Rack::Utils.status_code(status), Grape::Util::Header.new.merge(headers))
       end
 
       def format_message(message, backtrace, original_exception = nil)

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -4,6 +4,7 @@ module Grape
   module Middleware
     class Formatter < Base
       CHUNKED = 'chunked'
+      FORMAT = 'format'
 
       def default_options
         {
@@ -80,7 +81,7 @@ module Grape
           !request.parseable_data? &&
           (request.content_length.to_i.positive? || request.env[Grape::Http::Headers::HTTP_TRANSFER_ENCODING] == CHUNKED)
 
-        return unless (input = env[Grape::Env::RACK_INPUT])
+        return unless (input = env[Rack::RACK_INPUT])
 
         input.rewind
         body = env[Grape::Env::API_REQUEST_INPUT] = input.read
@@ -101,12 +102,12 @@ module Grape
           begin
             body = (env[Grape::Env::API_REQUEST_BODY] = parser.call(body, env))
             if body.is_a?(Hash)
-              env[Grape::Env::RACK_REQUEST_FORM_HASH] = if env.key?(Grape::Env::RACK_REQUEST_FORM_HASH)
-                                                          env[Grape::Env::RACK_REQUEST_FORM_HASH].merge(body)
-                                                        else
-                                                          body
-                                                        end
-              env[Grape::Env::RACK_REQUEST_FORM_INPUT] = env[Grape::Env::RACK_INPUT]
+              env[Rack::RACK_REQUEST_FORM_HASH] = if env.key?(Rack::RACK_REQUEST_FORM_HASH)
+                                                    env[Rack::RACK_REQUEST_FORM_HASH].merge(body)
+                                                  else
+                                                    body
+                                                  end
+              env[Rack::RACK_REQUEST_FORM_INPUT] = env[Rack::RACK_INPUT]
             end
           rescue Grape::Exceptions::Base => e
             raise e
@@ -139,7 +140,7 @@ module Grape
       end
 
       def format_from_params
-        fmt = Rack::Utils.parse_nested_query(env[Grape::Http::Headers::QUERY_STRING])[Grape::Http::Headers::FORMAT]
+        fmt = Rack::Utils.parse_nested_query(env[Rack::QUERY_STRING])[FORMAT]
         # avoid symbol memory leak on an unknown format
         return fmt.to_sym if content_type_for(fmt)
 

--- a/lib/grape/middleware/globals.rb
+++ b/lib/grape/middleware/globals.rb
@@ -7,7 +7,7 @@ module Grape
         request = Grape::Request.new(@env, build_params_with: @options[:build_params_with])
         @env[Grape::Env::GRAPE_REQUEST] = request
         @env[Grape::Env::GRAPE_REQUEST_HEADERS] = request.headers
-        @env[Grape::Env::GRAPE_REQUEST_PARAMS] = request.params if @env[Grape::Env::RACK_INPUT]
+        @env[Grape::Env::GRAPE_REQUEST_PARAMS] = request.params if @env[Rack::RACK_INPUT]
       end
     end
   end

--- a/lib/grape/middleware/versioner/param.rb
+++ b/lib/grape/middleware/versioner/param.rb
@@ -28,12 +28,12 @@ module Grape
         end
 
         def before
-          potential_version = Rack::Utils.parse_nested_query(env[Grape::Http::Headers::QUERY_STRING])[paramkey]
+          potential_version = Rack::Utils.parse_nested_query(env[Rack::QUERY_STRING])[paramkey]
           return if potential_version.nil?
 
           throw :error, status: 404, message: '404 API Version Not Found', headers: { Grape::Http::Headers::X_CASCADE => 'pass' } if options[:versions] && !options[:versions].find { |v| v.to_s == potential_version }
           env[Grape::Env::API_VERSION] = potential_version
-          env[Grape::Env::RACK_REQUEST_QUERY_HASH].delete(paramkey) if env.key? Grape::Env::RACK_REQUEST_QUERY_HASH
+          env[Rack::RACK_REQUEST_QUERY_HASH].delete(paramkey) if env.key? Rack::RACK_REQUEST_QUERY_HASH
         end
 
         private

--- a/lib/grape/middleware/versioner/path.rb
+++ b/lib/grape/middleware/versioner/path.rb
@@ -24,7 +24,7 @@ module Grape
         end
 
         def before
-          path = env[Grape::Http::Headers::PATH_INFO].dup
+          path = env[Rack::PATH_INFO].dup
           path.sub!(mount_path, '') if mounted_path?(path)
 
           if prefix && path.index(prefix) == 0 # rubocop:disable all

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -96,7 +96,7 @@ module Grape
 
       # If last_neighbor_route exists and request method is OPTIONS,
       # return response by using #call_with_allow_headers.
-      return call_with_allow_headers(env, last_neighbor_route) if last_neighbor_route && method == Grape::Http::Headers::OPTIONS && !cascade
+      return call_with_allow_headers(env, last_neighbor_route) if last_neighbor_route && method == Rack::OPTIONS && !cascade
 
       route = match?(input, '*')
 
@@ -123,8 +123,8 @@ module Grape
     end
 
     def extract_input_and_method(env)
-      input = string_for(env[Grape::Http::Headers::PATH_INFO])
-      method = env[Grape::Http::Headers::REQUEST_METHOD]
+      input = string_for(env[Rack::PATH_INFO])
+      method = env[Rack::REQUEST_METHOD]
       [input, method]
     end
 

--- a/spec/grape/api/custom_validations_spec.rb
+++ b/spec/grape/api/custom_validations_spec.rb
@@ -71,7 +71,7 @@ describe Grape::Validations do
     let(:in_body_validator) do
       Class.new(Grape::Validations::Validators::PresenceValidator) do
         def validate(request)
-          validate!(request.env['api.request.body'])
+          validate!(request.env[Grape::Env::API_REQUEST_BODY])
         end
       end
     end

--- a/spec/grape/api/defines_boolean_in_params_spec.rb
+++ b/spec/grape/api/defines_boolean_in_params_spec.rb
@@ -24,7 +24,7 @@ describe Grape::API::Instance do
     end
 
     context 'Params endpoint type' do
-      subject { app.new.router.map['POST'].first.options[:params]['message'][:type] }
+      subject { app.new.router.map[Rack::POST].first.options[:params]['message'][:type] }
 
       it 'params type is a boolean' do
         expect(subject).to eq 'Grape::API::Boolean'

--- a/spec/grape/api/patch_method_helpers_spec.rb
+++ b/spec/grape/api/patch_method_helpers_spec.rb
@@ -49,12 +49,12 @@ describe Grape::API::Helpers do
 
   context 'patch' do
     it 'public' do
-      patch '/', {}, 'HTTP_ACCEPT' => 'application/vnd.grape-public-v1+json'
+      patch '/', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.grape-public-v1+json'
       expect(last_response.status).to eq 405
     end
 
     it 'private' do
-      patch '/', {}, 'HTTP_ACCEPT' => 'application/vnd.grape-private-v1+json'
+      patch '/', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.grape-private-v1+json'
       expect(last_response.status).to eq 405
     end
 
@@ -66,13 +66,13 @@ describe Grape::API::Helpers do
 
   context 'default' do
     it 'public' do
-      get '/', {}, 'HTTP_ACCEPT' => 'application/vnd.grape-public-v1+json'
+      get '/', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.grape-public-v1+json'
       expect(last_response.status).to eq 200
       expect(last_response.body).to eq({ ok: 'public' }.to_json)
     end
 
     it 'private' do
-      get '/', {}, 'HTTP_ACCEPT' => 'application/vnd.grape-private-v1+json'
+      get '/', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.grape-private-v1+json'
       expect(last_response.status).to eq 200
       expect(last_response.body).to eq({ ok: 'private' }.to_json)
     end

--- a/spec/grape/dsl/inside_route_spec.rb
+++ b/spec/grape/dsl/inside_route_spec.rb
@@ -27,7 +27,7 @@ describe Grape::Endpoint do
     end
 
     it 'returns env[api.version]' do
-      subject.env['api.version'] = 'dummy'
+      subject.env[Grape::Env::API_VERSION] = 'dummy'
       expect(subject.version).to eq 'dummy'
     end
   end
@@ -96,27 +96,27 @@ describe Grape::Endpoint do
     %w[GET PUT OPTIONS].each do |method|
       it 'defaults to 200 on GET' do
         request = Grape::Request.new(Rack::MockRequest.env_for('/', method: method))
-        expect(subject).to receive(:request).and_return(request)
+        expect(subject).to receive(:request).and_return(request).twice
         expect(subject.status).to eq 200
       end
     end
 
     it 'defaults to 201 on POST' do
-      request = Grape::Request.new(Rack::MockRequest.env_for('/', method: 'POST'))
+      request = Grape::Request.new(Rack::MockRequest.env_for('/', method: Rack::POST))
       expect(subject).to receive(:request).and_return(request)
       expect(subject.status).to eq 201
     end
 
     it 'defaults to 204 on DELETE' do
-      request = Grape::Request.new(Rack::MockRequest.env_for('/', method: 'DELETE'))
-      expect(subject).to receive(:request).and_return(request)
+      request = Grape::Request.new(Rack::MockRequest.env_for('/', method: Rack::DELETE))
+      expect(subject).to receive(:request).and_return(request).twice
       expect(subject.status).to eq 204
     end
 
     it 'defaults to 200 on DELETE with a body present' do
-      request = Grape::Request.new(Rack::MockRequest.env_for('/', method: 'DELETE'))
+      request = Grape::Request.new(Rack::MockRequest.env_for('/', method: Rack::DELETE))
       subject.body 'content here'
-      expect(subject).to receive(:request).and_return(request)
+      expect(subject).to receive(:request).and_return(request).twice
       expect(subject.status).to eq 200
     end
 
@@ -247,7 +247,7 @@ describe Grape::Endpoint do
         before do
           subject.header Rack::CACHE_CONTROL, 'cache'
           subject.header Rack::CONTENT_LENGTH, 123
-          subject.header Grape::Http::Headers::TRANSFER_ENCODING, 'base64'
+          subject.header Rack::TRANSFER_ENCODING, 'base64'
         end
 
         it 'sends no deprecation warnings' do
@@ -277,7 +277,7 @@ describe Grape::Endpoint do
         it 'does not change the Transfer-Encoding header' do
           subject.sendfile file_path
 
-          expect(subject.header[Grape::Http::Headers::TRANSFER_ENCODING]).to eq 'base64'
+          expect(subject.header[Rack::TRANSFER_ENCODING]).to eq 'base64'
         end
       end
 
@@ -308,7 +308,7 @@ describe Grape::Endpoint do
         before do
           subject.header Rack::CACHE_CONTROL, 'cache'
           subject.header Rack::CONTENT_LENGTH, 123
-          subject.header Grape::Http::Headers::TRANSFER_ENCODING, 'base64'
+          subject.header Rack::TRANSFER_ENCODING, 'base64'
         end
 
         it 'emits no deprecation warnings' do
@@ -344,7 +344,7 @@ describe Grape::Endpoint do
         it 'sets Transfer-Encoding header to nil' do
           subject.stream file_path
 
-          expect(subject.header[Grape::Http::Headers::TRANSFER_ENCODING]).to be_nil
+          expect(subject.header[Rack::TRANSFER_ENCODING]).to be_nil
         end
       end
 
@@ -358,7 +358,7 @@ describe Grape::Endpoint do
         before do
           subject.header Rack::CACHE_CONTROL, 'cache'
           subject.header Rack::CONTENT_LENGTH, 123
-          subject.header Grape::Http::Headers::TRANSFER_ENCODING, 'base64'
+          subject.header Rack::TRANSFER_ENCODING, 'base64'
         end
 
         it 'emits no deprecation warnings' do
@@ -388,7 +388,7 @@ describe Grape::Endpoint do
         it 'sets Transfer-Encoding header to nil' do
           subject.stream stream_object
 
-          expect(subject.header[Grape::Http::Headers::TRANSFER_ENCODING]).to be_nil
+          expect(subject.header[Rack::TRANSFER_ENCODING]).to be_nil
         end
       end
 
@@ -409,8 +409,8 @@ describe Grape::Endpoint do
 
   describe '#route' do
     before do
-      subject.env['grape.routing_args'] = {}
-      subject.env['grape.routing_args'][:route_info] = 'dummy'
+      subject.env[Grape::Env::GRAPE_ROUTING_ARGS] = {}
+      subject.env[Grape::Env::GRAPE_ROUTING_ARGS][:route_info] = 'dummy'
     end
 
     it 'returns route_info' do

--- a/spec/grape/dsl/routing_spec.rb
+++ b/spec/grape/dsl/routing_spec.rb
@@ -128,49 +128,49 @@ module Grape
 
       describe '.get' do
         it 'delegates to .route' do
-          expect(subject).to receive(:route).with('GET', path, options)
+          expect(subject).to receive(:route).with(Rack::GET, path, options)
           subject.get path, options, &proc
         end
       end
 
       describe '.post' do
         it 'delegates to .route' do
-          expect(subject).to receive(:route).with('POST', path, options)
+          expect(subject).to receive(:route).with(Rack::POST, path, options)
           subject.post path, options, &proc
         end
       end
 
       describe '.put' do
         it 'delegates to .route' do
-          expect(subject).to receive(:route).with('PUT', path, options)
+          expect(subject).to receive(:route).with(Rack::PUT, path, options)
           subject.put path, options, &proc
         end
       end
 
       describe '.head' do
         it 'delegates to .route' do
-          expect(subject).to receive(:route).with('HEAD', path, options)
+          expect(subject).to receive(:route).with(Rack::HEAD, path, options)
           subject.head path, options, &proc
         end
       end
 
       describe '.delete' do
         it 'delegates to .route' do
-          expect(subject).to receive(:route).with('DELETE', path, options)
+          expect(subject).to receive(:route).with(Rack::DELETE, path, options)
           subject.delete path, options, &proc
         end
       end
 
       describe '.options' do
         it 'delegates to .route' do
-          expect(subject).to receive(:route).with('OPTIONS', path, options)
+          expect(subject).to receive(:route).with(Rack::OPTIONS, path, options)
           subject.options path, options, &proc
         end
       end
 
       describe '.patch' do
         it 'delegates to .route' do
-          expect(subject).to receive(:route).with('PATCH', path, options)
+          expect(subject).to receive(:route).with(Rack::PATCH, path, options)
           subject.patch path, options, &proc
         end
       end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -75,7 +75,7 @@ describe Grape::Endpoint do
   it 'sets itself in the env upon call' do
     subject.get('/') { 'Hello world.' }
     get '/'
-    expect(last_request.env['api.endpoint']).to be_a(described_class)
+    expect(last_request.env[Grape::Env::API_ENDPOINT]).to be_a(described_class)
   end
 
   describe '#status' do
@@ -136,15 +136,16 @@ describe Grape::Endpoint do
       end
     end
 
+    let(:headers) do
+      Grape::Util::Header.new.tap do |h|
+        h['Cookie'] = ''
+        h['Host'] = 'example.org'
+      end
+    end
+
     it 'includes request headers' do
       get '/headers'
-      cookie_header = Grape::Http::Headers.lowercase? ? 'cookie' : 'Cookie'
-      host_header = Grape::Http::Headers.lowercase? ? 'host' : 'Host'
-
-      expect(JSON.parse(last_response.body)).to include(
-        host_header => 'example.org',
-        cookie_header => ''
-      )
+      expect(JSON.parse(last_response.body)).to include(headers.to_h)
     end
 
     it 'includes additional request headers' do
@@ -969,12 +970,12 @@ describe Grape::Endpoint do
     end
 
     it 'result in a 406 response if they are invalid' do
-      get '/test', {}, 'HTTP_ACCEPT' => 'application/vnd.ohanapi.v1+json'
+      get '/test', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.ohanapi.v1+json'
       expect(last_response.status).to eq(406)
     end
 
     it 'result in a 406 response if they cannot be parsed' do
-      get '/test', {}, 'HTTP_ACCEPT' => 'application/vnd.ohanapi.v1+json; version=1'
+      get '/test', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.ohanapi.v1+json; version=1'
       expect(last_response.status).to eq(406)
     end
   end

--- a/spec/grape/exceptions/invalid_accept_header_spec.rb
+++ b/spec/grape/exceptions/invalid_accept_header_spec.rb
@@ -19,7 +19,7 @@ describe Grape::Exceptions::InvalidAcceptHeader do
 
   shared_examples_for 'a not-cascaded request' do
     it 'does not include the X-Cascade=pass header' do
-      expect(last_response.headers[Grape::Http::Headers::X_CASCADE]).to be_nil
+      expect(last_response.headers).not_to have_key(Grape::Http::Headers::X_CASCADE)
     end
 
     it 'does not accept the request' do
@@ -56,7 +56,7 @@ describe Grape::Exceptions::InvalidAcceptHeader do
     end
 
     context 'that received a request with correct vendor and version' do
-      before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v99' }
+      before { get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendorname-v99' }
 
       it_behaves_like 'a valid request'
     end
@@ -64,7 +64,7 @@ describe Grape::Exceptions::InvalidAcceptHeader do
     context 'that receives' do
       context 'an invalid vendor in the request' do
         before do
-          get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.invalidvendor-v99',
+          get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.invalidvendor-v99',
                            'CONTENT_TYPE' => 'application/json'
         end
 
@@ -88,20 +88,20 @@ describe Grape::Exceptions::InvalidAcceptHeader do
     end
 
     context 'that received a request with correct vendor and version' do
-      before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v99' }
+      before { get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendorname-v99' }
 
       it_behaves_like 'a valid request'
     end
 
     context 'that receives' do
       context 'an invalid version in the request' do
-        before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v77' }
+        before { get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendorname-v77' }
 
         it_behaves_like 'a not-cascaded request'
       end
 
       context 'an invalid vendor in the request' do
-        before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.invalidvendor-v99' }
+        before { get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.invalidvendor-v99' }
 
         it_behaves_like 'a not-cascaded request'
       end
@@ -131,7 +131,7 @@ describe Grape::Exceptions::InvalidAcceptHeader do
     end
 
     context 'that received a request with correct vendor and version' do
-      before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v99' }
+      before { get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendorname-v99' }
 
       it_behaves_like 'a valid request'
     end
@@ -139,7 +139,7 @@ describe Grape::Exceptions::InvalidAcceptHeader do
     context 'that receives' do
       context 'an invalid vendor in the request' do
         before do
-          get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.invalidvendor-v99',
+          get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.invalidvendor-v99',
                            'CONTENT_TYPE' => 'application/json'
         end
 
@@ -168,20 +168,20 @@ describe Grape::Exceptions::InvalidAcceptHeader do
     end
 
     context 'that received a request with correct vendor and version' do
-      before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v99' }
+      before { get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendorname-v99' }
 
       it_behaves_like 'a valid request'
     end
 
     context 'that receives' do
       context 'an invalid version in the request' do
-        before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v77' }
+        before { get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendorname-v77' }
 
         it_behaves_like 'a not-cascaded request'
       end
 
       context 'an invalid vendor in the request' do
-        before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.invalidvendor-v99' }
+        before { get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.invalidvendor-v99' }
 
         it_behaves_like 'a not-cascaded request'
       end
@@ -206,7 +206,7 @@ describe Grape::Exceptions::InvalidAcceptHeader do
     end
 
     context 'that received a request with correct vendor and version' do
-      before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v99' }
+      before { get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendorname-v99' }
 
       it_behaves_like 'a valid request'
     end
@@ -214,7 +214,7 @@ describe Grape::Exceptions::InvalidAcceptHeader do
     context 'that receives' do
       context 'an invalid version in the request' do
         before do
-          get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v77',
+          get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendorname-v77',
                            'CONTENT_TYPE' => 'application/json'
         end
 
@@ -223,7 +223,7 @@ describe Grape::Exceptions::InvalidAcceptHeader do
 
       context 'an invalid vendor in the request' do
         before do
-          get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.invalidvendor-v99',
+          get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.invalidvendor-v99',
                            'CONTENT_TYPE' => 'application/json'
         end
 
@@ -247,20 +247,20 @@ describe Grape::Exceptions::InvalidAcceptHeader do
     end
 
     context 'that received a request with correct vendor and version' do
-      before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v99' }
+      before { get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendorname-v99' }
 
       it_behaves_like 'a valid request'
     end
 
     context 'that receives' do
       context 'an invalid version in the request' do
-        before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v77' }
+        before { get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendorname-v77' }
 
         it_behaves_like 'a cascaded request'
       end
 
       context 'an invalid vendor in the request' do
-        before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.invalidvendor-v99' }
+        before { get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.invalidvendor-v99' }
 
         it_behaves_like 'a cascaded request'
       end
@@ -290,7 +290,7 @@ describe Grape::Exceptions::InvalidAcceptHeader do
     end
 
     context 'that received a request with correct vendor and version' do
-      before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v99' }
+      before { get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendorname-v99' }
 
       it_behaves_like 'a valid request'
     end
@@ -298,7 +298,7 @@ describe Grape::Exceptions::InvalidAcceptHeader do
     context 'that receives' do
       context 'an invalid version in the request' do
         before do
-          get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v77',
+          get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendorname-v77',
                            'CONTENT_TYPE' => 'application/json'
         end
 
@@ -307,7 +307,7 @@ describe Grape::Exceptions::InvalidAcceptHeader do
 
       context 'an invalid vendor in the request' do
         before do
-          get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.invalidvendor-v99',
+          get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.invalidvendor-v99',
                            'CONTENT_TYPE' => 'application/json'
         end
 
@@ -336,20 +336,20 @@ describe Grape::Exceptions::InvalidAcceptHeader do
     end
 
     context 'that received a request with correct vendor and version' do
-      before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v99' }
+      before { get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendorname-v99' }
 
       it_behaves_like 'a valid request'
     end
 
     context 'that receives' do
       context 'an invalid version in the request' do
-        before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.vendorname-v77' }
+        before { get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendorname-v77' }
 
         it_behaves_like 'a cascaded request'
       end
 
       context 'an invalid vendor in the request' do
-        before { get '/beer', {}, 'HTTP_ACCEPT' => 'application/vnd.invalidvendor-v99' }
+        before { get '/beer', {}, Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.invalidvendor-v99' }
 
         it_behaves_like 'a cascaded request'
       end

--- a/spec/grape/integration/rack_sendfile_spec.rb
+++ b/spec/grape/integration/rack_sendfile_spec.rb
@@ -16,7 +16,7 @@ describe Rack::Sendfile do
     end
 
     options = {
-      method: 'GET',
+      method: Rack::GET,
       'HTTP_X_SENDFILE_TYPE' => 'X-Accel-Redirect',
       'HTTP_X_ACCEL_MAPPING' => '/accel/mapping/=/replaced/'
     }

--- a/spec/grape/integration/rack_spec.rb
+++ b/spec/grape/integration/rack_spec.rb
@@ -14,7 +14,7 @@ describe Rack do
       input.rewind
       options = {
         input: input,
-        method: 'POST',
+        method: Rack::POST,
         'CONTENT_TYPE' => 'application/json'
       }
       env = Rack::MockRequest.env_for('/', options)

--- a/spec/grape/middleware/globals_spec.rb
+++ b/spec/grape/middleware/globals_spec.rb
@@ -14,17 +14,17 @@ describe Grape::Middleware::Globals do
   context 'environment' do
     it 'sets the grape.request environment' do
       subject.call({})
-      expect(subject.env['grape.request']).to be_a(Grape::Request)
+      expect(subject.env[Grape::Env::GRAPE_REQUEST]).to be_a(Grape::Request)
     end
 
     it 'sets the grape.request.headers environment' do
       subject.call({})
-      expect(subject.env['grape.request.headers']).to be_a(Hash)
+      expect(subject.env[Grape::Env::GRAPE_REQUEST_HEADERS]).to be_a(Hash)
     end
 
     it 'sets the grape.request.params environment' do
-      subject.call('QUERY_STRING' => 'test=1', 'rack.input' => StringIO.new)
-      expect(subject.env['grape.request.params']).to be_a(Hash)
+      subject.call(Rack::QUERY_STRING => 'test=1', Rack::RACK_INPUT => StringIO.new)
+      expect(subject.env[Grape::Env::GRAPE_REQUEST_PARAMS]).to be_a(Hash)
     end
   end
 end

--- a/spec/grape/middleware/versioner/accept_version_header_spec.rb
+++ b/spec/grape/middleware/versioner/accept_version_header_spec.rb
@@ -19,20 +19,20 @@ describe Grape::Middleware::Versioner::AcceptVersionHeader do
     end
 
     it 'is set' do
-      status, _, env = subject.call('HTTP_ACCEPT_VERSION' => 'v1')
-      expect(env['api.version']).to eql 'v1'
+      status, _, env = subject.call(Grape::Http::Headers::HTTP_ACCEPT_VERSION => 'v1')
+      expect(env[Grape::Env::API_VERSION]).to eql 'v1'
       expect(status).to eq(200)
     end
 
     it 'is set if format provided' do
-      status, _, env = subject.call('HTTP_ACCEPT_VERSION' => 'v1')
-      expect(env['api.version']).to eql 'v1'
+      status, _, env = subject.call(Grape::Http::Headers::HTTP_ACCEPT_VERSION => 'v1')
+      expect(env[Grape::Env::API_VERSION]).to eql 'v1'
       expect(status).to eq(200)
     end
 
     it 'fails with 406 Not Acceptable if version is not supported' do
       expect do
-        subject.call('HTTP_ACCEPT_VERSION' => 'v2').last
+        subject.call(Grape::Http::Headers::HTTP_ACCEPT_VERSION => 'v2').last
       end.to throw_symbol(
         :error,
         status: 406,
@@ -43,13 +43,13 @@ describe Grape::Middleware::Versioner::AcceptVersionHeader do
   end
 
   it 'succeeds if :strict is not set' do
-    expect(subject.call('HTTP_ACCEPT_VERSION' => '').first).to eq(200)
+    expect(subject.call(Grape::Http::Headers::HTTP_ACCEPT_VERSION => '').first).to eq(200)
     expect(subject.call({}).first).to eq(200)
   end
 
   it 'succeeds if :strict is set to false' do
     @options[:version_options][:strict] = false
-    expect(subject.call('HTTP_ACCEPT_VERSION' => '').first).to eq(200)
+    expect(subject.call(Grape::Http::Headers::HTTP_ACCEPT_VERSION => '').first).to eq(200)
     expect(subject.call({}).first).to eq(200)
   end
 
@@ -72,7 +72,7 @@ describe Grape::Middleware::Versioner::AcceptVersionHeader do
 
     it 'fails with 406 Not Acceptable if header is empty' do
       expect do
-        subject.call('HTTP_ACCEPT_VERSION' => '').last
+        subject.call(Grape::Http::Headers::HTTP_ACCEPT_VERSION => '').last
       end.to throw_symbol(
         :error,
         status: 406,
@@ -82,7 +82,7 @@ describe Grape::Middleware::Versioner::AcceptVersionHeader do
     end
 
     it 'succeeds if proper header is set' do
-      expect(subject.call('HTTP_ACCEPT_VERSION' => 'v1').first).to eq(200)
+      expect(subject.call(Grape::Http::Headers::HTTP_ACCEPT_VERSION => 'v1').first).to eq(200)
     end
   end
 
@@ -106,7 +106,7 @@ describe Grape::Middleware::Versioner::AcceptVersionHeader do
 
     it 'fails with 406 Not Acceptable if header is empty' do
       expect do
-        subject.call('HTTP_ACCEPT_VERSION' => '').last
+        subject.call(Grape::Http::Headers::HTTP_ACCEPT_VERSION => '').last
       end.to throw_symbol(
         :error,
         status: 406,
@@ -116,7 +116,7 @@ describe Grape::Middleware::Versioner::AcceptVersionHeader do
     end
 
     it 'succeeds if proper header is set' do
-      expect(subject.call('HTTP_ACCEPT_VERSION' => 'v1').first).to eq(200)
+      expect(subject.call(Grape::Http::Headers::HTTP_ACCEPT_VERSION => 'v1').first).to eq(200)
     end
   end
 end

--- a/spec/grape/middleware/versioner/header_spec.rb
+++ b/spec/grape/middleware/versioner/header_spec.rb
@@ -16,37 +16,37 @@ describe Grape::Middleware::Versioner::Header do
 
   context 'api.type and api.subtype' do
     it 'sets type and subtype to first choice of content type if no preference given' do
-      status, _, env = subject.call('HTTP_ACCEPT' => '*/*')
-      expect(env['api.type']).to eql 'application'
-      expect(env['api.subtype']).to eql 'vnd.vendor+xml'
+      status, _, env = subject.call(Grape::Http::Headers::HTTP_ACCEPT => '*/*')
+      expect(env[Grape::Env::API_TYPE]).to eql 'application'
+      expect(env[Grape::Env::API_SUBTYPE]).to eql 'vnd.vendor+xml'
       expect(status).to eq(200)
     end
 
     it 'sets preferred type' do
-      status, _, env = subject.call('HTTP_ACCEPT' => 'application/*')
-      expect(env['api.type']).to eql 'application'
-      expect(env['api.subtype']).to eql 'vnd.vendor+xml'
+      status, _, env = subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'application/*')
+      expect(env[Grape::Env::API_TYPE]).to eql 'application'
+      expect(env[Grape::Env::API_SUBTYPE]).to eql 'vnd.vendor+xml'
       expect(status).to eq(200)
     end
 
     it 'sets preferred type and subtype' do
-      status, _, env = subject.call('HTTP_ACCEPT' => 'text/plain')
-      expect(env['api.type']).to eql 'text'
-      expect(env['api.subtype']).to eql 'plain'
+      status, _, env = subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'text/plain')
+      expect(env[Grape::Env::API_TYPE]).to eql 'text'
+      expect(env[Grape::Env::API_SUBTYPE]).to eql 'plain'
       expect(status).to eq(200)
     end
   end
 
   context 'api.format' do
     it 'is set' do
-      status, _, env = subject.call('HTTP_ACCEPT' => 'application/vnd.vendor+json')
-      expect(env['api.format']).to eql 'json'
+      status, _, env = subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendor+json')
+      expect(env[Grape::Env::API_FORMAT]).to eql 'json'
       expect(status).to eq(200)
     end
 
     it 'is nil if not provided' do
-      status, _, env = subject.call('HTTP_ACCEPT' => 'application/vnd.vendor')
-      expect(env['api.format']).to be_nil
+      status, _, env = subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendor')
+      expect(env[Grape::Env::API_FORMAT]).to be_nil
       expect(status).to eq(200)
     end
 
@@ -57,14 +57,14 @@ describe Grape::Middleware::Versioner::Header do
         end
 
         it 'is set' do
-          status, _, env = subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1+json')
-          expect(env['api.format']).to eql 'json'
+          status, _, env = subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendor-v1+json')
+          expect(env[Grape::Env::API_FORMAT]).to eql 'json'
           expect(status).to eq(200)
         end
 
         it 'is nil if not provided' do
-          status, _, env = subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1')
-          expect(env['api.format']).to be_nil
+          status, _, env = subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendor-v1')
+          expect(env[Grape::Env::API_FORMAT]).to be_nil
           expect(status).to eq(200)
         end
       end
@@ -73,19 +73,19 @@ describe Grape::Middleware::Versioner::Header do
 
   context 'api.vendor' do
     it 'is set' do
-      status, _, env = subject.call('HTTP_ACCEPT' => 'application/vnd.vendor')
-      expect(env['api.vendor']).to eql 'vendor'
+      status, _, env = subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendor')
+      expect(env[Grape::Env::API_VENDOR]).to eql 'vendor'
       expect(status).to eq(200)
     end
 
     it 'is set if format provided' do
-      status, _, env = subject.call('HTTP_ACCEPT' => 'application/vnd.vendor+json')
-      expect(env['api.vendor']).to eql 'vendor'
+      status, _, env = subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendor+json')
+      expect(env[Grape::Env::API_VENDOR]).to eql 'vendor'
       expect(status).to eq(200)
     end
 
     it 'fails with 406 Not Acceptable if vendor is invalid' do
-      expect { subject.call('HTTP_ACCEPT' => 'application/vnd.othervendor+json').last }
+      expect { subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.othervendor+json').last }
         .to raise_exception do |exception|
           expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
           expect(exception.headers).to eql(Grape::Http::Headers::X_CASCADE => 'pass')
@@ -100,19 +100,19 @@ describe Grape::Middleware::Versioner::Header do
       end
 
       it 'is set' do
-        status, _, env = subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1')
-        expect(env['api.vendor']).to eql 'vendor'
+        status, _, env = subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendor-v1')
+        expect(env[Grape::Env::API_VENDOR]).to eql 'vendor'
         expect(status).to eq(200)
       end
 
       it 'is set if format provided' do
-        status, _, env = subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1+json')
-        expect(env['api.vendor']).to eql 'vendor'
+        status, _, env = subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendor-v1+json')
+        expect(env[Grape::Env::API_VENDOR]).to eql 'vendor'
         expect(status).to eq(200)
       end
 
       it 'fails with 406 Not Acceptable if vendor is invalid' do
-        expect { subject.call('HTTP_ACCEPT' => 'application/vnd.othervendor-v1+json').last }
+        expect { subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.othervendor-v1+json').last }
           .to raise_exception do |exception|
             expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
             expect(exception.headers).to eql(Grape::Http::Headers::X_CASCADE => 'pass')
@@ -129,19 +129,19 @@ describe Grape::Middleware::Versioner::Header do
     end
 
     it 'is set' do
-      status, _, env = subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1')
-      expect(env['api.version']).to eql 'v1'
+      status, _, env = subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendor-v1')
+      expect(env[Grape::Env::API_VERSION]).to eql 'v1'
       expect(status).to eq(200)
     end
 
     it 'is set if format provided' do
-      status, _, env = subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1+json')
-      expect(env['api.version']).to eql 'v1'
+      status, _, env = subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendor-v1+json')
+      expect(env[Grape::Env::API_VERSION]).to eql 'v1'
       expect(status).to eq(200)
     end
 
     it 'fails with 406 Not Acceptable if version is invalid' do
-      expect { subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v2+json').last }.to raise_exception do |exception|
+      expect { subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendor-v2+json').last }.to raise_exception do |exception|
         expect(exception).to be_a(Grape::Exceptions::InvalidVersionHeader)
         expect(exception.headers).to eql(Grape::Http::Headers::X_CASCADE => 'pass')
         expect(exception.status).to be 406
@@ -151,19 +151,19 @@ describe Grape::Middleware::Versioner::Header do
   end
 
   it 'succeeds if :strict is not set' do
-    expect(subject.call('HTTP_ACCEPT' => '').first).to eq(200)
+    expect(subject.call(Grape::Http::Headers::HTTP_ACCEPT => '').first).to eq(200)
     expect(subject.call({}).first).to eq(200)
   end
 
   it 'succeeds if :strict is set to false' do
     @options[:version_options][:strict] = false
-    expect(subject.call('HTTP_ACCEPT' => '').first).to eq(200)
+    expect(subject.call(Grape::Http::Headers::HTTP_ACCEPT => '').first).to eq(200)
     expect(subject.call({}).first).to eq(200)
   end
 
   it 'succeeds if :strict is set to false and given an invalid header' do
     @options[:version_options][:strict] = false
-    expect(subject.call('HTTP_ACCEPT' => 'yaml').first).to eq(200)
+    expect(subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'yaml').first).to eq(200)
     expect(subject.call({}).first).to eq(200)
   end
 
@@ -183,7 +183,7 @@ describe Grape::Middleware::Versioner::Header do
     end
 
     it 'fails with 406 Not Acceptable if header is empty' do
-      expect { subject.call('HTTP_ACCEPT' => '').last }.to raise_exception do |exception|
+      expect { subject.call(Grape::Http::Headers::HTTP_ACCEPT => '').last }.to raise_exception do |exception|
         expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
         expect(exception.headers).to eql(Grape::Http::Headers::X_CASCADE => 'pass')
         expect(exception.status).to be 406
@@ -192,7 +192,7 @@ describe Grape::Middleware::Versioner::Header do
     end
 
     it 'succeeds if proper header is set' do
-      expect(subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1+json').first).to eq(200)
+      expect(subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendor-v1+json').first).to eq(200)
     end
   end
 
@@ -213,7 +213,7 @@ describe Grape::Middleware::Versioner::Header do
     end
 
     it 'fails with 406 Not Acceptable if header is application/xml' do
-      expect { subject.call('HTTP_ACCEPT' => 'application/xml').last }
+      expect { subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'application/xml').last }
         .to raise_exception do |exception|
         expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
         expect(exception.headers).to eql({})
@@ -223,7 +223,7 @@ describe Grape::Middleware::Versioner::Header do
     end
 
     it 'fails with 406 Not Acceptable if header is empty' do
-      expect { subject.call('HTTP_ACCEPT' => '').last }.to raise_exception do |exception|
+      expect { subject.call(Grape::Http::Headers::HTTP_ACCEPT => '').last }.to raise_exception do |exception|
         expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
         expect(exception.headers).to eql({})
         expect(exception.status).to be 406
@@ -232,7 +232,7 @@ describe Grape::Middleware::Versioner::Header do
     end
 
     it 'fails with 406 Not Acceptable if header contains a single invalid accept' do
-      expect { subject.call('HTTP_ACCEPT' => 'application/json;application/vnd.vendor-v1+json').first }
+      expect { subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'application/json;application/vnd.vendor-v1+json').first }
         .to raise_exception do |exception|
         expect(exception).to be_a(Grape::Exceptions::InvalidAcceptHeader)
         expect(exception.headers).to eql({})
@@ -242,7 +242,7 @@ describe Grape::Middleware::Versioner::Header do
     end
 
     it 'succeeds if proper header is set' do
-      expect(subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1+json').first).to eq(200)
+      expect(subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendor-v1+json').first).to eq(200)
     end
   end
 
@@ -252,15 +252,15 @@ describe Grape::Middleware::Versioner::Header do
     end
 
     it 'succeeds with v1' do
-      expect(subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1+json').first).to eq(200)
+      expect(subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendor-v1+json').first).to eq(200)
     end
 
     it 'succeeds with v2' do
-      expect(subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v2+json').first).to eq(200)
+      expect(subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendor-v2+json').first).to eq(200)
     end
 
     it 'fails with another version' do
-      expect { subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v3+json') }.to raise_exception do |exception|
+      expect { subject.call(Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.vendor-v3+json') }.to raise_exception do |exception|
         expect(exception).to be_a(Grape::Exceptions::InvalidVersionHeader)
         expect(exception.headers).to eql(Grape::Http::Headers::X_CASCADE => 'pass')
         expect(exception.status).to be 406

--- a/spec/grape/middleware/versioner/param_spec.rb
+++ b/spec/grape/middleware/versioner/param_spec.rb
@@ -3,19 +3,19 @@
 describe Grape::Middleware::Versioner::Param do
   subject { described_class.new(app, **options) }
 
-  let(:app) { ->(env) { [200, env, env['api.version']] } }
+  let(:app) { ->(env) { [200, env, env[Grape::Env::API_VERSION]] } }
   let(:options) { {} }
 
   it 'sets the API version based on the default param (apiver)' do
     env = Rack::MockRequest.env_for('/awesome', params: { 'apiver' => 'v1' })
-    expect(subject.call(env)[1]['api.version']).to eq('v1')
+    expect(subject.call(env)[1][Grape::Env::API_VERSION]).to eq('v1')
   end
 
   it 'cuts (only) the version out of the params' do
     env = Rack::MockRequest.env_for('/awesome', params: { 'apiver' => 'v1', 'other_param' => '5' })
-    env['rack.request.query_hash'] = Rack::Utils.parse_nested_query(env['QUERY_STRING'])
-    expect(subject.call(env)[1]['rack.request.query_hash']['apiver']).to be_nil
-    expect(subject.call(env)[1]['rack.request.query_hash']['other_param']).to eq('5')
+    env[Rack::RACK_REQUEST_QUERY_HASH] = Rack::Utils.parse_nested_query(env[Rack::QUERY_STRING])
+    expect(subject.call(env)[1][Rack::RACK_REQUEST_QUERY_HASH]['apiver']).to be_nil
+    expect(subject.call(env)[1][Rack::RACK_REQUEST_QUERY_HASH]['other_param']).to eq('5')
   end
 
   it 'provides a nil version if no version is given' do
@@ -28,12 +28,12 @@ describe Grape::Middleware::Versioner::Param do
 
     it 'sets the API version based on the custom parameter name' do
       env = Rack::MockRequest.env_for('/awesome', params: { 'v' => 'v1' })
-      expect(subject.call(env)[1]['api.version']).to eq('v1')
+      expect(subject.call(env)[1][Grape::Env::API_VERSION]).to eq('v1')
     end
 
     it 'does not set the API version based on the default param' do
       env = Rack::MockRequest.env_for('/awesome', params: { 'apiver' => 'v1' })
-      expect(subject.call(env)[1]['api.version']).to be_nil
+      expect(subject.call(env)[1][Grape::Env::API_VERSION]).to be_nil
     end
   end
 
@@ -47,7 +47,7 @@ describe Grape::Middleware::Versioner::Param do
 
     it 'allows versions that have been specified' do
       env = Rack::MockRequest.env_for('/awesome', params: { 'apiver' => 'v1' })
-      expect(subject.call(env)[1]['api.version']).to eq('v1')
+      expect(subject.call(env)[1][Grape::Env::API_VERSION]).to eq('v1')
     end
   end
 

--- a/spec/grape/middleware/versioner/path_spec.rb
+++ b/spec/grape/middleware/versioner/path_spec.rb
@@ -3,30 +3,30 @@
 describe Grape::Middleware::Versioner::Path do
   subject { described_class.new(app, **options) }
 
-  let(:app) { ->(env) { [200, env, env['api.version']] } }
+  let(:app) { ->(env) { [200, env, env[Grape::Env::API_VERSION]] } }
   let(:options) { {} }
 
   it 'sets the API version based on the first path' do
-    expect(subject.call('PATH_INFO' => '/v1/awesome').last).to eq('v1')
+    expect(subject.call(Rack::PATH_INFO => '/v1/awesome').last).to eq('v1')
   end
 
   it 'does not cut the version out of the path' do
-    expect(subject.call('PATH_INFO' => '/v1/awesome')[1]['PATH_INFO']).to eq('/v1/awesome')
+    expect(subject.call(Rack::PATH_INFO => '/v1/awesome')[1][Rack::PATH_INFO]).to eq('/v1/awesome')
   end
 
   it 'provides a nil version if no path is given' do
-    expect(subject.call('PATH_INFO' => '/').last).to be_nil
+    expect(subject.call(Rack::PATH_INFO => '/').last).to be_nil
   end
 
   context 'with a pattern' do
     let(:options) { { pattern: /v./i } }
 
     it 'sets the version if it matches' do
-      expect(subject.call('PATH_INFO' => '/v1/awesome').last).to eq('v1')
+      expect(subject.call(Rack::PATH_INFO => '/v1/awesome').last).to eq('v1')
     end
 
     it 'ignores the version if it fails to match' do
-      expect(subject.call('PATH_INFO' => '/awesome/radical').last).to be_nil
+      expect(subject.call(Rack::PATH_INFO => '/awesome/radical').last).to be_nil
     end
   end
 
@@ -35,11 +35,11 @@ describe Grape::Middleware::Versioner::Path do
       let(:options) { { versions: versions } }
 
       it 'throws an error if a non-allowed version is specified' do
-        expect(catch(:error) { subject.call('PATH_INFO' => '/v3/awesome') }[:status]).to eq(404)
+        expect(catch(:error) { subject.call(Rack::PATH_INFO => '/v3/awesome') }[:status]).to eq(404)
       end
 
       it 'allows versions that have been specified' do
-        expect(subject.call('PATH_INFO' => '/v1/asoasd').last).to eq('v1')
+        expect(subject.call(Rack::PATH_INFO => '/v1/asoasd').last).to eq('v1')
       end
     end
   end
@@ -48,7 +48,7 @@ describe Grape::Middleware::Versioner::Path do
     let(:options) { { prefix: '/v1', pattern: /v./i } }
 
     it 'recognizes potential version' do
-      expect(subject.call('PATH_INFO' => '/v3/foo').last).to eq('v3')
+      expect(subject.call(Rack::PATH_INFO => '/v3/foo').last).to eq('v3')
     end
   end
 
@@ -56,7 +56,7 @@ describe Grape::Middleware::Versioner::Path do
     let(:options) { { mount_path: '/mounted', versions: [:v1] } }
 
     it 'recognizes potential version' do
-      expect(subject.call('PATH_INFO' => '/mounted/v1/foo').last).to eq('v1')
+      expect(subject.call(Rack::PATH_INFO => '/mounted/v1/foo').last).to eq('v1')
     end
   end
 end

--- a/spec/grape/request_spec.rb
+++ b/spec/grape/request_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Grape::Request do
-  let(:default_method) { 'GET' }
+  let(:default_method) { Rack::GET }
   let(:default_params) { {} }
   let(:default_options) do
     {

--- a/spec/grape/util/accept_header_handler_spec.rb
+++ b/spec/grape/util/accept_header_handler_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Grape::Util::AcceptHeaderHandler do
       context 'when allowed_methods present' do
         subject { instance.match_best_quality_media_type!(allowed_methods: allowed_methods) }
 
-        let(:allowed_methods) { ['OPTIONS'] }
+        let(:allowed_methods) { [Rack::OPTIONS] }
 
         it { is_expected.to match_array(allowed_methods) }
       end

--- a/spec/grape/validations/validators/presence_spec.rb
+++ b/spec/grape/validations/validators/presence_spec.rb
@@ -74,12 +74,12 @@ describe Grape::Validations::Validators::PresenceValidator do
       expect(last_response.body).to eq('{"error":"id is missing"}')
 
       io = StringIO.new('{"id" : "a56b"}')
-      post '/', {}, 'rack.input' => io, 'CONTENT_TYPE' => 'application/json', 'CONTENT_LENGTH' => io.length
+      post '/', {}, Rack::RACK_INPUT => io, 'CONTENT_TYPE' => 'application/json', 'CONTENT_LENGTH' => io.length
       expect(last_response.body).to eq('{"error":"id is invalid"}')
       expect(last_response.status).to eq(400)
 
       io = StringIO.new('{"id" : 56}')
-      post '/', {}, 'rack.input' => io, 'CONTENT_TYPE' => 'application/json', 'CONTENT_LENGTH' => io.length
+      post '/', {}, Rack::RACK_INPUT => io, 'CONTENT_TYPE' => 'application/json', 'CONTENT_LENGTH' => io.length
       expect(last_response.body).to eq('{"ret":56}')
       expect(last_response.status).to eq(201)
     end

--- a/spec/integration/hashie/hashie_spec.rb
+++ b/spec/integration/hashie/hashie_spec.rb
@@ -108,7 +108,7 @@ describe 'Hashie', if: defined?(Hashie) do
   end
 
   describe 'Grape::Request' do
-    let(:default_method) { 'GET' }
+    let(:default_method) { Rack::GET }
     let(:default_params) { {} }
     let(:default_options) do
       {

--- a/spec/integration/rack_2_0/headers_spec.rb
+++ b/spec/integration/rack_2_0/headers_spec.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-describe Grape::Http::Headers, if: Gem::Version.new(Rack.release) < Gem::Version.new('3.0.0') do
-  it { expect(described_class::ALLOW).to eq('Allow') }
-  it { expect(described_class::LOCATION).to eq('Location') }
-  it { expect(described_class::TRANSFER_ENCODING).to eq('Transfer-Encoding') }
-  it { expect(described_class::X_CASCADE).to eq('X-Cascade') }
-end

--- a/spec/integration/rack_3_0/headers_spec.rb
+++ b/spec/integration/rack_3_0/headers_spec.rb
@@ -1,8 +1,77 @@
 # frozen_string_literal: true
 
 describe Grape::Http::Headers, if: Gem::Version.new(Rack.release) >= Gem::Version.new('3') do
-  it { expect(described_class::ALLOW).to eq('allow') }
-  it { expect(described_class::LOCATION).to eq('location') }
-  it { expect(described_class::TRANSFER_ENCODING).to eq('transfer-encoding') }
-  it { expect(described_class::X_CASCADE).to eq('x-cascade') }
+  subject { last_response.headers }
+
+  describe 'returned headers should all be in lowercase' do
+    context 'when setting an header in an API' do
+      let(:app) do
+        Class.new(Grape::API) do
+          get do
+            header['GRAPE'] = '1'
+            return_no_content
+          end
+        end
+      end
+
+      before { get '/' }
+
+      it { is_expected.to include('grape' => '1') }
+    end
+
+    context 'when error!' do
+      let(:app) do
+        Class.new(Grape::API) do
+          rescue_from ArgumentError do
+            error!('error!', 500, { 'GRAPE' => '1' })
+          end
+
+          get { raise ArgumentError }
+        end
+      end
+
+      before { get '/' }
+
+      it { is_expected.to include('grape' => '1') }
+    end
+
+    context 'when redirect' do
+      let(:app) do
+        Class.new(Grape::API) do
+          get do
+            redirect 'https://www.ruby-grape.org/'
+          end
+        end
+      end
+
+      before { get '/' }
+
+      it { is_expected.to include('location' => 'https://www.ruby-grape.org/') }
+    end
+
+    context 'when options' do
+      let(:app) do
+        Class.new(Grape::API) do
+          get { return_no_content }
+        end
+      end
+
+      before { options '/' }
+
+      it { is_expected.to include('allow' => 'OPTIONS, GET, HEAD') }
+    end
+
+    context 'when cascade' do
+      let(:app) do
+        Class.new(Grape::API) do
+          version 'v0', using: :path, cascade: true
+          get { return_no_content }
+        end
+      end
+
+      before { get '/v1' }
+
+      it { is_expected.to include('x-cascade' => 'pass') }
+    end
+  end
 end

--- a/spec/shared/versioning_examples.rb
+++ b/spec/shared/versioning_examples.rb
@@ -5,7 +5,7 @@ shared_examples_for 'versioning' do
     subject.format :txt
     subject.version 'v1', macro_options
     subject.get :hello do
-      "Version: #{request.env['api.version']}"
+      "Version: #{request.env[Grape::Env::API_VERSION]}"
     end
     versioned_get '/hello', 'v1', **macro_options
     expect(last_response.body).to eql 'Version: v1'
@@ -16,7 +16,7 @@ shared_examples_for 'versioning' do
     subject.prefix 'api'
     subject.version 'v1', macro_options
     subject.get :hello do
-      "Version: #{request.env['api.version']}"
+      "Version: #{request.env[Grape::Env::API_VERSION]}"
     end
     versioned_get '/hello', 'v1', **macro_options.merge(prefix: 'api')
     expect(last_response.body).to eql 'Version: v1'
@@ -65,12 +65,12 @@ shared_examples_for 'versioning' do
         subject.format :txt
         subject.version 'v2', macro_options
         subject.get 'version' do
-          request.env['api.version']
+          request.env[Grape::Env::API_VERSION]
         end
 
         subject.version 'v1', macro_options do
           get 'version' do
-            "version #{request.env['api.version']}"
+            "version #{request.env[Grape::Env::API_VERSION]}"
           end
         end
 
@@ -89,12 +89,12 @@ shared_examples_for 'versioning' do
         subject.prefix 'api'
         subject.version 'v2', macro_options
         subject.get 'version' do
-          request.env['api.version']
+          request.env[Grape::Env::API_VERSION]
         end
 
         subject.version 'v1', macro_options do
           get 'version' do
-            "version #{request.env['api.version']}"
+            "version #{request.env[Grape::Env::API_VERSION]}"
           end
         end
 

--- a/spec/support/cookie_jar.rb
+++ b/spec/support/cookie_jar.rb
@@ -5,7 +5,7 @@ require 'uri'
 module Rack
   class MockResponse
     def cookie_jar
-      @cookie_jar ||= Array(headers['Set-Cookie']).flat_map { |h| h.split("\n") }.map { |c| Cookie.new(c).to_h }
+      @cookie_jar ||= Array(headers[Rack::SET_COOKIE]).flat_map { |h| h.split("\n") }.map { |c| Cookie.new(c).to_h }
     end
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie

--- a/spec/support/endpoint_faker.rb
+++ b/spec/support/endpoint_faker.rb
@@ -17,7 +17,7 @@ module Spec
           @request = Grape::Request.new(env.dup)
         end
 
-        @app.call(env.merge('api.endpoint' => @endpoint))
+        @app.call(env.merge(Grape::Env::API_ENDPOINT => @endpoint))
       end
     end
   end

--- a/spec/support/versioned_helpers.rb
+++ b/spec/support/versioned_helpers.rb
@@ -29,14 +29,14 @@ module Spec
           {}  # no-op
         when :header
           {
-            'HTTP_ACCEPT' => [
+            Grape::Http::Headers::HTTP_ACCEPT => [
               "application/vnd.#{options[:vendor]}-#{options[:version]}",
               options[:format]
             ].compact.join('+')
           }
         when :accept_version_header
           {
-            'HTTP_ACCEPT_VERSION' => options[:version].to_s
+            Grape::Http::Headers::HTTP_ACCEPT_VERSION => options[:version].to_s
           }
         else
           raise ArgumentError.new("unknown versioning strategy: #{options[:using]}")


### PR DESCRIPTION
### Motivation

Since we [dropped](#2426) support for rack 1.X, we can replace some of our constants by Rack's constants. For instance, we had defined all supported http methods like `Grape::Http::Headers::GET`, `Grape::Http::Headers::POST` etc... but its already defined as `Rack::GET`, `Rack::POST`, etc... in Rack.

We also had redefined some Rack's constants in our code base like `Grape::Env::RACK_INPUT`, `Grape::Env::RACK_REQUEST_FORM_HASH` etc ... but these are Rack's internals and we should not rely on them and use Rack's constants `Rack::INPUT`, `Rack::REQUEST_FORM_HASH`.

At least, if Rack as major internal changes, Grape's will be in line with these changes even if it's a renaming or a drop. In the end, Grape is rack based and it all makes sense to do that since we were already using several Rack's utility functions.

Although, Grape should have a smaller memory footprint since we have less string literals.

Finally, I've changed Rack 3.0's integrations tests to make sure all our response headers are lowercased instead of looking if our internal headers are in lowercase. If makes more sense with #2425.

Thanks