### PR TITLE
Fix middleware with keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 * [#2538](https://github.com/ruby-grape/grape/pull/2538): Fix validating nested json array params - [@mohammednasser-32](https://github.com/mohammednasser-32).
 * [#2543](https://github.com/ruby-grape/grape/pull/2543): Fix array allocation on mount - [@ericproulx](https://github.com/ericproulx).
+* [#2546](https://github.com/ruby-grape/grape/pull/2546): Fix middleware with keywords - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 2.3.0 (2025-02-08)

--- a/lib/grape/middleware/stack.rb
+++ b/lib/grape/middleware/stack.rb
@@ -15,7 +15,9 @@ module Grape
           @block = block
         end
 
-        def name; klass.name; end # rubocop:disable Style/SingleLineMethods
+        def name
+          klass.name
+        end
 
         def ==(other)
           case other

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1525,6 +1525,34 @@ describe Grape::API do
         expect(last_response).to be_bad_request
         expect(last_response.body).to eq('Caught in the Net')
       end
+
+      context 'when middleware initialize as keywords' do
+        let(:middleware_with_keywords) do
+          Class.new do
+            def initialize(app, keyword:)
+              @app = app
+              @keyword = keyword
+            end
+
+            def call(env)
+              env['middleware_with_keywords'] = @keyword
+              @app.call(env)
+            end
+          end
+        end
+
+        before do
+          subject.use middleware_with_keywords, keyword: 'hello'
+          subject.get '/' do
+            env['middleware_with_keywords']
+          end
+          get '/'
+        end
+
+        it 'returns the middleware value' do
+          expect(last_response.body).to eq('hello')
+        end
+      end
     end
 
     describe '.insert_before' do


### PR DESCRIPTION
This PR fix #2544. It adds the `ruby2_keyword_hash` flag dynamically since its serialized in the `namespace_stackable`. Contrary to Rails, when calling `use`, `insert`, `insert_before`, its serializing the arguments and not calling the stack. Thus, `ruby2_keywords` have no meaning in Grape's stack.