### PR TITLE
Remove unnecessary path string duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#2629](https://github.com/ruby-grape/grape/pull/2629): Refactor Router Architecture - [@ericproulx](https://github.com/ericproulx).
 * [#2633](https://github.com/ruby-grape/grape/pull/2633): Refactor API::Instance and reorganize DSL modules - [@ericproulx](https://github.com/ericproulx).
 * [#2636](https://github.com/ruby-grape/grape/pull/2636): Refactor router to simplify method signatures and reduce duplication - [@ericproulx](https://github.com/ericproulx).
+* [#2638](https://github.com/ruby-grape/grape/pull/2638): Remove unnecessary path string duplication - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/middleware/versioner/path.rb
+++ b/lib/grape/middleware/versioner/path.rb
@@ -22,7 +22,7 @@ module Grape
           return if path_info == '/'
 
           [mount_path, Grape::Router.normalize_path(prefix)].each do |path|
-            path_info.delete_prefix!(path) if path.present? && path != '/' && path_info.start_with?(path)
+            path_info = path_info.delete_prefix(path) if path.present? && path != '/' && path_info.start_with?(path)
           end
 
           slash_position = path_info.index('/', 1) # omit the first one

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -16,7 +16,7 @@ module Grape
       return path if path == '/'
 
       # Fast path for the overwhelming majority of paths that don't need to be normalized
-      return path.dup if path.start_with?('/') && !(path.end_with?('/') || path.match?(%r{%|//}))
+      return path if path.start_with?('/') && !(path.end_with?('/') || path.match?(%r{%|//}))
 
       # Slow path
       encoding = path.encoding


### PR DESCRIPTION
# Remove unnecessary path string duplication

## Summary

This PR removes unnecessary string duplication operations in path handling code, improving performance by avoiding redundant string allocations.

## Changes

### Path Versioner Middleware (`lib/grape/middleware/versioner/path.rb`)

- **Changed from mutating to non-mutating `delete_prefix`**: Replaced `path_info.delete_prefix!(path)` with `path_info = path_info.delete_prefix(path)`
  - `path_info` is a local variable (not the original `env[Rack::PATH_INFO]`), so the mutating version was unnecessary
  - The non-mutating version correctly returns a new string, which is what we need for the local variable assignment
  - This change makes the code's intent clearer and avoids potential confusion about mutation

### Router Path Normalization (`lib/grape/router.rb`)

- **Removed unnecessary `.dup` in fast path**: Changed `return path.dup` to `return path` in the `normalize_path` fast path
  - In the fast path, when the path doesn't need normalization, we simply return it as-is
  - Since we're not modifying the path in this case, there's no need to duplicate it
  - This eliminates an unnecessary string allocation for the common case

## Benefits

1. **Performance improvement**: Eliminates unnecessary string allocations in the common path normalization case
2. **Code clarity**: Makes the intent clearer by using non-mutating methods where appropriate
3. **Memory efficiency**: Reduces memory usage by avoiding redundant string copies

## Technical Details

Both changes are safe because:
- In the versioner middleware, `path_info` is a local variable that gets reassigned, so we don't need mutation
- In the router, the fast path returns the path without modification, so no duplication is needed

## Testing

- [x] All existing tests pass
- [x] No breaking changes to public API
- [x] Path normalization behavior remains unchanged
- [x] Versioner path middleware behavior remains unchanged

## Notes

This is a performance optimization with no functional changes. The behavior of both `normalize_path` and the path versioner middleware remains exactly the same, but with improved efficiency.
