### PR TITLE
Upgrade rubocop to 1.75.8

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,8 +7,10 @@ AllCops:
     - bin/**/*
 
 require:
-  - rubocop-performance
   - rubocop-rspec
+
+plugins:
+  - rubocop-performance
 
 inherit_from: .rubocop_todo.yml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#2557](https://github.com/ruby-grape/grape/pull/2557): Add `lint!` - [@ericproulx](https://github.com/ericproulx).
 * [#2561](https://github.com/ruby-grape/grape/pull/2561): Optimize hash alloc for middleware's default options - [@ericproulx](https://github.com/ericproulx).
 * [#2563](https://github.com/ruby-grape/grape/pull/2563): Update `Grape::Middleware::Auth::Base` - [@ericproulx](https://github.com/ericproulx).
+* [#2571](https://github.com/ruby-grape/grape/pull/2571): Update RuboCop 1.75.8 - [@pieterocp](https://github.com/pieterocp).
 * Your contribution here.
 
 #### Fixes

--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ group :development, :test do
   gem 'builder', require: false
   gem 'bundler'
   gem 'rake'
-  gem 'rubocop', '1.71.2', require: false
-  gem 'rubocop-performance', '1.23.1', require: false
+  gem 'rubocop', '1.75.8', require: false
+  gem 'rubocop-performance', '1.25.0', require: false
   gem 'rubocop-rspec', '3.4.0', require: false
 end
 

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1422,7 +1422,7 @@ describe Grape::API do
         def initialize(app, *args)
           @args = args
           @app = app
-          @block = block_given? ? true : nil
+          @block = block_given? || nil
         end
 
         def call(env)
@@ -4536,8 +4536,8 @@ describe Grape::API do
 
     let(:shared_api_module) do
       Module.new do
-        # rubocop:disable Style/ExplicitBlockArgument because this causes
-        #   the underlying issue in this form
+        # rubocop:disable Style/ExplicitBlockArgument -- because
+        # this causes the underlying issue in this form
         def uniqe_id_route
           params do
             use :unique_id

--- a/spec/support/integer_helpers.rb
+++ b/spec/support/integer_helpers.rb
@@ -3,7 +3,7 @@
 module Spec
   module Support
     module Helpers
-      INTEGER_CLASS_NAME = 0.to_i.class.to_s.freeze
+      INTEGER_CLASS_NAME = 0.class.to_s.freeze
 
       def integer_class_name
         INTEGER_CLASS_NAME


### PR DESCRIPTION
Off the back of looking at using standard, had to run a few upgrades to get it to work, so porting these minor updates over.

Rspec and rubocop run on my local and _should_ also run well in the actions.