### PR TITLE
Optimize hash alloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#2500](https://github.com/ruby-grape/grape/pull/2500): Remove deprecated `file` method - [@ericproulx](https://github.com/ericproulx).
 * [#2501](https://github.com/ruby-grape/grape/pull/2501): Remove deprecated `except` and `proc` options in values validator - [@ericproulx](https://github.com/ericproulx).
 * [#2502](https://github.com/ruby-grape/grape/pull/2502): Remove deprecation `options` in `desc` - [@ericproulx](https://github.com/ericproulx).
+* [#2512](https://github.com/ruby-grape/grape/pull/2512): Optimize hash alloc - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/benchmark/compile_many_routes.rb
+++ b/benchmark/compile_many_routes.rb
@@ -3,23 +3,20 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'grape'
 require 'benchmark/ips'
-require 'memory_profiler'
 
 class API < Grape::API
   prefix :api
   version 'v1', using: :path
 
-  namespace :test do
-    2000.times do |index|
-      namespace index do
-        get do
-          'hello'
-        end
-      end
+  2000.times do |index|
+    get "/test#{index}/" do
+      'hello'
     end
   end
 end
 
-MemoryProfiler.report(allow_files: 'grape') do
-  API.compile!
-end.pretty_print(to_file: 'without_double_splat.txt')
+Benchmark.ips do |ips|
+  ips.report('Compiling 2000 routes') do
+    API.compile!
+  end
+end

--- a/benchmark/compile_many_routes.rb
+++ b/benchmark/compile_many_routes.rb
@@ -3,20 +3,23 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'grape'
 require 'benchmark/ips'
+require 'memory_profiler'
 
 class API < Grape::API
   prefix :api
   version 'v1', using: :path
 
-  2000.times do |index|
-    get "/test#{index}/" do
-      'hello'
+  namespace :test do
+    2000.times do |index|
+      namespace index do
+        get do
+          'hello'
+        end
+      end
     end
   end
 end
 
-Benchmark.ips do |ips|
-  ips.report('Compiling 2000 routes') do
-    API.compile!
-  end
-end
+MemoryProfiler.report(allow_files: 'grape') do
+  API.compile!
+end.pretty_print(to_file: 'without_double_splat.txt')

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -91,7 +91,7 @@ module Grape
       # For instance, a description could be done using: `desc configuration[:description]` if it may vary
       # depending on where the endpoint is mounted. Use with care, if you find yourself using configuration
       # too much, you may actually want to provide a new API rather than remount it.
-      def mount_instance(**opts)
+      def mount_instance(opts = {})
         instance = Class.new(@base_parent)
         instance.configuration = Grape::Util::EndpointConfiguration.new(opts[:configuration] || {})
         instance.base = self

--- a/lib/grape/api/instance.rb
+++ b/lib/grape/api/instance.rb
@@ -150,7 +150,7 @@ module Grape
       # this API into a usable form.
       def initialize
         @router = Router.new
-        add_head_and_options_methods
+        add_head_not_allowed_methods_and_options_methods
         self.class.endpoints.each do |endpoint|
           endpoint.mount_in(@router)
         end
@@ -190,8 +190,10 @@ module Grape
       private
 
       # For every resource add a 'OPTIONS' route that returns an HTTP 204 response
-      # with a list of HTTP methods that can be called.
-      def add_head_and_options_methods
+      # with a list of HTTP methods that can be called. Also add a route that
+      # will return an HTTP 405 response for any HTTP method that the resource
+      # cannot handle.
+      def add_head_not_allowed_methods_and_options_methods
         # The paths we collected are prepared (cf. Path#prepare), so they
         # contain already versioning information when using path versioning.
         all_routes = self.class.endpoints.map(&:routes).flatten
@@ -217,7 +219,7 @@ module Grape
 
           @router.associate_routes(last_route.pattern, {
                                      endpoint: last_route.app,
-                                     allow_header: allow_header.join(', ').freeze
+                                     allow_header: allow_header
                                    })
         end
       end

--- a/lib/grape/api/instance.rb
+++ b/lib/grape/api/instance.rb
@@ -216,10 +216,8 @@ module Grape
           last_route.app.options[:options_route_enabled] = true unless self.class.namespace_inheritable(:do_not_route_options) || allowed_methods.include?(Rack::OPTIONS)
 
           @router.associate_routes(last_route.pattern, {
-                                     requirements: last_route.options[:requirements],
-                                     path: last_route.origin,
-                                     endpoint: last_route.app,
-                                     allow_header: allow_header
+            endpoint: last_route.app,
+                                     allow_header: allow_header.join(', ').freeze
                                    })
         end
       end

--- a/lib/grape/api/instance.rb
+++ b/lib/grape/api/instance.rb
@@ -150,7 +150,7 @@ module Grape
       # this API into a usable form.
       def initialize
         @router = Router.new
-        add_head_not_allowed_methods_and_options_methods
+        add_head_and_options_methods
         self.class.endpoints.each do |endpoint|
           endpoint.mount_in(@router)
         end
@@ -190,90 +190,56 @@ module Grape
       private
 
       # For every resource add a 'OPTIONS' route that returns an HTTP 204 response
-      # with a list of HTTP methods that can be called. Also add a route that
-      # will return an HTTP 405 response for any HTTP method that the resource
-      # cannot handle.
-      def add_head_not_allowed_methods_and_options_methods
-        versioned_route_configs = collect_route_config_per_pattern
+      # with a list of HTTP methods that can be called.
+      def add_head_and_options_methods
         # The paths we collected are prepared (cf. Path#prepare), so they
         # contain already versioning information when using path versioning.
+        all_routes = self.class.endpoints.map(&:routes).flatten
+
         # Disable versioning so adding a route won't prepend versioning
         # informations again.
-        without_root_prefix do
-          without_versioning do
-            versioned_route_configs.each do |config|
-              next if config.dig(:options, :matching_wildchar)
-
-              allowed_methods = config[:methods].dup
-              allowed_methods |= [Rack::HEAD] if !self.class.namespace_inheritable(:do_not_route_head) && allowed_methods.include?(Rack::GET)
-              allow_header = (self.class.namespace_inheritable(:do_not_route_options) ? allowed_methods : [Rack::OPTIONS] | allowed_methods)
-
-              config[:endpoint].options[:options_route_enabled] = true unless self.class.namespace_inheritable(:do_not_route_options) || allowed_methods.include?(Rack::OPTIONS)
-              config[:allowed_methods] = allowed_methods
-              config[:allow_header] = allow_header
-              generate_not_allowed_method(config[:pattern], config)
-            end
-          end
-        end
+        without_root_prefix_and_versioning { collect_route_config_per_pattern(all_routes) }
       end
 
-      def collect_route_config_per_pattern
-        all_routes       = self.class.endpoints.map(&:routes).flatten
+      def collect_route_config_per_pattern(all_routes)
         routes_by_regexp = all_routes.group_by(&:pattern_regexp)
 
         # Build the configuration based on the first endpoint and the collection of methods supported.
-        routes_by_regexp.values.map do |routes|
-          last_route        = routes.last # Most of the configuration is taken from the last endpoint
-          matching_wildchar = routes.any? { |route| route.request_method == '*' }
-          {
-            options: { matching_wildchar: matching_wildchar },
-            pattern: last_route.pattern,
-            requirements: last_route.requirements,
-            path: last_route.origin,
-            endpoint: last_route.app,
-            methods: matching_wildchar ? Grape::Http::Headers::SUPPORTED_METHODS : routes.map(&:request_method)
-          }
-        end
-      end
+        routes_by_regexp.each_value do |routes|
+          last_route = routes.last # Most of the configuration is taken from the last endpoint
+          next if routes.any? { |route| route.request_method == '*' }
 
-      # Generate a route that returns an HTTP 405 response for a user defined
-      # path on methods not specified
-      def generate_not_allowed_method(pattern, options)
-        supported_methods =
-          if self.class.namespace_inheritable(:do_not_route_options)
-            Grape::Http::Headers::SUPPORTED_METHODS
-          else
-            Grape::Http::Headers::SUPPORTED_METHODS_WITHOUT_OPTIONS
-          end
-        options[:not_allowed_methods] = supported_methods - options[:allowed_methods]
-        @router.associate_routes(pattern, options)
+          allowed_methods = routes.map(&:request_method)
+          allowed_methods |= [Rack::HEAD] if !self.class.namespace_inheritable(:do_not_route_head) && allowed_methods.include?(Rack::GET)
+
+          allow_header = self.class.namespace_inheritable(:do_not_route_options) ? allowed_methods : [Rack::OPTIONS] | allowed_methods
+          last_route.app.options[:options_route_enabled] = true unless self.class.namespace_inheritable(:do_not_route_options) || allowed_methods.include?(Rack::OPTIONS)
+
+          @router.associate_routes(last_route.pattern, {
+                                     requirements: last_route.options[:requirements],
+                                     path: last_route.origin,
+                                     endpoint: last_route.app,
+                                     allow_header: allow_header
+                                   })
+        end
       end
 
       # Allows definition of endpoints that ignore the versioning configuration
       # used by the rest of your API.
-      def without_versioning(&_block)
+      def without_root_prefix_and_versioning
         old_version = self.class.namespace_inheritable(:version)
         old_version_options = self.class.namespace_inheritable(:version_options)
+        old_root_prefix = self.class.namespace_inheritable(:root_prefix)
 
         self.class.namespace_inheritable_to_nil(:version)
         self.class.namespace_inheritable_to_nil(:version_options)
+        self.class.namespace_inheritable_to_nil(:root_prefix)
 
         yield
 
         self.class.namespace_inheritable(:version, old_version)
         self.class.namespace_inheritable(:version_options, old_version_options)
-      end
-
-      # Allows definition of endpoints that ignore the root prefix used by the
-      # rest of your API.
-      def without_root_prefix(&_block)
-        old_prefix = self.class.namespace_inheritable(:root_prefix)
-
-        self.class.namespace_inheritable_to_nil(:root_prefix)
-
-        yield
-
-        self.class.namespace_inheritable(:root_prefix, old_prefix)
+        self.class.namespace_inheritable(:root_prefix, old_root_prefix)
       end
     end
   end

--- a/lib/grape/api/instance.rb
+++ b/lib/grape/api/instance.rb
@@ -216,7 +216,7 @@ module Grape
           last_route.app.options[:options_route_enabled] = true unless self.class.namespace_inheritable(:do_not_route_options) || allowed_methods.include?(Rack::OPTIONS)
 
           @router.associate_routes(last_route.pattern, {
-            endpoint: last_route.app,
+                                     endpoint: last_route.app,
                                      allow_header: allow_header.join(', ').freeze
                                    })
         end

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -26,8 +26,8 @@ module Grape
       # has completed
       module PostBeforeFilter
         def declared(passed_params, options = {}, declared_params = nil, params_nested_path = [])
-          options = options.reverse_merge(include_missing: true, include_parent_namespaces: true, evaluate_given: false)
-          declared_params ||= optioned_declared_params(**options)
+          options.reverse_merge!(include_missing: true, include_parent_namespaces: true, evaluate_given: false)
+          declared_params ||= optioned_declared_params(options[:include_parent_namespaces])
 
           res = if passed_params.is_a?(Array)
                   declared_array(passed_params, options, declared_params, params_nested_path)
@@ -120,8 +120,8 @@ module Grape
           options[:stringify] ? declared_param.to_s : declared_param.to_sym
         end
 
-        def optioned_declared_params(**options)
-          declared_params = if options[:include_parent_namespaces]
+        def optioned_declared_params(include_parent_namespaces)
+          declared_params = if include_parent_namespaces
                               # Declared params including parent namespaces
                               route_setting(:declared_params)
                             else
@@ -199,10 +199,9 @@ module Grape
       # Redirect to a new url.
       #
       # @param url [String] The url to be redirect.
-      # @param options [Hash] The options used when redirect.
-      #                       :permanent, default false.
-      #                       :body, default a short message including the URL.
-      def redirect(url, permanent: false, body: nil, **_options)
+      # @param permanent [Boolean] default false.
+      # @param body default a short message including the URL.
+      def redirect(url, permanent: false, body: nil)
         body_message = body
         if permanent
           status 301

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -136,7 +136,7 @@ module Grape
           require_required_and_optional_fields(attrs.first, opts)
         else
           validate_attributes(attrs, opts, &block)
-          block ? new_scope(orig_attrs, &block) : push_declared_params(attrs, **opts.slice(:as))
+          block ? new_scope(orig_attrs, &block) : push_declared_params(attrs, opts.slice(:as))
         end
       end
 
@@ -162,7 +162,7 @@ module Grape
         else
           validate_attributes(attrs, opts, &block)
 
-          block ? new_scope(orig_attrs, true, &block) : push_declared_params(attrs, **opts.slice(:as))
+          block ? new_scope(orig_attrs, true, &block) : push_declared_params(attrs, opts.slice(:as))
         end
       end
 

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -175,19 +175,12 @@ module Grape
         #       end
         #     end
         def namespace(space = nil, options = {}, &block)
-          @namespace_description = nil unless instance_variable_defined?(:@namespace_description) && @namespace_description
+          return Namespace.joined_space_path(namespace_stackable(:namespace)) unless space || block
 
-          if space || block
-            within_namespace do
-              previous_namespace_description = @namespace_description
-              @namespace_description = (@namespace_description || {}).deep_merge(namespace_setting(:description) || {})
-              nest(block) do
-                namespace_stackable(:namespace, Namespace.new(space, **options)) if space
-              end
-              @namespace_description = previous_namespace_description
+          within_namespace do
+            nest(block) do
+              namespace_stackable(:namespace, Namespace.new(space, options)) if space
             end
-          else
-            Namespace.joined_space_path(namespace_stackable(:namespace))
           end
         end
 

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -153,7 +153,7 @@ module Grape
           methods = [route.request_method]
           methods << Rack::HEAD if !namespace_inheritable(:do_not_route_head) && route.request_method == Rack::GET
           methods.each do |method|
-            route = Grape::Router::Route.new(method, route.origin, **route.attributes.to_h) unless route.request_method == method
+            route = Grape::Router::Route.new(method, route.origin, route.attributes.to_h) unless route.request_method == method
             router.append(route.apply(self))
           end
         end
@@ -164,8 +164,9 @@ module Grape
       route_options = prepare_default_route_attributes
       map_routes do |method, path|
         path = prepare_path(path)
-        params = merge_route_options(**route_options.merge(suffix: path.suffix))
-        route = Router::Route.new(method, path.path, **params)
+        route_options[:suffix] = path.suffix
+        params = options[:route_options].merge(route_options)
+        route = Router::Route.new(method, path.path, params)
         route.apply(self)
       end.flatten
     end
@@ -194,10 +195,6 @@ module Grape
       return if version.blank?
 
       version.length == 1 ? version.first : version
-    end
-
-    def merge_route_options(**default)
-      options[:route_options].clone.merge!(**default)
     end
 
     def map_routes
@@ -411,7 +408,7 @@ module Grape
       return enum_for(:validations) unless block_given?
 
       route_setting(:saved_validations)&.each do |saved_validation|
-        yield Grape::Validations::ValidatorFactory.create_validator(**saved_validation)
+        yield Grape::Validations::ValidatorFactory.create_validator(saved_validation)
       end
     end
 

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -151,7 +151,8 @@ module Grape
       routes.each do |route|
         router.append(route.apply(self))
         if !namespace_inheritable(:do_not_route_head) && route.request_method == Rack::GET
-          Grape::Router::Route.new(Rack::HEAD, route.origin, route.attributes).then do |head_route|
+          route.dup.then do |head_route|
+            head_route.convert_to_head_request!
             router.append(head_route.apply(self))
           end
         end

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -255,9 +255,10 @@ module Grape
           run_filters befores, :before
 
           if (allowed_methods = env[Grape::Env::GRAPE_ALLOWED_METHODS])
-            raise Grape::Exceptions::MethodNotAllowed.new(header.merge('Allow' => allowed_methods)) unless options?
+            allow_header_value = allowed_methods.join(', ')
+            raise Grape::Exceptions::MethodNotAllowed.new(header.merge('Allow' => allow_header_value)) unless options?
 
-            header Grape::Http::Headers::ALLOW, allowed_methods
+            header Grape::Http::Headers::ALLOW, allow_header_value
             response_object = ''
             status 204
           else

--- a/lib/grape/exceptions/base.rb
+++ b/lib/grape/exceptions/base.rb
@@ -9,7 +9,7 @@ module Grape
 
       attr_reader :status, :headers
 
-      def initialize(status: nil, message: nil, headers: nil, **_options)
+      def initialize(status: nil, message: nil, headers: nil)
         super(message)
 
         @status  = status
@@ -26,42 +26,32 @@ module Grape
       # if BASE_ATTRIBUTES_KEY.key respond to a string message, then short_message is returned
       # if BASE_ATTRIBUTES_KEY.key respond to a Hash, means it may have problem , summary and resolution
       def compose_message(key, **attributes)
-        short_message = translate_message(key, **attributes)
-        if short_message.is_a? Hash
-          @problem = problem(key, **attributes)
-          @summary = summary(key, **attributes)
-          @resolution = resolution(key, **attributes)
-          [['Problem', @problem], ['Summary', @summary], ['Resolution', @resolution]].each_with_object(+'') do |detail_array, message|
-            message << "\n#{detail_array[0]}:\n  #{detail_array[1]}" unless detail_array[1].blank?
-            message
-          end
-        else
-          short_message
+        short_message = translate_message(key, attributes)
+        return short_message unless short_message.is_a?(Hash)
+
+        each_steps(key, attributes).with_object(+'') do |detail_array, message|
+          message << "\n#{detail_array[0]}:\n  #{detail_array[1]}" unless detail_array[1].blank?
         end
       end
 
-      def problem(key, **attributes)
-        translate_message(:"#{key}.problem", **attributes)
+      def each_steps(key, attributes)
+        return enum_for(:each_steps, key, attributes) unless block_given?
+
+        yield 'Problem', translate_message(:"#{key}.problem", attributes)
+        yield 'Summary', translate_message(:"#{key}.summary", attributes)
+        yield 'Resolution', translate_message(:"#{key}.resolution", attributes)
       end
 
-      def summary(key, **attributes)
-        translate_message(:"#{key}.summary", **attributes)
-      end
-
-      def resolution(key, **attributes)
-        translate_message(:"#{key}.resolution", **attributes)
-      end
-
-      def translate_attributes(keys, **options)
+      def translate_attributes(keys, options = {})
         keys.map do |key|
-          translate("#{BASE_ATTRIBUTES_KEY}.#{key}", default: key, **options)
+          translate("#{BASE_ATTRIBUTES_KEY}.#{key}", options.merge(default: key.to_s))
         end.join(', ')
       end
 
-      def translate_message(key, **options)
+      def translate_message(key, options = {})
         case key
         when Symbol
-          translate("#{BASE_MESSAGES_KEY}.#{key}", default: '', **options)
+          translate("#{BASE_MESSAGES_KEY}.#{key}", options.merge(default: ''))
         when Proc
           key.call
         else
@@ -69,14 +59,12 @@ module Grape
         end
       end
 
-      def translate(key, **options)
-        options = options.dup
-        options[:default] &&= options[:default].to_s
+      def translate(key, options)
         message = ::I18n.translate(key, **options)
-        message.presence || fallback_message(key, **options)
+        message.presence || fallback_message(key, options)
       end
 
-      def fallback_message(key, **options)
+      def fallback_message(key, options)
         if ::I18n.enforce_available_locales && ::I18n.available_locales.exclude?(FALLBACK_LOCALE)
           key
         else

--- a/lib/grape/exceptions/validation.rb
+++ b/lib/grape/exceptions/validation.rb
@@ -2,16 +2,17 @@
 
 module Grape
   module Exceptions
-    class Validation < Grape::Exceptions::Base
+    class Validation < Base
       attr_accessor :params, :message_key
 
-      def initialize(params:, message: nil, **args)
+      def initialize(params:, message: nil, status: nil, headers: nil)
         @params = params
         if message
           @message_key = message if message.is_a?(Symbol)
-          args[:message] = translate_message(message)
+          message = translate_message(message)
         end
-        super(**args)
+
+        super(status: status, message: message, headers: headers)
       end
 
       # Remove all the unnecessary stuff from Grape::Exceptions::Base like status

--- a/lib/grape/exceptions/validation_errors.rb
+++ b/lib/grape/exceptions/validation_errors.rb
@@ -2,7 +2,7 @@
 
 module Grape
   module Exceptions
-    class ValidationErrors < Grape::Exceptions::Base
+    class ValidationErrors < Base
       ERRORS_FORMAT_KEY = 'grape.errors.format'
       DEFAULT_ERRORS_FORMAT = '%<attributes>s %<message>s'
 
@@ -10,7 +10,7 @@ module Grape
 
       attr_reader :errors
 
-      def initialize(errors: [], headers: {}, **_options)
+      def initialize(errors: [], headers: {})
         @errors = errors.group_by(&:params)
         super(message: full_messages.join(', '), status: 400, headers: headers)
       end

--- a/lib/grape/middleware/versioner/header.rb
+++ b/lib/grape/middleware/versioner/header.rb
@@ -46,12 +46,8 @@ module Grape
           if media_type
             yield media_type
           else
-            fail!(allowed_methods)
+            fail!
           end
-        end
-
-        def allowed_methods
-          env[Grape::Env::GRAPE_ALLOWED_METHODS]
         end
 
         def accept_header
@@ -93,8 +89,8 @@ module Grape
           raise Grape::Exceptions::InvalidVersionHeader.new(message, error_headers)
         end
 
-        def fail!(grape_allowed_methods)
-          return grape_allowed_methods if grape_allowed_methods.present?
+        def fail!
+          return if env[Grape::Env::GRAPE_ALLOWED_METHODS].present?
 
           media_types = q_values_mime_types.map { |mime_type| Grape::Util::MediaType.parse(mime_type) }
           vendor_not_found!(media_types) || version_not_found!(media_types)

--- a/lib/grape/namespace.rb
+++ b/lib/grape/namespace.rb
@@ -12,7 +12,7 @@ module Grape
     # @option options :requirements [Hash] param-regex pairs, all of which must
     #   be met by a request's params for all endpoints in this namespace, or
     #   validation will fail and return a 422.
-    def initialize(space, **options)
+    def initialize(space, options)
       @space = space.to_s
       @options = options
     end

--- a/lib/grape/request.rb
+++ b/lib/grape/request.rb
@@ -6,8 +6,8 @@ module Grape
 
     alias rack_params params
 
-    def initialize(env, **options)
-      extend options[:build_params_with] || Grape.config.param_builder
+    def initialize(env, build_params_with: nil)
+      extend build_params_with || Grape.config.param_builder
       super(env)
     end
 

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -38,8 +38,8 @@ module Grape
       map[route.request_method] << route
     end
 
-    def associate_routes(pattern, **options)
-      Grape::Router::GreedyRoute.new(pattern: pattern, **options).then do |greedy_route|
+    def associate_routes(pattern, options)
+      Grape::Router::GreedyRoute.new(pattern, options).then do |greedy_route|
         @neutral_regexes << greedy_route.to_regexp(@neutral_map.length)
         @neutral_map << greedy_route
       end

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -107,7 +107,7 @@ module Grape
 
       route = match?(input, '*')
 
-      return last_neighbor_route.endpoint.call(env) if last_neighbor_route && last_response_cascade && route
+      return last_neighbor_route.options[:endpoint].call(env) if last_neighbor_route && last_response_cascade && route
 
       last_response_cascade = cascade_or_return_response.call(process_route(route, env)) if route
 
@@ -152,8 +152,8 @@ module Grape
 
     def call_with_allow_headers(env, route)
       prepare_env_from_route(env, route)
-      env[Grape::Env::GRAPE_ALLOWED_METHODS] = route.options[:allow_header].join(', ').freeze
-      route.endpoint.call(env)
+      env[Grape::Env::GRAPE_ALLOWED_METHODS] = route.options[:allow_header]
+      route.options[:endpoint].call(env)
     end
 
     def prepare_env_from_route(env, route)

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -152,7 +152,7 @@ module Grape
 
     def call_with_allow_headers(env, route)
       prepare_env_from_route(env, route)
-      env[Grape::Env::GRAPE_ALLOWED_METHODS] = route.allow_header.join(', ').freeze
+      env[Grape::Env::GRAPE_ALLOWED_METHODS] = route.options[:allow_header].join(', ').freeze
       route.endpoint.call(env)
     end
 

--- a/lib/grape/router/base_route.rb
+++ b/lib/grape/router/base_route.rb
@@ -7,7 +7,7 @@ module Grape
 
       attr_reader :index, :pattern, :options
 
-      def initialize(**options)
+      def initialize(options)
         @options = ActiveSupport::OrderedOptions.new.update(options)
       end
 

--- a/lib/grape/router/base_route.rb
+++ b/lib/grape/router/base_route.rb
@@ -8,7 +8,7 @@ module Grape
       attr_reader :index, :pattern, :options
 
       def initialize(options)
-        @options = ActiveSupport::OrderedOptions.new.update(options)
+        @options = options.is_a?(ActiveSupport::OrderedOptions) ? options : ActiveSupport::OrderedOptions.new.update(options)
       end
 
       alias attributes options

--- a/lib/grape/router/greedy_route.rb
+++ b/lib/grape/router/greedy_route.rb
@@ -6,9 +6,9 @@
 module Grape
   class Router
     class GreedyRoute < BaseRoute
-      def initialize(pattern:, **options)
+      def initialize(pattern, options)
         @pattern = pattern
-        super(**options)
+        super(options)
       end
 
       # Grape::Router:Route defines params as a function

--- a/lib/grape/router/pattern.rb
+++ b/lib/grape/router/pattern.rb
@@ -13,9 +13,9 @@ module Grape
       def_delegators :to_regexp, :===
       alias match? ===
 
-      def initialize(pattern, **options)
+      def initialize(pattern, options)
         @origin = pattern
-        @path = build_path(pattern, anchor: options[:anchor], suffix: options[:suffix])
+        @path = build_path(pattern, options)
         @pattern = build_pattern(@path, options)
         @to_regexp = @pattern.to_regexp
       end
@@ -33,15 +33,15 @@ module Grape
           path,
           uri_decode: true,
           params: options[:params],
-          capture: extract_capture(**options)
+          capture: extract_capture(options)
         )
       end
 
-      def build_path(pattern, anchor: false, suffix: nil)
-        PatternCache[[build_path_from_pattern(pattern, anchor: anchor), suffix]]
+      def build_path(pattern, options)
+        PatternCache[[build_path_from_pattern(pattern, options), options[:suffix]]]
       end
 
-      def extract_capture(**options)
+      def extract_capture(options)
         sliced_options = options
                          .slice(:format, :version)
                          .delete_if { |_k, v| v.blank? }
@@ -51,10 +51,10 @@ module Grape
         options[:requirements].merge(sliced_options)
       end
 
-      def build_path_from_pattern(pattern, anchor: false)
+      def build_path_from_pattern(pattern, options)
         if pattern.end_with?('*path')
           pattern.dup.insert(pattern.rindex('/') + 1, '?')
-        elsif anchor
+        elsif options[:anchor]
           pattern
         elsif pattern.end_with?('/')
           "#{pattern}?*path"

--- a/lib/grape/router/route.rb
+++ b/lib/grape/router/route.rb
@@ -9,10 +9,10 @@ module Grape
 
       def_delegators :pattern, :path, :origin
 
-      def initialize(method, pattern, **options)
+      def initialize(method, pattern, options)
         @request_method = upcase_method(method)
-        @pattern = Grape::Router::Pattern.new(pattern, **options)
-        super(**options)
+        @pattern = Grape::Router::Pattern.new(pattern, options)
+        super(options)
       end
 
       def exec(env)

--- a/lib/grape/router/route.rb
+++ b/lib/grape/router/route.rb
@@ -15,6 +15,10 @@ module Grape
         super(options)
       end
 
+      def convert_to_head_request!
+        @request_method = Rack::HEAD
+      end
+
       def exec(env)
         @app.call(env)
       end

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -174,16 +174,12 @@ module Grape
 
       # Adds a parameter declaration to our list of validations.
       # @param attrs [Array] (see Grape::DSL::Parameters#requires)
-      def push_declared_params(attrs, **opts)
-        opts = opts.merge(declared_params_scope: self) unless opts.key?(:declared_params_scope)
-        if lateral?
-          @parent.push_declared_params(attrs, **opts)
-        else
-          push_renamed_param(full_path + [attrs.first], opts[:as]) \
-            if opts && opts[:as]
+      def push_declared_params(attrs, opts = {})
+        opts[:declared_params_scope] = self unless opts.key?(:declared_params_scope)
+        return @parent.push_declared_params(attrs, opts) if lateral?
 
-          @declared_params.concat(attrs.map { |attr| ::Grape::Validations::ParamsScope::Attr.new(attr, opts[:declared_params_scope]) })
-        end
+        push_renamed_param(full_path + [attrs.first], opts[:as]) if opts[:as]
+        @declared_params.concat(attrs.map { |attr| ::Grape::Validations::ParamsScope::Attr.new(attr, opts[:declared_params_scope]) })
       end
 
       # Get the full path of the parameter scope in the hierarchy.

--- a/lib/grape/validations/validator_factory.rb
+++ b/lib/grape/validations/validator_factory.rb
@@ -3,12 +3,12 @@
 module Grape
   module Validations
     class ValidatorFactory
-      def self.create_validator(**options)
+      def self.create_validator(options)
         options[:validator_class].new(options[:attributes],
                                       options[:options],
                                       options[:required],
                                       options[:params_scope],
-                                      **options[:opts])
+                                      options[:opts])
       end
     end
   end

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -14,7 +14,7 @@ module Grape
         # @param required [Boolean] attribute(s) are required or optional
         # @param scope [ParamsScope] parent scope for this Validator
         # @param opts [Hash] additional validation options
-        def initialize(attrs, options, required, scope, opts = {})
+        def initialize(attrs, options, required, scope, opts)
           @attrs = Array(attrs)
           @option = options
           @required = required

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -13,15 +13,14 @@ module Grape
         # @param options [Object] implementation-dependent Validator options
         # @param required [Boolean] attribute(s) are required or optional
         # @param scope [ParamsScope] parent scope for this Validator
-        # @param opts [Array] additional validation options
-        def initialize(attrs, options, required, scope, *opts)
+        # @param opts [Hash] additional validation options
+        def initialize(attrs, options, required, scope, opts)
           @attrs = Array(attrs)
           @option = options
           @required = required
           @scope = scope
-          opts = opts.any? ? opts.shift : {}
-          @fail_fast = opts.fetch(:fail_fast, false)
-          @allow_blank = opts.fetch(:allow_blank, false)
+          @fail_fast = opts[:fail_fast]
+          @allow_blank = opts[:allow_blank]
         end
 
         # Validates a given request.

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -14,7 +14,7 @@ module Grape
         # @param required [Boolean] attribute(s) are required or optional
         # @param scope [ParamsScope] parent scope for this Validator
         # @param opts [Hash] additional validation options
-        def initialize(attrs, options, required, scope, opts)
+        def initialize(attrs, options, required, scope, opts = {})
           @attrs = Array(attrs)
           @option = options
           @required = required

--- a/lib/grape/validations/validators/coerce_validator.rb
+++ b/lib/grape/validations/validators/coerce_validator.rb
@@ -4,7 +4,7 @@ module Grape
   module Validations
     module Validators
       class CoerceValidator < Base
-        def initialize(attrs, options, required, scope, **opts)
+        def initialize(attrs, options, required, scope, opts)
           super
 
           @converter = if type.is_a?(Grape::Validations::Types::VariantCollectionCoercer)

--- a/lib/grape/validations/validators/coerce_validator.rb
+++ b/lib/grape/validations/validators/coerce_validator.rb
@@ -4,7 +4,7 @@ module Grape
   module Validations
     module Validators
       class CoerceValidator < Base
-        def initialize(attrs, options, required, scope, opts)
+        def initialize(attrs, options, required, scope, opts = {})
           super
 
           @converter = if type.is_a?(Grape::Validations::Types::VariantCollectionCoercer)

--- a/lib/grape/validations/validators/coerce_validator.rb
+++ b/lib/grape/validations/validators/coerce_validator.rb
@@ -4,7 +4,7 @@ module Grape
   module Validations
     module Validators
       class CoerceValidator < Base
-        def initialize(attrs, options, required, scope, opts = {})
+        def initialize(attrs, options, required, scope, opts)
           super
 
           @converter = if type.is_a?(Grape::Validations::Types::VariantCollectionCoercer)

--- a/lib/grape/validations/validators/default_validator.rb
+++ b/lib/grape/validations/validators/default_validator.rb
@@ -4,7 +4,7 @@ module Grape
   module Validations
     module Validators
       class DefaultValidator < Base
-        def initialize(attrs, options, required, scope, **opts)
+        def initialize(attrs, options, required, scope, opts)
           @default = options
           super
         end

--- a/lib/grape/validations/validators/default_validator.rb
+++ b/lib/grape/validations/validators/default_validator.rb
@@ -4,7 +4,7 @@ module Grape
   module Validations
     module Validators
       class DefaultValidator < Base
-        def initialize(attrs, options, required, scope, opts)
+        def initialize(attrs, options, required, scope, opts = {})
           @default = options
           super
         end

--- a/lib/grape/validations/validators/except_values_validator.rb
+++ b/lib/grape/validations/validators/except_values_validator.rb
@@ -4,7 +4,7 @@ module Grape
   module Validations
     module Validators
       class ExceptValuesValidator < Base
-        def initialize(attrs, options, required, scope, **opts)
+        def initialize(attrs, options, required, scope, opts)
           @except = options.is_a?(Hash) ? options[:value] : options
           super
         end

--- a/lib/grape/validations/validators/except_values_validator.rb
+++ b/lib/grape/validations/validators/except_values_validator.rb
@@ -4,7 +4,7 @@ module Grape
   module Validations
     module Validators
       class ExceptValuesValidator < Base
-        def initialize(attrs, options, required, scope, opts)
+        def initialize(attrs, options, required, scope, opts = {})
           @except = options.is_a?(Hash) ? options[:value] : options
           super
         end

--- a/lib/grape/validations/validators/except_values_validator.rb
+++ b/lib/grape/validations/validators/except_values_validator.rb
@@ -4,7 +4,7 @@ module Grape
   module Validations
     module Validators
       class ExceptValuesValidator < Base
-        def initialize(attrs, options, required, scope, opts = {})
+        def initialize(attrs, options, required, scope, opts)
           @except = options.is_a?(Hash) ? options[:value] : options
           super
         end

--- a/lib/grape/validations/validators/length_validator.rb
+++ b/lib/grape/validations/validators/length_validator.rb
@@ -4,7 +4,7 @@ module Grape
   module Validations
     module Validators
       class LengthValidator < Base
-        def initialize(attrs, options, required, scope, **opts)
+        def initialize(attrs, options, required, scope, opts)
           @min = options[:min]
           @max = options[:max]
           @is = options[:is]

--- a/lib/grape/validations/validators/length_validator.rb
+++ b/lib/grape/validations/validators/length_validator.rb
@@ -4,7 +4,7 @@ module Grape
   module Validations
     module Validators
       class LengthValidator < Base
-        def initialize(attrs, options, required, scope, opts = {})
+        def initialize(attrs, options, required, scope, opts)
           @min = options[:min]
           @max = options[:max]
           @is = options[:is]

--- a/lib/grape/validations/validators/length_validator.rb
+++ b/lib/grape/validations/validators/length_validator.rb
@@ -4,7 +4,7 @@ module Grape
   module Validations
     module Validators
       class LengthValidator < Base
-        def initialize(attrs, options, required, scope, opts)
+        def initialize(attrs, options, required, scope, opts = {})
           @min = options[:min]
           @max = options[:max]
           @is = options[:is]

--- a/lib/grape/validations/validators/values_validator.rb
+++ b/lib/grape/validations/validators/values_validator.rb
@@ -4,7 +4,7 @@ module Grape
   module Validations
     module Validators
       class ValuesValidator < Base
-        def initialize(attrs, options, required, scope, **opts)
+        def initialize(attrs, options, required, scope, opts)
           @values = options.is_a?(Hash) ? options[:value] : options
           super
         end

--- a/lib/grape/validations/validators/values_validator.rb
+++ b/lib/grape/validations/validators/values_validator.rb
@@ -4,7 +4,7 @@ module Grape
   module Validations
     module Validators
       class ValuesValidator < Base
-        def initialize(attrs, options, required, scope, opts)
+        def initialize(attrs, options, required, scope, opts = {})
           @values = options.is_a?(Hash) ? options[:value] : options
           super
         end

--- a/lib/grape/validations/validators/values_validator.rb
+++ b/lib/grape/validations/validators/values_validator.rb
@@ -4,7 +4,7 @@ module Grape
   module Validations
     module Validators
       class ValuesValidator < Base
-        def initialize(attrs, options, required, scope, opts = {})
+        def initialize(attrs, options, required, scope, opts)
           @values = options.is_a?(Hash) ? options[:value] : options
           super
         end

--- a/spec/grape/dsl/parameters_spec.rb
+++ b/spec/grape/dsl/parameters_spec.rb
@@ -20,7 +20,7 @@ describe Grape::DSL::Parameters do
         @validate_attributes
       end
 
-      def push_declared_params(args, **_opts)
+      def push_declared_params(args, _opts)
         @push_declared_params = args
       end
 

--- a/spec/grape/dsl/routing_spec.rb
+++ b/spec/grape/dsl/routing_spec.rb
@@ -179,7 +179,7 @@ describe Grape::DSL::Routing do
     it 'creates a new namespace with given name and options' do
       expect(subject).to receive(:within_namespace).and_yield
       expect(subject).to receive(:nest).and_yield
-      expect(Grape::Namespace).to receive(:new).with(:foo, foo: 'bar').and_return(new_namespace)
+      expect(Grape::Namespace).to receive(:new).with(:foo, { foo: 'bar' }).and_return(new_namespace)
       expect(subject).to receive(:namespace_stackable).with(:namespace, new_namespace)
 
       subject.namespace :foo, foo: 'bar', &proc {}

--- a/spec/grape/middleware/error_spec.rb
+++ b/spec/grape/middleware/error_spec.rb
@@ -29,7 +29,7 @@ describe Grape::Middleware::Error do
     context = self
     Rack::Builder.app do
       use Spec::Support::EndpointFaker
-      use Grape::Middleware::Error, **opts # rubocop:disable RSpec/DescribedClass
+      use Grape::Middleware::Error, opts # rubocop:disable RSpec/DescribedClass
       run context.err_app
     end
   end

--- a/spec/grape/middleware/versioner/accept_version_header_spec.rb
+++ b/spec/grape/middleware/versioner/accept_version_header_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Grape::Middleware::Versioner::AcceptVersionHeader do
-  subject { described_class.new(app, **(@options || {})) }
+  subject { described_class.new(app, @options) }
 
   let(:app) { ->(env) { [200, env, env] } }
 

--- a/spec/grape/middleware/versioner/header_spec.rb
+++ b/spec/grape/middleware/versioner/header_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Grape::Middleware::Versioner::Header do
-  subject { described_class.new(app, **(@options || {})) }
+  subject { described_class.new(app, @options) }
 
   let(:app) { ->(env) { [200, env, env] } }
 

--- a/spec/grape/middleware/versioner/param_spec.rb
+++ b/spec/grape/middleware/versioner/param_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Grape::Middleware::Versioner::Param do
-  subject { described_class.new(app, **options) }
+  subject { described_class.new(app, options) }
 
   let(:app) { ->(env) { [200, env, env[Grape::Env::API_VERSION]] } }
   let(:options) { {} }

--- a/spec/grape/middleware/versioner/path_spec.rb
+++ b/spec/grape/middleware/versioner/path_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Grape::Middleware::Versioner::Path do
-  subject { described_class.new(app, **options) }
+  subject { described_class.new(app, options) }
 
   let(:app) { ->(env) { [200, env, env[Grape::Env::API_VERSION]] } }
   let(:options) { {} }

--- a/spec/grape/router/greedy_route_spec.rb
+++ b/spec/grape/router/greedy_route_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Grape::Router::GreedyRoute do
-  let(:instance) { described_class.new(pattern: pattern, **options) }
+  let(:instance) { described_class.new(pattern, options) }
   let(:index) { 0 }
   let(:pattern) { :pattern }
   let(:params) do

--- a/spec/integration/grape_entity/entity_spec.rb
+++ b/spec/integration/grape_entity/entity_spec.rb
@@ -348,7 +348,7 @@ describe 'Grape::Entity', if: defined?(Grape::Entity) do
       opts = options
       Rack::Builder.app do
         use Spec::Support::EndpointFaker
-        use Grape::Middleware::Error, **opts
+        use Grape::Middleware::Error, opts
         run ErrApp
       end
     end

--- a/spec/integration/hashie/hashie_spec.rb
+++ b/spec/integration/hashie/hashie_spec.rb
@@ -164,11 +164,9 @@ describe 'Hashie', if: defined?(Hashie) do
     end
 
     describe 'when the build_params_with is set to Hashie' do
-      subject(:request_params) { Grape::Request.new(env, **opts).params }
+      subject(:request_params) { Grape::Request.new(env, build_params_with: Grape::Extensions::Hashie::Mash::ParamBuilder).params }
 
       context 'when the API includes a specific param builder' do
-        let(:opts) { { build_params_with: Grape::Extensions::Hashie::Mash::ParamBuilder } }
-
         it { is_expected.to be_a(Hashie::Mash) }
       end
     end

--- a/spec/shared/versioning_examples.rb
+++ b/spec/shared/versioning_examples.rb
@@ -7,7 +7,7 @@ shared_examples_for 'versioning' do
     subject.get :hello do
       "Version: #{request.env[Grape::Env::API_VERSION]}"
     end
-    versioned_get '/hello', 'v1', **macro_options
+    versioned_get '/hello', 'v1', macro_options
     expect(last_response.body).to eql 'Version: v1'
   end
 
@@ -18,7 +18,7 @@ shared_examples_for 'versioning' do
     subject.get :hello do
       "Version: #{request.env[Grape::Env::API_VERSION]}"
     end
-    versioned_get '/hello', 'v1', **macro_options.merge(prefix: 'api')
+    versioned_get '/hello', 'v1', macro_options.merge(prefix: 'api')
     expect(last_response.body).to eql 'Version: v1'
   end
 
@@ -34,14 +34,14 @@ shared_examples_for 'versioning' do
       end
     end
 
-    versioned_get '/awesome', 'v1', **macro_options
+    versioned_get '/awesome', 'v1', macro_options
     expect(last_response.status).to be 404
 
-    versioned_get '/awesome', 'v2', **macro_options
+    versioned_get '/awesome', 'v2', macro_options
     expect(last_response.status).to be 200
-    versioned_get '/legacy', 'v1', **macro_options
+    versioned_get '/legacy', 'v1', macro_options
     expect(last_response.status).to be 200
-    versioned_get '/legacy', 'v2', **macro_options
+    versioned_get '/legacy', 'v2', macro_options
     expect(last_response.status).to be 404
   end
 
@@ -51,11 +51,11 @@ shared_examples_for 'versioning' do
       'I exist'
     end
 
-    versioned_get '/awesome', 'v1', **macro_options
+    versioned_get '/awesome', 'v1', macro_options
     expect(last_response.status).to be 200
-    versioned_get '/awesome', 'v2', **macro_options
+    versioned_get '/awesome', 'v2', macro_options
     expect(last_response.status).to be 200
-    versioned_get '/awesome', 'v3', **macro_options
+    versioned_get '/awesome', 'v3', macro_options
     expect(last_response.status).to be 404
   end
 
@@ -74,10 +74,10 @@ shared_examples_for 'versioning' do
           end
         end
 
-        versioned_get '/version', 'v2', **macro_options
+        versioned_get '/version', 'v2', macro_options
         expect(last_response.status).to eq(200)
         expect(last_response.body).to eq('v2')
-        versioned_get '/version', 'v1', **macro_options
+        versioned_get '/version', 'v1', macro_options
         expect(last_response.status).to eq(200)
         expect(last_response.body).to eq('version v1')
       end
@@ -98,11 +98,11 @@ shared_examples_for 'versioning' do
           end
         end
 
-        versioned_get '/version', 'v1', **macro_options.merge(prefix: subject.prefix)
+        versioned_get '/version', 'v1', macro_options.merge(prefix: subject.prefix)
         expect(last_response.status).to eq(200)
         expect(last_response.body).to eq('version v1')
 
-        versioned_get '/version', 'v2', **macro_options.merge(prefix: subject.prefix)
+        versioned_get '/version', 'v2', macro_options.merge(prefix: subject.prefix)
         expect(last_response.status).to eq(200)
         expect(last_response.body).to eq('v2')
       end
@@ -133,11 +133,11 @@ shared_examples_for 'versioning' do
         end
       end
 
-      versioned_get '/version', 'v1', **macro_options.merge(prefix: subject.prefix)
+      versioned_get '/version', 'v1', macro_options.merge(prefix: subject.prefix)
       expect(last_response.status).to eq(200)
       expect(last_response.body).to eq('v1-version')
 
-      versioned_get '/version', 'v2', **macro_options.merge(prefix: subject.prefix)
+      versioned_get '/version', 'v2', macro_options.merge(prefix: subject.prefix)
       expect(last_response.status).to eq(200)
       expect(last_response.body).to eq('v2-version')
     end
@@ -150,7 +150,7 @@ shared_examples_for 'versioning' do
     subject.get :api_version_with_version_param do
       params[:version]
     end
-    versioned_get '/api_version_with_version_param?version=1', 'v1', **macro_options
+    versioned_get '/api_version_with_version_param?version=1', 'v1', macro_options
     expect(last_response.body).to eql '1'
   end
 
@@ -186,13 +186,13 @@ shared_examples_for 'versioning' do
 
     context 'v1' do
       it 'finds endpoint' do
-        versioned_get '/version', 'v1', **macro_options
+        versioned_get '/version', 'v1', macro_options
         expect(last_response.status).to eq(200)
         expect(last_response.body).to eq('v1')
       end
 
       it 'finds catch all' do
-        versioned_get '/whatever', 'v1', **macro_options
+        versioned_get '/whatever', 'v1', macro_options
         expect(last_response.status).to eq(200)
         expect(last_response.body).to end_with 'whatever'
       end
@@ -200,13 +200,13 @@ shared_examples_for 'versioning' do
 
     context 'v2' do
       it 'finds endpoint' do
-        versioned_get '/version', 'v2', **macro_options
+        versioned_get '/version', 'v2', macro_options
         expect(last_response.status).to eq(200)
         expect(last_response.body).to eq('v2')
       end
 
       it 'finds catch all' do
-        versioned_get '/whatever', 'v2', **macro_options
+        versioned_get '/whatever', 'v2', macro_options
         expect(last_response.status).to eq(200)
         expect(last_response.body).to end_with 'whatever'
       end

--- a/spec/support/versioned_helpers.rb
+++ b/spec/support/versioned_helpers.rb
@@ -6,7 +6,7 @@ module Spec
     module Helpers
       # Returns the path with options[:version] prefixed if options[:using] is :path.
       # Returns normal path otherwise.
-      def versioned_path(**options)
+      def versioned_path(options)
         case options[:using]
         when :path
           File.join('/', options[:prefix] || '', options[:version], options[:path])
@@ -17,7 +17,7 @@ module Spec
         end
       end
 
-      def versioned_headers(**options)
+      def versioned_headers(options)
         case options[:using]
         when :path, :param
           {}
@@ -37,9 +37,9 @@ module Spec
         end
       end
 
-      def versioned_get(path, version_name, **version_options)
-        path = versioned_path(**version_options.merge(version: version_name, path: path))
-        headers = versioned_headers(**version_options.merge(version: version_name))
+      def versioned_get(path, version_name, version_options)
+        path = versioned_path(version_options.merge(version: version_name, path: path))
+        headers = versioned_headers(version_options.merge(version: version_name))
         params = {}
         params = { version_options[:parameter] => version_name } if version_options[:using] == :param
         get path, params, headers


### PR DESCRIPTION
This PR is all about hash allocation.

### Double splat operator
Many functions had  a `**options` or `**_options` where a simple `options` or `options = {}` can do the work.

Double splat is useful when keywords are passed explicitly or when you have keyword arguments. Something like

```ruby
def my_function(**options)
  puts options
end

my_function(first_param: 'a', second_param: 'b')
# options = { first_param: 'a', second_param: 'b' }
```
```ruby
def my_function(first_param:, **options)
  puts options
end

my_function(first_param: 'a', second_param: 'b')
# options = { second_param: 'b' }
```

Most of our internal functions are just passing a plain Hash that had to be `**` because of the declared **options. The validator factory is a great example
```ruby
module Grape
  module Validations
    class ValidatorFactory
      def self.create_validator(**options)
        options[:validator_class].new(options[:attributes],
                                      options[:options],
                                      options[:required],
                                      options[:params_scope],
                                      **options[:opts])
      end
    end
  end
end
```
the `create_validator` function is called like this
```ruby
 yield Grape::Validations::ValidatorFactory.create_validator(**saved_validation)
```
and `saved_validation` is a plain Hash

### Namespace

I found a `@namespace_description` in `lib/grape/dsl/routing.rb#namespace` that wasn't use at all so I removed it. It was creating some hashes.

### Exceptions

- `Grape::Exceptions::Base` had a `**_options`. I had to update `Grape::Exceptions::Validation` declaration and `super` usage to fit the expected parameters.

### Validators
`Grape:: Validations::Validators::Base` had a `*opts`. It's been replaced by `opts` since its a [static hash](https://github.com/ruby-grape/grape/blob/0477baf66feb02833c0462f5f0dd4da4036703aa/lib/grape/validations/params_scope.rb#L520)

### Routing HEAD
I've optimized the `mount_in` function and `add_head_not_allowed_methods_and_options_methods`.

`HEAD` and `GET` are [identical](https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.2) except that `HEAD` does not return content. Instead of creating a new Route for the `HEAD`, I've just `dup` the `GET` and replace the `@request_method` to HEAD

### Benchmark

Before

```
Total allocated: 51146165 bytes (221499 objects)
Total retained:  5971658 bytes (15564 objects)

allocated memory by class
-----------------------------------
  27633240  Hash  <=====
   9604928  String
   6485704  Array
   4663405  Regexp
   2274584  ActiveSupport::OrderedOptions
    178224  Grape::Router::Route
    166896  Grape::Router::Pattern
     72720  Grape::Path
     30432  MatchData
     29400  Grape::Router::GreedyRoute
      1704  Class
      1224  Enumerator
       560  Proc
       488  Module
       448  Rack::Utils::HeaderHash


retained memory by class
-----------------------------------
   2274584  ActiveSupport::OrderedOptions
   1811845  Regexp
    933629  String
    305928  Array
    267800  Hash  <=====
    178224  Grape::Router::Route
    166896  Grape::Router::Pattern
     29400  Grape::Router::GreedyRoute
      1240  Class
       488  Module


```

```
Total allocated: 29384381 bytes (176924 objects)
Total retained:  5177218 bytes (12359 objects)

allocated memory by class
-----------------------------------
   9604928  String
   6699632  Hash  <=====
   6157528  Array
   4663405  Regexp
   1810584  ActiveSupport::OrderedOptions
    178224  Grape::Router::Route
    130896  Grape::Router::Pattern
     72720  Grape::Path
     30432  MatchData
     29400  Grape::Router::GreedyRoute


retained memory by class
-----------------------------------
   1811845  Regexp
   1810584  ActiveSupport::OrderedOptions
    933629  String
    178224  Grape::Router::Route
    144320  Hash  <=====
    134968  Array
    130896  Grape::Router::Pattern
     29400  Grape::Router::GreedyRoute
      1240  Class
       488  Module
       400  Proc
       280  Grape::Middleware::Stack::Middleware
       256  <<Unknown>>
       224  Rack::Utils::HeaderHash
       168  ActiveSupport::HashWithIndifferentAccess
```