### PR TITLE
Delegates calls to inner object is some classes by extends Forwardable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * [#2532](https://github.com/ruby-grape/grape/pull/2532): Update RuboCop 1.71.2 - [@ericproulx](https://github.com/ericproulx).
+* [#2535](https://github.com/ruby-grape/grape/pull/2535): Delegates calls to inner objects - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -20,12 +20,18 @@ module Grape
     end
 
     class << self
+      extend Forwardable
       attr_accessor :base_instance, :instances
 
-      # Rather than initializing an object of type Grape::API, create an object of type Instance
-      def new(...)
-        base_instance.new(...)
-      end
+      delegate_missing_to :base_instance
+      def_delegators :base_instance, :new, :configuration
+
+      # This is the interface point between Rack and Grape; it accepts a request
+      # from Rack and ultimately returns an array of three values: the status,
+      # the headers, and the body. See [the rack specification]
+      # (http://www.rubydoc.info/github/rack/rack/master/file/SPEC) for more.
+      # NOTE: This will only be called on an API directly mounted on RACK
+      def_delegators :instance_for_rack, :call, :compile!
 
       # When inherited, will create a list of all instances (times the API was mounted)
       # It will listen to the setup required to mount that endpoint, and replicate it on any new instance
@@ -69,15 +75,6 @@ module Grape
         end
       end
 
-      # This is the interface point between Rack and Grape; it accepts a request
-      # from Rack and ultimately returns an array of three values: the status,
-      # the headers, and the body. See [the rack specification]
-      # (http://www.rubydoc.info/github/rack/rack/master/file/SPEC) for more.
-      # NOTE: This will only be called on an API directly mounted on RACK
-      def call(...)
-        instance_for_rack.call(...)
-      end
-
       # The remountable class can have a configuration hash to provide some dynamic class-level variables.
       # For instance, a description could be done using: `desc configuration[:description]` if it may vary
       # depending on where the endpoint is mounted. Use with care, if you find yourself using configuration
@@ -96,27 +93,6 @@ module Grape
         @setup.each do |setup_step|
           replay_step_on(instance, setup_step)
         end
-      end
-
-      def respond_to?(method, include_private = false)
-        super || base_instance.respond_to?(method, include_private)
-      end
-
-      def respond_to_missing?(method, include_private = false)
-        base_instance.respond_to?(method, include_private)
-      end
-
-      def method_missing(method, *args, &block)
-        # If there's a missing method, it may be defined on the base_instance instead.
-        if respond_to_missing?(method)
-          base_instance.send(method, *args, &block)
-        else
-          super
-        end
-      end
-
-      def compile!
-        instance_for_rack.compile! # See API::Instance.compile!
       end
 
       private

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -6,11 +6,14 @@ module Grape
   # on the instance level of this class may be called
   # from inside a `get`, `post`, etc.
   class Endpoint
+    extend Forwardable
     include Grape::DSL::Settings
     include Grape::DSL::InsideRoute
 
     attr_accessor :block, :source, :options
-    attr_reader :env, :request, :headers, :params
+    attr_reader :env, :request
+
+    def_delegators :request, :params, :headers
 
     class << self
       def new(...)
@@ -247,8 +250,6 @@ module Grape
       ActiveSupport::Notifications.instrument('endpoint_run.grape', endpoint: self, env: env) do
         @header = Grape::Util::Header.new
         @request = Grape::Request.new(env, build_params_with: namespace_inheritable(:build_params_with))
-        @params = @request.params
-        @headers = @request.headers
         begin
           cookies.read(@request)
           self.class.run_before_each(self)

--- a/lib/grape/middleware/stack.rb
+++ b/lib/grape/middleware/stack.rb
@@ -5,17 +5,18 @@ module Grape
     # Class to handle the stack of middlewares based on ActionDispatch::MiddlewareStack
     # It allows to insert and insert after
     class Stack
+      extend Forwardable
       class Middleware
+        extend Forwardable
+
         attr_reader :args, :block, :klass
+
+        def_delegators :klass, :name
 
         def initialize(klass, *args, &block)
           @klass = klass
           @args = args
           @block = block
-        end
-
-        def name
-          klass.name
         end
 
         def ==(other)
@@ -32,7 +33,7 @@ module Grape
         end
 
         def use_in(builder)
-          builder.use(@klass, *@args, &@block)
+          builder.use(klass, *args, &block)
         end
       end
 
@@ -40,25 +41,11 @@ module Grape
 
       attr_accessor :middlewares, :others
 
+      def_delegators :middlewares, :each, :size, :last, :[]
+
       def initialize
         @middlewares = []
         @others = []
-      end
-
-      def each(&block)
-        @middlewares.each(&block)
-      end
-
-      def size
-        middlewares.size
-      end
-
-      def last
-        middlewares.last
-      end
-
-      def [](index)
-        middlewares[index]
       end
 
       def insert(index, *args, &block)

--- a/lib/grape/request.rb
+++ b/lib/grape/request.rb
@@ -26,21 +26,16 @@ module Grape
     private
 
     def grape_routing_args
-      args = env[Grape::Env::GRAPE_ROUTING_ARGS].dup
       # preserve version from query string parameters
-      args.delete(:version)
-      args.delete(:route_info)
-      args
+      env[Grape::Env::GRAPE_ROUTING_ARGS].except(:version, :route_info)
     end
 
     def build_headers
-      Grape::Util::Lazy::Object.new do
-        env.each_pair.with_object(Grape::Util::Header.new) do |(k, v), headers|
-          next unless k.to_s.start_with? HTTP_PREFIX
+      each_header.with_object(Grape::Util::Header.new) do |(k, v), headers|
+        next unless k.start_with? HTTP_PREFIX
 
-          transformed_header = Grape::Http::Headers::HTTP_HEADERS[k] || transform_header(k)
-          headers[transformed_header] = v
-        end
+        transformed_header = Grape::Http::Headers::HTTP_HEADERS[k] || transform_header(k)
+        headers[transformed_header] = v
       end
     end
 


### PR DESCRIPTION
This PR will delegate some functions to some inner objects. Here are the details:

#### api.rb
Add delegation to `base_instance` and `instance_for_rack`
Use `delegate_missing_to` instead of method_missing functions

#### endpoint.rb
Delegate `params` and `headers` to `request`
Remove `LazyObject` for `build_headers` since its not forced 

#### request.rb
Use `each_header` from Rack::Request instead of `env.each_pair`
Remove `.to_s` since Ruby 2.7 added `start_with?` to symbols

#### stack.rb
Delegates some functions