### PR TITLE
New feature : linting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,51 +36,6 @@ jobs:
           - ruby: '2.7'
             gemfile: gemfiles/rack_3_0.gemfile
             specs: 'spec/integration/rack_3_0'
-          - ruby: '3.1'
-            gemfile: gemfiles/grape_entity.gemfile
-            specs: 'spec/integration/grape_entity'
-          - ruby: '3.1'
-            gemfile: gemfiles/hashie.gemfile
-            specs: 'spec/integration/hashie'
-          - ruby: '3.1'
-            gemfile: gemfiles/dry_validation.gemfile
-            specs: 'spec/integration/dry_validation'
-          - ruby: '3.1'
-            gemfile: gemfiles/rails_6_1.gemfile
-            specs: 'spec/integration/rails'
-          - ruby: '3.1'
-            gemfile: gemfiles/rails_7_0.gemfile
-            specs: 'spec/integration/rails'
-          - ruby: '3.1'
-            gemfile: gemfiles/rails_7_1.gemfile
-            specs: 'spec/integration/rails'
-          - ruby: '3.1'
-            gemfile: gemfiles/rails_7_2.gemfile
-            specs: 'spec/integration/rails'
-          - ruby: '3.2'
-            gemfile: gemfiles/grape_entity.gemfile
-            specs: 'spec/integration/grape_entity'
-          - ruby: '3.2'
-            gemfile: gemfiles/hashie.gemfile
-            specs: 'spec/integration/hashie'
-          - ruby: '3.2'
-            gemfile: gemfiles/dry_validation.gemfile
-            specs: 'spec/integration/dry_validation'
-          - ruby: '3.2'
-            gemfile: gemfiles/rails_6_1.gemfile
-            specs: 'spec/integration/rails'
-          - ruby: '3.2'
-            gemfile: gemfiles/rails_7_0.gemfile
-            specs: 'spec/integration/rails'
-          - ruby: '3.2'
-            gemfile: gemfiles/rails_7_1.gemfile
-            specs: 'spec/integration/rails'
-          - ruby: '3.2'
-            gemfile: gemfiles/rails_7_2.gemfile
-            specs: 'spec/integration/rails'
-          - ruby: '3.2'
-            gemfile: gemfiles/rails_8_0.gemfile
-            specs: 'spec/integration/rails'
           - ruby: '3.3'
             gemfile: gemfiles/grape_entity.gemfile
             specs: 'spec/integration/grape_entity'
@@ -103,30 +58,6 @@ jobs:
             gemfile: gemfiles/rails_7_2.gemfile
             specs: 'spec/integration/rails'
           - ruby: '3.3'
-            gemfile: gemfiles/rails_8_0.gemfile
-            specs: 'spec/integration/rails'
-          - ruby: '3.4'
-            gemfile: gemfiles/grape_entity.gemfile
-            specs: 'spec/integration/grape_entity'
-          - ruby: '3.4'
-            gemfile: gemfiles/hashie.gemfile
-            specs: 'spec/integration/hashie'
-          - ruby: '3.4'
-            gemfile: gemfiles/dry_validation.gemfile
-            specs: 'spec/integration/dry_validation'
-          - ruby: '3.4'
-            gemfile: gemfiles/rails_6_1.gemfile
-            specs: 'spec/integration/rails'
-          - ruby: '3.4'
-            gemfile: gemfiles/rails_7_0.gemfile
-            specs: 'spec/integration/rails'
-          - ruby: '3.4'
-            gemfile: gemfiles/rails_7_1.gemfile
-            specs: 'spec/integration/rails'
-          - ruby: '3.4'
-            gemfile: gemfiles/rails_7_2.gemfile
-            specs: 'spec/integration/rails'
-          - ruby: '3.4'
             gemfile: gemfiles/rails_8_0.gemfile
             specs: 'spec/integration/rails'
         exclude:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,51 @@ jobs:
           - ruby: '2.7'
             gemfile: gemfiles/rack_3_0.gemfile
             specs: 'spec/integration/rack_3_0'
