### PR TITLE
Validators bad encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#2506](https://github.com/ruby-grape/grape/pull/2506): Fix fetch_formatter api_format - [@ericproulx](https://github.com/ericproulx).
 * [#2507](https://github.com/ruby-grape/grape/pull/2507): Fix type: Set with values - [@nikolai-b](https://github.com/nikolai-b).
 * [#2510](https://github.com/ruby-grape/grape/pull/2510): Fix ContractScope's validator inheritance - [@ericproulx](https://github.com/ericproulx).
+* [#2524](https://github.com/ruby-grape/grape/pull/2524): Fix validators bad encoding - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 2.2.0 (2024-09-14)

--- a/lib/grape/middleware/versioner/accept_version_header.rb
+++ b/lib/grape/middleware/versioner/accept_version_header.rb
@@ -18,7 +18,9 @@ module Grape
       # route.
       class AcceptVersionHeader < Base
         def before
-          potential_version = env[Grape::Http::Headers::HTTP_ACCEPT_VERSION]&.strip
+          potential_version = env[Grape::Http::Headers::HTTP_ACCEPT_VERSION]
+          potential_version = potential_version.scrub unless potential_version.nil?
+
           not_acceptable!('Accept-Version header must be set.') if strict? && potential_version.blank?
 
           return if potential_version.blank?

--- a/lib/grape/validations/validators/allow_blank_validator.rb
+++ b/lib/grape/validations/validators/allow_blank_validator.rb
@@ -8,7 +8,7 @@ module Grape
           return if (options_key?(:value) ? @option[:value] : @option) || !params.is_a?(Hash)
 
           value = params[attr_name]
-          value = value.strip if value.respond_to?(:strip)
+          value = value.scrub if value.respond_to?(:scrub)
 
           return if value == false || value.present?
 

--- a/lib/grape/validations/validators/regexp_validator.rb
+++ b/lib/grape/validations/validators/regexp_validator.rb
@@ -6,7 +6,7 @@ module Grape
       class RegexpValidator < Base
         def validate_param!(attr_name, params)
           return unless params.respond_to?(:key?) && params.key?(attr_name)
-          return if Array.wrap(params[attr_name]).all? { |param| param.nil? || param.to_s.match?((options_key?(:value) ? @option[:value] : @option)) }
+          return if Array.wrap(params[attr_name]).all? { |param| param.nil? || param.to_s.scrub.match?((options_key?(:value) ? @option[:value] : @option)) }
 
           raise Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message(:regexp))
         end

--- a/lib/grape/validations/validators/values_validator.rb
+++ b/lib/grape/validations/validators/values_validator.rb
@@ -16,6 +16,8 @@ module Grape
 
           return if val.nil? && !required_for_root_scope?
 
+          val = val.scrub if val.respond_to?(:scrub)
+
           # don't forget that +false.blank?+ is true
           return if val != false && val.blank? && @allow_blank
 

--- a/spec/grape/middleware/versioner/accept_version_header_spec.rb
+++ b/spec/grape/middleware/versioner/accept_version_header_spec.rb
@@ -13,6 +13,23 @@ describe Grape::Middleware::Versioner::AcceptVersionHeader do
     }
   end
 
+  describe '#bad encoding' do
+    before do
+      @options[:versions] = %w(v1)
+    end
+
+    it 'does not raise an error' do
+      expect do
+        subject.call(Grape::Http::Headers::HTTP_ACCEPT_VERSION => "\x80")
+      end.to throw_symbol(
+               :error,
+               status: 406,
+               headers: { Grape::Http::Headers::X_CASCADE => 'pass' },
+               message: 'The requested version is not supported.'
+             )
+    end
+  end
+
   context 'api.version' do
     before do
       @options[:versions] = ['v1']

--- a/spec/grape/middleware/versioner/accept_version_header_spec.rb
+++ b/spec/grape/middleware/versioner/accept_version_header_spec.rb
@@ -15,18 +15,13 @@ describe Grape::Middleware::Versioner::AcceptVersionHeader do
 
   describe '#bad encoding' do
     before do
-      @options[:versions] = %w(v1)
+      @options[:versions] = %w[v1]
     end
 
     it 'does not raise an error' do
       expect do
         subject.call(Grape::Http::Headers::HTTP_ACCEPT_VERSION => "\x80")
-      end.to throw_symbol(
-               :error,
-               status: 406,
-               headers: { Grape::Http::Headers::X_CASCADE => 'pass' },
-               message: 'The requested version is not supported.'
-             )
+      end.to throw_symbol(:error, status: 406, headers: { Grape::Http::Headers::X_CASCADE => 'pass' }, message: 'The requested version is not supported.')
     end
   end
 

--- a/spec/grape/validations/validators/allow_blank_validator_spec.rb
+++ b/spec/grape/validations/validators/allow_blank_validator_spec.rb
@@ -244,6 +244,25 @@ describe Grape::Validations::Validators::AllowBlankValidator do
     end
   end
 
+  describe 'bad encoding' do
+    let(:app) do
+      Class.new(Grape::API) do
+        default_format :json
+
+        params do
+          requires :name, type: String, allow_blank: false
+        end
+        get '/bad_encoding'
+      end
+    end
+
+    context 'when value has bad encoding' do
+      it 'does not raise an error' do
+        expect { get('/bad_encoding', { name: "Hello \x80" }) }.not_to raise_error
+      end
+    end
+  end
+
   context 'invalid input' do
     it 'refuses empty string' do
       get '/disallow_blank', name: ''

--- a/spec/grape/validations/validators/regexp_validator_spec.rb
+++ b/spec/grape/validations/validators/regexp_validator_spec.rb
@@ -41,6 +41,25 @@ describe Grape::Validations::Validators::RegexpValidator do
     end
   end
 
+  describe '#bad encoding' do
+    let(:app) do
+      Class.new(Grape::API) do
+        default_format :json
+
+        params do
+          requires :name, regexp: { value: /^[a-z]+$/ }
+        end
+        get '/bad_encoding'
+      end
+    end
+
+    context 'when value as bad encoding' do
+      it 'does not raise an error' do
+        expect { get '/bad_encoding', name: "Hello \x80" }.not_to raise_error
+      end
+    end
+  end
+
   context 'custom validation message' do
     context 'with invalid input' do
       it 'refuses inapppopriate' do

--- a/spec/grape/validations/validators/values_validator_spec.rb
+++ b/spec/grape/validations/validators/values_validator_spec.rb
@@ -283,7 +283,7 @@ describe Grape::Validations::Validators::ValuesValidator do
         default_format :json
 
         params do
-          requires :type, type: String, values: %w(a b)
+          requires :type, type: String, values: %w[a b]
         end
         get '/bad_encoding'
       end
@@ -326,7 +326,7 @@ describe Grape::Validations::Validators::ValuesValidator do
 
   context 'with a custom exclude validation message' do
     it 'does not allow an invalid value for a parameter' do
-      get('/custom_message/exclude/exclude_message', type: "invalid-type1")
+      get('/custom_message/exclude/exclude_message', type: 'invalid-type1')
       expect(last_response.status).to eq 400
       expect(last_response.body).to eq({ error: 'type value is on exclusions list' }.to_json)
     end

--- a/spec/grape/validations/validators/values_validator_spec.rb
+++ b/spec/grape/validations/validators/values_validator_spec.rb
@@ -277,6 +277,25 @@ describe Grape::Validations::Validators::ValuesValidator do
     stub_const('ValuesModel', values_model)
   end
 
+  describe '#bad encoding' do
+    let(:app) do
+      Class.new(Grape::API) do
+        default_format :json
+
+        params do
+          requires :type, type: String, values: %w(a b)
+        end
+        get '/bad_encoding'
+      end
+    end
+
+    context 'when value as bad encoding' do
+      it 'does not raise an error' do
+        expect { get '/bad_encoding', type: "Hello \x80" }.not_to raise_error
+      end
+    end
+  end
+
   context 'with a custom validation message' do
     it 'allows a valid value for a parameter' do
       get('/custom_message', type: 'valid-type1')
@@ -307,7 +326,7 @@ describe Grape::Validations::Validators::ValuesValidator do
 
   context 'with a custom exclude validation message' do
     it 'does not allow an invalid value for a parameter' do
-      get('/custom_message/exclude/exclude_message', type: 'invalid-type1')
+      get('/custom_message/exclude/exclude_message', type: "invalid-type1")
       expect(last_response.status).to eq 400
       expect(last_response.body).to eq({ error: 'type value is on exclusions list' }.to_json)
     end


### PR DESCRIPTION
Fix #2523

It fixes the `allow_blank`, `regexp` and `values` validator.
It also covers the `Accept-Version` http header. 