### PR TITLE
Prioritize env API_FORMAT over Rack::CONTENT_TYPE header

### DIFF
--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -53,7 +53,7 @@ module Grape
       end
 
       def fetch_formatter(headers, options)
-        api_format = mime_types[headers[Rack::CONTENT_TYPE]] || env[Grape::Env::API_FORMAT]
+        api_format = env[Grape::Env::API_FORMAT] || mime_types[headers[Rack::CONTENT_TYPE]]
         Grape::Formatter.formatter_for(api_format, options[:formatters])
       end
 


### PR DESCRIPTION
As per https://github.com/ruby-grape/grape/issues/2171

# Fix the Order of Conditions in `fetch_formatter` to Correctly Use Custom Formatters

**Issue:**

In `Grape::Middleware::Formatter.fetch_formatter`, the current order of conditions causes custom formatters specified in `env[Grape::Env::API_FORMAT]` to be ignored in favor of the default formatter associated with the `Content-Type` header.

**Original Code:**

```ruby
def fetch_formatter(headers, options)
  api_format = mime_types[headers[Grape::Http::Headers::CONTENT_TYPE]] || env[Grape::Env::API_FORMAT]
  Grape::Formatter.formatter_for(api_format, **options)
end
```

**Problem:**

This code prioritizes the `Content-Type` header over the `env[Grape::Env::API_FORMAT]`. As a result, even if a custom formatter is explicitly set in the environment, it may be overridden by the default formatter determined by the `Content-Type`.

**Solution:**

Swap the order of conditions so that `env[Grape::Env::API_FORMAT]` takes precedence:

```ruby
def fetch_formatter(headers, options)
  api_format = env[Grape::Env::API_FORMAT] || mime_types[headers[Grape::Http::Headers::CONTENT_TYPE]]
  Grape::Formatter.formatter_for(api_format, **options)
end
```

**Rationale:**

By giving priority to `env[Grape::Env::API_FORMAT]`, we ensure that custom formatters are correctly recognized and applied, allowing for more flexible and accurate response formatting.

**Example:**

```ruby
# Define a custom formatter
content_type :raw_json, 'application/json'
formatter :raw_json, ->(object, _env) { object }

# Use the custom formatter within an endpoint
get do
  env['api.format'] = :raw_json
  body <<-HERE
  {
    "glossary": {
      "title": "example glossary",
      "GlossDiv": {
        "title": "S",
        "GlossList": {
          "GlossEntry": {
            "ID": "SGML",
            "SortAs": "SGML",
            "GlossTerm": "Standard Generalized Markup Language",
            "Acronym": "SGML",
            "Abbrev": "ISO 8879:1986",
            "GlossDef": {
              "para": "A meta-markup language, used to create markup languages such as DocBook.",
              "GlossSeeAlso": ["GML", "XML"]
            },
            "GlossSee": "markup"
          }
        }
      }
    }
  }
  HERE
end
```

**Before the Fix:**

The custom formatter `:raw_json` is not applied. Instead, Grape uses its default JSON formatter.

**After the Fix:**

The custom formatter `:raw_json` is correctly applied, and the response body is returned exactly as intended.