### PR TITLE
Optimize Grape::Path -> Reduce Hash Allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#2501](https://github.com/ruby-grape/grape/pull/2501): Remove deprecated `except` and `proc` options in values validator - [@ericproulx](https://github.com/ericproulx).
 * [#2502](https://github.com/ruby-grape/grape/pull/2502): Remove deprecation `options` in `desc` - [@ericproulx](https://github.com/ericproulx).
 * [#2512](https://github.com/ruby-grape/grape/pull/2512): Optimize hash alloc - [@ericproulx](https://github.com/ericproulx).
+* [#2513](https://github.com/ruby-grape/grape/pull/2513): Optimize Grape::Path - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/benchmark/compile_many_routes.rb
+++ b/benchmark/compile_many_routes.rb
@@ -3,6 +3,7 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'grape'
 require 'benchmark/ips'
+require 'memory_profiler'
 
 class API < Grape::API
   prefix :api
@@ -15,8 +16,6 @@ class API < Grape::API
   end
 end
 
-Benchmark.ips do |ips|
-  ips.report('Compiling 2000 routes') do
-    API.compile!
-  end
-end
+MemoryProfiler.report(allow_files: 'grape') do
+  API.compile!
+end.pretty_print(to_file: 'optimize_path.txt')

--- a/benchmark/compile_many_routes.rb
+++ b/benchmark/compile_many_routes.rb
@@ -3,7 +3,6 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'grape'
 require 'benchmark/ips'
-require 'memory_profiler'
 
 class API < Grape::API
   prefix :api
@@ -16,6 +15,8 @@ class API < Grape::API
   end
 end
 
-MemoryProfiler.report(allow_files: 'grape') do
-  API.compile!
-end.pretty_print(to_file: 'optimize_path.txt')
+Benchmark.ips do |ips|
+  ips.report('Compiling 2000 routes') do
+    API.compile!
+  end
+end

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -208,7 +208,7 @@ module Grape
       namespace_stackable_hash = inheritable_setting.namespace_stackable.to_hash
       namespace_inheritable_hash = inheritable_setting.namespace_inheritable.to_hash
       path_settings = namespace_stackable_hash.merge!(namespace_inheritable_hash)
-      Path.new(path, namespace, path_settings)
+      Path.new(path, namespace, **path_settings)
     end
 
     def namespace

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -208,7 +208,7 @@ module Grape
       namespace_stackable_hash = inheritable_setting.namespace_stackable.to_hash
       namespace_inheritable_hash = inheritable_setting.namespace_inheritable.to_hash
       path_settings = namespace_stackable_hash.merge!(namespace_inheritable_hash)
-      Path.new(path, namespace, **path_settings)
+      Path.new(path, namespace, path_settings)
     end
 
     def namespace

--- a/lib/grape/path.rb
+++ b/lib/grape/path.rb
@@ -9,7 +9,7 @@ module Grape
 
     attr_reader :path, :suffix
 
-    def initialize(raw_path, raw_namespace, **settings)
+    def initialize(raw_path, raw_namespace, settings)
       @path = PartsCache[build_parts(raw_path, raw_namespace, settings)]
       @suffix = build_suffix(raw_path, raw_namespace, settings)
     end

--- a/lib/grape/path.rb
+++ b/lib/grape/path.rb
@@ -7,15 +7,15 @@ module Grape
     NO_VERSIONING_WITH_VALID_PATH_FORMAT_SEGMENT = '(.:format)'
     VERSION_SEGMENT = ':version'
 
-    attr_reader :path, :suffix
+    attr_reader :origin, :suffix
 
     def initialize(raw_path, raw_namespace, settings)
-      @path = PartsCache[build_parts(raw_path, raw_namespace, settings)]
+      @origin = PartsCache[build_parts(raw_path, raw_namespace, settings)]
       @suffix = build_suffix(raw_path, raw_namespace, settings)
     end
 
     def to_s
-      "#{path}#{suffix}"
+      "#{origin}#{suffix}"
     end
 
     private

--- a/lib/grape/path.rb
+++ b/lib/grape/path.rb
@@ -3,81 +3,39 @@
 module Grape
   # Represents a path to an endpoint.
   class Path
-    attr_reader :raw_path, :namespace, :settings
+    DEFAULT_FORMAT_SEGMENT = '(/.:format)'
+    NO_VERSIONING_WITH_VALID_PATH_FORMAT_SEGMENT = '(.:format)'
+    VERSION_SEGMENT = ':version'
 
-    def initialize(raw_path, namespace, settings)
-      @raw_path = raw_path
-      @namespace = namespace
-      @settings = settings
-    end
+    attr_reader :path, :suffix
 
-    def mount_path
-      settings[:mount_path]
-    end
-
-    def root_prefix
-      settings[:root_prefix]
-    end
-
-    def uses_specific_format?
-      return false unless settings.key?(:format) && settings.key?(:content_types)
-
-      settings[:format] && Array(settings[:content_types]).size == 1
-    end
-
-    def uses_path_versioning?
-      return false unless settings.key?(:version) && settings[:version_options]&.key?(:using)
-
-      settings[:version] && settings[:version_options][:using] == :path
-    end
-
-    def namespace?
-      namespace&.match?(/^\S/) && not_slash?(namespace)
-    end
-
-    def path?
-      raw_path&.match?(/^\S/) && not_slash?(raw_path)
-    end
-
-    def suffix
-      if uses_specific_format?
-        "(.#{settings[:format]})"
-      elsif !uses_path_versioning? || (namespace? || path?)
-        '(.:format)'
-      else
-        '(/.:format)'
-      end
-    end
-
-    def path
-      PartsCache[parts]
-    end
-
-    def path_with_suffix
-      "#{path}#{suffix}"
+    def initialize(raw_path, raw_namespace, **settings)
+      @path = PartsCache[build_parts(raw_path, raw_namespace, settings)]
+      @suffix = build_suffix(raw_path, raw_namespace, settings)
     end
 
     def to_s
-      path_with_suffix
+      "#{path}#{suffix}"
     end
 
     private
 
-    class PartsCache < Grape::Util::Cache
-      def initialize
-        super
-        @cache = Hash.new do |h, parts|
-          h[parts] = Grape::Router.normalize_path(parts.join('/'))
-        end
+    def build_suffix(raw_path, raw_namespace, settings)
+      if uses_specific_format?(settings)
+        "(.#{settings[:format]})"
+      elsif !uses_path_versioning?(settings) || (valid_part?(raw_namespace) || valid_part?(raw_path))
+        NO_VERSIONING_WITH_VALID_PATH_FORMAT_SEGMENT
+      else
+        DEFAULT_FORMAT_SEGMENT
       end
     end
 
-    def parts
+    def build_parts(raw_path, raw_namespace, settings)
       [].tap do |parts|
-        add_part(parts, mount_path)
-        add_part(parts, root_prefix)
-        parts << ':version' if uses_path_versioning?
-        add_part(parts, namespace)
+        add_part(parts, settings[:mount_path])
+        add_part(parts, settings[:root_prefix])
+        parts << VERSION_SEGMENT if uses_path_versioning?(settings)
+        add_part(parts, raw_namespace)
         add_part(parts, raw_path)
       end
     end
@@ -88,6 +46,31 @@ module Grape
 
     def not_slash?(value)
       value != '/'
+    end
+
+    def uses_specific_format?(settings)
+      return false unless settings.key?(:format) && settings.key?(:content_types)
+
+      settings[:format] && Array(settings[:content_types]).size == 1
+    end
+
+    def uses_path_versioning?(settings)
+      return false unless settings.key?(:version) && settings[:version_options]&.key?(:using)
+
+      settings[:version] && settings[:version_options][:using] == :path
+    end
+
+    def valid_part?(part)
+      part&.match?(/^\S/) && not_slash?(part)
+    end
+
+    class PartsCache < Grape::Util::Cache
+      def initialize
+        super
+        @cache = Hash.new do |h, parts|
+          h[parts] = Grape::Router.normalize_path(parts.join('/'))
+        end
+      end
     end
   end
 end

--- a/spec/grape/path_spec.rb
+++ b/spec/grape/path_spec.rb
@@ -9,14 +9,14 @@ describe Grape::Path do
       end
 
       it 'is included when it is not nil' do
-        path = described_class.new(nil, nil)
+        path = described_class.new(nil, nil, {})
         expect(path.path).to eql('/')
       end
     end
 
     context 'root_prefix' do
       it 'is not included when it is nil' do
-        path = described_class.new(nil, nil)
+        path = described_class.new(nil, nil, {})
         expect(path.path).to eql('/')
       end
 
@@ -72,7 +72,7 @@ describe Grape::Path do
 
     context 'when path versioning is not used' do
       it "does not include a '/' when the path has a namespace" do
-        path = described_class.new(nil, 'namespace')
+        path = described_class.new(nil, 'namespace', {})
         expect(path.suffix).to eql('(.:format)')
       end
 

--- a/spec/grape/path_spec.rb
+++ b/spec/grape/path_spec.rb
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 
 describe Grape::Path do
-  describe '#path' do
+  describe '#origin' do
     context 'mount_path' do
       it 'is not included when it is nil' do
         path = described_class.new(nil, nil, mount_path: '/foo/bar')
-        expect(path.path).to eql '/foo/bar'
+        expect(path.origin).to eql '/foo/bar'
       end
 
       it 'is included when it is not nil' do
         path = described_class.new(nil, nil, {})
-        expect(path.path).to eql('/')
+        expect(path.origin).to eql('/')
       end
     end
 
     context 'root_prefix' do
       it 'is not included when it is nil' do
         path = described_class.new(nil, nil, {})
-        expect(path.path).to eql('/')
+        expect(path.origin).to eql('/')
       end
 
       it 'is included after the mount path' do
@@ -28,7 +28,7 @@ describe Grape::Path do
           root_prefix: '/hello'
         )
 
-        expect(path.path).to eql('/foo/hello')
+        expect(path.origin).to eql('/foo/hello')
       end
     end
 
@@ -40,7 +40,7 @@ describe Grape::Path do
         root_prefix: '/hello'
       )
 
-      expect(path.path).to eql('/foo/hello/namespace')
+      expect(path.origin).to eql('/foo/hello/namespace')
     end
 
     it 'uses the raw path after the namespace' do
@@ -51,7 +51,7 @@ describe Grape::Path do
         root_prefix: '/hello'
       )
 
