### PR TITLE
Keep `within_namespace` as part of our internal api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#2588](https://github.com/ruby-grape/grape/pull/2588): Fix defaut format regression on */* - [@ericproulx](https://github.com/ericproulx).
 * [#2593](https://github.com/ruby-grape/grape/pull/2593): Fix warning message when overriding global registry key - [@ericproulx](https://github.com/ericproulx).
 * [#2594](https://github.com/ruby-grape/grape/pull/2594): Fix routes memoization - [@ericproulx](https://github.com/ericproulx).
+* [#2595](https://github.com/ruby-grape/grape/pull/2595): Keep `within_namespace` as part of our internal api - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 2.4.0 (2025-06-18)

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -154,7 +154,7 @@ module Grape
         new_endpoint = Grape::Endpoint.new(inheritable_setting, endpoint_options, &block)
         endpoints << new_endpoint unless endpoints.any? { |e| e.equals?(new_endpoint) }
 
-        route_end
+        inheritable_setting.route_end
         reset_validations!
       end
 


### PR DESCRIPTION
### Clarify `within_namespace` visibility; remove legacy `namespace_start`/`namespace_end`

**Motivation**
- Keep `within_namespace` as a private, internal helper for scoping settings safely.
- Remove references to legacy `namespace_start`/`namespace_end` to simplify internals and tests.

**Changes**
- `within_namespace` remains private in `Grape::DSL::Settings` and continues to be used internally by DSL methods (e.g., `namespace`, `version`, `scope`).
- Clean up and refactor related code/comments; adjust specs to exercise namespacing behavior without relying on legacy helpers.
- Minor updates in `lib/grape/dsl/settings.rb` and corresponding specs.

**Impact**
- No public API change; typical `namespace` usage is unaffected.
- If any external code was calling internal helpers directly, that usage is unsupported and may need to rely on public DSL (`namespace`, `group`, `resources`, etc.).

**Tests**
- Specs updated to reflect internal scoping behavior while keeping `within_namespace` private; removed legacy helper references.

