### PR TITLE
Delegate cookies management to Grape::Request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#2537](https://github.com/ruby-grape/grape/pull/2537): Use activesupport `try` pattern - [@ericproulx](https://github.com/ericproulx).
 * [#2536](https://github.com/ruby-grape/grape/pull/2536): Update normalize_path like Rails - [@ericproulx](https://github.com/ericproulx).
 * [#2540](https://github.com/ruby-grape/grape/pull/2540): Introduce Params builder with symbolized short name - [@ericproulx](https://github.com/ericproulx).
+* [#2549](https://github.com/ruby-grape/grape/pull/2549): Delegate cookies management to Grape::Request - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/cookies.rb
+++ b/lib/grape/cookies.rb
@@ -12,12 +12,13 @@ module Grape
 
     def_delegators :cookies, :[], :each
 
-    def initialize(lazy_rack_cookies)
-      @lazy_cookies = lazy_rack_cookies
+    def initialize(rack_cookies)
+      @cookies = rack_cookies
+      @send_cookies = nil
     end
 
-    def each_response_cookies
-      return unless defined?(@send_cookies)
+    def response_cookies
+      return unless @send_cookies
 
       send_cookies.each do |name|
         yield name, cookies[name]
@@ -37,12 +38,9 @@ module Grape
     private
 
     def cookies
-      return @cookies if defined?(@cookies)
+      return @cookies unless @cookies.is_a?(Proc)
 
-      # we don't want read cookies from rack if it has never been called
-      @cookies = @lazy_cookies.call.with_indifferent_access
-      @lazy_cookies = nil
-      @cookies
+      @cookies = @cookies.call.with_indifferent_access
     end
 
     def send_cookies

--- a/lib/grape/cookies.rb
+++ b/lib/grape/cookies.rb
@@ -2,41 +2,51 @@
 
 module Grape
   class Cookies
-    def initialize
-      @cookies = {}
-      @send_cookies = {}
+    extend Forwardable
+
+    DELETED_COOKIES_ATTRS = {
+      max_age: '0',
+      value: '',
+      expires: Time.at(0)
+    }.freeze
+
+    def_delegators :cookies, :[], :each
+
+    def initialize(lazy_rack_cookies)
+      @lazy_cookies = lazy_rack_cookies
     end
 
-    def read(request)
-      request.cookies.each do |name, value|
-        @cookies[name.to_s] = value
+    def each_response_cookies
+      return unless defined?(@send_cookies)
+
+      send_cookies.each do |name|
+        yield name, cookies[name]
       end
-    end
-
-    def write(header)
-      @cookies.select { |key, _value| @send_cookies[key] == true }.each do |name, value|
-        cookie_value = value.is_a?(Hash) ? value : { value: value }
-        Rack::Utils.set_cookie_header! header, name, cookie_value
-      end
-    end
-
-    def [](name)
-      @cookies[name.to_s]
     end
 
     def []=(name, value)
-      @cookies[name.to_s] = value
-      @send_cookies[name.to_s] = true
-    end
-
-    def each(&block)
-      @cookies.each(&block)
+      cookies[name] = value
+      send_cookies << name
     end
 
     # see https://github.com/rack/rack/blob/main/lib/rack/utils.rb#L338-L340
     def delete(name, **opts)
-      options = opts.merge(max_age: '0', value: '', expires: Time.at(0))
-      self.[]=(name, options)
+      self.[]=(name, opts.merge(DELETED_COOKIES_ATTRS))
+    end
+
+    private
+
+    def cookies
+      return @cookies if defined?(@cookies)
+
+      # we don't want read cookies from rack if it has never been called
+      @cookies = @lazy_cookies.call.with_indifferent_access
+      @lazy_cookies = nil
+      @cookies
+    end
+
+    def send_cookies
+      @send_cookies ||= Set.new
     end
   end
 end

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -257,18 +257,6 @@ module Grape
         end
       end
 
-      # Set or get a cookie
-      #
-      # @example
-      #   cookies[:mycookie] = 'mycookie val'
-      #   cookies['mycookie-string'] = 'mycookie string val'
-      #   cookies[:more] = { value: '123', expires: Time.at(0) }
-      #   cookies.delete :more
-      #
-      def cookies
-        @cookies ||= Cookies.new
-      end
-
       # Allows you to define the response body as something other than the
       # return value.
       #

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -14,7 +14,7 @@ module Grape
     attr_reader :env, :request
 
     def_delegators :request, :params, :headers, :cookies
-    def_delegators :cookies, :each_response_cookies
+    def_delegator :cookies, :response_cookies
 
     class << self
       def new(...)
@@ -403,7 +403,7 @@ module Grape
     end
 
     def build_response_cookies
-      each_response_cookies do |name, value|
+      response_cookies do |name, value|
         cookie_value = value.is_a?(Hash) ? value : { value: value }
         Rack::Utils.set_cookie_header! header, name, cookie_value
       end

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -13,7 +13,7 @@ module Grape
     attr_accessor :block, :source, :options
     attr_reader :env, :request
 
-    def_delegators :request, :params, :headers
+    def_delegators :request, :params, :headers, :cookies
     def_delegators :cookies, :each_response_cookies
 
     class << self

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -13,7 +13,8 @@ module Grape
     attr_accessor :block, :source, :options
     attr_reader :env, :request
 
-    def_delegators :request, :params, :headers, :cookies
+    def_delegators :request, :params, :headers
+    def_delegators :cookies, :each_response_cookies
 
     class << self
       def new(...)
@@ -329,7 +330,7 @@ module Grape
       extend post_extension if post_extension
     end
 
-    %i(befores before_validations after_validations afters finallies).each do |method|
+    %i[befores before_validations after_validations afters finallies].each do |method|
       define_method method do
         namespace_stackable(method)
       end
@@ -402,7 +403,7 @@ module Grape
     end
 
     def build_response_cookies
-      cookies.each_response_cookies do |name, value|
+      each_response_cookies do |name, value|
         cookie_value = value.is_a?(Hash) ? value : { value: value }
         Rack::Utils.set_cookie_header! header, name, cookie_value
       end

--- a/lib/grape/request.rb
+++ b/lib/grape/request.rb
@@ -6,6 +6,7 @@ module Grape
     HTTP_PREFIX = 'HTTP_'
 
     alias rack_params params
+    alias rack_cookies cookies
 
     def initialize(env, build_params_with: nil)
       super(env)
@@ -18,6 +19,10 @@ module Grape
 
     def headers
       @headers ||= build_headers
+    end
+
+    def cookies
+      @cookies ||= Grape::Cookies.new(-> { rack_cookies })
     end
 
     # needs to be public until extensions param_builder are removed

--- a/spec/grape/dsl/inside_route_spec.rb
+++ b/spec/grape/dsl/inside_route_spec.rb
@@ -165,12 +165,6 @@ describe Grape::DSL::InsideRoute do
     end
   end
 
-  describe '#cookies' do
-    it 'returns an instance of Cookies' do
-      expect(subject.cookies).to be_a Grape::Cookies
-    end
-  end
-
   describe '#body' do
     describe 'set' do
       before do


### PR DESCRIPTION
This PR delegates `cookies` to Grape::Request like the actual `params` and `headers` are. Minor tweaks have been made in `Grape::Cookies`:

- Rack's cookies will be read only if the API calls cookies
- Response cookies management is now done with a Set instead of Hash containing `true`
- Uses Forwardable module