### PR TITLE
Refactor: Simplify mime_types_for method implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#2629](https://github.com/ruby-grape/grape/pull/2629): Refactor Router Architecture - [@ericproulx](https://github.com/ericproulx).
 * [#2633](https://github.com/ruby-grape/grape/pull/2633): Refactor API::Instance and reorganize DSL modules - [@ericproulx](https://github.com/ericproulx).
 * [#2636](https://github.com/ruby-grape/grape/pull/2636): Refactor router to simplify method signatures and reduce duplication - [@ericproulx](https://github.com/ericproulx).
+* [#2639](https://github.com/ruby-grape/grape/pull/2639): Refactor mime_types_for - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/content_types.rb
+++ b/lib/grape/content_types.rb
@@ -22,10 +22,7 @@ module Grape
     def mime_types_for(from_settings)
       return MIME_TYPES if from_settings == Grape::ContentTypes::DEFAULTS
 
-      from_settings.each_with_object({}) do |(k, v), types_without_params|
-        # remove optional parameter
-        types_without_params[v.split(';', 2).first] = k
-      end
+      from_settings.invert.transform_keys! { |k| k.include?(';') ? k.split(';', 2).first : k }
     end
   end
 end


### PR DESCRIPTION
# Refactor: Simplify `mime_types_for` method implementation

## Summary

This PR refactors the `mime_types_for` method in `Grape::ContentTypes` to use a more concise and idiomatic Ruby implementation. The refactoring replaces the `each_with_object` pattern with `invert` and `transform_keys!`, making the code more readable while maintaining the same functionality.

## Changes

### Content Types Module (`lib/grape/content_types.rb`)

- **Simplified `mime_types_for` implementation**: Replaced `each_with_object` with `invert.transform_keys!`
  - **Before**: Used `each_with_object({})` to build a new hash by iterating and manually constructing key-value pairs
  - **After**: Uses `invert` to swap keys and values, then `transform_keys!` to remove optional MIME type parameters (e.g., `;charset=utf-8`)
  - **Optimization**: Added conditional check `k.include?(';')` before splitting, avoiding unnecessary string operations and allocations when the MIME type doesn't contain parameters

## Benefits

1. **More idiomatic Ruby**: Uses built-in hash methods (`invert`, `transform_keys!`) instead of manual iteration
2. **Improved readability**: The intent is clearer - we're inverting the hash and transforming the keys
3. **Performance optimization**: Only splits strings that contain `;`, avoiding unnecessary operations
4. **Reduced code complexity**: Fewer lines and less explicit iteration logic

## Technical Details

The method transforms a hash like:
```ruby
{ xml: 'application/xml;charset=utf-8' }
```

Into:
```ruby
{ 'application/xml' => :xml }
```

Both the old and new implementations produce identical results:
- Invert the hash (swap keys and values)
- Remove optional parameters from MIME types (everything after `;`)
- Return the transformed hash

## Testing

- [x] All existing tests pass
- [x] No breaking changes to public API
- [x] `mime_types_for` behavior remains unchanged
- [x] Handles MIME types with and without optional parameters correctly

## Notes

This is a pure refactoring with no functional changes. The behavior of `mime_types_for` remains exactly the same, but the implementation is cleaner and more efficient.

