### PR TITLE
Private namespace reverse stackable with hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#2588](https://github.com/ruby-grape/grape/pull/2588): Fix defaut format regression on */* - [@ericproulx](https://github.com/ericproulx).
 * [#2593](https://github.com/ruby-grape/grape/pull/2593): Fix warning message when overriding global registry key - [@ericproulx](https://github.com/ericproulx).
 * [#2594](https://github.com/ruby-grape/grape/pull/2594): Fix routes memoization - [@ericproulx](https://github.com/ericproulx).
+* [#2595](https://github.com/ruby-grape/grape/pull/2595): Keep `within_namespace` as part of our internal api - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 2.4.0 (2025-06-18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#2593](https://github.com/ruby-grape/grape/pull/2593): Fix warning message when overriding global registry key - [@ericproulx](https://github.com/ericproulx).
 * [#2594](https://github.com/ruby-grape/grape/pull/2594): Fix routes memoization - [@ericproulx](https://github.com/ericproulx).
 * [#2595](https://github.com/ruby-grape/grape/pull/2595): Keep `within_namespace` as part of our internal api - [@ericproulx](https://github.com/ericproulx).
+* [#2596](https://github.com/ruby-grape/grape/pull/2596): Remove `namespace_reverse_stackable_with_hash` from public scope - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 2.4.0 (2025-06-18)

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -154,7 +154,7 @@ module Grape
         new_endpoint = Grape::Endpoint.new(inheritable_setting, endpoint_options, &block)
         endpoints << new_endpoint unless endpoints.any? { |e| e.equals?(new_endpoint) }
 
-        route_end
+        inheritable_setting.route_end
         reset_validations!
       end
 

--- a/lib/grape/dsl/settings.rb
+++ b/lib/grape/dsl/settings.rb
@@ -89,15 +89,6 @@ module Grape
         settings.each_with_object({}) { |value, result| result.deep_merge!(value) }
       end
 
-      def namespace_reverse_stackable_with_hash(key)
-        settings = get_or_set :namespace_reverse_stackable, key, nil
-        return if settings.blank?
-
-        settings.each_with_object({}) do |setting, result|
-          result.merge!(setting) { |_k, s1, _s2| s1 }
-        end
-      end
-
       private
 
       # Execute the block within a context where our inheritable settings are forked

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -333,7 +333,7 @@ module Grape
                 default_error_formatter: namespace_inheritable(:default_error_formatter),
                 error_formatters: namespace_stackable_with_hash(:error_formatters),
                 rescue_options: namespace_stackable_with_hash(:rescue_options),
-                rescue_handlers: namespace_reverse_stackable_with_hash(:rescue_handlers),
+                rescue_handlers: rescue_handlers,
                 base_only_rescue_handlers: namespace_stackable_with_hash(:base_only_rescue_handlers),
                 all_rescue_handler: namespace_inheritable(:all_rescue_handler),
                 grape_exceptions_rescue_handler: namespace_inheritable(:grape_exceptions_rescue_handler)
@@ -376,6 +376,15 @@ module Grape
 
     def lint?
       namespace_inheritable(:lint) || Grape.config.lint
+    end
+
+    def rescue_handlers
+      rescue_handlers = inheritable_setting.namespace_reverse_stackable[:rescue_handlers]
+      return if rescue_handlers.blank?
+
+      rescue_handlers.each_with_object({}) do |rescue_handler, result|
+        result.merge!(rescue_handler) { |_k, s1, _s2| s1 }
+      end
     end
   end
 end


### PR DESCRIPTION
## Remove `namespace_reverse_stackable_with_hash`

Scope: commit `53eed5db81286fa9b55a7e8dfd818dd9c6f4be1e` only.

- Removed private helper from `lib/grape/dsl/settings.rb`.
- `lib/grape/endpoint.rb` now handles reverse-ordered rescue handler merging internally via a private `rescue_handlers` method.
- Public API and behavior are unchanged; no test updates required.