-      expect(path.path).to eql('/foo/hello/namespace/raw_path')
+      expect(path.origin).to eql('/foo/hello/namespace/raw_path')
     end
   end
 

--- a/spec/grape/path_spec.rb
+++ b/spec/grape/path_spec.rb
@@ -1,130 +1,6 @@
 # frozen_string_literal: true
 
 describe Grape::Path do
-  describe '#initialize' do
-    it 'remembers the path' do
-      path = described_class.new('/:id', anything, anything)
-      expect(path.raw_path).to eql('/:id')
-    end
-
-    it 'remembers the namespace' do
-      path = described_class.new(anything, '/users', anything)
-      expect(path.namespace).to eql('/users')
-    end
-
-    it 'remebers the settings' do
-      path = described_class.new(anything, anything, foo: 'bar')
-      expect(path.settings).to eql(foo: 'bar')
-    end
-  end
-
-  describe '#mount_path' do
-    it 'is nil when no mount path setting exists' do
-      path = described_class.new(anything, anything, {})
-      expect(path.mount_path).to be_nil
-    end
-
-    it 'is nil when the mount path is nil' do
-      path = described_class.new(anything, anything, mount_path: nil)
-      expect(path.mount_path).to be_nil
-    end
-
-    it 'splits the mount path' do
-      path = described_class.new(anything, anything, mount_path: %w[foo bar])
-      expect(path.mount_path).to eql(%w[foo bar])
-    end
-  end
-
-  describe '#root_prefix' do
-    it 'is nil when no root prefix setting exists' do
-      path = described_class.new(anything, anything, {})
-      expect(path.root_prefix).to be_nil
-    end
-
-    it 'is nil when the mount path is nil' do
-      path = described_class.new(anything, anything, root_prefix: nil)
-      expect(path.root_prefix).to be_nil
-    end
-
-    it 'splits the mount path' do
-      path = described_class.new(anything, anything, root_prefix: 'hello/world')
-      expect(path.root_prefix).to eql('hello/world')
-    end
-  end
-
-  describe '#uses_path_versioning?' do
-    it 'is false when the version setting is nil' do
-      path = described_class.new(anything, anything, version: nil)
-      expect(path.uses_path_versioning?).to be false
-    end
-
-    it 'is false when the version option is header' do
-      path = described_class.new(
-        anything,
-        anything,
-        version: 'v1',
-        version_options: { using: :header }
-      )
-
-      expect(path.uses_path_versioning?).to be false
-    end
-
-    it 'is true when the version option is path' do
-      path = described_class.new(
-        anything,
-        anything,
-        version: 'v1',
-        version_options: { using: :path }
-      )
-
-      expect(path.uses_path_versioning?).to be true
-    end
-  end
-
-  describe '#namespace?' do
-    it 'is false when the namespace is nil' do
-      path = described_class.new(anything, nil, anything)
-      expect(path).not_to be_namespace
-    end
-
-    it 'is false when the namespace starts with whitespace' do
-      path = described_class.new(anything, ' /foo', anything)
-      expect(path).not_to be_namespace
-    end
-
-    it 'is false when the namespace is the root path' do
-      path = described_class.new(anything, '/', anything)
-      expect(path.namespace?).to be false
-    end
-
-    it 'is true otherwise' do
-      path = described_class.new(anything, '/world', anything)
-      expect(path.namespace?).to be true
-    end
-  end
-
-  describe '#path?' do
-    it 'is false when the path is nil' do
-      path = described_class.new(nil, anything, anything)
-      expect(path).not_to be_path
-    end
-
-    it 'is false when the path starts with whitespace' do
-      path = described_class.new(' /foo', anything, anything)
-      expect(path).not_to be_path
-    end
-
-    it 'is false when the path is the root path' do
-      path = described_class.new('/', anything, anything)
-      expect(path.path?).to be false
-    end
-
-    it 'is true otherwise' do
-      path = described_class.new('/hello', anything, anything)
-      expect(path.path?).to be true
-    end
-  end
-
   describe '#path' do
     context 'mount_path' do
       it 'is not included when it is nil' do
