### PR TITLE
Align `error!` method signatures across different places.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * [#2467](https://github.com/ruby-grape/grape/pull/2467): Fix repo coverage - [@ericproulx](https://github.com/ericproulx).
+* [#2468](https://github.com/ruby-grape/grape/pull/2468): Align `error!` method signatures across different places - [@numbata](https://github.com/numbata).
 * Your contribution here.
 
 ### 2.1.2 (2024-06-28)

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -163,12 +163,14 @@ module Grape
       # end user with the specified message.
       #
       # @param message [String] The message to display.
-      # @param status [Integer] the HTTP Status Code. Defaults to default_error_status, 500 if not set.
+      # @param status [Integer] The HTTP Status Code. Defaults to default_error_status, 500 if not set.
       # @param additional_headers [Hash] Addtional headers for the response.
-      def error!(message, status = nil, additional_headers = nil)
+      # @param backtrace [Array<String>] The backtrace of the exception that caused the error.
+      # @param original_exception [Exception] The original exception that caused the error.
+      def error!(message, status = nil, additional_headers = nil, backtrace = nil, original_exception = nil)
         status = self.status(status || namespace_inheritable(:default_error_status))
         headers = additional_headers.present? ? header.merge(additional_headers) : header
-        throw :error, message: message, status: status, headers: headers
+        throw :error, message: message, status: status, headers: headers, backtrace: backtrace, original_exception: original_exception
       end
 
       # Creates a Rack response based on the provided message, status, and headers.

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -2532,6 +2532,18 @@ describe Grape::API do
         get '/exception'
         expect(last_response.body).to eq('message: rain! @backtrace')
       end
+
+      it 'returns a modified error with a custom error format' do
+        subject.rescue_from :all, backtrace: true do |e|
+          error!('raining dogs and cats', 418, {}, e.backtrace, e)
+        end
+        subject.error_formatter :txt, with: custom_error_formatter
+        subject.get '/exception' do
+          raise 'rain!'
+        end
+        get '/exception'
+        expect(last_response.body).to eq('message: raining dogs and cats @backtrace')
+      end
     end
 
     it 'rescues all errors and return :json' do


### PR DESCRIPTION
This pull request fix a compatibility issue with the `error!` method when used in `rescue_from` block.

Previously, the `rescue_from` block ran in context of `Grape::Middleware::Error`, where `error!` method had one signature. Now, block run in context of `Grape::DSL::InsideRoute`, where `error!` method has different signature. This change cause runtime errors when `error!` method was called with extra arguments like `backtrace` and `original_exception`.

This update make `error!` method signatures same across different contexts. By aligning these signatures, `error!` method can handle additional arguments consistently and preventing errors.