### PR TITLE
Remove unused `Request::DEFAULT_PARAMS_BUILDER` constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#2550](https://github.com/ruby-grape/grape/pull/2550): Drop ActiveSupport 6.0 - [@ericproulx](https://github.com/ericproulx).
 * [#2549](https://github.com/ruby-grape/grape/pull/2549): Delegate cookies management to `Grape::Request` - [@ericproulx](https://github.com/ericproulx).
 * [#2554](https://github.com/ruby-grape/grape/pull/2554): Remove `Grape::Http::Headers` and `Grape::Util::Lazy::Object` - [@ericproulx](https://github.com/ericproulx).
+* [#2556](https://github.com/ruby-grape/grape/pull/2556): Remove unused `Grape::Request::DEFAULT_PARAMS_BUILDER` constant - [@eriklovmo](https://github.com/eriklovmo).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/request.rb
+++ b/lib/grape/request.rb
@@ -2,7 +2,6 @@
 
 module Grape
   class Request < Rack::Request
-    DEFAULT_PARAMS_BUILDER = :hash_with_indifferent_access
     # Based on rack 3 KNOWN_HEADERS
     # https://github.com/rack/rack/blob/4f15e7b814922af79605be4b02c5b7c3044ba206/lib/rack/headers.rb#L10
 


### PR DESCRIPTION
The constant was introduced in 45abe0dd9f18fcc0e1993b1d5a2988135cb216e1 but is never referenced and hasn't been since its inception.