### PR TITLE
Fix memory leak when using recognize_path inside Grape::API

### DIFF
--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -5,7 +5,7 @@ module Grape
   # should subclass this class in order to build an API.
   class API
     # Class methods that we want to call on the API rather than on the API object
-    NON_OVERRIDABLE = %i[call call! configuration compile! inherited].freeze
+    NON_OVERRIDABLE = %i[call call! configuration compile! inherited recognize_path].freeze
 
     class Boolean
       def self.build(val)

--- a/spec/support/cookie_jar.rb
+++ b/spec/support/cookie_jar.rb
@@ -1,15 +1,10 @@
 # frozen_string_literal: true
 
 require 'uri'
-
-module Rack
-  class MockResponse
-    def cookie_jar
-      @cookie_jar ||= Array(headers[Rack::SET_COOKIE]).flat_map { |h| h.split("\n") }.map { |c| Cookie.new(c).to_h }
-    end
-
+module Spec
+  module Support
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
-    class Cookie
+    class CookieJar
       attr_reader :attributes
 
       def initialize(raw)
@@ -49,6 +44,14 @@ module Rack
           unescape(value)
         end
       end
+    end
+  end
+end
+
+module Rack
+  class MockResponse
+    def cookie_jar
+      @cookie_jar ||= Array(headers[Rack::SET_COOKIE]).flat_map { |h| h.split("\n") }.map { |c| Spec::Support::CookieJar.new(c).to_h }
     end
   end
 end


### PR DESCRIPTION
Fix #2566 