### PR TITLE
Fix Grape::Endpoint's inspect method when not called in the context of an API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#2480](https://github.com/ruby-grape/grape/pull/2480): Fix rescue_from ValidationErrors exception - [@numbata](https://github.com/numbata).
 * [#2464](https://github.com/ruby-grape/grape/pull/2464): The `length` validator only takes effect for parameters with types that support `#length` method - [@OuYangJinTing](https://github.com/OuYangJinTing).
 * [#2485](https://github.com/ruby-grape/grape/pull/2485): Add `is:` param to length validator - [@dakad](https://github.com/dakad).
+* [#2492](https://github.com/ruby-grape/grape/pull/2492): Fix Grape::Endpoint's inspect method - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 2.1.3 (2024-07-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * [#2480](https://github.com/ruby-grape/grape/pull/2480): Fix rescue_from ValidationErrors exception - [@numbata](https://github.com/numbata).
 * [#2464](https://github.com/ruby-grape/grape/pull/2464): The `length` validator only takes effect for parameters with types that support `#length` method - [@OuYangJinTing](https://github.com/OuYangJinTing).
 * [#2485](https://github.com/ruby-grape/grape/pull/2485): Add `is:` param to length validator - [@dakad](https://github.com/dakad).
-* [#2492](https://github.com/ruby-grape/grape/pull/2492): Fix Grape::Endpoint's inspect method - [@ericproulx](https://github.com/ericproulx).
+* [#2492](https://github.com/ruby-grape/grape/pull/2492): Fix `Grape::Endpoint#inspect` method - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 2.1.3 (2024-07-13)

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -234,13 +234,13 @@ module Grape
       (options == endpoint.options) && (inheritable_setting.to_hash == endpoint.inheritable_setting.to_hash)
     end
 
-    # the purpose of this override is solely for stripping internals when an error occurs while calling
-    # an endpoint through an api. See #https://github.com/ruby-grape/grape/issues/2398
-    # Otherwise, it calls super
+    # The purpose of this override is solely for stripping internals when an error occurs while calling
+    # an endpoint through an api. See https://github.com/ruby-grape/grape/issues/2398
+    # Otherwise, it calls super.
     def inspect
       return super unless env
 
-      "#{self.class} in `#{route.origin}' endpoint"
+      "#{self.class} in '#{route.origin}' endpoint"
     end
 
     protected

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -234,6 +234,15 @@ module Grape
       (options == endpoint.options) && (inheritable_setting.to_hash == endpoint.inheritable_setting.to_hash)
     end
 
+    # the purpose of this override is solely for stripping internals when an error occurs while calling
+    # an endpoint through an api. See #https://github.com/ruby-grape/grape/issues/2398
+    # Otherwise, it calls super
+    def inspect
+      return super unless env
+
+      "#{self.class} in `#{route.origin}' endpoint"
+    end
+
     protected
 
     def run
@@ -402,10 +411,6 @@ module Grape
     def options?
       options[:options_route_enabled] &&
         env[Rack::REQUEST_METHOD] == Rack::OPTIONS
-    end
-
-    def inspect
-      "#{self.class} in `#{route.origin}' endpoint"
     end
   end
 end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -1089,7 +1089,7 @@ describe Grape::Endpoint do
     end
   end
 
-  context '#inspect' do
+  describe '#inspect' do
     subject { described_class.new(settings, options).inspect }
 
     let(:options) do
@@ -1105,7 +1105,7 @@ describe Grape::Endpoint do
     let(:settings) { Grape::Util::InheritableSetting.new }
 
     it 'does not raise an error' do
-      expect { subject }.to_not raise_error
+      expect { subject }.not_to raise_error
     end
   end
 end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -683,7 +683,7 @@ describe Grape::Endpoint do
     context 'when referencing an undefined local variable or method' do
       let(:error_message) do
         if Gem::Version.new(RUBY_VERSION).release <= Gem::Version.new('3.2')
-          %r{undefined local variable or method `undefined_helper' for #<Class:0x[0-9a-fA-F]+> in `/hey' endpoint}
+          %r{undefined local variable or method `undefined_helper' for #<Class:0x[0-9a-fA-F]+> in '/hey' endpoint}
         else
           /undefined local variable or method `undefined_helper' for/
         end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -1088,4 +1088,24 @@ describe Grape::Endpoint do
       )
     end
   end
+
+  context '#inspect' do
+    subject { described_class.new(settings, options).inspect }
+
+    let(:options) do
+      {
+        method: :path,
+        path: '/path',
+        app: {},
+        route_options: { anchor: false },
+        forward_match: true,
+        for: Class.new
+      }
+    end
+    let(:settings) { Grape::Util::InheritableSetting.new }
+
+    it 'does not raise an error' do
+      expect { subject }.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
Fix #2491