### PR TITLE
Just keep `helpers` method in the public scope.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 #### Fixes
 
+* [#2586](https://github.com/ruby-grape/grape/pull/2586): Limit helpers DSL public scope - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 2.4.0 (2025-06-18)

--- a/lib/grape/dsl/helpers.rb
+++ b/lib/grape/dsl/helpers.rb
@@ -34,7 +34,7 @@ module Grape
         include_all_in_scope if !block && new_modules.empty?
       end
 
-      protected
+      private
 
       def include_new_modules(modules)
         return if modules.empty?

--- a/spec/grape/dsl/helpers_spec.rb
+++ b/spec/grape/dsl/helpers_spec.rb
@@ -113,5 +113,11 @@ describe Grape::DSL::Helpers do
         expect { api_class }.not_to raise_exception
       end
     end
+
+    context 'public scope' do
+      it 'returns helpers only' do
+        expect(Class.new { extend Grape::DSL::Helpers }.singleton_methods - Class.methods).to contain_exactly(:helpers)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Description

This PR changes the visibility of the helper methods in `Grape::DSL::Helpers` from `protected` to `private`. This ensures that these internal methods are not accessible as part of the public or protected API, improving encapsulation and reducing the risk of accidental usage outside their intended scope.

#### Change Summary
- Changed `protected` to `private` for internal methods in `lib/grape/dsl/helpers.rb`.

#### Rationale
Marking these methods as `private` clarifies their intended usage and helps prevent misuse by consumers of the DSL.