### PR TITLE
the delete request with an empty hash/array should respond with a 200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * [#2581](https://github.com/ruby-grape/grape/pull/2581): Delegate `to_s` in Grape::API::Instance - [@ericproulx](https://github.com/ericproulx).
 * [#2582](https://github.com/ruby-grape/grape/pull/2582): Fix leaky slash when normalizing - [@ericproulx](https://github.com/ericproulx).
 * [#2583](https://github.com/ruby-grape/grape/pull/2583): Optimize api parameter documentation and memory usage - [@ericproulx](https://github.com/ericproulx).
+* [#2587](https://github.com/ruby-grape/grape/pull/2587): Delete request should respond with an 200 status code when a empty array/hash - [@elvinra](https://github.com/Elvinra).
+
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -213,7 +213,7 @@ module Grape
           if request.post?
             201
           elsif request.delete?
-            if instance_variable_defined?(:@body) && @body.present?
+            if instance_variable_defined?(:@body) && (@body.respond_to?(:each) || @body.present?)
               200
             else
               204

--- a/spec/grape/dsl/inside_route_spec.rb
+++ b/spec/grape/dsl/inside_route_spec.rb
@@ -162,6 +162,20 @@ describe Grape::DSL::InsideRoute do
       expect(subject.status).to eq 200
     end
 
+    it 'defaults to 200 on DELETE with empty array is present' do
+      request = Grape::Request.new(Rack::MockRequest.env_for('/', method: Rack::DELETE))
+      subject.body []
+      expect(subject).to receive(:request).and_return(request).twice
+      expect(subject.status).to eq 200
+    end
+
+    it 'defaults to 200 on DELETE with empty hash is present' do
+      request = Grape::Request.new(Rack::MockRequest.env_for('/', method: Rack::DELETE))
+      subject.body({})
+      expect(subject).to receive(:request).and_return(request).twice
+      expect(subject.status).to eq 200
+    end
+
     it 'returns status set' do
       subject.status 501
       expect(subject.status).to eq 501


### PR DESCRIPTION
On the version 1.6 of grape the behavior was to send a 204 no content with the body when an empty array was supplied

So after the migration to the latest version, the delete request now send a 204 no content, but the body is empty.
The only way to have the body is to force an "status 200".

So the correct status code should be 200 when an empty Hash/Array is supplied to the body.

"present?" return false on a empty array/hash :/