### PR TITLE
Fix `cascade` reading at Grape::API's level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Fixes
     
+* [#2633](https://github.com/ruby-grape/grape/pull/2633): Fix cascade reading - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.0.1 (2025-11-24)

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -16,7 +16,7 @@ module Grape
       end
 
       def cascade(value = nil)
-        return inheritable_setting.namespace_inheritable.key?(:cascade) ? !inheritable_setting.namespace_inheritable(:cascade).nil? : true if value.nil?
+        return inheritable_setting.namespace_inheritable.key?(:cascade) ? !inheritable_setting.namespace_inheritable[:cascade].nil? : true if value.nil?
 
         inheritable_setting.namespace_inheritable[:cascade] = value
       end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -4715,4 +4715,16 @@ describe Grape::API do
       expect { get '/' }.to raise_error(Rack::Lint::LintError)
     end
   end
+
+  describe '.cascade' do
+    subject { api.cascade }
+
+    let(:api) do
+      Class.new(Grape::API) do
+        cascade true
+      end
+    end
+
+    it { is_expected.to be(true) }
+  end
 end


### PR DESCRIPTION
This PR fixes the call to `cascade` when read from the api.

The following test was failing
```ruby
describe '.cascade' do
  subject { api.cascade }
  let(:api) do 
    Class.new(Grape::API) do
      cascade true
    end
  end

  it { is_expected.to eq(true)}
end
```

All make proper changes after #2633 is merged since the latter is moving the function in routing module
  