### PR TITLE
Refactor API::Instance and reorganize DSL modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * [#2629](https://github.com/ruby-grape/grape/pull/2629): Refactor Router Architecture - [@ericproulx](https://github.com/ericproulx).
+* [#2633](https://github.com/ruby-grape/grape/pull/2633): Refactor API::Instance and reorganize DSL modules - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -5,7 +5,7 @@ module Grape
   # should subclass this class in order to build an API.
   class API
     # Class methods that we want to call on the API rather than on the API object
-    NON_OVERRIDABLE = %i[call call! configuration compile! inherited recognize_path routes].freeze
+    NON_OVERRIDABLE = %i[base= base_instance? call change! configuration compile! inherit_settings recognize_path reset! routes top_level_setting= top_level_setting].freeze
 
     Helpers = Grape::DSL::Helpers::BaseHelper
 
@@ -29,7 +29,7 @@ module Grape
       # the headers, and the body. See [the rack specification]
       # (https://github.com/rack/rack/blob/main/SPEC.rdoc) for more.
       # NOTE: This will only be called on an API directly mounted on RACK
-      def_delegators :base_instance, :new, :configuration, :call, :compile!
+      def_delegators :base_instance, :new, :configuration, :call, :change!, :compile!, :recognize_path, :routes
 
       # Initialize the instance variables on the remountable class, and the base_instance
       # an instance that will be used to create the set up but will not be mounted

--- a/lib/grape/dsl/settings.rb
+++ b/lib/grape/dsl/settings.rb
@@ -7,7 +7,7 @@ module Grape
     # matter where they're defined, and inheritable settings which apply only
     # in the current scope and scopes nested under it.
     module Settings
-      attr_writer :inheritable_setting, :top_level_setting
+      attr_writer :inheritable_setting
 
       # Fetch our top-level settings, which apply to all endpoints in the API.
       def top_level_setting

--- a/lib/grape/dsl/validations.rb
+++ b/lib/grape/dsl/validations.rb
@@ -3,6 +3,28 @@
 module Grape
   module DSL
     module Validations
+      # Opens a root-level ParamsScope, defining parameter coercions and
+      # validations for the endpoint.
+      # @yield instance context of the new scope
+      def params(&block)
+        Grape::Validations::ParamsScope.new(api: self, type: Hash, &block)
+      end
+
+      # Declare the contract to be used for the endpoint's parameters.
+      # @param contract [Class<Dry::Validation::Contract> | Dry::Schema::Processor]
+      #   The contract or schema to be used for validation. Optional.
+      # @yield a block yielding a new instance of Dry::Schema::Params
+      #   subclass, allowing to define the schema inline. When the
+      #   +contract+ parameter is a schema, it will be used as a parent. Optional.
+      def contract(contract = nil, &block)
+        raise ArgumentError, 'Either contract or block must be provided' unless contract || block
+        raise ArgumentError, 'Cannot inherit from contract, only schema' if block && contract.respond_to?(:schema)
+
+        Grape::Validations::ContractScope.new(self, contract, &block)
+      end
+
+      private
+
       # Clears all defined parameters and validations. The main purpose of it is to clean up
       # settings, so next endpoint won't interfere with previous one.
       #
@@ -23,26 +45,6 @@ module Grape
       #    end
       def reset_validations!
         inheritable_setting.namespace_stackable.delete(:declared_params, :params, :validations)
-      end
-
-      # Opens a root-level ParamsScope, defining parameter coercions and
-      # validations for the endpoint.
-      # @yield instance context of the new scope
-      def params(&block)
-        Grape::Validations::ParamsScope.new(api: self, type: Hash, &block)
-      end
-
-      # Declare the contract to be used for the endpoint's parameters.
-      # @param contract [Class<Dry::Validation::Contract> | Dry::Schema::Processor]
-      #   The contract or schema to be used for validation. Optional.
-      # @yield a block yielding a new instance of Dry::Schema::Params
-      #   subclass, allowing to define the schema inline. When the
-      #   +contract+ parameter is a schema, it will be used as a parent. Optional.
-      def contract(contract = nil, &block)
-        raise ArgumentError, 'Either contract or block must be provided' unless contract || block
-        raise ArgumentError, 'Cannot inherit from contract, only schema' if block && contract.respond_to?(:schema)
-
-        Grape::Validations::ContractScope.new(self, contract, &block)
       end
     end
   end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3938,19 +3938,12 @@ describe Grape::API do
     end
   end
 
-  describe '.compile' do
-    it 'sets the instance' do
-      expect(subject.instance).to be_nil
-      subject.compile
-      expect(subject.instance).to be_a(subject.base_instance)
-    end
-  end
-
   describe '.change!' do
     it 'invalidates any compiled instance' do
-      subject.compile
+      expect(Grape::API::Instance.singleton_class::LOCK).to receive(:synchronize).and_call_original.twice
+      subject.compile!
       subject.change!
-      expect(subject.instance).to be_nil
+      subject.compile!
     end
   end
 

--- a/spec/grape/dsl/validations_spec.rb
+++ b/spec/grape/dsl/validations_spec.rb
@@ -10,21 +10,6 @@ describe Grape::DSL::Validations do
     end
   end
 
-  describe '.reset_validations' do
-    subject { dummy_class.reset_validations! }
-
-    before do
-      %i[declared_params params validations other].each do |key|
-        dummy_class.inheritable_setting.namespace_stackable[key] = key
-      end
-    end
-
-    it 'calls unset_namespace_stackable properly' do
-      subject
-      expect(dummy_class.inheritable_setting.namespace_stackable.to_hash).to eq(other: [:other])
-    end
-  end
-
   describe '.params' do
     subject { dummy_class.params { :my_block } }
 


### PR DESCRIPTION
## Summary

This PR refactors the `Grape::API::Instance` class and reorganizes methods across DSL modules to improve code organization and maintainability. The changes move routing-related methods from `Instance` to the `DSL::Routing` module, simplify instance variable access patterns, and improve test coverage by using actual HTTP calls instead of inspecting internal state.

## Changes

### API::Instance Refactoring

- **Removed attr_readers**: Replaced `instance` and `base` attr_readers with direct `@instance` and `@base` instance variable access
- **Simplified compilation**: Removed separate `compile` and `call!` methods, consolidating logic into `compile!` and `call`
- **Method visibility**: Moved `change!` from protected to public section for better API consistency
- **Updated delegators**: Changed `def_delegators :base` to `def_delegators :@base` to work with instance variables

### DSL Module Reorganization

- **Moved methods to DSL::Routing**: Relocated `given`, `mounted`, and `cascade` methods from `API::Instance` to `DSL::Routing` module where they logically belong
- **Method ordering in DSL::Validations**: Moved `params` and `contract` methods to the top of the module, with `reset_validations!` moved to private section
- **Private method organization**: Moved `reset_routes!` and `reset_endpoints!` to private section in `DSL::Routing`
- **Instance variable access**: Updated `evaluate_as_instance_with_configuration` to use `@base` instead of `base`

### API Class Updates

- **NON_OVERRIDABLE list**: Expanded to include additional methods that should not be overridden (`base=`, `base_instance?`, `change!`, `inherit_settings`, `recognize_path`, `reset!`, `top_level_setting=`, `top_level_setting`)
- **Delegators**: Added `change!`, `recognize_path`, and `routes` to the list of methods delegated to `base_instance`

### Settings Module

- **Removed attr_writer**: Removed `top_level_setting` from `attr_writer` in `DSL::Settings` (now handled differently)

### Test Improvements

- **Removed internal state tests**: Removed `.compile` test that checked internal instance state
- **Updated `.change!` test**: Now verifies that compilation happens twice after calling `change!`
- **Integration-style routing tests**: Updated routing tests to use actual HTTP calls (`Rack::MockRequest`) instead of checking internal settings hash
- **Integration-style validation tests**: Updated validation tests to use actual HTTP calls and verify JSON responses instead of directly checking `declared_params` internal state

## Benefits

1. **Better code organization**: Methods are now located in their appropriate DSL modules
2. **Improved test coverage**: Tests now verify actual behavior through HTTP calls rather than internal state
3. **Cleaner API**: Direct instance variable access reduces unnecessary method indirection
4. **Better encapsulation**: Private methods are properly scoped

## Files Changed

- `lib/grape/api.rb`
- `lib/grape/api/instance.rb`
- `lib/grape/dsl/routing.rb`
- `lib/grape/dsl/settings.rb`
- `lib/grape/dsl/validations.rb`
- `spec/grape/api_spec.rb`
- `spec/grape/dsl/routing_spec.rb`
- `spec/grape/dsl/validations_spec.rb`
- `spec/grape/validations_spec.rb`


