### PR TITLE
Avoid multiple mount pollution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#2605](https://github.com/ruby-grape/grape/pull/2605): Add Rack 3.2 support with new gemfile and CI integration - [@ericproulx](https://github.com/ericproulx).
 * [#2607](https://github.com/ruby-grape/grape/pull/2607): Remove namespace_stackable and namespace_inheritable from public API - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
+* [#2612](https://github.com/ruby-grape/grape/pull/2612): Avoid multiple mount pollution - [@alexanderadam](https://github.com/alexanderadam).
 
 #### Fixes
 

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -22,14 +22,13 @@ module Grape
       attr_accessor :base_instance, :instances
 
       delegate_missing_to :base_instance
-      def_delegators :base_instance, :new, :configuration
 
       # This is the interface point between Rack and Grape; it accepts a request
       # from Rack and ultimately returns an array of three values: the status,
       # the headers, and the body. See [the rack specification]
-      # (http://www.rubydoc.info/github/rack/rack/master/file/SPEC) for more.
+      # (https://github.com/rack/rack/blob/main/SPEC.rdoc) for more.
       # NOTE: This will only be called on an API directly mounted on RACK
-      def_delegators :instance_for_rack, :call, :compile!
+      def_delegators :base_instance, :new, :configuration, :call, :compile!
 
       # When inherited, will create a list of all instances (times the API was mounted)
       # It will listen to the setup required to mount that endpoint, and replicate it on any new instance
@@ -92,14 +91,6 @@ module Grape
       def replay_setup_on(instance)
         @setup.each do |setup_step|
           replay_step_on(instance, **setup_step)
-        end
-      end
-
-      def instance_for_rack
-        if never_mounted?
-          base_instance
-        else
-          mounted_instances.first
         end
       end
 

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1055,28 +1055,6 @@ describe Grape::API do
     end
   end
 
-  # NOTE: this method is required to preserve the ability of pre-mounting
-  # the root API into a namespace, it may be deprecated in the future.
-  describe 'instance_for_rack' do
-    context 'when the app was not mounted' do
-      it 'returns the base_instance' do
-        expect(app.__send__(:instance_for_rack)).to eq app.base_instance
-      end
-    end
-
-    context 'when the app was mounted' do
-      it 'returns the first mounted instance' do
-        mounted_app = app
-        Class.new(described_class) do
-          namespace 'new_namespace' do
-            mount mounted_app
-          end
-        end
-        expect(app.__send__(:instance_for_rack)).to eq app.__send__(:mounted_instances).first
-      end
-    end
-  end
-
   describe 'filters' do
     it 'adds a before filter' do
       subject.before { @foo = 'first'  }


### PR DESCRIPTION
Soooo, I might have missed something here but the way I see this is, that PR #1893 introduced the behaviour seen in #2576.

And the problem to be tackled was different than what was implemented.
According to the [Rack Spec](https://github.com/rack/rack/blob/main/SPEC.rdoc), a Rack app only needs to be

> a Ruby object that responds to `call`. It takes exactly one argument, the `environment` (representing an HTTP request) and returns a non-frozen `Array` of exactly three elements: the `status`, the `headers`, and the `body` (representing an HTTP response).

Therefore having `Grape::API.call` delegating to [`base_instance.call`](https://github.com/ruby-grape/grape/blob/2cbeeac50648deb11df13f726ec62f483151f75e/lib/grape/api/instance.rb#L73) should be enough.

Howeveeeeeer, [when using `Rack::Test` with def app returning a `Grape::API` class directly (e.g., `API::V1::Ping`)](https://github.com/ruby-grape/grape/pull/1893/files#diff-ba279e71539c2483403d189cb8cb691c35921fc9dff02031d6cb3bf85965a408R42-R55), tests would naturally fail with `404`.

So to me this looks like the fix with d29eb793098a871aec02cd4903af0bf5f76ddd49 was a bit weird and introduced that bug in #2576. :thinking: 

But I could also be totally wrong with _my_ understanding here.
And I'm therefore open to any corrections and learnings.

**PS:** I'm looking for a new adventure in case anybody is looking to hire or work with a Ruby/Rails/Crystal dev