### PR TITLE
Force endpoint status in error_response and error!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#2521](https://github.com/ruby-grape/grape/pull/2521): Fixed typo in README - [@datpmt](https://github.com/datpmt).
 * [#2525](https://github.com/ruby-grape/grape/pull/2525): Require logger before active_support - [@ericproulx](https://github.com/ericproulx).
 * [#2524](https://github.com/ruby-grape/grape/pull/2524): Fix validators bad encoding - [@ericproulx](https://github.com/ericproulx).
+* [#2530](https://github.com/ruby-grape/grape/pull/2530): Fix endpoint's status when rescue_from without a block - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 2.2.0 (2024-09-14)

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -65,6 +65,7 @@ module Grape
 
       def error_response(error = {})
         status = error[:status] || options[:default_status]
+        env[Grape::Env::API_ENDPOINT].status(status) # error! may not have been called
         message = error[:message] || options[:default_message]
         headers = { Rack::CONTENT_TYPE => content_type }.tap do |h|
           h.merge!(error[:headers]) if error[:headers].is_a?(Hash)
@@ -130,6 +131,7 @@ module Grape
       end
 
       def error!(message, status = options[:default_status], headers = {}, backtrace = [], original_exception = nil)
+        env[Grape::Env::API_ENDPOINT].status(status) # not error! inside route
         rack_response(
           status, headers.reverse_merge(Rack::CONTENT_TYPE => content_type),
           format_message(message, backtrace, original_exception)


### PR DESCRIPTION
Following this [comment](https://github.com/ruby-grape/grape/issues/2527#issuecomment-2625351197), this PR fixes the issue with the endpoint's status when not invoking `error!` through a block or a helper.