### PR TITLE
Fix ContractScope validator + small tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#2504](https://github.com/ruby-grape/grape/pull/2504): Fix leaky modules in specs - [@ericproulx](https://github.com/ericproulx).
 * [#2506](https://github.com/ruby-grape/grape/pull/2506): Fix fetch_formatter api_format - [@ericproulx](https://github.com/ericproulx).
 * [#2507](https://github.com/ruby-grape/grape/pull/2507): Fix type: Set with values - [@nikolai-b](https://github.com/nikolai-b).
+* [#2510](https://github.com/ruby-grape/grape/pull/2510): Fix ContractScope's validator inheritance - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 2.2.0 (2024-09-14)

--- a/spec/integration/dry_validation/dry_validation_spec.rb
+++ b/spec/integration/dry_validation/dry_validation_spec.rb
@@ -73,12 +73,6 @@ describe 'Dry::Schema', if: defined?(Dry::Schema) do
       end
     end
 
-    describe '.inherits' do
-      subject { described_class }
-
-      it { is_expected.to be < Grape::Validations::Validators::Base }
-    end
-
     context 'with simple schema, pre-defined' do
       let(:contract) do
         Dry::Schema.Params do
@@ -240,6 +234,14 @@ describe 'Dry::Schema', if: defined?(Dry::Schema) do
         expect(last_response).to be_bad_request
         expect(last_response.body).to eq('foo_id is not allowed')
       end
+    end
+  end
+
+  describe Grape::Validations::ContractScope::Validator do
+    describe '.inherits' do
+      subject { described_class }
+
+      it { is_expected.to be < Grape::Validations::Validators::Base }
     end
   end
 end

--- a/spec/integration/dry_validation/dry_validation_spec.rb
+++ b/spec/integration/dry_validation/dry_validation_spec.rb
@@ -62,12 +62,6 @@ describe 'Dry::Schema', if: defined?(Dry::Schema) do
   end
 
   describe 'Grape::Validations::ContractScope' do
-    describe '.inherits' do
-      subject { described_class }
-
-      it { is_expected.to be < Grape::Validations::Validators::Base }
-    end
-
     let(:validated_params) { {} }
     let(:app) do
       vp = validated_params
@@ -77,6 +71,12 @@ describe 'Dry::Schema', if: defined?(Dry::Schema) do
           vp.replace(params)
         end
       end
+    end
+
+    describe '.inherits' do
+      subject { described_class }
+
+      it { is_expected.to be < Grape::Validations::Validators::Base }
     end
 
     context 'with simple schema, pre-defined' do

--- a/spec/integration/dry_validation/dry_validation_spec.rb
+++ b/spec/integration/dry_validation/dry_validation_spec.rb
@@ -62,6 +62,12 @@ describe 'Dry::Schema', if: defined?(Dry::Schema) do
   end
 
   describe 'Grape::Validations::ContractScope' do
+    describe '.inherits' do
+      subject { described_class }
+
+      it { is_expected.to be < Grape::Validations::Validators::Base }
+    end
+
     let(:validated_params) { {} }
     let(:app) do
       vp = validated_params


### PR DESCRIPTION
I recently came across the ContactScope's validator. Like other validators, it should inherits from `Grape::Validations::Validators::Base`. This PR fix that and refactor a small part when building error messages