### PR TITLE
Remove jsonapi related code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#2538](https://github.com/ruby-grape/grape/pull/2538): Fix validating nested json array params - [@mohammednasser-32](https://github.com/mohammednasser-32).
 * [#2543](https://github.com/ruby-grape/grape/pull/2543): Fix array allocation on mount - [@ericproulx](https://github.com/ericproulx).
 * [#2546](https://github.com/ruby-grape/grape/pull/2546): Fix middleware with keywords - [@ericproulx](https://github.com/ericproulx).
+* [#2547](https://github.com/ruby-grape/grape/pull/2547): Remove jsonapi related code - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 2.3.0 (2025-02-08)

--- a/lib/grape/error_formatter/jsonapi.rb
+++ b/lib/grape/error_formatter/jsonapi.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Grape
-  module ErrorFormatter
-    class Jsonapi < Json; end
-  end
-end

--- a/lib/grape/parser/jsonapi.rb
+++ b/lib/grape/parser/jsonapi.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Grape
-  module Parser
-    class Jsonapi < Json; end
-  end
-end

--- a/spec/grape/middleware/exception_spec.rb
+++ b/spec/grape/middleware/exception_spec.rb
@@ -164,27 +164,6 @@ describe Grape::Middleware::Error do
 
   context do
     let(:running_app) { exception_app }
-    let(:options) { { rescue_all: true, format: :jsonapi } }
-
-    it 'is possible to return errors in jsonapi format' do
-      get '/'
-      expect(last_response.body).to eq('{&quot;error&quot;:&quot;rain!&quot;}')
-    end
-  end
-
-  context do
-    let(:running_app) { error_hash_app }
-    let(:options) { { rescue_all: true, format: :jsonapi } }
-
-    it 'is possible to return hash errors in jsonapi format' do
-      get '/'
-      expect(['{&quot;error&quot;:&quot;rain!&quot;,&quot;detail&quot;:&quot;missing widget&quot;}',
-              '{&quot;detail&quot;:&quot;missing widget&quot;,&quot;error&quot;:&quot;rain!&quot;}']).to include(last_response.body)
-    end
-  end
-
-  context do
-    let(:running_app) { exception_app }
     let(:options) { { rescue_all: true, format: :xml } }
 
     it 'is possible to return errors in xml format' do

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -36,23 +36,6 @@ describe Grape::Middleware::Formatter do
       end
     end
 
-    context 'jsonapi' do
-      let(:body) { { 'foos' => [{ 'bar' => 'baz' }] } }
-      let(:env) do
-        { Rack::PATH_INFO => '/somewhere', Grape::Http::Headers::HTTP_ACCEPT => 'application/vnd.api+json' }
-      end
-
-      it 'calls #to_json if the content type is jsonapi' do
-        body.instance_eval do
-          def to_json(*_args)
-            '{"foos":[{"bar":"baz"}] }'
-          end
-        end
-        r = Rack::MockResponse[*subject.call(env)]
-        expect(r.body).to eq(Grape::Json.dump(body))
-      end
-    end
-
     context 'xml' do
       let(:body) { +'string' }
       let(:env) do


### PR DESCRIPTION
This PR removes code and specs related to jsonapi. Since [0.10.0](https://github.com/ruby-grape/grape/blob/master/CHANGELOG.md#0100-20141219), Grape's doesn't support jsonapi but there were still some code related to it.

