### PR TITLE
Fix routes memoization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#2586](https://github.com/ruby-grape/grape/pull/2586): Limit helpers DSL public scope - [@ericproulx](https://github.com/ericproulx).
 * [#2588](https://github.com/ruby-grape/grape/pull/2588): Fix defaut format regression on */* - [@ericproulx](https://github.com/ericproulx).
 * [#2593](https://github.com/ruby-grape/grape/pull/2593): Fix warning message when overriding global registry key - [@ericproulx](https://github.com/ericproulx).
+* [#2594](https://github.com/ruby-grape/grape/pull/2594): Fix routes memoization - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 2.4.0 (2025-06-18)

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -5,7 +5,7 @@ module Grape
   # should subclass this class in order to build an API.
   class API
     # Class methods that we want to call on the API rather than on the API object
-    NON_OVERRIDABLE = %i[call call! configuration compile! inherited recognize_path].freeze
+    NON_OVERRIDABLE = %i[call call! configuration compile! inherited recognize_path routes].freeze
 
     Helpers = Grape::DSL::Helpers::BaseHelper
 

--- a/lib/grape/api/instance.rb
+++ b/lib/grape/api/instance.rb
@@ -103,10 +103,6 @@ module Grape
 
         protected
 
-        def prepare_routes
-          endpoints.map(&:routes).flatten
-        end
-
         # Execute first the provided block, then each of the
         # block passed in. Allows for simple 'before' setups
         # of settings stack pushes.

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -195,7 +195,7 @@ module Grape
 
       # An array of API routes.
       def routes
-        @routes ||= prepare_routes
+        @routes ||= endpoints.map(&:routes).flatten
       end
 
       # Remove all defined routes.

--- a/spec/grape/dsl/routing_spec.rb
+++ b/spec/grape/dsl/routing_spec.rb
@@ -274,22 +274,23 @@ describe Grape::DSL::Routing do
   end
 
   describe '.routes' do
-    let(:routes) { Object.new }
+    let(:main_app) { Class.new(Grape::API) }
+    let(:first_app) { Class.new(Grape::API) }
+    let(:second_app) { Class.new(Grape::API) }
 
-    it 'returns value received from #prepare_routes' do
-      expect(subject).to receive(:prepare_routes).and_return(routes)
-      expect(subject.routes).to eq routes
+    before do
+      main_app.mount(first_app => '/first_app', second_app => '/second_app')
+    end
+
+    it 'returns flatten endpoints routes' do
+      expect(main_app.endpoints).not_to be_empty
+      expect(main_app.routes).to eq(main_app.endpoints.map(&:routes).flatten)
     end
 
     context 'when #routes was already called once' do
-      before do
-        allow(subject).to receive(:prepare_routes).and_return(routes)
-        subject.routes
-      end
-
-      it 'does not call prepare_routes again' do
-        expect(subject).not_to receive(:prepare_routes)
-        expect(subject.routes).to eq routes
+      it 'memoizes' do
+        object_id = main_app.routes.object_id
+        expect(main_app.routes.object_id).to eq(object_id)
       end
     end
   end


### PR DESCRIPTION
## Fix routes memoization

**Base**: `master`  
**Branch**: `fix_routes_memoization`

### Summary
Ensure `routes` memoization works reliably by making `routes` a non-overridable method and tightening specs to verify the memoization behavior directly.

### Motivation / Context
- The `routes` method was eligible to be overridden, which could inadvertently break memoization and force repeated route computation.
- This PR safeguards memoization and updates tests to validate the behavior without relying on private implementation details.

### Changes
- Make `routes` non-overridable to preserve memoization guarantees.
- Improve specs so they assert actual memoization effects rather than depending on private methods.

### Implementation Notes
- Commit(s):
  - 017e762c — Add `routes` as a non overridable methods so that memoization works properly. Added a better specs so that a private method is not expected and memoization is really tested. (Eric Proulx)

### Files Changed (4)
- `lib/grape/api.rb`
- `lib/grape/api/instance.rb`
- `lib/grape/dsl/routing.rb`
- `spec/grape/dsl/routing_spec.rb`

### Diff Stats
4 files changed, 15 insertions(+), 18 deletions(-)

### Testing
- Added/updated specs in `spec/grape/dsl/routing_spec.rb` to validate memoization behavior.
- Run:
  - `bundle install`
  - `bundle exec rspec spec/grape/dsl/routing_spec.rb`
  - `bundle exec rspec`

### Backwards Compatibility / Risk
- Low risk for typical usage; behavior is preserved with improved guarantees.
- Potentially breaking only if external code previously overrode `routes`. Marking it non-overridable is intentional to protect memoization semantics.

### Checklist
- [x] Tests updated/added
- [x] No public API changes beyond making `routes` non-overridable
- [x] Changelog entry considered (if maintainers require)

### Notes for Reviewers
- Focus on how `routes` is protected from overriding and how tests assert memoization without relying on private methods.