### PR TITLE
Remove TOC Danger check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#2604](https://github.com/ruby-grape/grape/pull/2604): Enable branch coverage  - [@ericproulx](https://github.com/ericproulx).
 * [#2605](https://github.com/ruby-grape/grape/pull/2605): Add Rack 3.2 support with new gemfile and CI integration - [@ericproulx](https://github.com/ericproulx).
 * [#2607](https://github.com/ruby-grape/grape/pull/2607): Remove namespace_stackable and namespace_inheritable from public API - [@ericproulx](https://github.com/ericproulx).
+* [#2615](https://github.com/ruby-grape/grape/pull/2615): Remove manual toc and tod danger check - [@alexanderadam](https://github.com/alexanderadam).
 * Your contribution here.
 
 #### Fixes

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,4 +1,3 @@
 # frozen_string_literal: true
 
 danger.import_dangerfile(gem: 'ruby-grape-danger')
-toc.check!


### PR DESCRIPTION
As discussed [here](https://github.com/ruby-grape/grape/pull/2614#issuecomment-3429212172) and as announced [here](https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/).

**PS:** I'm looking for a new adventure in case anybody is looking to hire or work with a Ruby/Rails/Crystal dev