### PR TITLE
Use require_relative instead of $LOAD_PATH in gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [#2595](https://github.com/ruby-grape/grape/pull/2595): Keep `within_namespace` as part of our internal api - [@ericproulx](https://github.com/ericproulx).
 * [#2596](https://github.com/ruby-grape/grape/pull/2596): Remove `namespace_reverse_stackable_with_hash` from public scope - [@ericproulx](https://github.com/ericproulx).
 * [#2621](https://github.com/ruby-grape/grape/pull/2621): Update upgrading notes regarding `return` usage and simplify endpoint execution - [@ericproulx](https://github.com/ericproulx).
+* [#2622](https://github.com/ruby-grape/grape/pull/2622): Use `require_relative` instead of `$LOAD_PATH` in gemspec - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 2.4.0 (2025-06-18)

--- a/grape.gemspec
+++ b/grape.gemspec
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path('lib', __dir__)
-require 'grape/version'
+require_relative 'lib/grape/version'
 
 Gem::Specification.new do |s|
   s.name        = 'grape'


### PR DESCRIPTION
# Use `require_relative` instead of `$LOAD_PATH` in gemspec

## Description

This PR simplifies the gemspec by replacing the `$LOAD_PATH` manipulation with `require_relative`, which is more idiomatic and cleaner for Ruby gems.

### Changes
- Removed `$LOAD_PATH.unshift File.expand_path('lib', __dir__)`
- Replaced `require 'grape/version'` with `require_relative 'lib/grape/version'`

## Benefits

1. **Simplicity**: `require_relative` is more straightforward and doesn't mutate global state
2. **Idiomatic**: Follows modern Ruby best practices for gemspecs
3. **Safety**: Avoids potential pollution of `$LOAD_PATH` that could affect other gems

## Context

This follows a modern Ruby convention where `require_relative` is preferred over manipulating `$LOAD_PATH` in gemspecs. The previous approach was added in [#1758](https://github.com/ruby-grape/grape/pull/1758) to fix issues with `Grape::VERSION` potentially referencing system-wide installed gem versions, but `require_relative` provides the same isolation without global state mutation.

## Testing

- ✅ All existing tests pass
- ✅ Gem builds successfully
- ✅ Version constant loads correctly