### PR TITLE
Remove deprecation msg + small refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#2497](https://github.com/ruby-grape/grape/pull/2497): Update RuboCop to 1.66.1 - [@ericproulx](https://github.com/ericproulx).
 * [#2500](https://github.com/ruby-grape/grape/pull/2500): Remove deprecated `file` method - [@ericproulx](https://github.com/ericproulx).
 * [#2501](https://github.com/ruby-grape/grape/pull/2501): Remove deprecated `except` and `proc` options in values validator - [@ericproulx](https://github.com/ericproulx).
+* [#2502](https://github.com/ruby-grape/grape/pull/2502): Remove deprecation `options` in `desc` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -11,6 +11,9 @@ See [#2500](https://github.com/ruby-grape/grape/pull/2500) for more information.
 - The `except` and `proc` options have been removed from the `values` validator. Use `except_values` validator or assign `proc` directly to `values`.
 See [#2501](https://github.com/ruby-grape/grape/pull/2501) for more information.
 
+- `Passing an options hash and a block to 'desc'` deprecation has been removed. Move all hash options to block instead.
+See [#2502](https://github.com/ruby-grape/grape/pull/2502) for more information.
+
 ### Upgrading to >= 2.2.0
 
 ### `Length` validator

--- a/spec/grape/dsl/desc_spec.rb
+++ b/spec/grape/dsl/desc_spec.rb
@@ -81,18 +81,5 @@ describe Grape::DSL::Desc do
       expect(subject.namespace_setting(:description)).to eq(expected_options)
       expect(subject.route_setting(:description)).to eq(expected_options)
     end
-
-    it 'can be set with options and a block' do
-      expect(Grape.deprecator).to receive(:warn).with('Passing a options hash and a block to `desc` is deprecated. Move all hash options to block.')
-
-      desc_text = 'The description'
-      detail_text = 'more details'
-      options = { message: 'none' }
-      subject.desc desc_text, options do
-        detail detail_text
-      end
-      expect(subject.namespace_setting(:description)).to eq(description: desc_text, detail: detail_text)
-      expect(subject.route_setting(:description)).to eq(description: desc_text, detail: detail_text)
-    end
   end
 end


### PR DESCRIPTION
This PR will remove the deprecation message when `options` and `block` are used simultaneously when describing an API through the DSL function `desc`.