### PR TITLE
The `length` validator only takes effect for parameters with types that support `#length` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#2471](https://github.com/ruby-grape/grape/pull/2471): Fix absence of original_exception and/or backtrace even if passed in error! - [@numbata](https://github.com/numbata).
 * [#2478](https://github.com/ruby-grape/grape/pull/2478): Fix rescue_from with invalid response - [@ericproulx](https://github.com/ericproulx).
 * [#2480](https://github.com/ruby-grape/grape/pull/2480): Fix rescue_from ValidationErrors exception - [@numbata](https://github.com/numbata).
+* [#2464](https://github.com/ruby-grape/grape/pull/2464): The `length` validator only takes effect for parameters with types that support `#length` method - [@OuYangJinTing](https://github.com/OuYangJinTing).
 * Your contribution here.
 
 ### 2.1.3 (2024-07-13)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,14 @@
 Upgrading Grape
 ===============
 
+### Upgrading to >= 2.2.0
+
+### `Length` validator
+
+After Grape 2.2.0, `length` validator will only take effect for parameters with types that support `#length` method, will not throw `ArgumentError` exception.
+
+See [#2464](https://github.com/ruby-grape/grape/pull/2464) for more information.
+
 ### Upgrading to >= 2.1.0
 
 #### Optional Builder

--- a/lib/grape/validations/validators/length_validator.rb
+++ b/lib/grape/validations/validators/length_validator.rb
@@ -18,7 +18,7 @@ module Grape
         def validate_param!(attr_name, params)
           param = params[attr_name]
 
-          raise ArgumentError, "parameter #{param} does not support #length" unless param.respond_to?(:length)
+          return unless param.respond_to?(:length)
 
           return unless (!@min.nil? && param.length < @min) || (!@max.nil? && param.length > @max)
 

--- a/spec/grape/validations/validators/length_spec.rb
+++ b/spec/grape/validations/validators/length_spec.rb
@@ -188,11 +188,11 @@ describe Grape::Validations::Validators::LengthValidator do
   end
 
   describe '/type_is_not_array' do
-    context 'raises an error' do
+    context 'does not raise an error' do
       it do
         expect do
           post 'type_is_not_array', list: 12
-        end.to raise_error(ArgumentError, 'parameter 12 does not support #length')
+        end.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
Thanks to @dhruvCW for adding the length validator(#2437).

I found that in the case of optional parameters, passing in nil will lead to an exception. This behavior is not very friendly.
For nil, it should be a better choice to skip verification directly.