### PR TITLE
Update rubocop to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Features
 
-* [#2497](https://github.com/ruby-grape/grape/pull/2497): Update Rubocop - [@ericproulx](https://github.com/ericproulx).
+* [#2497](https://github.com/ruby-grape/grape/pull/2497): Update RuboCop to 1.66.1 - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features
 
+* [#2497](https://github.com/ruby-grape/grape/pull/2497): Update Rubocop - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,9 @@ group :development, :test do
   gem 'builder', require: false
   gem 'bundler'
   gem 'rake'
-  gem 'rubocop', '1.64.1', require: false
-  gem 'rubocop-performance', '1.21.0', require: false
-  gem 'rubocop-rspec', '3.0.1', require: false
+  gem 'rubocop', '1.66.1', require: false
+  gem 'rubocop-performance', '1.21.1', require: false
+  gem 'rubocop-rspec', '3.0.5', require: false
 end
 
 group :development do

--- a/grape.gemspec
+++ b/grape.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
-  s.add_runtime_dependency 'activesupport', '>= 6'
-  s.add_runtime_dependency 'dry-types', '>= 1.1'
-  s.add_runtime_dependency 'mustermann-grape', '~> 1.1.0'
-  s.add_runtime_dependency 'rack', '>= 2'
-  s.add_runtime_dependency 'zeitwerk'
+  s.add_dependency 'activesupport', '>= 6'
+  s.add_dependency 'dry-types', '>= 1.1'
+  s.add_dependency 'mustermann-grape', '~> 1.1.0'
+  s.add_dependency 'rack', '>= 2'
+  s.add_dependency 'zeitwerk'
 
   s.files = Dir['lib/**/*', 'CHANGELOG.md', 'CONTRIBUTING.md', 'README.md', 'grape.png', 'UPGRADING.md', 'LICENSE', 'grape.gemspec']
   s.require_paths = ['lib']


### PR DESCRIPTION
This PR updates the following gems.

- rubocop 1.66.1
- rubocop-performance 1.21.1
- rubocop-rspec 3.0.5

This PR also changes `add_runtime_dependency` to `add_dependency` [Gemspec/AddRuntimeDependency](https://rubydoc.info/gems/rubocop/RuboCop/Cop/Gemspec/AddRuntimeDependency)