### PR TITLE
Fixes #2347 - Correct full path building for lateral scopes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,7 +40,7 @@ Metrics/BlockLength:
     - spec/**/*_spec.rb
 
 Metrics/ClassLength:
-  Max: 300
+  Max: 305
 
 Metrics/CyclomaticComplexity:
   Max: 15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * [#2467](https://github.com/ruby-grape/grape/pull/2467): Fix repo coverage - [@ericproulx](https://github.com/ericproulx).
 * [#2468](https://github.com/ruby-grape/grape/pull/2468): Align `error!` method signatures across different places - [@numbata](https://github.com/numbata).
+* [#2469](https://github.com/ruby-grape/grape/pull/2469): Fix full path building for lateral scopes - [@numbata](https://github.com/numbata).
 * Your contribution here.
 
 ### 2.1.2 (2024-06-28)

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -190,7 +190,13 @@ module Grape
       #
       # @return [Array<Symbol>] the nesting/path of the current parameter scope
       def full_path
-        nested? ? @parent.full_path + [@element] : []
+        if nested?
+          (@parent.full_path + [@element])
+        elsif lateral?
+          @parent.full_path
+        else
+          []
+        end
       end
 
       private


### PR DESCRIPTION
Should fix the #2347 issue.

This pull request fixes an issue where the full_path method would stop building the full path when encountering lateral scopes like `with` or `given`. The updated method now correctly handles these cases, ensuring accurate path construction

Thanks @seriousdev-gh  for the [spec](https://github.com/ruby-grape/grape/pull/2462).