### PR TITLE
Remove incorrect documentation about combining `values` and `allow_blank`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1702,14 +1702,6 @@ end
 
 While Procs are convenient for single cases, consider using [Custom Validators](#custom-validators) in cases where a validation is used more than once.
 
-Note that [allow_blank](#allow_blank) validator applies while using `:values`. In the following example the absence of `:allow_blank` does not prevent `:state` from receiving blank values because `:allow_blank` defaults to `true`.
-
-```ruby
-params do
-  requires :state, type: Symbol, values: [:active, :inactive]
-end
-```
-
 #### `except_values`
 
 Parameters can be restricted from having a specific set of values with the `:except_values` option.


### PR DESCRIPTION
The deleted example was incorrect: you can, in fact, not supply a blank value to  the `state` parameter with such a `params` block. I don't know the background, maybe it was correct at one point in time.