### PR TITLE
Fixed typo in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#2506](https://github.com/ruby-grape/grape/pull/2506): Fix fetch_formatter api_format - [@ericproulx](https://github.com/ericproulx).
 * [#2507](https://github.com/ruby-grape/grape/pull/2507): Fix type: Set with values - [@nikolai-b](https://github.com/nikolai-b).
 * [#2510](https://github.com/ruby-grape/grape/pull/2510): Fix ContractScope's validator inheritance - [@ericproulx](https://github.com/ericproulx).
+* [#2521](https://github.com/ruby-grape/grape/pull/2521): Fixed typo in README - [@datpmt](https://github.com/datpmt).
 * Your contribution here.
 
 ### 2.2.0 (2024-09-14)

--- a/README.md
+++ b/README.md
@@ -2046,7 +2046,7 @@ end
 ```ruby
 params do
   requires :code, type: String, length: { is: 2, message: 'code is expected to be exactly 2 characters long' }
-  requires :str, type: String, length: { min: 5, message: 'str is expected to be atleast 5 characters long' }
+  requires :str, type: String, length: { min: 5, message: 'str is expected to be at least 5 characters long' }
   requires :list, type: [Integer], length: { min: 2, max: 3, message: 'list is expected to have between 2 and 3 elements' }
 end
 ```
@@ -3536,8 +3536,8 @@ Please use `Route#xyz` instead.
 
 Note that difference of `Route#options` and `Route#settings`.
 
-The `options` can be referred from your route, it should be set by specifing key and value on verb methods such as `get`, `post` and `put`.
-The `settings` can also be referred from your route, but it should be set by specifing key and value on `route_setting`.
+The `options` can be referred from your route, it should be set by specifying key and value on verb methods such as `get`, `post` and `put`.
+The `settings` can also be referred from your route, but it should be set by specifying key and value on `route_setting`.
 
 ## Current Route and Endpoint
 


### PR DESCRIPTION
- Fixed typos found in `README.md` using the `typo_checker scan .` command with the [typo_checker](https://github.com/datpmt/typo_checker) Ruby gem.
  - [### Custom Validation messages](https://github.com/ruby-grape/grape?tab=readme-ov-file#custom-validation-messages)

    - Should replace `atleast` with `at least`.
  - [## Describing and Inspecting an API](https://github.com/ruby-grape/grape?tab=readme-ov-file#describing-and-inspecting-an-api)
    - Should replace `specifing` with `specifying`.

- I recommend using the [typocop GitHub Action](https://github.com/datpmt/typocop) to automatically check for typos in future pull requests.