### PR TITLE
enable_frozen_string_literal in CI

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -27,7 +27,7 @@ jobs:
         bundler-cache: true
 
     - name: Run tests
-      run: "RUBYOPT='--enable=frozen-string-literal --debug=frozen-string-literal' bundle exec rspec"
+      run: "RUBYOPT='--enable=frozen-string-literal' bundle exec rspec"
 
     - name: Coveralls
       uses: coverallsapp/github-action@v2

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -27,7 +27,7 @@ jobs:
         bundler-cache: true
 
     - name: Run tests
-      run: bundle exec rake spec
+      run: "RUBYOPT='--enable=frozen-string-literal --debug=frozen-string-literal' bundle exec rspec"
 
     - name: Coveralls
       uses: coverallsapp/github-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
         bundler-cache: true
 
     - name: Run Tests (${{ matrix.specs }})
-      run: bundle exec rspec ${{ matrix.specs }}
+      run: "RUBYOPT='--enable=frozen-string-literal --debug=frozen-string-literal' bundle exec rspec ${{ matrix.specs }}"
 
     - name: Coveralls
       uses: coverallsapp/github-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
         bundler-cache: true
 
     - name: Run Tests (${{ matrix.specs }})
-      run: "RUBYOPT='--enable=frozen-string-literal --debug=frozen-string-literal' bundle exec rspec ${{ matrix.specs }}"
+      run: "RUBYOPT='--enable=frozen-string-literal' bundle exec rspec ${{ matrix.specs }}"
 
     - name: Coveralls
       uses: coverallsapp/github-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#2549](https://github.com/ruby-grape/grape/pull/2549): Delegate cookies management to `Grape::Request` - [@ericproulx](https://github.com/ericproulx).
 * [#2554](https://github.com/ruby-grape/grape/pull/2554): Remove `Grape::Http::Headers` and `Grape::Util::Lazy::Object` - [@ericproulx](https://github.com/ericproulx).
 * [#2556](https://github.com/ruby-grape/grape/pull/2556): Remove unused `Grape::Request::DEFAULT_PARAMS_BUILDER` constant - [@eriklovmo](https://github.com/eriklovmo).
+* [#2558](https://github.com/ruby-grape/grape/pull/2558): Add Ruby's option `enable_frozen_string_literal` in CI - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes


### PR DESCRIPTION
This PR will enable `frozen_string_literal` at Ruby's level when running CI. It's already done locally through the our Docker setup but I thought it would be great to also have it in the CI.

Inspired from this [gist](https://gist.github.com/fxn/bf4eed2505c76f4fca03ab48c43adc72#how-to-help)