### PR TITLE
Replace methods by singleton_methods when overriding them.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#2581](https://github.com/ruby-grape/grape/pull/2581): Delegate `to_s` in Grape::API::Instance - [@ericproulx](https://github.com/ericproulx).
 * [#2582](https://github.com/ruby-grape/grape/pull/2582): Fix leaky slash when normalizing - [@ericproulx](https://github.com/ericproulx).
 * [#2583](https://github.com/ruby-grape/grape/pull/2583): Optimize api parameter documentation and memory usage - [@ericproulx](https://github.com/ericproulx).
+* [#2585](https://github.com/ruby-grape/grape/pull/2585): Optimize mount methods overriding - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -5,7 +5,7 @@ module Grape
   # should subclass this class in order to build an API.
   class API
     # Class methods that we want to call on the API rather than on the API object
-    NON_OVERRIDABLE = %i[call call! configuration compile! inherited recognize_path].freeze
+    NON_OVERRIDABLE = %i[call call! configuration compile! inherited recognize_path to_s].freeze
 
     Helpers = Grape::DSL::Helpers::BaseHelper
 
@@ -51,7 +51,7 @@ module Grape
 
       # Redefines all methods so that are forwarded to add_setup and be recorded
       def override_all_methods!
-        (base_instance.methods - Class.methods - NON_OVERRIDABLE).each do |method_override|
+        (base_instance.singleton_methods - NON_OVERRIDABLE).each do |method_override|
           define_singleton_method(method_override) do |*args, &block|
             add_setup(method: method_override, args: args, block: block)
           end


### PR DESCRIPTION
## Overview

This PR refines the mechanism for overriding class methods on the API's base instance to ensure proper setup recording for remountable APIs in Grape.

## Key Change

- **Replaced `methods` with `singleton_methods`:**  
  The logic that dynamically overrides methods on the API class now uses `singleton_methods` instead of `methods`. This ensures that only singleton methods defined directly on the base instance are considered for overriding, rather than all methods (including inherited ones).

## Motivation

Previously, using `methods` could result in unintended methods being overridden, including those inherited from parent classes or modules. By switching to `singleton_methods`, we ensure that only the relevant, directly-defined methods are overridden for setup recording. This makes the remounting and inheritance behavior of Grape APIs more predictable and robust.

## Impact

- No breaking changes to the public API.
- Internal API setup and remounting are now more precise and maintainable.
- Lower memory foot print

## Testing

- All existing specs pass.
- Manual testing confirms that remounting and inheritance behave as expected.