### PR TITLE
feature(#2385): Param with multiple acceptable Hash Types

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,11 +6,31 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
+# Offense count: 2
+# Configuration parameters: CountComments, Max, CountAsOne, AllowedMethods, AllowedPatterns.
+Metrics/ClassLength:
+  Exclude:
+    - 'lib/grape/validations/params_scope.rb'
+
 # Offense count: 1
+# Configuration parameters: CountComments, Max, CountAsOne, AllowedMethods, AllowedPatterns.
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - 'lib/grape/validations/types/hash_schema.rb'
+
+# Offense count: 2
 # Configuration parameters: CountComments, Max, CountAsOne, AllowedMethods, AllowedPatterns.
 Metrics/MethodLength:
   Exclude:
     - 'lib/grape/endpoint.rb'
+    - 'lib/grape/validations/types/hash_schema.rb'
+
+# Offense count: 2
+# Configuration parameters: CountComments, Max, CountAsOne, AllowedMethods, AllowedPatterns.
+Metrics/PerceivedComplexity:
+  Exclude:
+    - 'lib/grape/validations/params_scope.rb'
+    - 'lib/grape/validations/types/hash_schema.rb'
 
 # Offense count: 18
 # Configuration parameters: EnforcedStyle, CheckMethodNames, CheckSymbols, AllowedIdentifiers, AllowedPatterns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#2657](https://github.com/ruby-grape/grape/pull/2657): Instantiate validators at definition time - [@ericproulx](https://github.com/ericproulx).
 * [#2667](https://github.com/ruby-grape/grape/pull/2667): Skip instrumentation in run_validators when no validators present - [@ericproulx](https://github.com/ericproulx).
 * [#](https://github.com/ruby-grape/grape/pull/xxx): Param with multiple acceptable Hash Types - [@jcagarcia](https://github.com/jcagarcia).
+* [#2661](https://github.com/ruby-grape/grape/pull/2661): Param with multiple acceptable Hash Types - [@jcagarcia](https://github.com/jcagarcia).
 * Your contribution here.
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#2665](https://github.com/ruby-grape/grape/pull/2665): Pass `attrs` directly to `AttributesIterator` instead of `validator` - [@ericproulx](https://github.com/ericproulx).
 * [#2657](https://github.com/ruby-grape/grape/pull/2657): Instantiate validators at definition time - [@ericproulx](https://github.com/ericproulx).
 * [#2667](https://github.com/ruby-grape/grape/pull/2667): Skip instrumentation in run_validators when no validators present - [@ericproulx](https://github.com/ericproulx).
+* [#](https://github.com/ruby-grape/grape/pull/xxx): Param with multiple acceptable Hash Types - [@jcagarcia](https://github.com/jcagarcia).
 * Your contribution here.
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 * [#2665](https://github.com/ruby-grape/grape/pull/2665): Pass `attrs` directly to `AttributesIterator` instead of `validator` - [@ericproulx](https://github.com/ericproulx).
 * [#2657](https://github.com/ruby-grape/grape/pull/2657): Instantiate validators at definition time - [@ericproulx](https://github.com/ericproulx).
 * [#2667](https://github.com/ruby-grape/grape/pull/2667): Skip instrumentation in run_validators when no validators present - [@ericproulx](https://github.com/ericproulx).
-* [#](https://github.com/ruby-grape/grape/pull/xxx): Param with multiple acceptable Hash Types - [@jcagarcia](https://github.com/jcagarcia).
 * [#2661](https://github.com/ruby-grape/grape/pull/2661): Param with multiple acceptable Hash Types - [@jcagarcia](https://github.com/jcagarcia).
 * Your contribution here.
 

--- a/README.md
+++ b/README.md
@@ -1357,6 +1357,62 @@ end
 client.get('/', status_codes: %w(1 two)) # => [1, "two"]
 ```
 
+#### Multiple Hash Schemas
+
+When you need to accept different hash structures for the same parameter (e.g., for polymorphic data), you can use `hash_schema` with the `types` option. Each schema defines a different valid structure:
+
+```ruby
+params do
+  requires :value, types: [
+    hash_schema { requires :fixed_price, type: Float },
+    hash_schema { requires :time_unit, type: String; requires :rate, type: Float }
+  ]
+end
+post '/pricing' do
+  # params[:value] will be validated against each schema until one matches
+  params[:value]
+end
+```
+
+**Valid Requests:**
+
+```ruby
+# Matches first schema
+{ value: { fixed_price: 100.0 } }
+
+# Matches second schema
+{ value: { time_unit: 'hour', rate: 50.0 } }
+```
+
+**Nested Hash Schemas:**
+
+Hash schemas also support nested structures with multiple required fields. When validation fails with multiple errors, all errors are reported together:
+
+```ruby
+params do
+  requires :options, types: [
+    hash_schema {
+      requires :form, type: Hash do
+        requires :colour, type: String
+        requires :font, type: String
+      end
+    },
+    hash_schema {
+      requires :api, type: Hash do
+        requires :authenticated, type: Grape::API::Boolean
+      end
+    }
+  ]
+end
+
+# Valid request matching first schema
+{ options: { form: { colour: 'red', font: 'Arial' } } }
+
+# Invalid request with multiple missing fields - all errors reported at once
+{ options: { form: {} } }
+# => { "error": "options[form][colour] is missing, options[form][font] is missing" }
+```
+
 ### Validation of Nested Parameters
 
 Parameters can be nested using `group` or by calling `requires` or `optional` with a block.

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -204,6 +204,24 @@ module Grape
 
       alias group requires
 
+      # Define a hash schema for use with multiple hash type variants.
+      # Used with the +types+ option to allow a parameter to accept one of several
+      # different hash structures.
+      #
+      # @param block [Proc] the validation block defining the Hash schema
+      # @return [Grape::Validations::Types::HashSchema]
+      # @example
+      #
+      #     params do
+      #       requires :value, types: [
+      #         hash_schema { requires :fixed_price, type: Float },
+      #         hash_schema { requires :time_unit, type: String; requires :rate, type: Float }
+      #       ]
+      #     end
+      def hash_schema(&)
+        Grape::Validations::Types::HashSchema.new(&)
+      end
+
       class EmptyOptionalValue; end # rubocop:disable Lint/EmptyClass
 
       def map_params(params, element, is_array = false)

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -361,6 +361,12 @@ module Grape
         # type casted values
         coerce_type validations.extract!(:coerce, :coerce_with, :coerce_message), attrs, required, opts
 
+        # If we have hash schemas, validate against them
+        if validations.key?(:hash_schemas)
+          validate('multiple_hash_schema', validations[:hash_schemas], attrs, required, opts)
+          validations.delete(:hash_schemas)
+        end
+
         validations.each do |type, options|
           # Don't try to look up validators for documentation params that don't have one.
           next if RESERVED_DOCUMENTATION_KEYWORDS.include?(type)
@@ -394,9 +400,15 @@ module Grape
 
         coerce_type = validations[:coerce]
 
+        # Special case - when the types array contains HashSchema instances
+        if Types.multiple_hash_schemas?(coerce_type)
+          # Store schemas for validation
+          validations[:hash_schemas] = coerce_type
+          # Set coerce to Hash so we validate it's a Hash type, but don't try to coerce the schemas
+          validations[:coerce] = Hash
         # Special case - when the argument is a single type that is a
         # variant-type collection.
-        if Types.multiple?(coerce_type) && validations.key?(:type)
+        elsif Types.multiple?(coerce_type) && validations.key?(:type)
           validations[:coerce] = Types::VariantCollectionCoercer.new(
             coerce_type,
             validations.delete(:coerce_with)

--- a/lib/grape/validations/types.rb
+++ b/lib/grape/validations/types.rb
@@ -78,6 +78,14 @@ module Grape
         (type.is_a?(Array) || type.is_a?(Set)) && type.size > 1
       end
 
+      # Does the type list contain HashSchema instances?
+      #
+      # @param types [Array] type list to check
+      # @return [Boolean] +true+ if the list contains HashSchema instances
+      def multiple_hash_schemas?(types)
+        types.is_a?(Array) && types.any?(Grape::Validations::Types::HashSchema)
+      end
+
       # Does Grape provide special coercion and validation
       # routines for the given class? This does not include
       # automatic handling for primitives, structures and

--- a/lib/grape/validations/types/hash_schema.rb
+++ b/lib/grape/validations/types/hash_schema.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+require 'ostruct'
+
+module Grape
+  module Validations
+    module Types
+      # Represents a Hash type with a specific schema defined by a block.
+      # Used to support multiple Hash type variants in the types option.
+      #
+      # @example
+      #   params do
+      #     requires :value, types: [
+      #       HashSchema.new { requires :fixed_price, type: Float },
+      #       HashSchema.new { requires :time_unit, type: String; requires :rate, type: Float }
+      #     ]
+      #   end
+      class HashSchema
+        attr_reader :block
+
+        # Result object containing validation details
+        class ValidationResult
+          attr_reader :errors, :matched_keys
+
+          def initialize
+            @errors = []
+            @matched_keys = 0
+            @success = true
+          end
+
+          def add_error(path, message)
+            @errors << { path: path, message: message }
+            @success = false
+          end
+
+          def increment_matched_keys
+            @matched_keys += 1
+          end
+
+          def success?
+            @success
+          end
+
+          # Calculate a score for this validation attempt
+          # Higher score means closer to being valid
+          def score
+            # Prioritize schemas that matched more keys
+            # Even if they failed validation, matching keys suggests intent
+            (matched_keys * 100) - errors.length
+          end
+
+          def valid?
+            @success
+          end
+        end
+
+        # @param block [Proc] the validation block defining the Hash schema
+        def initialize(&block)
+          raise ArgumentError, 'HashSchema requires a block' unless block
+
+          @block = block
+          @schema_structure = nil
+        end
+
+        # Parses the schema block to extract the validation structure
+        def parse_schema
+          return @schema_structure if @schema_structure
+
+          @schema_structure = { required: {}, optional: {} }
+
+          # Create a mock scope that captures the schema structure
+          parser = SchemaParser.new(@schema_structure)
+          parser.instance_eval(&@block)
+
+          @schema_structure
+        end
+
+        # Validates a hash value against this schema and returns detailed results
+        # @param hash_value [Hash] the hash to validate
+        # @param attr_name [Symbol] the parameter name
+        # @param api [Grape::API] the API instance
+        # @param parent_scope [ParamsScope] the parent scope
+        # @return [ValidationResult] detailed validation result
+        def validate_hash(hash_value, _attr_name, _api, _parent_scope)
+          result = ValidationResult.new
+
+          unless hash_value.is_a?(Hash)
+            result.add_error([], 'must be a hash')
+            return result
+          end
+
+          schema = parse_schema
+          validate_structure(hash_value, schema, [], result)
+
+          result
+        end
+
+        private
+
+        def validate_structure(hash_value, schema, path, result)
+          # Check all required fields
+          schema[:required].each do |key, config|
+            # Check if key exists (as symbol or string)
+            actual_key = hash_value.key?(key) ? key : key.to_s
+            value = hash_value[actual_key]
+
+            if value.nil?
+              result.add_error(path + [key], 'is missing')
+              next
+            end
+
+            # Track that this key was present
+            result.increment_matched_keys if path.empty?
+
+            # If there's a type, validate and coerce it
+            if config[:type]
+              coerced_value = coerce_value(value, config[:type])
+              if coerced_value.is_a?(Types::InvalidValue)
+                result.add_error(path + [key], 'is invalid')
+                next
+              else
+                # Update the hash with the coerced value
+                hash_value[actual_key] = coerced_value
+              end
+            end
+
+            # If there's a nested schema, validate recursively
+            validate_structure(hash_value[actual_key], config[:schema], path + [key], result) if config[:schema]
+          end
+
+          # Validate optional fields if present
+          schema[:optional].each do |key, config|
+            actual_key = if hash_value.key?(key)
+                           key
+                         else
+                           (hash_value.key?(key.to_s) ? key.to_s : nil)
+                         end
+            next if actual_key.nil?
+
+            value = hash_value[actual_key]
+            next if value.nil?
+
+            # Track that this key was present
+            result.increment_matched_keys if path.empty?
+
+            # If there's a type, validate and coerce it
+            if config[:type]
+              coerced_value = coerce_value(value, config[:type])
+              if coerced_value.is_a?(Types::InvalidValue)
+                result.add_error(path + [key], 'is invalid')
+                next
+              else
+                # Update the hash with the coerced value
+                hash_value[actual_key] = coerced_value
+              end
+            end
+
+            # If there's a nested schema, validate recursively
+            validate_structure(hash_value[actual_key], config[:schema], path + [key], result) if config[:schema]
+          end
+        end
+
+        def coerce_value(value, type)
+          # If it's already the right type and Hash, no coercion needed
+          return value if type == Hash && value.is_a?(Hash)
+
+          # Try coercion
+          coercer = Types.build_coercer(type)
+          coercer.call(value)
+        rescue StandardError
+          Types::InvalidValue.new
+        end
+
+        # Helper class to parse schema definition blocks
+        class SchemaParser
+          def initialize(schema_structure)
+            @schema_structure = schema_structure
+          end
+
+          def requires(key, type: nil, **_opts, &block)
+            if block
+              # Nested schema
+              nested_schema = { required: {}, optional: {} }
+              parser = SchemaParser.new(nested_schema)
+              parser.instance_eval(&block)
+              @schema_structure[:required][key] = { type: type, schema: nested_schema }
+            else
+              @schema_structure[:required][key] = { type: type }
+            end
+          end
+
+          def optional(key, type: nil, **_opts, &block)
+            if block
+              # Nested schema
+              nested_schema = { required: {}, optional: {} }
+              parser = SchemaParser.new(nested_schema)
+              parser.instance_eval(&block)
+              @schema_structure[:optional][key] = { type: type, schema: nested_schema }
+            else
+              @schema_structure[:optional][key] = { type: type }
+            end
+          end
+
+          def group(*args, &)
+            # Ignore group for now
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/grape/validations/types/hash_schema.rb
+++ b/lib/grape/validations/types/hash_schema.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'ostruct'
-
 module Grape
   module Validations
     module Types

--- a/lib/grape/validations/types/multiple_hash_schema_coercer.rb
+++ b/lib/grape/validations/types/multiple_hash_schema_coercer.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Grape
+  module Validations
+    module Types
+      # This class handles coercion and validation for parameters declared
+      # with multiple Hash schema variants using the +:types+ option with
+      # HashSchema instances.
+      #
+      # It will validate the parameter value against each schema in order
+      # and return the value if any schema passes validation.
+      class MultipleHashSchemaCoercer
+        attr_reader :schemas
+
+        # Construct a new coercer for multiple Hash schemas.
+        #
+        # @param schemas [Array<HashSchema>] list of hash schemas
+        def initialize(schemas)
+          @schemas = schemas
+        end
+
+        # Validates the given Hash value against each schema.
+        # Note: Actual validation happens in the validator, this just
+        # ensures the value is a Hash.
+        #
+        # @param val [Hash] value to be validated
+        # @return [Hash,InvalidValue] the validated hash, or an instance
+        #   of {InvalidValue} if the value is not a Hash.
+        def call(val)
+          return InvalidValue.new unless val.is_a?(Hash)
+
+          # Return the hash - actual schema validation will happen
+          # in MultipleHashSchemaValidator
+          val
+        end
+      end
+    end
+  end
+end

--- a/lib/grape/validations/validators/multiple_hash_schema_validator.rb
+++ b/lib/grape/validations/validators/multiple_hash_schema_validator.rb
@@ -24,15 +24,18 @@ module Grape
 
           # Try to validate against each schema and collect results
           results = []
-          @schemas.each do |schema|
+          valid_schema = @schemas.any? do |schema|
             result = schema.validate_hash(value, attr_name, @api, @scope)
             if result.valid?
-              # Validation succeeded for this schema
-              return
+              true
+            else
+              results << result
+              false
             end
-
-            results << result
           end
+
+          # Validation succeeded for one of the schemas
+          return if valid_schema
 
           # None of the schemas matched - determine best error message
           raise_best_error(attr_name, results)

--- a/lib/grape/validations/validators/multiple_hash_schema_validator.rb
+++ b/lib/grape/validations/validators/multiple_hash_schema_validator.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Grape
+  module Validations
+    module Validators
+      # Validates that a parameter matches at least one of the provided Hash schemas.
+      class MultipleHashSchemaValidator < Base
+        def initialize(attrs, options, required, scope, opts)
+          super
+          @schemas = Array(options).select { |s| s.is_a?(Grape::Validations::Types::HashSchema) }
+          @api = scope.instance_variable_get(:@api)
+        end
+
+        def validate_param!(attr_name, params)
+          value = params[attr_name]
+          return if value.nil? && !@required
+
+          unless value.is_a?(Hash)
+            raise Grape::Exceptions::Validation.new(
+              params: [@scope.full_name(attr_name)],
+              message: 'is invalid'
+            )
+          end
+
+          # Try to validate against each schema and collect results
+          results = []
+          @schemas.each do |schema|
+            result = schema.validate_hash(value, attr_name, @api, @scope)
+            if result.valid?
+              # Validation succeeded for this schema
+              return
+            end
+
+            results << result
+          end
+
+          # None of the schemas matched - determine best error message
+          raise_best_error(attr_name, results)
+        end
+
+        private
+
+        def raise_best_error(attr_name, results)
+          # Find the result with the highest score (closest match)
+          best_result = results.max_by(&:score)
+
+          # If we have a result with matched keys, it suggests user intent
+          # Use specific errors from that schema
+          if best_result.matched_keys.positive?
+            # Collect all errors from the best matching schema
+            if best_result.errors.length == 1
+              # Single error - use original format
+              error = best_result.errors.first
+              param_path = build_param_path(attr_name, error[:path])
+
+              raise Grape::Exceptions::Validation.new(
+                params: [param_path],
+                message: error[:message]
+              )
+            else
+              # Multiple errors - combine them into a single message
+              # Format: "field1 is missing, field2 is missing"
+              error_messages = best_result.errors.map do |error|
+                # Build the relative path from the attribute name
+                if error[:path].empty?
+                  "#{@scope.full_name(attr_name)} #{error[:message]}"
+                else
+                  path_suffix = "[#{error[:path].join('][')}]"
+                  "#{@scope.full_name(attr_name)}#{path_suffix} #{error[:message]}"
+                end
+              end.join(', ')
+
+              # Use a proc for the message to bypass the default formatting
+              # which would add the param name prefix
+              raise Grape::Exceptions::Validation.new(
+                params: [@scope.full_name(attr_name)],
+                message: -> { error_messages }
+              )
+            end
+          else
+            # No keys matched any schema - generic error
+            raise Grape::Exceptions::Validation.new(
+              params: [@scope.full_name(attr_name)],
+              message: 'does not match any of the allowed schemas'
+            )
+          end
+        end
+
+        def build_param_path(attr_name, path)
+          if path.empty?
+            @scope.full_name(attr_name)
+          else
+            base = @scope.full_name(attr_name)
+            "#{base}[#{path.join('][')}]"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/grape/validations/types/multiple_hash_schema_spec.rb
+++ b/spec/grape/validations/types/multiple_hash_schema_spec.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+describe Grape::Validations::Types::HashSchema do
+  subject { Class.new(Grape::API) }
+
+  let(:app) { subject }
+
+  describe 'multiple hash schemas' do
+    context 'with two different hash schemas' do
+      before do
+        subject.params do
+          requires :value, desc: 'Price value', types: [
+            hash_schema { requires :fixed_price, type: Float },
+            hash_schema do
+              requires :time_unit, type: String
+              requires :rate, type: Float
+            end
+          ]
+        end
+        subject.post('/pricing') { params[:value].to_json }
+      end
+
+      it 'accepts the first schema variant' do
+        post '/pricing', value: { fixed_price: 100.0 }
+        expect(last_response.status).to eq(201)
+        expect(JSON.parse(last_response.body)).to have_key('fixed_price')
+      end
+
+      it 'accepts the second schema variant' do
+        post '/pricing', value: { time_unit: 'hour', rate: 50.0 }
+        expect(last_response.status).to eq(201)
+        result = JSON.parse(last_response.body)
+        expect(result).to have_key('time_unit')
+        expect(result).to have_key('rate')
+      end
+
+      it 'rejects a hash that matches neither schema' do
+        post '/pricing', value: { invalid_key: 'test' }
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to include('does not match any of the allowed schemas')
+      end
+
+      it 'rejects incomplete first schema (missing required field)' do
+        post '/pricing', value: { time_unit: 'hour' }
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to include('value[rate] is missing')
+      end
+
+      it 'rejects a non-hash value' do
+        post '/pricing', value: 'not a hash'
+        expect(last_response.status).to eq(400)
+      end
+    end
+
+    context 'with coercion' do
+      before do
+        subject.params do
+          requires :config, types: [
+            hash_schema { requires :count, type: Integer },
+            hash_schema { requires :enabled, type: Grape::API::Boolean }
+          ]
+        end
+        subject.post('/config') { params[:config].to_json }
+      end
+
+      it 'accepts the first schema with coercion' do
+        post '/config', config: { count: '42' }
+        expect(last_response.status).to eq(201)
+        result = JSON.parse(last_response.body)
+        expect(result).to have_key('count')
+        expect(result['count']).to eq(42)
+      end
+
+      it 'accepts the second schema with coercion' do
+        post '/config', config: { enabled: 'true' }
+        expect(last_response.status).to eq(201)
+        result = JSON.parse(last_response.body)
+        expect(result).to have_key('enabled')
+        expect(result['enabled']).to be(true)
+      end
+
+      it 'rejects invalid type for first schema' do
+        post '/config', config: { count: 'not a number' }
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to include('config[count] is invalid')
+      end
+    end
+
+    context 'with nested hash schemas' do
+      before do
+        subject.params do
+          requires :options, types: [
+            hash_schema do
+              requires :form, type: Hash do
+                requires :colour, type: String
+                requires :font, type: String
+                optional :size, type: Integer
+              end
+            end,
+            hash_schema do
+              requires :api, type: Hash do
+                requires :authenticated, type: Grape::API::Boolean
+              end
+            end
+          ]
+        end
+        subject.post('/settings') { params[:options].to_json }
+      end
+
+      it 'accepts first schema with all required nested fields' do
+        post '/settings', options: { form: { colour: 'red', font: 'Arial' } }
+        expect(last_response.status).to eq(201)
+        result = JSON.parse(last_response.body)
+        expect(result['form']['colour']).to eq('red')
+        expect(result['form']['font']).to eq('Arial')
+      end
+
+      it 'accepts first schema with optional nested field' do
+        post '/settings', options: { form: { colour: 'blue', font: 'Helvetica', size: 12 } }
+        expect(last_response.status).to eq(201)
+        result = JSON.parse(last_response.body)
+        expect(result['form']['size']).to eq(12)
+      end
+
+      it 'rejects first schema when missing required nested field (colour)' do
+        post '/settings', options: { form: { font: 'Arial' } }
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to include('options[form][colour] is missing')
+      end
+
+      it 'rejects first schema when missing required nested field (font)' do
+        post '/settings', options: { form: { colour: 'red' } }
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to include('options[form][font] is missing')
+      end
+
+      it 'accepts second schema with required nested field' do
+        post '/settings', options: { api: { authenticated: true } }
+        expect(last_response.status).to eq(201)
+        result = JSON.parse(last_response.body)
+        expect(result['api']['authenticated']).to be(true)
+      end
+
+      it 'rejects second schema when missing required nested field' do
+        # Use JSON encoding for empty nested hashes as form encoding doesn't handle them properly
+        header 'Content-Type', 'application/json'
+        post '/settings', { options: { api: {} } }.to_json
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to include('options[api][authenticated] is missing')
+      end
+
+      it 'validates nested field types' do
+        post '/settings', options: { form: { colour: 'red', font: 'Arial', size: 'not a number' } }
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to include('options[form][size] is invalid')
+      end
+
+      it 'coerces nested boolean fields' do
+        post '/settings', options: { api: { authenticated: 'true' } }
+        expect(last_response.status).to eq(201)
+        result = JSON.parse(last_response.body)
+        expect(result['api']['authenticated']).to be(true)
+      end
+
+      it 'reports all missing nested fields at once' do
+        # Send a hash with the form key present but empty nested hash
+        header 'Content-Type', 'application/json'
+        post '/settings', { options: { form: {} } }.to_json
+        expect(last_response.status).to eq(400)
+        # Should include both missing fields in the error message
+        expect(last_response.body).to include('options[form][colour] is missing')
+        expect(last_response.body).to include('options[form][font] is missing')
+      end
+    end
+
+    context 'with complex nested structures' do
+      before do
+        subject.params do
+          requires :data, types: [
+            hash_schema do
+              requires :user, type: Hash do
+                requires :name, type: String
+                requires :age, type: Integer
+                optional :email, type: String
+              end
+            end,
+            hash_schema do
+              requires :product, type: Hash do
+                requires :id, type: Integer
+                requires :price, type: Float
+              end
+            end
+          ]
+        end
+        subject.post('/data') { params[:data].to_json }
+      end
+
+      it 'validates deeply nested required fields in first schema' do
+        post '/data', data: { user: { name: 'John', age: 30 } }
+        expect(last_response.status).to eq(201)
+      end
+
+      it 'rejects first schema when nested required field is missing' do
+        post '/data', data: { user: { name: 'John' } }
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to include('data[user][age] is missing')
+      end
+
+      it 'validates deeply nested required fields in second schema' do
+        post '/data', data: { product: { id: 123, price: 19.99 } }
+        expect(last_response.status).to eq(201)
+      end
+
+      it 'coerces nested integer fields' do
+        post '/data', data: { user: { name: 'John', age: '30' } }
+        expect(last_response.status).to eq(201)
+        result = JSON.parse(last_response.body)
+        expect(result['user']['age']).to eq(30)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Tries to resolve https://github.com/ruby-grape/grape/issues/2385 😄 

**Summary**

This PR implements support for defining parameters that accept multiple different hash structures (polymorphic hashes) using the new `hash_schema` helper with the types option. This addresses the feature request in #2385, which asked for a cleaner way to validate parameters that can have multiple valid schemas.

Previously, developers had to use a combination of optional fields with complex mutually_exclusive and given constraints, which was difficult to read and maintain. This new approach provides a clear, declarative syntax for defining multiple acceptable hash structures.

**What's New**

  - hash_schema helper: A new DSL method that defines a Hash schema with specific validation rules
  - Multiple schema support: Use the types option with an array of hash_schema definitions
  - Comprehensive validation: Validates that the parameter matches at least one of the provided schemas
  - Type coercion: Supports automatic type coercion within each schema (Integer, Float, Boolean, etc.)
  - Nested structures: Full support for nested hash schemas with required and optional fields
  - Better error messages: Reports specific validation errors from the closest-matching schema

**Usage Examples**

**Basic Usage - Multiple Hash Schemas**

```ruby
params do
  requires :value, desc: 'Price value', types: [
    hash_schema { requires :fixed_price, type: Float },
    hash_schema do
      requires :time_unit, type: String
      requires :rate, type: Float
    end
  ]
end
post '/pricing' do
  puts params[:value]
end
```


```
  Valid Requests:
  #Matches first schema
  { value: { fixed_price: 100.0 } }

  # Matches second schema
  { value: { time_unit: 'hour', rate: 50.0 } }
```

**Nested Hash Schemas**

```ruby
params do
  requires :options, types: [
    hash_schema do
      requires :form, type: Hash do
        requires :colour, type: String
        requires :font, type: String
        optional :size, type: Integer
      end
    end,
    hash_schema do
      requires :api, type: Hash do
        requires :authenticated, type: Grape::API::Boolean
      end
    end
  ]
end
```

```
  Valid Requests:
  # Matches first schema
  { options: { form: { colour: 'red', font: 'Arial' } } }

  # Matches first schema with optional field
  { options: { form: { colour: 'blue', font: 'Helvetica', size: 12 } } }

  # Matches second schema
  { options: { api: { authenticated: true } } }
```

**Error Reporting**

When validation fails, the error messages are clear and specific:

```
  # Missing field in nested structure
  { options: { form: { colour: 'red' } } }
  # => { "error": "options[form][font] is missing" }

  # Multiple missing fields - all reported at once
  { options: { form: {} } }
  # => { "error": "options[form][colour] is missing, options[form][font] is missing" }

  # Doesn't match any schema
  { value: { invalid_key: 'test' } }
  # => { "error": "value does not match any of the allowed schemas" }
```

  All tests pass and the implementation maintains backward compatibility with existing Grape functionality.

  ---
  cc @mia-n @dblock - This implements the feature you requested in #2385. Would love to hear your feedback!