### PR TITLE
Remove useless instance_variable_defined? checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features
 
+* [#2656](https://github.com/ruby-grape/grape/pull/2656): Remove useless instance_variable_defined? checks - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -70,12 +70,12 @@ module Grape
         when Integer
           @status = status
         when nil
-          return @status if instance_variable_defined?(:@status) && @status
+          return @status if @status
 
           if request.post?
             201
           elsif request.delete?
-            if instance_variable_defined?(:@body) && @body.present?
+            if @body.present?
               200
             else
               204
@@ -114,7 +114,7 @@ module Grape
           @body = ''
           status 204
         else
-          instance_variable_defined?(:@body) ? @body : nil
+          @body
         end
       end
 

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -124,7 +124,7 @@ module Grape
       #     end
       def requires(*attrs, **opts, &block)
         opts[:presence] = { value: true, message: opts[:message] }
-        opts = @group.deep_merge(opts) if instance_variable_defined?(:@group) && @group
+        opts = @group.deep_merge(opts) if @group
 
         if opts[:using]
           require_required_and_optional_fields(attrs.first, opts)
@@ -140,7 +140,7 @@ module Grape
       # @option (see #requires)
       def optional(*attrs, **opts, &block)
         type = opts[:type]
-        opts = @group.deep_merge(opts) if instance_variable_defined?(:@group) && @group
+        opts = @group.deep_merge(opts) if @group
 
         # check type for optional parameter group
         if attrs && block
@@ -224,8 +224,8 @@ module Grape
       # @return hash of parameters relevant for the current scope
       # @api private
       def params(params)
-        params = @parent.params_meeting_dependency.presence || @parent.params(params) if instance_variable_defined?(:@parent) && @parent
-        params = map_params(params, @element) if instance_variable_defined?(:@element) && @element
+        params = @parent.params_meeting_dependency.presence || @parent.params(params) if @parent
+        params = map_params(params, @element) if @element
         params
       end
 

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -60,7 +60,7 @@ module Grape
           end
         end
 
-        @versions.last if instance_variable_defined?(:@versions) && @versions
+        @versions&.last
       end
 
       # Define a root URL prefix for your entire API.

--- a/spec/grape/api/custom_validations_spec.rb
+++ b/spec/grape/api/custom_validations_spec.rb
@@ -216,7 +216,7 @@ describe Grape::Validations do
     let(:validator_type) do
       Class.new(Grape::Validations::Validators::Base) do
         def validate_param!(_attr_name, _params)
-          if instance_variable_defined?(:@instance_variable) && @instance_variable
+          if @instance_variable
             raise Grape::Exceptions::Validation.new(params: ['params'],
                                                     message: 'This should never happen')
           end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -1069,7 +1069,7 @@ describe Grape::API do
 
     it 'adds a before filter to current and child namespaces only' do
       subject.get '/' do
-        "root - #{@foo if instance_variable_defined?(:@foo)}"
+        "root - #{@foo if @foo}"
       end
       subject.namespace :blah do
         before { @foo = 'foo' }


### PR DESCRIPTION
This PR removes `instance_variable_defined?` calls in the codebase. Just verifying the instance variable is enough.