@@ -133,14 +9,14 @@ describe Grape::Path do
       end
 
       it 'is included when it is not nil' do
-        path = described_class.new(nil, nil, {})
+        path = described_class.new(nil, nil)
         expect(path.path).to eql('/')
       end
     end
 
     context 'root_prefix' do
       it 'is not included when it is nil' do
-        path = described_class.new(nil, nil, {})
+        path = described_class.new(nil, nil)
         expect(path.path).to eql('/')
       end
 
@@ -182,60 +58,32 @@ describe Grape::Path do
   describe '#suffix' do
     context 'when using a specific format' do
       it 'accepts specified format' do
-        path = described_class.new(nil, nil, {})
-        allow(path).to receive_messages(uses_specific_format?: true, settings: { format: :json })
-
+        path = described_class.new(nil, nil, format: 'json', content_types: 'application/json')
         expect(path.suffix).to eql('(.json)')
       end
     end
 
     context 'when path versioning is used' do
       it "includes a '/'" do
-        path = described_class.new(nil, nil, {})
-        allow(path).to receive_messages(uses_specific_format?: false, uses_path_versioning?: true)
-
+        path = described_class.new(nil, nil, version: :v1, version_options: { using: :path })
         expect(path.suffix).to eql('(/.:format)')
       end
     end
 
     context 'when path versioning is not used' do
       it "does not include a '/' when the path has a namespace" do
