### PR TITLE
Remove deprecated except and proc in values validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#2497](https://github.com/ruby-grape/grape/pull/2497): Update RuboCop to 1.66.1 - [@ericproulx](https://github.com/ericproulx).
 * [#2500](https://github.com/ruby-grape/grape/pull/2500): Remove deprecated `file` method - [@ericproulx](https://github.com/ericproulx).
+* [#2501](https://github.com/ruby-grape/grape/pull/2501): Remove deprecated `except` and `proc` options in values validator - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,10 +6,10 @@ Upgrading Grape
 #### Remove Deprecated Methods and Options
 
 - Deprecated `file` method has been removed. Use `send_file` or `stream`.
-See [#2500](https://github.com/ruby-grape/grape/pull/2500) for more information
+See [#2500](https://github.com/ruby-grape/grape/pull/2500) for more information.
 
 - The `except` and `proc` options have been removed from the `values` validator. Use `except_values` validator or assign `proc` directly to `values`.
-See [#2501](https://github.com/ruby-grape/grape/pull/2501) for more information
+See [#2501](https://github.com/ruby-grape/grape/pull/2501) for more information.
 
 ### Upgrading to >= 2.2.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,7 +3,7 @@ Upgrading Grape
 
 ### Upgrading to >= 2.3.0
 
-#### Remove Deprecated Methods and Pptions
+#### Remove Deprecated Methods and Options
 
 - Deprecated `file` method has been removed. Use `send_file` or `stream`.
 See [#2500](https://github.com/ruby-grape/grape/pull/2500) for more information

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,11 +3,13 @@ Upgrading Grape
 
 ### Upgrading to >= 2.3.0
 
-#### Remove deprecated methods
+#### Remove deprecated methods and options
 
-Deprecated `file` method has been removed. Use `send_file` or `stream`.
-
+- Deprecated `file` method has been removed. Use `send_file` or `stream`.
 See [#2500](https://github.com/ruby-grape/grape/pull/2500)
+
+- `except` and `proc` options has been removed from the `values` validator. Use `except validator` or assign `proc` directly to `values`
+See [#2501](https://github.com/ruby-grape/grape/pull/2501)
 
 ### Upgrading to >= 2.2.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,13 +3,13 @@ Upgrading Grape
 
 ### Upgrading to >= 2.3.0
 
-#### Remove deprecated methods and options
+#### Remove Deprecated Methods and Pptions
 
 - Deprecated `file` method has been removed. Use `send_file` or `stream`.
-See [#2500](https://github.com/ruby-grape/grape/pull/2500)
+See [#2500](https://github.com/ruby-grape/grape/pull/2500) for more information
 
-- `except` and `proc` options have been removed from the `values` validator. Use `except validator` or assign `proc` directly to `values`.
-See [#2501](https://github.com/ruby-grape/grape/pull/2501)
+- The `except` and `proc` options have been removed from the `values` validator. Use `except_values` validator or assign `proc` directly to `values`.
+See [#2501](https://github.com/ruby-grape/grape/pull/2501) for more information
 
 ### Upgrading to >= 2.2.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,7 +8,7 @@ Upgrading Grape
 - Deprecated `file` method has been removed. Use `send_file` or `stream`.
 See [#2500](https://github.com/ruby-grape/grape/pull/2500)
 
-- `except` and `proc` options has been removed from the `values` validator. Use `except validator` or assign `proc` directly to `values`
+- `except` and `proc` options have been removed from the `values` validator. Use `except validator` or assign `proc` directly to `values`.
 See [#2501](https://github.com/ruby-grape/grape/pull/2501)
 
 ### Upgrading to >= 2.2.0

--- a/lib/grape/validations/validators/values_validator.rb
+++ b/lib/grape/validations/validators/values_validator.rb
@@ -19,12 +19,12 @@ module Grape
           # don't forget that +false.blank?+ is true
           return if val != false && val.blank? && @allow_blank
 
-          unless check_values?(val, attr_name)
-            raise Grape::Exceptions::Validation.new(
-              params: [@scope.full_name(attr_name)],
-              message: message(:values)
-            )
-          end
+          return if check_values?(val, attr_name)
+
+          raise Grape::Exceptions::Validation.new(
+            params: [@scope.full_name(attr_name)],
+            message: message(:values)
+          )
         end
 
         private

--- a/lib/grape/validations/validators/values_validator.rb
+++ b/lib/grape/validations/validators/values_validator.rb
@@ -5,22 +5,7 @@ module Grape
     module Validators
       class ValuesValidator < Base
         def initialize(attrs, options, required, scope, **opts)
-          if options.is_a?(Hash)
-            @excepts = options[:except]
-            @values = options[:value]
-            @proc = options[:proc]
-
-            Grape.deprecator.warn('The values validator except option is deprecated. Use the except validator instead.') if @excepts
-
-            raise ArgumentError, 'proc must be a Proc' if @proc && !@proc.is_a?(Proc)
-
-            Grape.deprecator.warn('The values validator proc option is deprecated. The lambda expression can now be assigned directly to values.') if @proc
-          else
-            @excepts = nil
-            @values = nil
-            @proc = nil
-            @values = options
-          end
+          @values = options.is_a?(Hash) ? options[:value] : options
           super
         end
 
@@ -34,54 +19,29 @@ module Grape
           # don't forget that +false.blank?+ is true
           return if val != false && val.blank? && @allow_blank
 
-          param_array = val.nil? ? [nil] : Array.wrap(val)
-
-          raise validation_exception(attr_name, except_message) \
-          unless check_excepts(param_array)
-
-          raise validation_exception(attr_name, message(:values)) \
-          unless check_values(param_array, attr_name)
-
-          raise validation_exception(attr_name, message(:values)) \
-            if @proc && !validate_proc(@proc, param_array)
+          unless check_values?(val, attr_name)
+            raise Grape::Exceptions::Validation.new(
+              params: [@scope.full_name(attr_name)],
+              message: message(:values)
+            )
+          end
         end
 
         private
 
-        def check_values(param_array, attr_name)
+        def check_values?(val, attr_name)
           values = @values.is_a?(Proc) && @values.arity.zero? ? @values.call : @values
           return true if values.nil?
 
+          param_array = val.nil? ? [nil] : Array.wrap(val)
+          return param_array.all? { |param| values.include?(param) } unless values.is_a?(Proc)
+
           begin
-            return param_array.all? { |param| values.call(param) } if values.is_a? Proc
+            param_array.all? { |param| values.call(param) }
           rescue StandardError => e
             warn "Error '#{e}' raised while validating attribute '#{attr_name}'"
-            return false
+            false
           end
-          param_array.all? { |param| values.include?(param) }
-        end
-
-        def check_excepts(param_array)
-          excepts = @excepts.is_a?(Proc) ? @excepts.call : @excepts
-          return true if excepts.nil?
-
-          param_array.none? { |param| excepts.include?(param) }
-        end
-
-        def validate_proc(proc, param_array)
-          case proc.arity
-          when 0
-            param_array.all? { |_param| proc.call }
-          when 1
-            param_array.all? { |param| proc.call(param) }
-          else
-            raise ArgumentError, 'proc arity must be 0 or 1'
-          end
-        end
-
-        def except_message
-          options = instance_variable_get(:@option)
-          options_key?(:except_message) ? options[:except_message] : message(:except_values)
         end
 
         def required_for_root_scope?
@@ -91,10 +51,6 @@ module Grape
           scope = scope.parent while scope.lateral?
 
           scope.root?
-        end
-
-        def validation_exception(attr_name, message)
-          Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message)
         end
       end
     end


### PR DESCRIPTION
This PR removes the option `proc` and `except` in the values validator. It's been deprecated since version [1.0.0](https://github.com/ruby-grape/grape/blob/master/UPGRADING.md#the-except-except_message-and-proc-options-of-the-values-validator-are-deprecated)