### PR TITLE
Compile endpoints on first call or when API compile!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * [#2643](https://github.com/ruby-grape/grape/pull/2638): Remove `try` method in codebase - [@ericproulx](https://github.com/ericproulx).
 * [#2646](https://github.com/ruby-grape/grape/pull/2646): Call `valid_encoding?` before scrub - [@ericproulx](https://github.com/ericproulx).
 * [#2644](https://github.com/ruby-grape/grape/pull/2644): Clean useless/not valuable dependencies - [@ericproulx](https://github.com/ericproulx).
+* [#2645](https://github.com/ruby-grape/grape/pull/2645): Endpoints are compiled when API is compiled - [@ericproulx](https://github.com/ericproulx).
+
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,12 @@
 Upgrading Grape
 ===============
 
+### Upgrading to >= 3.1.0
+
+#### Enhanced API compile!
+
+Endpoints are now "compiled" instead of lazy loaded. Historically, when calling `YourAPI.compile!` in `config.ru` (or just receiving the first API call), only routing was compiled see [Grape::Router#compile!](https://github.com/ruby-grape/grape/blob/bf90e95c3b17c415c944363b1c07eb9727089ee7/lib/grape/router.rb#L41-L54) and endpoints were lazy loaded. Now, it's part of the API compilation. See [#2645](https://github.com/ruby-grape/grape/pull/2645) for more information.
+
 ### Upgrading to >= 3.0.0
 
 #### Ruby 3+ Argument Delegation Modernization

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -2,8 +2,6 @@
 
 module Grape
   class Router
-    attr_reader :map, :compiled
-
     # Taken from Rails
     #     normalize_path("/foo")  # => "/foo"
     #     normalize_path("/foo/") # => "/foo"
@@ -39,14 +37,14 @@ module Grape
     end
 
     def compile!
-      return if compiled
+      return if @compiled
 
       @union = Regexp.union(@neutral_regexes)
       @neutral_regexes = nil
       (Grape::HTTP_SUPPORTED_METHODS + ['*']).each do |method|
-        next unless map.key?(method)
+        next unless @map.key?(method)
 
-        routes = map[method]
+        routes = @map[method]
         optimized_map = routes.map.with_index { |route, index| route.to_regexp(index) }
         @optimized_map[method] = Regexp.union(optimized_map)
       end
@@ -54,7 +52,7 @@ module Grape
     end
 
     def append(route)
-      map[route.request_method] << route
+      @map[route.request_method] << route
     end
 
     def associate_routes(greedy_route)
@@ -91,7 +89,7 @@ module Grape
 
     def rotation(input, method, env, exact_route)
       response = nil
-      map[method].each do |route|
+      @map[method].each do |route|
         next if exact_route == route
         next unless route.match?(input)
 
@@ -143,7 +141,7 @@ module Grape
     end
 
     def with_optimization
-      compile! unless compiled
+      compile!
       yield || default_response
     end
 

--- a/spec/grape/api/defines_boolean_in_params_spec.rb
+++ b/spec/grape/api/defines_boolean_in_params_spec.rb
@@ -22,13 +22,5 @@ describe Grape::API::Instance do
       expect(last_response.status).to eq(201)
       expect(last_response.body).to eq expected_body
     end
-
-    context 'Params endpoint type' do
-      subject { app.new.router.map[Rack::POST].first.options[:params]['message'][:type] }
-
-      it 'params type is a boolean' do
-        expect(subject).to eq 'Grape::API::Boolean'
-      end
-    end
   end
 end


### PR DESCRIPTION
This PR removes the lazy initialization of all endpoints in favor of compiling them through the instance compilation. I wouldn't bet that Grape will be faster but there will be only 1 compile phase.

`map` and `compiled` attributes readers have been removed from the public space. This is pure internal stuff so it should not impact anyone

## Old behavior
Endpoints are `compiled` on the first call. See `COMPILE!` in the following logs.
```ruby
Puma starting in single mode...
* Puma version: 7.1.0 ("Neon Witch")
* Ruby version: ruby 3.4.8 (2025-12-17 revision 995b59f666) +PRISM [arm64-darwin25]
*  Min threads: 0
*  Max threads: 5
*  Environment: development
*          PID: 48751
* Listening on http://127.0.0.1:9292
* Listening on http://[::1]:9292
Use Ctrl-C to stop
LOCK ACQUIRED!
UNLOCK!
COMPILE! /spline ["POST"] ["/"]
::1 - - [19/Dec/2025:11:43:10 +0000] "POST /api/spline HTTP/1.1" 201 - 0.0031
COMPILE! /reticulated_splines ["GET"] ["/"] - 2760
::1 - - [19/Dec/2025:11:43:10 +0000] "GET /api/reticulated_splines?splines=%5B%7B%22id%22%3A1%2C%22reticulated%22%3Atrue%7D%5D HTTP/1.1" 200 - 0.0013
COMPILE! / ["GET"] ["/ping"]
::1 - - [19/Dec/2025:11:43:10 +0000] "GET /api/ping HTTP/1.1" 200 - 0.0043
::1 - - [19/Dec/2025:11:43:10 +0000] "GET /api/reticulated_splines?splines=%5B%7B%22id%22%3A1%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A2%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A3%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A4%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A5%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A6%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A7%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A8%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A9%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A10%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A11%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A12%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A13%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A14%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A15%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A16%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A17%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A18%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A19%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A20%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A21%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A22%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A23%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A24%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A25%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A26%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A27%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A28%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A29%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A30%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A31%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A32%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A33%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A34%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A35%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A36%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A37%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A38%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A39%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A40%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A41%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A42%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A43%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A44%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A45%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A46%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A47%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A48%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A49%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A50%2C%22reticulated%22%3Atrue%7D%5D HTTP/1.1" 200 - 0.0008
::1 - - [19/Dec/2025:11:43:10 +0000] "POST /api/spline HTTP/1.1" 201 - 0.0002
::1 - - [19/Dec/2025:11:43:10 +0000] "POST /api/spline HTTP/1.1" 201 - 0.0070
::1 - - [19/Dec/2025:11:43:10 +0000] "GET /api/reticulated_splines?splines=%5B%7B%22id%22%3A1%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A2%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A3%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A4%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A5%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A6%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A7%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A8%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A9%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A10%2C%22reticulated%22%3Afalse%7D%5D HTTP/1.1" 200 - 0.0004
::1 - - [19/Dec/2025:11:43:10 +0000] "POST /api/spline HTTP/1.1" 201 - 0.0041
::1 - - [19/Dec/2025:11:43:10 +0000] "POST /api/spline HTTP/1.1" 201 - 0.0002
COMPILE! / ["GET"] [:ring]
::1 - - [19/Dec/2025:11:43:10 +0000] "GET /api/ring HTTP/1.1" 200 - 0.0009
COMPILE! / ["POST"] [:ring]
::1 - - [19/Dec/2025:11:43:10 +0000] "POST /api/ring HTTP/1.1" 201 - 0.0004
COMPILE! / ["PUT"] [:ring]
::1 - - [19/Dec/2025:11:43:10 +0000] "PUT /api/ring HTTP/1.1" 200 - 0.0007
::1 - - [19/Dec/2025:11:43:10 +0000] "GET /api/reticulated_splines?splines=%5B%7B%22id%22%3A1%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A2%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A3%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A4%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A5%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A6%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A7%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A8%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A9%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A10%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A11%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A12%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A13%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A14%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A15%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A16%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A17%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A18%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A19%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A20%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A21%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A22%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A23%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A24%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A25%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A26%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A27%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A28%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A29%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A30%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A31%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A32%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A33%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A34%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A35%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A36%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A37%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A38%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A39%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A40%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A41%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A42%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A43%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A44%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A45%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A46%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A47%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A48%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A49%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A50%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A51%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A52%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A53%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A54%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A55%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A56%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A57%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A58%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A59%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A60%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A61%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A62%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A63%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A64%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A65%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A66%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A67%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A68%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A69%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A70%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A71%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A72%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A73%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A74%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A75%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A76%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A77%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A78%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A79%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A80%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A81%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A82%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A83%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A84%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A85%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A86%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A87%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A88%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A89%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A90%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A91%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A92%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A93%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A94%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A95%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A96%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A97%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A98%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A99%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A100%2C%22reticulated%22%3Atrue%7D%5D HTTP/1.1" 200 - 0.0011
::1 - - [19/Dec/2025:11:43:10 +0000] "PUT /api/ring HTTP/1.1" 200 - 0.0002
::1 - - [19/Dec/2025:11:43:10 +0000] "PUT /api/ring HTTP/1.1" 200 - 0.0002
COMPILE! /headers ["GET"] [":key"] - 2792
::1 - - [19/Dec/2025:11:43:10 +0000] "GET /api/headers/Content-Type HTTP/1.1" 200 - 0.0007
::1 - - [19/Dec/2025:11:43:10 +0000] "GET /api/reticulated_splines?splines=%5B%7B%22id%22%3A1%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A2%2C%22reticulated%22%3Atrue%7D%5D HTTP/1.1" 200 - 0.0003
::1 - - [19/Dec/2025:11:43:10 +0000] "PUT /api/ring HTTP/1.1" 200 - 0.0002
::1 - - [19/Dec/2025:11:43:10 +0000] "GET /api/headers/Accept HTTP/1.1" 200 - 0.0002
COMPILE! /headers ["GET"] ["/"] - 2800
::1 - - [19/Dec/2025:11:43:10 +0000] "GET /api/headers/Authorization HTTP/1.1" 200 - 0.0002
::1 - - [19/Dec/2025:11:43:10 +0000] "GET /api/headers/User-Agent HTTP/1.1" 200 - 0.0002
COMPILE! /entities ["GET"] [":id"] - 2808
```
## New behavior
When not [precompiled](https://github.com/ruby-grape/grape?tab=readme-ov-file#all), the first thread to acquire the lock will compile endpoints`
```ruby
Puma starting in single mode...
* Puma version: 7.1.0 ("Neon Witch")
* Ruby version: ruby 3.4.8 (2025-12-17 revision 995b59f666) +PRISM [arm64-darwin25]
*  Min threads: 0
*  Max threads: 5
*  Environment: development
*          PID: 46327
* Listening on http://127.0.0.1:9292
* Listening on http://[::1]:9292
Use Ctrl-C to stop
LOCK ACQUIRED!
COMPILE! / [:any] ["/"]
COMPILE! / ["GET"] ["/swagger_doc"]
COMPILE! / ["GET"] ["/swagger_doc/:name"]
COMPILE! / [:any] ["/"]
COMPILE! / ["GET"] ["/ping"] - 2656
COMPILE! / [:any] ["/"] - 2664
COMPILE! / ["GET"] [:raise] - 2672
COMPILE! / [:any] ["/"] - 2680
COMPILE! / ["GET"] ["/"] - 2688
COMPILE! / [:any] ["/"] - 2696
COMPILE! / ["GET"] ["/"] - 2704
COMPILE! / [:any] ["/"] - 2712
COMPILE! / ["GET"] [:ring] - 2720
COMPILE! / ["POST"] [:ring] - 2728
COMPILE! / ["PUT"] [:ring] - 2736
COMPILE! / [:any] ["/"] - 2744
COMPILE! /decorated ["GET"] [:ping] - 2752
COMPILE! / [:any] ["/"] - 2760
COMPILE! /spline ["POST"] ["/"] - 2768
COMPILE! / [:any] ["/"] - 2776
COMPILE! /reticulated_splines ["GET"] ["/"] - 2784
COMPILE! / [:any] ["/"] - 2792
COMPILE! / ["GET"] ["plain_text"] - 2800
COMPILE! / ["GET"] ["mixed"] - 2808
COMPILE! / [:any] ["/"] - 2816
COMPILE! / ["POST"] ["avatar"] - 2824
COMPILE! / ["POST"] ["download"] - 2832
COMPILE! / [:any] ["/"] - 2840
COMPILE! /entities ["GET"] [":id"] - 2848
COMPILE! / [:any] ["/"] - 2856
COMPILE! /headers ["GET"] [":key"] - 2864
COMPILE! /headers ["GET"] ["/"] - 2872
COMPILE! / [:any] ["/"] - 2880
COMPILE! / ["GET"] [:stream] - 2888
UNLOCK!
::1 - - [19/Dec/2025:11:31:18 +0000] "POST /api/spline HTTP/1.1" 201 - 0.0116
LOCK ACQUIRED!
UNLOCK!
::1 - - [19/Dec/2025:11:31:18 +0000] "GET /api/reticulated_splines?splines=%5B%7B%22id%22%3A1%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A2%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A3%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A4%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A5%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A6%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A7%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A8%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A9%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A10%2C%22reticulated%22%3Afalse%7D%5D HTTP/1.1" 200 - 0.0118
LOCK ACQUIRED!
::1 - - [19/Dec/2025:11:31:18 +0000] "GET /api/reticulated_splines?splines=%5B%7B%22id%22%3A1%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A2%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A3%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A4%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A5%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A6%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A7%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A8%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A9%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A10%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A11%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A12%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A13%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A14%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A15%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A16%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A17%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A18%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A19%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A20%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A21%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A22%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A23%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A24%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A25%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A26%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A27%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A28%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A29%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A30%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A31%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A32%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A33%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A34%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A35%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A36%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A37%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A38%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A39%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A40%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A41%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A42%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A43%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A44%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A45%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A46%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A47%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A48%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A49%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A50%2C%22reticulated%22%3Atrue%7D%5D HTTP/1.1" 200 - 0.0010
UNLOCK!
LOCK ACQUIRED!
::1 - - [19/Dec/2025:11:31:18 +0000] "POST /api/spline HTTP/1.1" 201 - 0.0130
UNLOCK!
::1 - - [19/Dec/2025:11:31:18 +0000] "POST /api/spline HTTP/1.1" 201 - 0.0132
LOCK ACQUIRED!
UNLOCK!
```

When precompiled
```ruby
LOCK ACQUIRED!
/ [:any] ["/"]
/ ["GET"] ["/swagger_doc"]
/ ["GET"] ["/swagger_doc/:name"]
/ [:any] ["/"]
/ ["GET"] ["/ping"]
/ [:any] ["/"]
/ ["GET"] [:raise]
/ [:any] ["/"]
/ ["GET"] ["/"]
/ [:any] ["/"]
/ ["GET"] ["/"]
/ [:any] ["/"]
/ ["GET"] [:ring]
/ ["POST"] [:ring]
/ ["PUT"] [:ring]
/ [:any] ["/"]
/decorated ["GET"] [:ping]
/ [:any] ["/"]
/spline ["POST"] ["/"]
/ [:any] ["/"]
/reticulated_splines ["GET"] ["/"]
/ [:any] ["/"]
/ ["GET"] ["plain_text"]
/ ["GET"] ["mixed"]
/ [:any] ["/"]
/ ["POST"] ["avatar"]
/ ["POST"] ["download"]
/ [:any] ["/"]
/entities ["GET"] [":id"]
/ [:any] ["/"]
/headers ["GET"] [":key"]
/headers ["GET"] ["/"]
/ [:any] ["/"]
/ ["GET"] [:stream]
UNLOCK!
Puma starting in single mode...
* Puma version: 7.1.0 ("Neon Witch")
* Ruby version: ruby 3.4.8 (2025-12-17 revision 995b59f666) +PRISM [arm64-darwin25]
*  Min threads: 0
*  Max threads: 5
*  Environment: development
*          PID: 51771
* Listening on http://127.0.0.1:9292
* Listening on http://[::1]:9292
Use Ctrl-C to stop
::1 - - [19/Dec/2025:12:14:16 +0000] "GET /api/ping HTTP/1.1" 200 - 0.0025
::1 - - [19/Dec/2025:12:14:16 +0000] "POST /api/spline HTTP/1.1" 201 - 0.0005
::1 - - [19/Dec/2025:12:14:16 +0000] "GET /api/reticulated_splines?splines=%5B%7B%22id%22%3A1%2C%22reticulated%22%3Atrue%7D%5D HTTP/1.1" 200 - 0.0014
::1 - - [19/Dec/2025:12:14:16 +0000] "GET /api/reticulated_splines?splines=%5B%7B%22id%22%3A1%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A2%2C%22reticulated%22%3Atrue%7D%5D HTTP/1.1" 200 - 0.0004
::1 - - [19/Dec/2025:12:14:16 +0000] "GET /api/reticulated_splines?splines=%5B%7B%22id%22%3A1%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A2%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A3%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A4%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A5%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A6%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A7%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A8%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A9%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A10%2C%22reticulated%22%3Afalse%7D%5D HTTP/1.1" 200 - 0.0003
::1 - - [19/Dec/2025:12:14:16 +0000] "POST /api/spline HTTP/1.1" 201 - 0.0002
::1 - - [19/Dec/2025:12:14:16 +0000] "POST /api/spline HTTP/1.1" 201 - 0.0055
::1 - - [19/Dec/2025:12:14:16 +0000] "POST /api/spline HTTP/1.1" 201 - 0.0002
::1 - - [19/Dec/2025:12:14:16 +0000] "GET /api/reticulated_splines?splines=%5B%7B%22id%22%3A1%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A2%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A3%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A4%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A5%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A6%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A7%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A8%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A9%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A10%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A11%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A12%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A13%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A14%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A15%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A16%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A17%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A18%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A19%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A20%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A21%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A22%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A23%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A24%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A25%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A26%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A27%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A28%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A29%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A30%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A31%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A32%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A33%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A34%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A35%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A36%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A37%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A38%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A39%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A40%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A41%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A42%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A43%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A44%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A45%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A46%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A47%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A48%2C%22reticulated%22%3Atrue%7D%2C%7B%22id%22%3A49%2C%22reticulated%22%3Afalse%7D%2C%7B%22id%22%3A50%2C%22reticulated%22%3Atrue%7D%5D HTTP/1.1" 200 - 0.0006
::1 - - [19/Dec/2025:12:14:16 +0000] "POST /api/ring HTTP/1.1" 201 - 0.0001
```