### PR TITLE
Refactor router to simplify method signatures and reduce duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#2629](https://github.com/ruby-grape/grape/pull/2629): Refactor Router Architecture - [@ericproulx](https://github.com/ericproulx).
 * [#2633](https://github.com/ruby-grape/grape/pull/2633): Refactor API::Instance and reorganize DSL modules - [@ericproulx](https://github.com/ericproulx).
+* [#2636](https://github.com/ruby-grape/grape/pull/2636): Refactor router to simplify method signatures and reduce duplication - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/router/route.rb
+++ b/lib/grape/router/route.rb
@@ -3,10 +3,14 @@
 module Grape
   class Router
     class Route < BaseRoute
+      extend Forwardable
+
       FORWARD_MATCH_METHOD = ->(input, pattern) { input.start_with?(pattern.origin) }
       NON_FORWARD_MATCH_METHOD = ->(input, pattern) { pattern.match?(input) }
 
       attr_reader :app, :request_method, :index
+
+      def_delegators :@app, :call
 
       def initialize(endpoint, method, pattern, options)
         super(pattern, options)
@@ -17,10 +21,6 @@ module Grape
 
       def convert_to_head_request!
         @request_method = Rack::HEAD
-      end
-
-      def exec(env)
-        @app.call(env)
       end
 
       def apply(app)


### PR DESCRIPTION
# Router Simplification Refactor

## Summary

This PR refactors the `Grape::Router` class to simplify method signatures, reduce code duplication, and improve overall code clarity. The changes consolidate route processing logic and eliminate redundant helper methods.

## Changes

### Router (`lib/grape/router.rb`)

- **Extract input and method normalization earlier**: Path normalization and method extraction now happen once at the beginning of `call`, rather than being extracted multiple times throughout the call chain
- **Simplified method signatures**: Methods like `identity`, `rotation`, and `transaction` now accept `input` and `method` as explicit parameters instead of extracting them from `env` internally
- **Consolidated route processing**: Combined `process_route`, `prepare_env_from_route`, `make_routing_args`, and `call_with_allow_headers` into a single `process_route` method with an optional `include_allow_header` parameter
- **Removed redundant helpers**: Eliminated `extract_input_and_method`, `string_for`, `prepare_env_from_route`, `make_routing_args`, and `call_with_allow_headers` methods

### Route (`lib/grape/router/route.rb`)

- **Simplified delegation**: Replaced `exec` method with `Forwardable` delegation to `@app.call`, making the code more idiomatic Ruby
- **Cleaner interface**: The `Route` class now directly delegates `call` to its app endpoint

## Benefits

1. **Reduced duplication**: Path normalization and method extraction happen once instead of multiple times
2. **Clearer data flow**: Explicit parameters make it easier to understand what data flows through each method
3. **Simpler code**: Fewer helper methods means less indirection and easier maintenance
4. **Better performance**: Eliminates redundant path normalization calls

## Testing

- [ ] All existing tests pass
- [ ] No breaking changes to public API
- [ ] Router behavior remains unchanged

## Notes

This is a pure refactoring with no functional changes. The router's behavior and API remain the same, but the internal implementation is cleaner and more maintainable.