+          - ruby: '3.1'
+            gemfile: gemfiles/grape_entity.gemfile
+            specs: 'spec/integration/grape_entity'
+          - ruby: '3.1'
+            gemfile: gemfiles/hashie.gemfile
+            specs: 'spec/integration/hashie'
+          - ruby: '3.1'
+            gemfile: gemfiles/dry_validation.gemfile
+            specs: 'spec/integration/dry_validation'
+          - ruby: '3.1'
+            gemfile: gemfiles/rails_6_1.gemfile
+            specs: 'spec/integration/rails'
+          - ruby: '3.1'
+            gemfile: gemfiles/rails_7_0.gemfile
+            specs: 'spec/integration/rails'
+          - ruby: '3.1'
+            gemfile: gemfiles/rails_7_1.gemfile
+            specs: 'spec/integration/rails'
+          - ruby: '3.1'
+            gemfile: gemfiles/rails_7_2.gemfile
+            specs: 'spec/integration/rails'
+          - ruby: '3.2'
+            gemfile: gemfiles/grape_entity.gemfile
+            specs: 'spec/integration/grape_entity'
+          - ruby: '3.2'
+            gemfile: gemfiles/hashie.gemfile
+            specs: 'spec/integration/hashie'
+          - ruby: '3.2'
+            gemfile: gemfiles/dry_validation.gemfile
+            specs: 'spec/integration/dry_validation'
+          - ruby: '3.2'
+            gemfile: gemfiles/rails_6_1.gemfile
+            specs: 'spec/integration/rails'
+          - ruby: '3.2'
+            gemfile: gemfiles/rails_7_0.gemfile
+            specs: 'spec/integration/rails'
+          - ruby: '3.2'
+            gemfile: gemfiles/rails_7_1.gemfile
+            specs: 'spec/integration/rails'
+          - ruby: '3.2'
+            gemfile: gemfiles/rails_7_2.gemfile
+            specs: 'spec/integration/rails'
+          - ruby: '3.2'
+            gemfile: gemfiles/rails_8_0.gemfile
+            specs: 'spec/integration/rails'
           - ruby: '3.3'
             gemfile: gemfiles/grape_entity.gemfile
             specs: 'spec/integration/grape_entity'
@@ -58,6 +103,30 @@ jobs:
             gemfile: gemfiles/rails_7_2.gemfile
             specs: 'spec/integration/rails'
           - ruby: '3.3'
