### PR TITLE
Memoize regexp_capture_index reduces array allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 #### Fixes
     
 * [#2633](https://github.com/ruby-grape/grape/pull/2633): Fix cascade reading - [@ericproulx](https://github.com/ericproulx).
+* [#2642](https://github.com/ruby-grape/grape/pull/2642): Fix array allocation in base_route.rb - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.0.1 (2025-11-24)

--- a/lib/grape/router/base_route.rb
+++ b/lib/grape/router/base_route.rb
@@ -7,7 +7,7 @@ module Grape
 
       delegate_missing_to :@options
 
-      attr_reader :index, :options, :pattern
+      attr_reader :options, :pattern
 
       def_delegators :@pattern, :path, :origin
       def_delegators :@options, :description, :version, :requirements, :prefix, :anchor, :settings, :forward_match, *Grape::Util::ApiDescription::DSL_METHODS
@@ -19,11 +19,11 @@ module Grape
 
       # see https://github.com/ruby-grape/grape/issues/1348
       def namespace
-        @options[:namespace]
+        @namespace ||= @options[:namespace]
       end
 
       def regexp_capture_index
-        CaptureIndexCache[index]
+        @regexp_capture_index ||= CaptureIndexCache[@index]
       end
 
       def pattern_regexp


### PR DESCRIPTION
This PR reduces array allocation in `base_route`. I've been profiling endpoints on `https://github.com/ruby-grape/grape-on-rack` and this small change reduced the array allocation.

This images is about memory usage after 6400 requests:

<img width="952" height="277" alt="Screenshot 2025-12-14 at 16 38 53" src="https://github.com/user-attachments/assets/2b88f104-bb55-4d37-8f06-a077829b9586" />
