### PR TITLE
Refactor route_setting internal usage to use inheritable_setting.route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#2598](https://github.com/ruby-grape/grape/pull/2598): Refactor settings DSL to use explicit methods instead of dynamic generation - [@ericproulx](https://github.com/ericproulx).
 * [#2599](https://github.com/ruby-grape/grape/pull/2599): Simplify settings DSL get_or_set method and optimize logger implementation - [@ericproulx](https://github.com/ericproulx).
 * [#2600](https://github.com/ruby-grape/grape/pull/2600): Refactor versioner middleware: simplify base class and improve consistency - [@ericproulx](https://github.com/ericproulx).
+* [#2601](https://github.com/ruby-grape/grape/pull/2601): Refactor route_setting internal usage to use inheritable_setting.route for improved consistency and performance - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#2583](https://github.com/ruby-grape/grape/pull/2583): Optimize api parameter documentation and memory usage - [@ericproulx](https://github.com/ericproulx).
 * [#2589](https://github.com/ruby-grape/grape/pull/2589): Replace `send` by `__send__` in codebase - [@ericproulx](https://github.com/ericproulx).
 * [#2598](https://github.com/ruby-grape/grape/pull/2598): Refactor settings DSL to use explicit methods instead of dynamic generation - [@ericproulx](https://github.com/ericproulx).
+* [#2599](https://github.com/ruby-grape/grape/pull/2599): Simplify settings DSL get_or_set method and optimize logger implementation - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#2582](https://github.com/ruby-grape/grape/pull/2582): Fix leaky slash when normalizing - [@ericproulx](https://github.com/ericproulx).
 * [#2583](https://github.com/ruby-grape/grape/pull/2583): Optimize api parameter documentation and memory usage - [@ericproulx](https://github.com/ericproulx).
 * [#2589](https://github.com/ruby-grape/grape/pull/2589): Replace `send` by `__send__` in codebase - [@ericproulx](https://github.com/ericproulx).
+* [#2598](https://github.com/ruby-grape/grape/pull/2598): Refactor settings DSL to use explicit methods instead of dynamic generation - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#2589](https://github.com/ruby-grape/grape/pull/2589): Replace `send` by `__send__` in codebase - [@ericproulx](https://github.com/ericproulx).
 * [#2598](https://github.com/ruby-grape/grape/pull/2598): Refactor settings DSL to use explicit methods instead of dynamic generation - [@ericproulx](https://github.com/ericproulx).
 * [#2599](https://github.com/ruby-grape/grape/pull/2599): Simplify settings DSL get_or_set method and optimize logger implementation - [@ericproulx](https://github.com/ericproulx).
+* [#2600](https://github.com/ruby-grape/grape/pull/2600): Refactor versioner middleware: simplify base class and improve consistency - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/api/instance.rb
+++ b/lib/grape/api/instance.rb
@@ -232,22 +232,19 @@ module Grape
         end
       end
 
+      ROOT_PREFIX_VERSIONING_KEY = %i[version version_options root_prefix].freeze
+      private_constant :ROOT_PREFIX_VERSIONING_KEY
+
       # Allows definition of endpoints that ignore the versioning configuration
       # used by the rest of your API.
       def without_root_prefix_and_versioning
-        old_version = self.class.namespace_inheritable(:version)
-        old_version_options = self.class.namespace_inheritable(:version_options)
-        old_root_prefix = self.class.namespace_inheritable(:root_prefix)
-
-        self.class.namespace_inheritable_to_nil(:version)
-        self.class.namespace_inheritable_to_nil(:version_options)
-        self.class.namespace_inheritable_to_nil(:root_prefix)
-
+        inheritable_setting = self.class.inheritable_setting
+        deleted_values = inheritable_setting.namespace_inheritable.delete(*ROOT_PREFIX_VERSIONING_KEY)
         yield
-
-        self.class.namespace_inheritable(:version, old_version)
-        self.class.namespace_inheritable(:version_options, old_version_options)
-        self.class.namespace_inheritable(:root_prefix, old_root_prefix)
+      ensure
+        ROOT_PREFIX_VERSIONING_KEY.each_with_index do |key, index|
+          inheritable_setting.namespace_inheritable[key] = deleted_values[index]
+        end
       end
     end
   end

--- a/lib/grape/dsl/desc.rb
+++ b/lib/grape/dsl/desc.rb
@@ -58,7 +58,7 @@ module Grape
             options.merge(description: description)
           end
         namespace_setting :description, settings
-        route_setting :description, settings
+        inheritable_setting.route[:description] = settings
       end
     end
   end

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -55,7 +55,7 @@ module Grape
         end
 
         def declared_hash_attr(passed_params, options, declared_param, params_nested_path, memo)
-          renamed_params = route_setting(:renamed_params) || {}
+          renamed_params = inheritable_setting.route[:renamed_params] || {}
           if declared_param.is_a?(Hash)
             declared_param.each_pair do |declared_parent_param, declared_children_params|
               params_nested_path_dup = params_nested_path.dup
@@ -119,7 +119,7 @@ module Grape
         def optioned_declared_params(include_parent_namespaces)
           declared_params = if include_parent_namespaces
                               # Declared params including parent namespaces
-                              route_setting(:declared_params)
+                              inheritable_setting.route[:declared_params]
                             else
                               # Declared params at current namespace
                               namespace_stackable(:declared_params).last || []

--- a/lib/grape/dsl/logger.rb
+++ b/lib/grape/dsl/logger.rb
@@ -7,10 +7,11 @@ module Grape
       # method will create a new one, logging to stdout.
       # @param logger [Object] the new logger to use
       def logger(logger = nil)
+        global_settings = inheritable_setting.global
         if logger
-          global_setting(:logger, logger)
+          global_settings[:logger] = logger
         else
-          global_setting(:logger) || global_setting(:logger, ::Logger.new($stdout))
+          global_settings[:logger] || global_settings[:logger] = ::Logger.new($stdout)
         end
       end
     end

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -141,14 +141,15 @@ module Grape
       #     end
       #   end
       def route(methods, paths = ['/'], route_options = {}, &block)
-        methods = '*' if methods == :any
+        method = methods == :any ? '*' : methods
+        description = inheritable_setting.route[:description] || {}
         endpoint_options = {
-          method: methods,
+          method: method,
           path: paths,
           for: self,
           route_options: {
             params: namespace_stackable_with_hash(:params) || {}
-          }.deep_merge(route_setting(:description) || {}).deep_merge(route_options || {})
+          }.deep_merge(description).deep_merge(route_options || {})
         }
 
         new_endpoint = Grape::Endpoint.new(inheritable_setting, endpoint_options, &block)

--- a/lib/grape/dsl/settings.rb
+++ b/lib/grape/dsl/settings.rb
@@ -26,46 +26,32 @@ module Grape
         @inheritable_setting ||= Grape::Util::InheritableSetting.new.tap { |new_settings| new_settings.inherit_from top_level_setting }
       end
 
-      # @param type [Symbol]
-      # @param key [Symbol]
-      # @param value [Object] will be stored if the value is currently empty
-      # @return either the old value, if it wasn't nil, or the given value
-      def get_or_set(type, key, value)
-        setting = inheritable_setting.__send__(type)
-        if value.nil?
-          setting[key]
-        else
-          setting[key] = value
-        end
+      def namespace_inheritable(key, value = nil)
+        get_or_set(inheritable_setting.namespace_inheritable, key, value)
       end
 
-      # defines the following methods:
-      # - namespace_inheritable
-      # - namespace_stackable
-
-      %i[namespace_inheritable namespace_stackable].each do |method_name|
-        define_method method_name do |key, value = nil|
-          get_or_set method_name, key, value
-        end
+      def namespace_stackable(key, value = nil)
+        get_or_set(inheritable_setting.namespace_stackable, key, value)
       end
 
-      # defines the following methods:
-      # - global_setting
-      # - route_setting
-      # - namespace_setting
+      def global_setting(key, value = nil)
+        get_or_set(inheritable_setting.global, key, value)
+      end
 
-      %i[global route namespace].each do |method_name|
-        define_method :"#{method_name}_setting" do |key, value = nil|
-          get_or_set method_name, key, value
-        end
+      def route_setting(key, value = nil)
+        get_or_set(inheritable_setting.route, key, value)
+      end
+
+      def namespace_setting(key, value = nil)
+        get_or_set(inheritable_setting.namespace, key, value)
       end
 
       def namespace_reverse_stackable(key, value = nil)
-        get_or_set :namespace_reverse_stackable, key, value
+        get_or_set(inheritable_setting.namespace_reverse_stackable, key, value)
       end
 
       def namespace_stackable_with_hash(key)
-        settings = get_or_set :namespace_stackable, key, nil
+        settings = namespace_stackable(key)
         return if settings.blank?
 
         settings.each_with_object({}) { |value, result| result.deep_merge!(value) }
@@ -88,6 +74,12 @@ module Grape
         reset_validations!
 
         result
+      end
+
+      def get_or_set(setting, key, value)
+        return setting[key] if value.nil?
+
+        setting[key] = value
       end
     end
   end

--- a/lib/grape/dsl/settings.rb
+++ b/lib/grape/dsl/settings.rb
@@ -28,13 +28,6 @@ module Grape
 
       # @param type [Symbol]
       # @param key [Symbol]
-      def unset(type, key)
-        setting = inheritable_setting.__send__(type)
-        setting.delete key
-      end
-
-      # @param type [Symbol]
-      # @param key [Symbol]
       # @param value [Object] will be stored if the value is currently empty
       # @return either the old value, if it wasn't nil, or the given value
       def get_or_set(type, key, value)
@@ -56,12 +49,6 @@ module Grape
         end
       end
 
-      def unset_namespace_stackable(*keys)
-        keys.each do |key|
-          unset :namespace_stackable, key
-        end
-      end
-
       # defines the following methods:
       # - global_setting
       # - route_setting
@@ -71,11 +58,6 @@ module Grape
         define_method :"#{method_name}_setting" do |key, value = nil|
           get_or_set method_name, key, value
         end
-      end
-
-      # @param key [Symbol]
-      def namespace_inheritable_to_nil(key)
-        inheritable_setting.namespace_inheritable[key] = nil
       end
 
       def namespace_reverse_stackable(key, value = nil)

--- a/lib/grape/dsl/validations.rb
+++ b/lib/grape/dsl/validations.rb
@@ -22,7 +22,7 @@ module Grape
       #      # whatever
       #    end
       def reset_validations!
-        unset_namespace_stackable :declared_params, :params, :validations
+        inheritable_setting.namespace_stackable.delete(:declared_params, :params, :validations)
       end
 
       # Opens a root-level ParamsScope, defining parameter coercions and

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -55,8 +55,8 @@ module Grape
       # now +namespace_stackable(:declared_params)+ contains all params defined for
       # this endpoint and its parents, but later it will be cleaned up,
       # see +reset_validations!+ in lib/grape/dsl/validations.rb
-      route_setting(:declared_params, namespace_stackable(:declared_params).flatten)
-      route_setting(:saved_validations, namespace_stackable(:validations))
+      inheritable_setting.route[:declared_params] = namespace_stackable(:declared_params).flatten
+      inheritable_setting.route[:saved_validations] = namespace_stackable(:validations)
 
       namespace_stackable(:representations, []) unless namespace_stackable(:representations)
       namespace_inheritable(:default_error_status, 500) unless namespace_inheritable(:default_error_status)
@@ -302,9 +302,11 @@ module Grape
     end
 
     def validations
+      saved_validations = inheritable_setting.route[:saved_validations]
+      return if saved_validations.nil?
       return enum_for(:validations) unless block_given?
 
-      route_setting(:saved_validations)&.each do |saved_validation|
+      saved_validations.each do |saved_validation|
         yield Grape::Validations::ValidatorFactory.create_validator(saved_validation)
       end
     end

--- a/lib/grape/middleware/versioner/accept_version_header.rb
+++ b/lib/grape/middleware/versioner/accept_version_header.rb
@@ -19,7 +19,7 @@ module Grape
       class AcceptVersionHeader < Base
         def before
           potential_version = env['HTTP_ACCEPT_VERSION'].try(:scrub)
-          not_acceptable!('Accept-Version header must be set.') if strict? && potential_version.blank?
+          not_acceptable!('Accept-Version header must be set.') if strict && potential_version.blank?
 
           return if potential_version.blank?
 

--- a/lib/grape/middleware/versioner/base.rb
+++ b/lib/grape/middleware/versioner/base.rb
@@ -6,67 +6,49 @@ module Grape
       class Base < Grape::Middleware::Base
         DEFAULT_OPTIONS = {
           pattern: /.*/i,
+          prefix: nil,
+          mount_path: nil,
           version_options: {
             strict: false,
             cascade: true,
-            parameter: 'apiver'
+            parameter: 'apiver',
+            vendor: nil
           }.freeze
         }.freeze
+
+        CASCADE_PASS_HEADER = { 'X-Cascade' => 'pass' }.freeze
+
+        DEFAULT_OPTIONS.each_key do |key|
+          define_method key do
+            options[key]
+          end
+        end
+
+        DEFAULT_OPTIONS[:version_options].each_key do |key|
+          define_method key do
+            options[:version_options][key]
+          end
+        end
 
         def self.inherited(klass)
           super
           Versioner.register(klass)
         end
 
-        def versions
-          options[:versions]
-        end
+        attr_reader :error_headers, :versions
 
-        def prefix
-          options[:prefix]
-        end
-
-        def mount_path
-          options[:mount_path]
-        end
-
-        def pattern
-          options[:pattern]
-        end
-
-        def version_options
-          options[:version_options]
-        end
-
-        def strict?
-          version_options[:strict]
-        end
-
-        # By default those errors contain an `X-Cascade` header set to `pass`, which allows nesting and stacking
-        # of routes (see Grape::Router) for more information). To prevent
-        # this behavior, and not add the `X-Cascade` header, one can set the `:cascade` option to `false`.
-        def cascade?
-          version_options[:cascade]
-        end
-
-        def parameter_key
-          version_options[:parameter]
-        end
-
-        def vendor
-          version_options[:vendor]
-        end
-
-        def error_headers
-          cascade? ? { 'X-Cascade' => 'pass' } : {}
+        def initialize(app, **options)
+          super
+          @error_headers = cascade ? CASCADE_PASS_HEADER : {}
+          @versions = options[:versions]&.map(&:to_s) # making sure versions are strings to ease potential match
         end
 
         def potential_version_match?(potential_version)
-          versions.blank? || versions.any? { |v| v.to_s == potential_version }
+          versions.blank? || versions.include?(potential_version)
         end
 
         def version_not_found!
-          throw :error, status: 404, message: '404 API Version Not Found', headers: { 'X-Cascade' => 'pass' }
+          throw :error, status: 404, message: '404 API Version Not Found', headers: CASCADE_PASS_HEADER
         end
       end
     end

--- a/lib/grape/middleware/versioner/header.rb
+++ b/lib/grape/middleware/versioner/header.rb
@@ -53,7 +53,7 @@ module Grape
         end
 
         def strict_header_checks!
-          return unless strict?
+          return unless strict
 
           accept_header_check!
           version_and_vendor_check!

--- a/lib/grape/middleware/versioner/param.rb
+++ b/lib/grape/middleware/versioner/param.rb
@@ -20,11 +20,11 @@ module Grape
       #   env['api.version'] => 'v1'
       class Param < Base
         def before
-          potential_version = query_params[parameter_key]
+          potential_version = query_params[parameter]
           return if potential_version.blank?
 
           version_not_found! unless potential_version_match?(potential_version)
-          env[Grape::Env::API_VERSION] = env[Rack::RACK_REQUEST_QUERY_HASH].delete(parameter_key)
+          env[Grape::Env::API_VERSION] = env[Rack::RACK_REQUEST_QUERY_HASH].delete(parameter)
         end
       end
     end

--- a/lib/grape/util/base_inheritable.rb
+++ b/lib/grape/util/base_inheritable.rb
@@ -14,8 +14,11 @@ module Grape
         @new_values = {}
       end
 
-      def delete(key)
-        new_values.delete key
+      def delete(*keys)
+        keys.map do |key|
+          # since delete returns the deleted value, seems natural to `map` the result
+          new_values.delete key
+        end
       end
 
       def initialize_copy(other)

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -211,9 +211,10 @@ module Grape
       # @param new_name [String, Symbol] the new name of the parameter (the
       #   renamed name, with the +as: ...+ semantic)
       def push_renamed_param(path, new_name)
-        base = @api.route_setting(:renamed_params) || {}
+        api_route_setting = @api.inheritable_setting.route
+        base = api_route_setting[:renamed_params] || {}
         base[Array(path).map(&:to_s)] = new_name.to_s
-        @api.route_setting(:renamed_params, base)
+        api_route_setting[:renamed_params] = base
       end
 
       def require_required_and_optional_fields(context, opts)

--- a/spec/grape/dsl/desc_spec.rb
+++ b/spec/grape/dsl/desc_spec.rb
@@ -6,30 +6,7 @@ describe Grape::DSL::Desc do
   let(:dummy_class) do
     Class.new do
       extend Grape::DSL::Desc
-
-      def self.namespace_setting(key, value = nil)
-        if value
-          namespace_setting_hash[key] = value
-        else
-          namespace_setting_hash[key]
-        end
-      end
-
-      def self.route_setting(key, value = nil)
-        if value
-          route_setting_hash[key] = value
-        else
-          route_setting_hash[key]
-        end
-      end
-
-      def self.namespace_setting_hash
-        @namespace_setting_hash ||= {}
-      end
-
-      def self.route_setting_hash
-        @route_setting_hash ||= {}
-      end
+      extend Grape::DSL::Settings
     end
   end
 

--- a/spec/grape/dsl/logger_spec.rb
+++ b/spec/grape/dsl/logger_spec.rb
@@ -4,17 +4,7 @@ describe Grape::DSL::Logger do
   let(:dummy_logger) do
     Class.new do
       extend Grape::DSL::Logger
-      def self.global_setting(key, value = nil)
-        if value
-          global_setting_hash[key] = value
-        else
-          global_setting_hash[key]
-        end
-      end
-
-      def self.global_setting_hash
-        @global_setting_hash ||= {}
-      end
+      extend Grape::DSL::Settings
     end
   end
 

--- a/spec/grape/dsl/routing_spec.rb
+++ b/spec/grape/dsl/routing_spec.rb
@@ -123,8 +123,8 @@ describe Grape::DSL::Routing do
     end
 
     it 'generates correct endpoint options' do
-      allow(subject).to receive(:route_setting).with(:description).and_return(fiz: 'baz')
-      allow(subject).to receive(:namespace_stackable_with_hash).and_return(nuz: 'naz')
+      subject.inheritable_setting.route[:description] = { fiz: 'baz' }
+      subject.inheritable_setting.namespace_stackable[:params] = { nuz: 'naz' }
 
       expect(Grape::Endpoint).to receive(:new) do |_inheritable_setting, endpoint_options|
         expect(endpoint_options[:method]).to eq :get

--- a/spec/grape/dsl/settings_spec.rb
+++ b/spec/grape/dsl/settings_spec.rb
@@ -15,47 +15,29 @@ describe Grape::DSL::Settings do
     end
   end
 
-  describe '#get_or_set' do
-    it 'sets a values' do
-      subject.get_or_set :namespace, :dummy, 1
-      expect(subject.namespace_setting(:dummy)).to eq 1
-    end
-
-    it 'returns a value when nil is new value is provided' do
-      subject.get_or_set :namespace, :dummy, 1
-      expect(subject.get_or_set(:namespace, :dummy, nil)).to eq 1
-    end
-  end
-
   describe '#global_setting' do
-    it 'delegates to get_or_set' do
-      expect(subject).to receive(:get_or_set).with(:global, :dummy, 1)
-      subject.global_setting(:dummy, 1)
+    it 'sets a value globally' do
+      subject.global_setting :some_thing, :foo_bar
+      expect(subject.global_setting(:some_thing)).to eq :foo_bar
+      subject.with_namespace do
+        subject.global_setting :some_thing, :foo_bar_baz
+        expect(subject.global_setting(:some_thing)).to eq :foo_bar_baz
+      end
+      expect(subject.global_setting(:some_thing)).to eq(:foo_bar_baz)
     end
   end
 
   describe '#route_setting' do
-    it 'delegates to get_or_set' do
-      expect(subject).to receive(:get_or_set).with(:route, :dummy, 1)
-      subject.route_setting(:dummy, 1)
-    end
-
-    it 'sets a value until the next route' do
-      subject.route_setting :some_thing, :foo_bar
-      expect(subject.route_setting(:some_thing)).to eq :foo_bar
-
-      subject.inheritable_setting.route_end
-
+    it 'sets a value until the end of a namespace' do
+      subject.with_namespace do
+        subject.route_setting :some_thing, :foo_bar
+        expect(subject.route_setting(:some_thing)).to eq :foo_bar
+      end
       expect(subject.route_setting(:some_thing)).to be_nil
     end
   end
 
   describe '#namespace_setting' do
-    it 'delegates to get_or_set' do
-      expect(subject).to receive(:get_or_set).with(:namespace, :dummy, 1)
-      subject.namespace_setting(:dummy, 1)
-    end
-
     it 'sets a value until the end of a namespace' do
       subject.with_namespace do
         subject.namespace_setting :some_thing, :foo_bar
@@ -78,11 +60,6 @@ describe Grape::DSL::Settings do
   end
 
   describe '#namespace_inheritable' do
-    it 'delegates to get_or_set' do
-      expect(subject).to receive(:get_or_set).with(:namespace_inheritable, :dummy, 1)
-      subject.namespace_inheritable(:dummy, 1)
-    end
-
     it 'inherits values from surrounding namespace' do
       subject.with_namespace do
         subject.namespace_inheritable(:some_thing, :foo_bar)
@@ -98,11 +75,6 @@ describe Grape::DSL::Settings do
   end
 
   describe '#namespace_stackable' do
-    it 'delegates to get_or_set' do
-      expect(subject).to receive(:get_or_set).with(:namespace_stackable, :dummy, 1)
-      subject.namespace_stackable(:dummy, 1)
-    end
-
     it 'stacks values from surrounding namespace' do
       subject.with_namespace do
         subject.namespace_stackable(:some_thing, :foo_bar)

--- a/spec/grape/dsl/settings_spec.rb
+++ b/spec/grape/dsl/settings_spec.rb
@@ -15,16 +15,6 @@ describe Grape::DSL::Settings do
     end
   end
 
-  describe '#unset' do
-    it 'deletes a key from settings' do
-      subject.namespace_setting :dummy, 1
-      expect(subject.inheritable_setting.namespace.keys).to include(:dummy)
-
-      subject.unset :namespace, :dummy
-      expect(subject.inheritable_setting.namespace.keys).not_to include(:dummy)
-    end
-  end
-
   describe '#get_or_set' do
     it 'sets a values' do
       subject.get_or_set :namespace, :dummy, 1
@@ -123,13 +113,6 @@ describe Grape::DSL::Settings do
         end
         expect(subject.namespace_stackable(:some_thing)).to eq [:foo_bar]
       end
-    end
-  end
-
-  describe '#unset_namespace_stackable' do
-    it 'delegates to unset' do
-      expect(subject).to receive(:unset).with(:namespace_stackable, :dummy)
-      subject.unset_namespace_stackable(:dummy)
     end
   end
 

--- a/spec/grape/dsl/validations_spec.rb
+++ b/spec/grape/dsl/validations_spec.rb
@@ -5,17 +5,23 @@ describe Grape::DSL::Validations do
 
   let(:dummy_class) do
     Class.new do
+      extend Grape::DSL::Settings
       extend Grape::DSL::Validations
-      def self.unset_namespace_stackable(*_keys); end
     end
   end
 
   describe '.reset_validations' do
     subject { dummy_class.reset_validations! }
 
+    before do
+      %i[declared_params params validations other].each do |key|
+        dummy_class.inheritable_setting.namespace_stackable[key] = key
+      end
+    end
+
     it 'calls unset_namespace_stackable properly' do
-      expect(dummy_class).to receive(:unset_namespace_stackable).with(:declared_params, :params, :validations)
       subject
+      expect(dummy_class.inheritable_setting.namespace_stackable.to_hash).to eq(other: [:other])
     end
   end
 


### PR DESCRIPTION
# Refactor route_setting internal usage to use inheritable_setting.route

## Summary

This PR refactors the internal usage of `route_setting` method calls to directly use `inheritable_setting.route` hash access. This change improves code consistency and removes the need for the intermediate `route_setting` method in internal Grape code.

## Changes Made

### Core Library Changes

- **`lib/grape/dsl/desc.rb`**: Replaced `route_setting(:description, settings)` with `inheritable_setting.route[:description] = settings`
- **`lib/grape/dsl/inside_route.rb`**: 
  - Replaced `route_setting(:renamed_params)` with `inheritable_setting.route[:renamed_params]`
  - Replaced `route_setting(:declared_params)` with `inheritable_setting.route[:declared_params]`
- **`lib/grape/dsl/routing.rb`**: 
  - Replaced `route_setting(:description)` with `inheritable_setting.route[:description]`
  - Fixed method handling for `:any` routes (changed `methods` to `method`)
- **`lib/grape/endpoint.rb`**: 
  - Replaced `route_setting(:declared_params, ...)` with `inheritable_setting.route[:declared_params] = ...`
  - Replaced `route_setting(:saved_validations, ...)` with `inheritable_setting.route[:saved_validations] = ...`
  - Updated `validations` method to use direct hash access
- **`lib/grape/validations/params_scope.rb`**: 
  - Replaced `route_setting(:renamed_params)` with `inheritable_setting.route[:renamed_params]`

### Test Updates

- **`spec/grape/dsl/desc_spec.rb`**: Simplified test class by extending `Grape::DSL::Settings` instead of manually implementing route_setting methods
- **`spec/grape/dsl/routing_spec.rb`**: Updated test expectations to use `inheritable_setting.route` structure

## Benefits

1. **Consistency**: All internal code now uses the same pattern for accessing route settings
2. **Performance**: Direct hash access is more efficient than method calls
3. **Maintainability**: Reduces the number of methods that need to be maintained
4. **Clarity**: Makes it clear that we're working with the inheritable setting structure

## Breaking Changes

None. This is an internal refactoring that doesn't change the public API.

## Testing

- All existing tests pass
- Test classes have been updated to use the proper inheritable_setting structure
- No new functionality has been added, only internal implementation changes

## Files Changed

- `lib/grape/dsl/desc.rb`
- `lib/grape/dsl/inside_route.rb`
- `lib/grape/dsl/routing.rb`
- `lib/grape/endpoint.rb`
- `lib/grape/validations/params_scope.rb`
- `spec/grape/dsl/desc_spec.rb`
- `spec/grape/dsl/routing_spec.rb`

## Related Issues

This refactoring is part of improving the internal architecture of Grape's route setting management system.
