### PR TITLE
Fix rescue_from ValidationErrors exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 * [#2471](https://github.com/ruby-grape/grape/pull/2471): Fix absence of original_exception and/or backtrace even if passed in error! - [@numbata](https://github.com/numbata).
 * [#2478](https://github.com/ruby-grape/grape/pull/2478): Fix rescue_from with invalid response - [@ericproulx](https://github.com/ericproulx).
+* [#2480](https://github.com/ruby-grape/grape/pull/2480): Fix rescue_from ValidationErrors exception - [@numbata](https://github.com/numbata).
 * Your contribution here.
 
 ### 2.1.3 (2024-07-13)

--- a/lib/grape/error_formatter/json.rb
+++ b/lib/grape/error_formatter/json.rb
@@ -9,17 +9,18 @@ module Grape
         def call(message, backtrace, options = {}, env = nil, original_exception = nil)
           result = wrap_message(present(message, env))
 
-          rescue_options = options[:rescue_options] || {}
-          result = result.merge(backtrace: backtrace) if rescue_options[:backtrace] && backtrace && !backtrace.empty?
-          result = result.merge(original_exception: original_exception.inspect) if rescue_options[:original_exception] && original_exception
+          result = merge_rescue_options(result, backtrace, options, original_exception) if result.is_a?(Hash)
+
           ::Grape::Json.dump(result)
         end
 
         private
 
         def wrap_message(message)
-          if message.is_a?(Exceptions::ValidationErrors) || message.is_a?(Hash)
+          if message.is_a?(Hash)
             message
+          elsif message.is_a?(Exceptions::ValidationErrors)
+            message.as_json
           else
             { error: ensure_utf8(message) }
           end
@@ -29,6 +30,14 @@ module Grape
           return message unless message.respond_to? :encode
 
           message.encode('UTF-8', invalid: :replace, undef: :replace)
+        end
+
+        def merge_rescue_options(result, backtrace, options, original_exception)
+          rescue_options = options[:rescue_options] || {}
+          result = result.merge(backtrace: backtrace) if rescue_options[:backtrace] && backtrace && !backtrace.empty?
+          result = result.merge(original_exception: original_exception.inspect) if rescue_options[:original_exception] && original_exception
+
+          result
         end
       end
     end


### PR DESCRIPTION
If the structure of the resulting error message does not lend itself to adding the original exception and custom backtrace, it should be skipped.

Fixes the #2472