### PR TITLE
Remove obsolete docker-compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 volumes:
   gems:
 


### PR DESCRIPTION
This PR removes the obsolete docker-compose version specification from the configuration file.