+            gemfile: gemfiles/rails_8_0.gemfile
+            specs: 'spec/integration/rails'
+          - ruby: '3.4'
+            gemfile: gemfiles/grape_entity.gemfile
+            specs: 'spec/integration/grape_entity'
+          - ruby: '3.4'
+            gemfile: gemfiles/hashie.gemfile
+            specs: 'spec/integration/hashie'
+          - ruby: '3.4'
+            gemfile: gemfiles/dry_validation.gemfile
+            specs: 'spec/integration/dry_validation'
+          - ruby: '3.4'
+            gemfile: gemfiles/rails_6_1.gemfile
+            specs: 'spec/integration/rails'
+          - ruby: '3.4'
+            gemfile: gemfiles/rails_7_0.gemfile
+            specs: 'spec/integration/rails'
+          - ruby: '3.4'
+            gemfile: gemfiles/rails_7_1.gemfile
+            specs: 'spec/integration/rails'
+          - ruby: '3.4'
+            gemfile: gemfiles/rails_7_2.gemfile
+            specs: 'spec/integration/rails'
+          - ruby: '3.4'
             gemfile: gemfiles/rails_8_0.gemfile
             specs: 'spec/integration/rails'
         exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#2549](https://github.com/ruby-grape/grape/pull/2549): Delegate cookies management to `Grape::Request` - [@ericproulx](https://github.com/ericproulx).
 * [#2554](https://github.com/ruby-grape/grape/pull/2554): Remove `Grape::Http::Headers` and `Grape::Util::Lazy::Object` - [@ericproulx](https://github.com/ericproulx).
 * [#2556](https://github.com/ruby-grape/grape/pull/2556): Remove unused `Grape::Request::DEFAULT_PARAMS_BUILDER` constant - [@eriklovmo](https://github.com/eriklovmo).
+* [#2557](https://github.com/ruby-grape/grape/pull/2557): Add lint! - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@
     - [Header](#header)
     - [Accept-Version Header](#accept-version-header)
     - [Param](#param)
+- [Linting](#linting)
+  - [Bug in Rack::ETag under Rack 3.X](#bug-in-racketag-under-rack-3x)
 - [Describing Methods](#describing-methods)
 - [Configuration](#configuration)
 - [Parameters](#parameters)
@@ -649,6 +651,25 @@ version 'v1', using: :param, parameter: 'v'
 
     curl http://localhost:9292/statuses/public_timeline?v=v1
 
+
+## Linting
+
+You can check if your API is in conformance with [Rack's specification](https://github.com/rack/rack/blob/main/SPEC.rdoc) by calling `lint!` at the API level or through [configuration](#configuration):
+```ruby
+# API Level
+class Api < Grape::API
+  lint!
+end
+# OR through configuration
+Grape.configure do |config|
+  config.lint = true
+end
+# OR
+Grape.config.lint = true
+```
+
+### Bug in Rack::ETag under Rack 3.X
+If you're using Rack 3.X and the `Rack::Etag` middleware (used by [Rails](https://guides.rubyonrails.org/rails_on_rack.html#inspecting-middleware-stack)), a [bug](https://github.com/rack/rack/pull/2324) related to linting has been fixed in [3.1.13](https://github.com/rack/rack/blob/v3.1.13/CHANGELOG.md#3113---2025-04-13) and [3.0.15](https://github.com/rack/rack/blob/v3.1.13/CHANGELOG.md#3015---2025-04-13) respectively.
 
 ## Describing Methods
 

--- a/README.md
+++ b/README.md
@@ -654,17 +654,19 @@ version 'v1', using: :param, parameter: 'v'
 
 ## Linting
 
-You can check if your API is in conformance with [Rack's specification](https://github.com/rack/rack/blob/main/SPEC.rdoc) by calling `lint!` at the API level or through [configuration](#configuration):
+You can check whether your API is in conformance with the [Rack's specification](https://github.com/rack/rack/blob/main/SPEC.rdoc) by calling `lint!` at the API level or through [configuration](#configuration).
+
 ```ruby
-# API Level
 class Api < Grape::API
   lint!
 end
-# OR through configuration
+```
+```ruby
 Grape.configure do |config|
   config.lint = true
 end
-# OR
+```
+```ruby
 Grape.config.lint = true
 ```
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -130,7 +130,7 @@ When using together with `Grape::Extensions::Hash::ParamBuilder`, `route_param` 
 This was a regression introduced by [#2326](https://github.com/ruby-grape/grape/pull/2326) in Grape v1.8.0.
 
 ```ruby
-grape.configure do |config|
+Grape.configure do |config|
   config.param_builder = Grape::Extensions::Hash::ParamBuilder
 end
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ ENV RUBYOPT --enable-frozen-string-literal --yjit
 ENV LD_PRELOAD libjemalloc.so.2
 ENV MALLOC_CONF dirty_decay_ms:1000,narenas:2,background_thread:true
 
-RUN apk add --update --no-cache make gcc git libc-dev gcompat jemalloc && \
+RUN apk add --update --no-cache make gcc git libc-dev yaml-dev gcompat jemalloc && \
     gem update --system && gem install bundler
 
 WORKDIR $LIB_PATH

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -75,7 +75,7 @@ module Grape
 
   configure do |config|
     config.param_builder = :hash_with_indifferent_access
-    config.lint_api = false
+    config.lint = false
     config.compile_methods!
   end
 end

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -75,6 +75,7 @@ module Grape
 
   configure do |config|
     config.param_builder = :hash_with_indifferent_access
+    config.lint_api = false
     config.compile_methods!
   end
 end

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -81,8 +81,8 @@ module Grape
           namespace_inheritable(:do_not_route_options, true)
         end
 
-        def lint_api!
-          namespace_inheritable(:lint_api, true)
+        def lint!
+          namespace_inheritable(:lint, true)
         end
 
         def do_not_document!

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -81,6 +81,10 @@ module Grape
           namespace_inheritable(:do_not_route_options, true)
         end
 
+        def lint_api!
+          namespace_inheritable(:lint_api, true)
+        end
+
         def do_not_document!
           namespace_inheritable(:do_not_document, true)
         end

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -358,7 +358,7 @@ module Grape
       format = namespace_inheritable(:format)
 
       stack.use Rack::Head
-      stack.use Rack::Lint if lint_api?
+      stack.use Rack::Lint if lint?
       stack.use Class.new(Grape::Middleware::Error),
                 helpers: helpers,
                 format: format,
@@ -410,8 +410,8 @@ module Grape
       end
     end
 
-    def lint_api?
-      namespace_inheritable(:lint_api) || Grape.config.lint_api
+    def lint?
+      namespace_inheritable(:lint) || Grape.config.lint
     end
   end
 end

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -358,6 +358,7 @@ module Grape
       format = namespace_inheritable(:format)
 
       stack.use Rack::Head
+      stack.use Rack::Lint if lint_api?
       stack.use Class.new(Grape::Middleware::Error),
                 helpers: helpers,
                 format: format,
@@ -407,6 +408,10 @@ module Grape
         cookie_value = value.is_a?(Hash) ? value : { value: value }
         Rack::Utils.set_cookie_header! header, name, cookie_value
       end
+    end
+
+    def lint_api?
+      namespace_inheritable(:lint_api) || Grape.config.lint_api
     end
   end
 end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -4739,10 +4739,10 @@ describe Grape::API do
     end
   end
 
-  describe '.lint_api!' do
+  describe '.lint!' do
     let(:app) do
       Class.new(described_class) do
-        lint_api!
+        lint!
         get '/' do
           status 42
         end
@@ -4750,9 +4750,9 @@ describe Grape::API do
     end
 
     around do |example|
-      Grape.config.lint_api = false
+      Grape.config.lint = false
       example.run
-      Grape.config.lint_api = true
+      Grape.config.lint = true
     end
 
     it 'raises a Rack::Lint error' do

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -4756,7 +4756,8 @@ describe Grape::API do
     end
 
     it 'raises a Rack::Lint error' do
-      expect { get '/' }.to raise_error(Rack::Lint::LintError, 'Status must be an Integer >=100')
+      # Status must be an Integer >= 100
+      expect { get '/' }.to raise_error(Rack::Lint::LintError)
     end
   end
 end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -4750,9 +4750,11 @@ describe Grape::API do
     end
 
     around do |example|
+      @lint = Grape.config.lint
       Grape.config.lint = false
       example.run
-      Grape.config.lint = true
+    ensure
+      Grape.config.lint = @lint
     end
 
     it 'raises a Rack::Lint error' do

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -4738,4 +4738,25 @@ describe Grape::API do
       expect(last_response.body).to eq('unknown params_builder: unknown')
     end
   end
+
+  describe '.lint_api!' do
+    let(:app) do
+      Class.new(described_class) do
+        lint_api!
+        get '/' do
+          status 42
+        end
+      end
+    end
+
+    around do |example|
+      Grape.config.lint_api = false
+      example.run
+      Grape.config.lint_api = true
+    end
+
+    it 'raises a Rack::Lint error' do
+      expect { get '/' }.to raise_error(Rack::Lint::LintError, 'Status must be an Integer >=100')
+    end
+  end
 end

--- a/spec/integration/rails/mounting_spec.rb
+++ b/spec/integration/rails/mounting_spec.rb
@@ -17,7 +17,7 @@ describe 'Rails', if: defined?(Rails) do
       ActiveSupport::Dependencies.autoload_paths = []
       ActiveSupport::Dependencies.autoload_once_paths = []
 
-      Class.new(Rails::Application) do
+      app = Class.new(Rails::Application) do
         config.eager_load = false
         config.load_defaults "#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}"
         config.api_only = true
@@ -28,15 +28,16 @@ describe 'Rails', if: defined?(Rails) do
           mount GrapeApi => '/'
 
           get 'up', to: lambda { |_env|
-            ['200', {}, ['hello world']]
+            [200, {}, ['hello world']]
           }
         end
       end
+      app.initialize!
+      Rack::Lint.new(app)
     end
 
     before do
       stub_const('GrapeApi', api)
-      app.initialize!
     end
 
     it 'cascades' do

--- a/spec/integration/rails/mounting_spec.rb
+++ b/spec/integration/rails/mounting_spec.rb
@@ -4,6 +4,7 @@ describe 'Rails', if: defined?(Rails) do
   context 'rails mounted' do
     let(:api) do
       Class.new(Grape::API) do
+        lint!
         get('/test_grape') { 'rails mounted' }
       end
     end
@@ -17,7 +18,7 @@ describe 'Rails', if: defined?(Rails) do
       ActiveSupport::Dependencies.autoload_paths = []
       ActiveSupport::Dependencies.autoload_once_paths = []
 
-      app = Class.new(Rails::Application) do
+      Class.new(Rails::Application) do
         config.eager_load = false
         config.load_defaults "#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}"
         config.api_only = true
@@ -32,12 +33,11 @@ describe 'Rails', if: defined?(Rails) do
           }
         end
       end
-      app.initialize!
-      Rack::Lint.new(app)
     end
 
     before do
       stub_const('GrapeApi', api)
+      app.initialize!
     end
 
     it 'cascades' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ Grape.deprecator.behavior = :raise
   end
 end
 
+Grape.config.lint_api = true # lint all apis by default
 Grape::Util::Registry.include(Deregister)
 # issue with ruby 2.7 with ^. We need to extend it again
 Grape::Validations.extend(Grape::Util::Registry) if Gem::Version.new(RUBY_VERSION).release < Gem::Version.new('3.0')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ Grape.deprecator.behavior = :raise
   end
 end
 
-Grape.config.lint_api = true # lint all apis by default
+Grape.config.lint = true # lint all apis by default
 Grape::Util::Registry.include(Deregister)
 # issue with ruby 2.7 with ^. We need to extend it again
 Grape::Validations.extend(Grape::Util::Registry) if Gem::Version.new(RUBY_VERSION).release < Gem::Version.new('3.0')


### PR DESCRIPTION
This PR adds a linting feature that can activated through `Grape.config.lint = true` or `lint!` in a `Grape::Api`.
Suggested in this [comment](https://github.com/ruby-grape/grape/issues/2334#issuecomment-2795024096).

By design, Grape's CI has `Grape.config.lint = true`, so all specs calling an endpoint are linted.
