### PR TITLE
Revert PR #2577: Restore support for `return` in endpoint blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 #### Fixes
     
 * [#2633](https://github.com/ruby-grape/grape/pull/2633): Fix cascade reading - [@ericproulx](https://github.com/ericproulx).
+* [#2641](https://github.com/ruby-grape/grape/pull/2641): Restore support for `return` in endpoint blocks - [@ericproulx](https://github.com/ericproulx).
 * [#2642](https://github.com/ruby-grape/grape/pull/2642): Fix array allocation in base_route.rb - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -762,27 +762,11 @@ describe Grape::Endpoint do
     expect(last_response.body).to eq('yo')
   end
 
-  context 'when `return`' do
-    it 'calls deprecator' do
+  context 'when calling return' do
+    it 'does not raise a LocalJumpError' do
       subject.get('/home') do
         return 'Hello'
       end
-
-      expect(Grape.deprecator).to receive(:warn).with('Using `return` in an endpoint has been deprecated. Use `next` instead.')
-
-      get '/home'
-      expect(last_response.status).to eq(200)
-      expect(last_response.body).to eq('Hello')
-    end
-  end
-
-  context 'when `next`' do
-    it 'does not call deprecator' do
-      subject.get('/home') do
-        next 'Hello'
-      end
-
-      expect(Grape.deprecator).not_to receive(:warn)
 
       get '/home'
       expect(last_response.status).to eq(200)


### PR DESCRIPTION
# Revert PR #2577: Restore support for `return` in endpoint blocks

## Summary

This PR reverts the changes introduced in PR #2577 that deprecated the use of `return` in endpoint blocks and simplified endpoint block execution. Based on the discussion in PR #2577, we are restoring the previous behavior that allows `return` statements to work without deprecation warnings.

## Background

PR #2577 ("Simplify endpoint block execution and deprecate `return` call in it") changed how endpoint blocks are executed by:
- Using `instance_exec` instead of converting blocks to unbound methods
- Catching `LocalJumpError` exceptions and issuing deprecation warnings when `return` was used
- Recommending the use of `next` instead of `return`

After further discussion, it was decided to revert these changes to maintain backward compatibility and restore the original behavior.

## Changes

### Endpoint Block Execution (`lib/grape/endpoint.rb`)

- **Restored `block_to_unbound_method` class method**: Converts blocks to unbound methods for proper `return` handling
- **Restored unbound method binding**: Changed from `instance_exec(&@source)` back to `@source.bind_call(self)`
- **Removed deprecation warning**: Removed the `LocalJumpError` rescue block that issued deprecation warnings for `return` statements

### Tests (`spec/grape/endpoint_spec.rb`)

- **Simplified `return` test**: Removed deprecation warning expectations
- **Removed `next` test**: No longer needed since `return` is the supported approach again

## Impact

- ✅ `return` statements in endpoint blocks now work without deprecation warnings
- ✅ Restores backward compatibility with existing codebases using `return`
- ✅ Maintains the same functionality as before PR #2577

## Related

- Reverts: [#2577](https://github.com/ruby-grape/grape/pull/2577) - Simplify endpoint block execution and deprecate `return` call in it
