### PR TITLE
Fixes #2470 Expose original_exception and/or backtrace if present

### DIFF
--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -170,7 +170,12 @@ module Grape
       def error!(message, status = nil, additional_headers = nil, backtrace = nil, original_exception = nil)
         status = self.status(status || namespace_inheritable(:default_error_status))
         headers = additional_headers.present? ? header.merge(additional_headers) : header
-        throw :error, message: message, status: status, headers: headers, backtrace: backtrace, original_exception: original_exception
+        throw :error,
+              message: message,
+              status: status,
+              headers: headers,
+              backtrace: backtrace,
+              original_exception: original_exception
       end
 
       # Creates a Rack response based on the provided message, status, and headers.

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -120,9 +120,9 @@ module Grape
           handler.arity.zero? ? endpoint.instance_exec(&handler) : endpoint.instance_exec(error, &handler)
         end
 
-        response = error!(response[:message], response[:status], response[:headers]) if error?(response)
-
-        if response.is_a?(Rack::Response)
+        if error?(response)
+          error_response(response)
+        elsif response.is_a?(Rack::Response)
           response
         else
           run_rescue_handler(:default_rescue_handler, Grape::Exceptions::InvalidResponse.new, endpoint)
@@ -137,7 +137,9 @@ module Grape
       end
 
       def error?(response)
-        response.is_a?(Hash) && response[:message] && response[:status] && response[:headers]
+        return false unless response.is_a?(Hash)
+
+        response.key?(:message) && response.key?(:status) && response.key?(:headers)
       end
     end
   end


### PR DESCRIPTION
Fix the case where backtrace and/or original_exception arguments are passed, but then do not become part of the returned message, even if `backtrace: true` and/or `original_exception: true` are set at the `rescue_from` level.

Thanks to @ericproulx for pointing out the problem and provided specs.