### PR TITLE
Add irb in development to fix bundle console warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :development do
   gem 'guard'
   gem 'guard-rspec'
   gem 'guard-rubocop'
+  gem 'irb'
 end
 
 group :test do


### PR DESCRIPTION
This PR adds the `irb` gem to the development group in the Gemfile to resolve warnings that occur when running `bundle console`.

When `bundle console` is executed without the `irb` gem explicitly listed in the Gemfile, bundler shows warnings about missing dependencies. Adding `irb` to the development group ensures a clean console experience for developers.

**Changes:**
- Added `gem 'irb'` to the `:development` group in Gemfile

**Testing:**
- Verified that `bundle console` runs without warnings after this change