### PR TITLE
Less query params parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#2546](https://github.com/ruby-grape/grape/pull/2546): Fix middleware with keywords - [@ericproulx](https://github.com/ericproulx).
 * [#2547](https://github.com/ruby-grape/grape/pull/2547): Remove jsonapi related code - [@ericproulx](https://github.com/ericproulx).
 * [#2548](https://github.com/ruby-grape/grape/pull/2548): Formatting from header acts like versioning from header - [@ericproulx](https://github.com/ericproulx).
+* [#2553](https://github.com/ruby-grape/grape/pull/2553): Less query params parsing - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 2.3.0 (2025-02-08)

--- a/lib/grape/exceptions/conflicting_types.rb
+++ b/lib/grape/exceptions/conflicting_types.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Grape
+  module Exceptions
+    class ConflictingTypes < Base
+      def initialize
+        super(message: compose_message(:conflicting_types), status: 400)
+      end
+    end
+  end
+end

--- a/lib/grape/exceptions/invalid_parameters.rb
+++ b/lib/grape/exceptions/invalid_parameters.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Grape
+  module Exceptions
+    class InvalidParameters < Base
+      def initialize
+        super(message: compose_message(:invalid_parameters), status: 400)
+      end
+    end
+  end
+end

--- a/lib/grape/exceptions/too_deep_parameters.rb
+++ b/lib/grape/exceptions/too_deep_parameters.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Grape
+  module Exceptions
+    class TooDeepParameters < Base
+      def initialize(limit)
+        super(message: compose_message(:too_deep_parameters, limit: limit), status: 400)
+      end
+    end
+  end
+end

--- a/lib/grape/locale/en.yml
+++ b/lib/grape/locale/en.yml
@@ -58,4 +58,6 @@ en:
           problem: 'invalid version header'
           resolution: '%{message}'
         invalid_response: 'Invalid response'
-        query_parsing: 'query params are not parsable'
+        conflicting_types: 'query params contains conflicting types'
+        invalid_parameters: 'query params contains invalid format or byte sequence'
+        too_deep_parameters: 'query params are recursively nested over the specified limit (%{limit})'

--- a/lib/grape/middleware/base.rb
+++ b/lib/grape/middleware/base.rb
@@ -79,7 +79,7 @@ module Grape
       end
 
       def query_params
-        @rack_request.GET
+        rack_request.GET
       rescue Rack::QueryParser::ParamsTooDeepError
         raise Grape::Exceptions::TooDeepParameters.new(Rack::Utils.param_depth_limit)
       rescue Rack::Utils::ParameterTypeError

--- a/lib/grape/middleware/base.rb
+++ b/lib/grape/middleware/base.rb
@@ -6,7 +6,7 @@ module Grape
       include Helpers
       include Grape::DSL::Headers
 
-      attr_reader :app, :env, :options, :rack_request
+      attr_reader :app, :env, :options
 
       # @param [Rack Application] app The standard argument for a Rack middleware.
       # @param [Hash] options A hash of options, simply stored for use by subclasses.

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -39,7 +39,7 @@ module Grape
       private
 
       def rack_response(status, headers, message)
-        message = Rack::Utils.escape_html(message) if headers[Rack::CONTENT_TYPE] == TEXT_HTML
+        message = Rack::Utils.escape_html(message) if headers[Rack::CONTENT_TYPE] == 'text/html'
         Rack::Response.new(Array.wrap(message), Rack::Utils.status_code(status), Grape::Util::Header.new.merge(headers))
       end
 

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -3,7 +3,6 @@
 module Grape
   module Middleware
     class Formatter < Base
-
       def default_options
         {
           default_format: :txt,

--- a/lib/grape/middleware/versioner/param.rb
+++ b/lib/grape/middleware/versioner/param.rb
@@ -20,12 +20,11 @@ module Grape
       #   env['api.version'] => 'v1'
       class Param < Base
         def before
-          potential_version = Rack::Utils.parse_nested_query(env[Rack::QUERY_STRING])[parameter_key]
+          potential_version = query_params[parameter_key]
           return if potential_version.blank?
 
           version_not_found! unless potential_version_match?(potential_version)
-          env[Grape::Env::API_VERSION] = potential_version
-          env[Rack::RACK_REQUEST_QUERY_HASH].delete(parameter_key) if env.key? Rack::RACK_REQUEST_QUERY_HASH
+          env[Grape::Env::API_VERSION] = env[Rack::RACK_REQUEST_QUERY_HASH].delete(parameter_key)
         end
       end
     end

--- a/lib/grape/request.rb
+++ b/lib/grape/request.rb
@@ -37,8 +37,14 @@ module Grape
       @params_builder.call(rack_params).deep_merge!(grape_routing_args)
     rescue EOFError
       raise Grape::Exceptions::EmptyMessageBody.new(content_type)
-    rescue Rack::Multipart::MultipartPartLimitError
+    rescue Rack::Multipart::MultipartPartLimitError, Rack::Multipart::MultipartTotalPartLimitError
       raise Grape::Exceptions::TooManyMultipartFiles.new(Rack::Utils.multipart_part_limit)
+    rescue Rack::QueryParser::ParamsTooDeepError
+      raise Grape::Exceptions::TooDeepParameters.new(Rack::Utils.param_depth_limit)
+    rescue Rack::Utils::ParameterTypeError
+      raise Grape::Exceptions::ConflictingTypes
+    rescue Rack::Utils::InvalidParameterError
+      raise Grape::Exceptions::InvalidParameters
     end
 
     def build_headers

--- a/spec/grape/middleware/base_spec.rb
+++ b/spec/grape/middleware/base_spec.rb
@@ -225,6 +225,22 @@ describe Grape::Middleware::Base do
   end
 
   describe 'query_params' do
+    let(:dummy_middleware) do
+      Class.new(Grape::Middleware::Base) do
+        def before
+          query_params
+        end
+      end
+    end
+
+    let(:app) do
+      context = self
+      Rack::Builder.app do
+        use context.dummy_middleware
+        run ->(_) { [200, {}, ['Yeah']] }
+      end
+    end
+
     context 'when query params are conflicting' do
       it 'raises an ConflictingTypes error' do
         expect { get '/?x[y]=1&x[y]z=2' } .to raise_error(Grape::Exceptions::ConflictingTypes)

--- a/spec/grape/middleware/base_spec.rb
+++ b/spec/grape/middleware/base_spec.rb
@@ -223,4 +223,20 @@ describe Grape::Middleware::Base do
       expect(last_response.headers['X-Test-Overwriting']).to eq('Bye')
     end
   end
+
+  describe 'query_params' do
+    context 'when query params are conflicting' do
+      it 'raises an ConflictingTypes error' do
+        expect { get '/?x[y]=1&x[y]z=2' } .to raise_error(Grape::Exceptions::ConflictingTypes)
+      end
+    end
+
+    context 'when query params is over the specified limit' do
+      let(:query_params) { "foo#{"[a]" * Rack::Utils.param_depth_limit}=bar" }
+
+      it 'raises an ConflictingTypes error' do
+        expect { get "/?foo#{"[a]" * Rack::Utils.param_depth_limit}=bar" } .to raise_error(Grape::Exceptions::TooDeepParameters)
+      end
+    end
+  end
 end

--- a/spec/grape/middleware/base_spec.rb
+++ b/spec/grape/middleware/base_spec.rb
@@ -243,15 +243,15 @@ describe Grape::Middleware::Base do
 
     context 'when query params are conflicting' do
       it 'raises an ConflictingTypes error' do
-        expect { get '/?x[y]=1&x[y]z=2' } .to raise_error(Grape::Exceptions::ConflictingTypes)
+        expect { get '/?x[y]=1&x[y]z=2' }.to raise_error(Grape::Exceptions::ConflictingTypes)
       end
     end
 
     context 'when query params is over the specified limit' do
-      let(:query_params) { "foo#{"[a]" * Rack::Utils.param_depth_limit}=bar" }
+      let(:query_params) { "foo#{'[a]' * Rack::Utils.param_depth_limit}=bar" }
 
       it 'raises an ConflictingTypes error' do
-        expect { get "/?foo#{"[a]" * Rack::Utils.param_depth_limit}=bar" } .to raise_error(Grape::Exceptions::TooDeepParameters)
+        expect { get "/?foo#{'[a]' * Rack::Utils.param_depth_limit}=bar" }.to raise_error(Grape::Exceptions::TooDeepParameters)
       end
     end
   end

--- a/spec/grape/request_spec.rb
+++ b/spec/grape/request_spec.rb
@@ -59,6 +59,78 @@ describe Grape::Request do
         expect(request.params).to eq(ActiveSupport::HashWithIndifferentAccess.new(a: '123', b: 'xyz', c: 'ccc'))
       end
     end
+
+    context 'when rack_params raises an EOF error' do
+      before do
+        allow(request).to receive(:rack_params).and_raise(EOFError)
+      end
+
+      let(:message) { Grape::Exceptions::EmptyMessageBody.new(nil).to_s }
+
+      it 'raises an Grape::Exceptions::EmptyMessageBody' do
+        expect { request.params }.to raise_error(Grape::Exceptions::EmptyMessageBody, message)
+      end
+    end
+
+    context 'when rack_params raises a Rack::Multipart::MultipartPartLimitError' do
+      before do
+        allow(request).to receive(:rack_params).and_raise(Rack::Multipart::MultipartPartLimitError)
+      end
+
+      let(:message) { Grape::Exceptions::TooManyMultipartFiles.new(Rack::Utils.multipart_part_limit).to_s }
+
+      it 'raises an Rack::Multipart::MultipartPartLimitError' do
+        expect { request.params }.to raise_error(Grape::Exceptions::TooManyMultipartFiles, message)
+      end
+    end
+
+    context 'when rack_params raises a Rack::Multipart::MultipartTotalPartLimitError' do
+      before do
+        allow(request).to receive(:rack_params).and_raise(Rack::Multipart::MultipartTotalPartLimitError)
+      end
+
+      let(:message) { Grape::Exceptions::TooManyMultipartFiles.new(Rack::Utils.multipart_part_limit).to_s }
+
+      it 'raises an Rack::Multipart::MultipartPartLimitError' do
+        expect { request.params }.to raise_error(Grape::Exceptions::TooManyMultipartFiles, message)
+      end
+    end
+
+    context 'when rack_params raises a Rack::QueryParser::ParamsTooDeepError' do
+      before do
+        allow(request).to receive(:rack_params).and_raise(Rack::QueryParser::ParamsTooDeepError)
+      end
+
+      let(:message) { Grape::Exceptions::TooDeepParameters.new(Rack::Utils.param_depth_limit).to_s }
+
+      it 'raises a Grape::Exceptions::TooDeepParameters' do
+        expect { request.params }.to raise_error(Grape::Exceptions::TooDeepParameters, message)
+      end
+    end
+
+    context 'when rack_params raises a Rack::Utils::ParameterTypeError' do
+      before do
+        allow(request).to receive(:rack_params).and_raise(Rack::Utils::ParameterTypeError)
+      end
+
+      let(:message) { Grape::Exceptions::ConflictingTypes.new.to_s }
+
+      it 'raises a Grape::Exceptions::ConflictingTypes' do
+        expect { request.params }.to raise_error(Grape::Exceptions::ConflictingTypes, message)
+      end
+    end
+
+    context 'when rack_params raises a Rack::Utils::InvalidParameterError' do
+      before do
+        allow(request).to receive(:rack_params).and_raise(Rack::Utils::InvalidParameterError)
+      end
+
+      let(:message) { Grape::Exceptions::InvalidParameters.new.to_s }
+
+      it 'raises an Rack::Multipart::MultipartPartLimitError' do
+        expect { request.params }.to raise_error(Grape::Exceptions::InvalidParameters, message)
+      end
+    end
   end
 
   describe '#headers' do


### PR DESCRIPTION
This PRs reduces potential query params parsing. Instead of calling `Rack::Utils.parse_nested_query(env[Rack::QUERY_STRING])` directly, Grape will call Rack's function [GET](https://github.com/rack/rack/blob/4f15e7b814922af79605be4b02c5b7c3044ba206/lib/rack/request.rb#L491) that does the same work but keeps the parsed version in `RACK_REQUEST_QUERY_HASH`. This way, parsing will be done at most once.

Also, it fixes #2488 and it comes with a tiny refactor in `Grape::Middleware::Formatter` including comments in the code. Finally, this PR adds a new function named `rack_request` that's create a instance of `Rack::Request` from `env` in `Grape::Middleware::Base`. `Grape::Middleware::Formatter` had already the equivalent but named `request`. This helps for calling `GET` in middlewares and I think user might benefit from it.





