### PR TITLE
Remove namespace_reverse_stackable from public DSL interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#2599](https://github.com/ruby-grape/grape/pull/2599): Simplify settings DSL get_or_set method and optimize logger implementation - [@ericproulx](https://github.com/ericproulx).
 * [#2600](https://github.com/ruby-grape/grape/pull/2600): Refactor versioner middleware: simplify base class and improve consistency - [@ericproulx](https://github.com/ericproulx).
 * [#2601](https://github.com/ruby-grape/grape/pull/2601): Refactor route_setting internal usage to use inheritable_setting.route for improved consistency and performance - [@ericproulx](https://github.com/ericproulx).
+* [#2602](https://github.com/ruby-grape/grape/pull/2602): Remove `namespace_reverse_stackable` from public DSL interface and use direct inheritable_setting access - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/dsl/desc.rb
+++ b/lib/grape/dsl/desc.rb
@@ -57,7 +57,7 @@ module Grape
           else
             options.merge(description: description)
           end
-        namespace_setting :description, settings
+        inheritable_setting.namespace[:description] = settings
         inheritable_setting.route[:description] = settings
       end
     end

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -117,7 +117,7 @@ module Grape
               :base_only_rescue_handlers
             end
 
-          namespace_reverse_stackable(handler_type, args.to_h { |arg| [arg, handler] })
+          inheritable_setting.namespace_reverse_stackable[handler_type] = args.to_h { |arg| [arg, handler] }
         end
 
         namespace_stackable(:rescue_options, options)

--- a/lib/grape/dsl/settings.rb
+++ b/lib/grape/dsl/settings.rb
@@ -46,10 +46,6 @@ module Grape
         get_or_set(inheritable_setting.namespace, key, value)
       end
 
-      def namespace_reverse_stackable(key, value = nil)
-        get_or_set(inheritable_setting.namespace_reverse_stackable, key, value)
-      end
-
       def namespace_stackable_with_hash(key)
         settings = namespace_stackable(key)
         return if settings.blank?


### PR DESCRIPTION
# Remove namespace_reverse_stackable from public DSL interface

## Summary

This PR removes the `namespace_reverse_stackable` method from the public DSL interface in `Grape::DSL::Settings` and replaces its usage with direct access to `inheritable_setting.namespace_reverse_stackable`.

## Changes Made

### DSL Interface Changes
- **Removed** `namespace_reverse_stackable` method from `Grape::DSL::Settings`
- **Updated** `Grape::DSL::Desc` to use direct inheritable_setting access instead of `namespace_setting`
- **Updated** `Grape::DSL::RequestResponse` to use direct inheritable_setting access for rescue handlers

### Test Improvements
- **Simplified** test setup in `request_response_spec.rb` by extending `Grape::DSL::Settings` instead of manually stubbing methods
- **Updated** test expectations to verify actual behavior instead of mocking internal method calls
- **Removed** unnecessary manual stubbing of namespace methods

## Benefits

1. **Cleaner API**: Removes an internal implementation detail from the public DSL interface
2. **Better Test Coverage**: Tests now verify actual behavior rather than just method calls
3. **Simplified Code**: Reduces the number of wrapper methods in the DSL
4. **Direct Access**: Allows direct manipulation of inheritable settings when needed

## Files Modified

- `lib/grape/dsl/desc.rb` - Use direct inheritable_setting access
- `lib/grape/dsl/request_response.rb` - Use direct inheritable_setting access for rescue handlers
- `lib/grape/dsl/settings.rb` - Remove namespace_reverse_stackable method
- `spec/grape/dsl/request_response_spec.rb` - Update tests to verify actual behavior

## Breaking Changes

This change removes a public method from the DSL interface. However, this method was primarily used internally and direct access to `inheritable_setting.namespace_reverse_stackable` provides the same functionality.

## Testing

All existing tests pass with the updated implementation. The rescue_from functionality continues to work as expected with the new direct access pattern.