-        path = described_class.new(nil, 'namespace', {})
-        allow(path).to receive_messages(uses_specific_format?: false, uses_path_versioning?: true)
-
+        path = described_class.new(nil, 'namespace')
         expect(path.suffix).to eql('(.:format)')
       end
 
       it "does not include a '/' when the path has a path" do
-        path = described_class.new('/path', nil, {})
-        allow(path).to receive_messages(uses_specific_format?: false, uses_path_versioning?: true)
-
+        path = described_class.new('/path', nil, version: :v1, version_options: { using: :path })
         expect(path.suffix).to eql('(.:format)')
       end
 
       it "includes a '/' otherwise" do
-        path = described_class.new(nil, nil, {})
-        allow(path).to receive_messages(uses_specific_format?: false, uses_path_versioning?: true)
-
+        path = described_class.new(nil, nil, version: :v1, version_options: { using: :path })
         expect(path.suffix).to eql('(/.:format)')
-      end
-    end
-  end
-
-  describe '#path_with_suffix' do
-    it 'combines the path and suffix' do
-      path = described_class.new(nil, nil, {})
-      allow(path).to receive_messages(path: '/the/path', suffix: 'suffix')
-
-      expect(path.path_with_suffix).to eql('/the/pathsuffix')
-    end
-
-    context 'when using a specific format' do
-      it 'might have a suffix with specified format' do
-        path = described_class.new(nil, nil, {})
-        allow(path).to receive_messages(path: '/the/path', uses_specific_format?: true, settings: { format: :json })
-
-        expect(path.path_with_suffix).to eql('/the/path(.json)')
       end
     end
   end


### PR DESCRIPTION
This PR refactors the usage of Grape::Path and it comes with a lower Hash allocation. Most of the changes are in `Grape::Path` and the `to_routes` function in `Grape::Endpoint`

This is the result taken from the `benchmark/compile_many_routes.rb`
```ruby
require 'memory_profiler'

class API < Grape::API
  prefix :api
  version 'v1', using: :path

  2000.times do |index|
    get "/test#{index}/" do
      'hello'
    end
  end
end

MemoryProfiler.report(allow_files: 'grape') do
  API.compile!
end.pretty_print
```

<img width="1222" alt="Screenshot 2024-11-26 at 20 34 00" src="https://github.com/user-attachments/assets/26d6e2fe-462d-4518-8352-3af679de168a">
<img width="1491" alt="Screenshot 2024-11-26 at 20 33 34" src="https://github.com/user-attachments/assets/feb31569-1b9d-43f2-bce9-2eea5ed55ec9">
