### PR TITLE
Revisit endpoint helpers and Grape::Middleware::Error helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#2573](https://github.com/ruby-grape/grape/pull/2573): Clean up deprecated code - [@ericproulx](https://github.com/ericproulx).
 * [#2575](https://github.com/ruby-grape/grape/pull/2575): Refactor Api description class - [@ericproulx](https://github.com/ericproulx).
 * [#2577](https://github.com/ruby-grape/grape/pull/2577): Deprecate `return` in endpoint execution - [@ericproulx](https://github.com/ericproulx).
+* [#13](https://github.com/ericproulx/grape/pull/13): Refactor endpoint helpers and error middleware integration - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -16,11 +16,6 @@ module Grape
         }.freeze
       }.freeze
 
-      def initialize(app, **options)
-        super
-        self.class.include(options[:helpers]) if options[:helpers]
-      end
-
       def call!(env)
         @env = env
         error_response(catch(:error) { return @app.call(@env) })
@@ -103,12 +98,7 @@ module Grape
       end
 
       def run_rescue_handler(handler, error, endpoint)
-        if handler.instance_of?(Symbol)
-          raise NoMethodError, "undefined method '#{handler}'" unless respond_to?(handler)
-
-          handler = public_method(handler)
-        end
-
+        handler = endpoint.public_method(handler) if handler.instance_of?(Symbol)
         response = catch(:error) do
           handler.arity.zero? ? endpoint.instance_exec(&handler) : endpoint.instance_exec(error, &handler)
         end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -2369,7 +2369,7 @@ describe Grape::API do
       subject.rescue_from :all, with: :not_exist_method
       subject.get('/rescue_method') { raise StandardError }
 
-      expect { get '/rescue_method' }.to raise_error(NoMethodError, /^undefined method 'not_exist_method'/)
+      expect { get '/rescue_method' }.to raise_error(NameError, /^undefined method [`']not_exist_method'/)
     end
 
     it 'correctly chooses exception handler if :all handler is specified' do

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -735,18 +735,9 @@ describe Grape::Endpoint do
 
   describe 'NameError' do
     context 'when referencing an undefined local variable or method' do
-      let(:error_message) do
-        if Gem::Version.new(RUBY_VERSION).release <= Gem::Version.new('3.2')
-          %r{undefined local variable or method `undefined_helper' for #<Class:0x[0-9a-fA-F]+> in '/hey' endpoint}
-        else
-          opening_quote = Gem::Version.new(RUBY_VERSION).release >= Gem::Version.new('3.4') ? "'" : '`'
-          /undefined local variable or method #{opening_quote}undefined_helper' for/
-        end
-      end
-
       it 'raises NameError but stripping the internals of the Grape::Endpoint class and including the API route' do
         subject.get('/hey') { undefined_helper }
-        expect { get '/hey' }.to raise_error(NameError, error_message)
+        expect { get '/hey' }.to raise_error(NameError, /^undefined local variable or method ['`]undefined_helper' for/)
       end
     end
   end


### PR DESCRIPTION
### Summary

This PR refactors the integration of endpoint helpers and error middleware in Grape, focusing on clarity, maintainability, and improved error handling. The changes are motivated by the need to simplify the endpoint lifecycle, ensure correct helper inclusion, and make error handling more robust and intuitive.

### Key Changes

- **Endpoint Helpers Refactor:**
  - Helpers are now included via  at endpoint initialization, ensuring they are available in the endpoint context without polluting the global scope.
  - The lazy initialization logic is simplified, and the block handling for endpoints is made more explicit and robust.

- **Middleware Error Handling:**
  - The dynamic inclusion of helpers in  is removed. Error handlers always been executed in the context of the endpoint.
  - The error handler logic is updated to use the endpoint's method for symbol handlers, improving encapsulation and error reporting.

- **Spec Update:**
  - The spec is updated to expect a  instead of a  when a rescue handler method is missing, reflecting the new error handling approach.

### Motivation

- Reduces complexity in how helpers are managed and included in endpoints.
- Ensures that error handling is always performed in the correct context, avoiding subtle bugs and making the codebase easier to reason about.
- Aligns error reporting with Ruby conventions, making debugging and maintenance easier for contributors.

### Impact

- No breaking changes to the public API, but internal behavior is more predictable and maintainable.
- Error messages for missing rescue handlers are now more accurate and Ruby-idiomatic.
- The codebase is easier to extend for future improvements in endpoint and middleware behavior.

---

Please review the implementation and let me know if further clarifications or tests are needed.