### PR TITLE
Reduce array alloc on mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 #### Fixes
 
 * [#2538](https://github.com/ruby-grape/grape/pull/2538): Fix validating nested json array params - [@mohammednasser-32](https://github.com/mohammednasser-32).
+* [#2543](https://github.com/ruby-grape/grape/pull/2543): Fix array allocation on mount - [@ericproulx](https://github.com/ericproulx).
+* Your contribution here.
 
 ### 2.3.0 (2025-02-08)
 

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -113,7 +113,7 @@ module Grape
           last_response = replay_step_on(instance, **step)
         end
 
-        refresh_mount_step(step) if step[:method] != :mount
+        refresh_mount_step if step[:method] != :mount
         last_response
       end
 

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1699,11 +1699,6 @@ describe Grape::API do
         expect(subject.io.string).to include(message)
       end
     end
-
-    it 'does not unnecessarily retain duplicate setup blocks' do
-      subject.logger
-      expect { subject.logger }.not_to change(subject.instance_variable_get(:@setup), :size)
-    end
   end
 
   describe '.helpers' do


### PR DESCRIPTION
#2529 change the `@setup` variable to an [] but the code is using `+=` when adding a new step. This creates a new `[]` everytime and its not the best in terms on memory footprint. This PR replaced the `+=` by `<<` to not create new arrays.

I had to remove a [test](https://github.com/ruby-grape/grape/blob/45abe0dd9f18fcc0e1993b1d5a2988135cb216e1/spec/grape/api_spec.rb#L1703-L1705) since having duplicates is expected. It would have failed in #2529 if the test had been like this since @setup is not the same object.

```ruby
it 'does not unnecessarily retain duplicate setup blocks' do
  subject.logger
  first_setup = subject.instance_variable_get(:@setup)
  subject.logger
  last_setup = subject.instance_variable_get(:@setup)
  expect(first_setup.size).to eq(last_setup.size)
end
```

Running `benchmark/remounting.rb`  shows the efficiency. It shows the difference between a Set and an Array but we still see a difference between `<<` and `+=`
This is currently
```
Calculating -------------------------------------
 setup size: 1000
         using Array    19.623M memsize (   226.006k retained)
                       116.426k objects (     2.123k retained)
                        50.000  strings (     7.000  retained)
 setup size: 1
           using Set    11.680M memsize (     4.024k retained)
                       117.004k objects (    16.000  retained)
                         5.000  strings (     1.000  retained)

Comparison:
           using Set:   11680280 allocated
         using Array:   19623445 allocated - 1.68x more
```
This is with the PR
```
Calculating -------------------------------------
 setup size: 1000
         using Array    11.815M memsize (   229.806k retained)
                       112.426k objects (     2.123k retained)
                        50.000  strings (     7.000  retained)
 setup size: 1
           using Set    11.680M memsize (     4.024k retained)
                       111.004k objects (    16.000  retained)
                         5.000  strings (     1.000  retained)

Comparison:
           using Set:   11680280 allocated
         using Array:   11814541 allocated - 1.01x more
```


