### PR TITLE
Fix repo coverage

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+if ENV['GITHUB_USER'] # only when running CI
+  require 'simplecov-lcov'
+  SimpleCov::Formatter::LcovFormatter.config do |c|
+    c.report_with_single_file = true
+    c.single_report_path = 'coverage/lcov.info'
+  end
+
+  SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+end
+
+SimpleCov.start do
+  add_filter '/spec/'
+end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#2467](https://github.com/ruby-grape/grape/pull/2467): Fix repo coverage - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 2.1.2 (2024-06-28)

--- a/Gemfile
+++ b/Gemfile
@@ -28,8 +28,8 @@ group :test do
   gem 'rack-test', '~> 2.1'
   gem 'rspec', '~> 3.13'
   gem 'ruby-grape-danger', '~> 0.2', require: false
-  gem 'simplecov', '~> 0.21'
-  gem 'simplecov-lcov', '~> 0.8'
+  gem 'simplecov', '~> 0.21', require: false
+  gem 'simplecov-lcov', '~> 0.8', require: false
   gem 'test-prof', require: false
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,9 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.dirname(__FILE__))
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), 'support'))
-
+require 'simplecov'
 require 'rubygems'
 require 'bundler'
 Bundler.require :default, :test
-
-require 'grape'
 
 Grape.deprecator.behavior = :raise
 
@@ -27,7 +22,6 @@ RSpec.configure do |config|
   config.include Spec::Support::Helpers
   config.raise_errors_for_deprecations!
   config.filter_run_when_matching :focus
-  config.warnings = true
 
   config.before(:all) { Grape::Util::InheritableSetting.reset_global! }
   config.before { Grape::Util::InheritableSetting.reset_global! }
@@ -35,13 +29,3 @@ RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
 end
-
-require 'simplecov'
-require 'simplecov-lcov'
-SimpleCov::Formatter::LcovFormatter.config do |c|
-  c.report_with_single_file = true
-  c.single_report_path = 'coverage/lcov.info'
-end
-
-SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
-SimpleCov.start


### PR DESCRIPTION
Fix #2466

Also, `lcov` format will be used only when running GH Actions.
