### PR TITLE
Fix leaky slash when normalizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 * [#2573](https://github.com/ruby-grape/grape/pull/2573): Clean up deprecated code - [@ericproulx](https://github.com/ericproulx).
 * [#2575](https://github.com/ruby-grape/grape/pull/2575): Refactor Api description class - [@ericproulx](https://github.com/ericproulx).
 * [#2577](https://github.com/ruby-grape/grape/pull/2577): Deprecate `return` in endpoint execution - [@ericproulx](https://github.com/ericproulx).
-* [#13](https://github.com/ericproulx/grape/pull/13): Refactor endpoint helpers and error middleware integration - [@ericproulx](https://github.com/ericproulx).
+* [#2580](https://github.com/ruby-grape/grape/pull/2580): Refactor endpoint helpers and error middleware integration - [@ericproulx](https://github.com/ericproulx).
+* [#2582](https://github.com/ruby-grape/grape/pull/2582): Fix leaky slash when normalizing - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -12,10 +12,11 @@ module Grape
     #     normalize_path("/%ab")  # => "/%AB"
     # https://github.com/rails/rails/blob/00cc4ff0259c0185fe08baadaa40e63ea2534f6e/actionpack/lib/action_dispatch/journey/router/utils.rb#L19
     def self.normalize_path(path)
-      return +'/' unless path
+      return '/' unless path
+      return path if path == '/'
 
       # Fast path for the overwhelming majority of paths that don't need to be normalized
-      return path.dup if path == '/' || (path.start_with?('/') && !(path.end_with?('/') || path.match?(%r{%|//})))
+      return path.dup if path.start_with?('/') && !(path.end_with?('/') || path.match?(%r{%|//}))
 
       # Slow path
       encoding = path.encoding


### PR DESCRIPTION
## Fix leaky slash handling in router

### Summary
This PR addresses an issue with leaky slash handling in the router. While profiling [grape-on-rack](https://github.com/ruby-grape/grape-on-rack) locally, I found multiple `/` that were retained for nothing.

```
Retained String Report
-----------------------------------
        28  "/"
        27  grape-2.4.0/lib/grape/router.rb:18
         1  grape-2.4.0/lib/grape/router.rb:22
```