### PR TITLE
Refactor ParamsScope and Parameters DSL to use named kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#2656](https://github.com/ruby-grape/grape/pull/2656): Remove useless instance_variable_defined? checks - [@ericproulx](https://github.com/ericproulx).
 * [#2619](https://github.com/ruby-grape/grape/pull/2619): Remove TOC from README.md and danger-toc check - [@alexanderadam](https://github.com/alexanderadam).
+* [#2663](https://github.com/ruby-grape/grape/pull/2663): Refactor `ParamsScope` and `Parameters` DSL to use named kwargs - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,26 @@
 Upgrading Grape
 ===============
 
+### Upgrading to >= 3.2
+
+#### `with` now uses keyword arguments
+
+The `with` DSL method now uses `**opts` instead of a positional hash. Calls using bare keyword syntax are unaffected:
+
+```ruby
+# still works
+with(type: String, documentation: { in: 'body' }) { ... }
+```
+
+However, passing an explicit hash literal will now raise an `ArgumentError`:
+
+```ruby
+# raises ArgumentError
+with({ type: String }) { ... }
+```
+
+See [#2663](https://github.com/ruby-grape/grape/pull/2663) for more information.
+
 ### Upgrading to >= 3.1
 
 #### Explicit kwargs for `namespace` and `route_param`

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -127,10 +127,10 @@ module Grape
         opts = @group.deep_merge(opts) if @group
 
         if opts[:using]
-          require_required_and_optional_fields(attrs.first, opts)
+          require_required_and_optional_fields(attrs.first, using: opts[:using], except: opts[:except])
         else
-          validate_attributes(attrs, opts, &block)
-          block ? new_scope(attrs, opts, &block) : push_declared_params(attrs, opts.slice(:as))
+          validate_attributes(attrs, **opts, &block)
+          block ? new_scope(attrs.first, type: opts[:type], as: opts[:as], &block) : push_declared_params(attrs, as: opts[:as])
         end
       end
 
@@ -149,20 +149,20 @@ module Grape
         end
 
         if opts[:using]
-          require_optional_fields(attrs.first, opts)
+          require_optional_fields(attrs.first, using: opts[:using], except: opts[:except])
         else
-          validate_attributes(attrs, opts, &block)
+          validate_attributes(attrs, **opts, &block)
 
-          block ? new_scope(attrs, opts, true, &block) : push_declared_params(attrs, opts.slice(:as))
+          block ? new_scope(attrs.first, type: opts[:type], as: opts[:as], optional: true, &block) : push_declared_params(attrs, as: opts[:as])
         end
       end
 
       # Define common settings for one or more parameters
       # @param (see #requires)
       # @option (see #requires)
-      def with(*attrs, &)
-        new_group_attrs = [@group, attrs.clone.first].compact.reduce(&:deep_merge)
-        new_group_scope([new_group_attrs], &)
+      def with(**opts, &)
+        new_group_attrs = [@group, opts].compact.reduce(&:deep_merge)
+        new_group_scope(new_group_attrs, &)
       end
 
       %i[mutually_exclusive exactly_one_of at_least_one_of all_or_none_of].each do |validator|

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -51,29 +51,31 @@ module Grape
 
       # Open up a new ParamsScope, allowing parameter definitions per
       #   Grape::DSL::Params.
-      # @param opts [Hash] options for this scope
-      # @option opts :element [Symbol] the element that contains this scope; for
-      #   this to be relevant, @parent must be set
-      # @option opts :element_renamed [Symbol, nil] whenever this scope should
+      # @param api [API] the API endpoint to modify
+      # @param element [Symbol] the element that contains this scope; for
+      #   this to be relevant, parent must be set
+      # @param element_renamed [Symbol, nil] whenever this scope should
       #   be renamed and to what, given +nil+ no renaming is done
-      # @option opts :parent [ParamsScope] the scope containing this scope
-      # @option opts :api [API] the API endpoint to modify
-      # @option opts :optional [Boolean] whether or not this scope needs to have
+      # @param parent [ParamsScope] the scope containing this scope
+      # @param optional [Boolean] whether or not this scope needs to have
       #   any parameters set or not
-      # @option opts :type [Class] a type meant to govern this scope (deprecated)
-      # @option opts :type [Hash] group options for this scope
-      # @option opts :dependent_on [Symbol] if present, this scope should only
+      # @param type [Class] a type meant to govern this scope (deprecated)
+      # @param type [Hash] group options for this scope
+      # @param dependent_on [Symbol] if present, this scope should only
       #   validate if this param is present in the parent scope
       # @yield the instance context, open for parameter definitions
-      def initialize(opts, &block)
-        @element          = opts[:element]
-        @element_renamed  = opts[:element_renamed]
-        @parent           = opts[:parent]
-        @api              = opts[:api]
-        @optional         = opts[:optional] || false
-        @type             = opts[:type]
-        @group            = opts[:group]
-        @dependent_on     = opts[:dependent_on]
+      def initialize(api:, element: nil, element_renamed: nil, parent: nil, optional: false, type: nil, group: nil, dependent_on: nil, &block)
+        @element          = element
+        @element_renamed  = element_renamed
+        @parent           = parent
+        @api              = api
+        @optional         = optional
+        @type             = type
+        @group            = group
+        @dependent_on     = dependent_on
+        # Must be an ivar: push_declared_params is dispatched on self during
+        # instance_eval, so local variables from initialize are unreachable.
+        # configure_declared_params consumes it and clears @declared_params to nil.
         @declared_params = []
 
         instance_eval(&block) if block
@@ -184,9 +186,9 @@ module Grape
 
       # Adds a parameter declaration to our list of validations.
       # @param attrs [Array] (see Grape::DSL::Parameters#requires)
-      def push_declared_params(attrs, opts = {})
+      def push_declared_params(attrs, **opts)
         opts[:declared_params_scope] = self unless opts.key?(:declared_params_scope)
-        return @parent.push_declared_params(attrs, opts) if lateral?
+        return @parent.push_declared_params(attrs, **opts) if lateral?
 
         push_renamed_param(full_path + [attrs.first], opts[:as]) if opts[:as]
         @declared_params.concat(attrs.map { |attr| ::Grape::Validations::ParamsScope::Attr.new(attr, opts[:declared_params_scope]) })
@@ -221,9 +223,9 @@ module Grape
         api_route_setting[:renamed_params] = base
       end
 
-      def require_required_and_optional_fields(context, opts)
-        except_fields = Array.wrap(opts[:except])
-        using_fields = opts[:using].keys.delete_if { |f| except_fields.include?(f) }
+      def require_required_and_optional_fields(context, using:, except: nil)
+        except_fields = Array.wrap(except)
+        using_fields = using.keys.delete_if { |f| except_fields.include?(f) }
 
         if context == :all
           optional_fields = except_fields
@@ -233,54 +235,53 @@ module Grape
           optional_fields = using_fields
         end
         required_fields.each do |field|
-          field_opts = opts[:using][field]
+          field_opts = using[field]
           raise ArgumentError, "required field not exist: #{field}" unless field_opts
 
           requires(field, **field_opts)
         end
         optional_fields.each do |field|
-          field_opts = opts[:using][field]
+          field_opts = using[field]
           optional(field, **field_opts) if field_opts
         end
       end
 
-      def require_optional_fields(context, opts)
-        optional_fields = opts[:using].keys
+      def require_optional_fields(context, using:, except: nil)
+        optional_fields = using.keys
         unless context == :all
-          except_fields = Array.wrap(opts[:except])
+          except_fields = Array.wrap(except)
           optional_fields.delete_if { |f| except_fields.include?(f) }
         end
         optional_fields.each do |field|
-          field_opts = opts[:using][field]
+          field_opts = using[field]
           optional(field, **field_opts) if field_opts
         end
       end
 
-      def validate_attributes(attrs, opts, &block)
-        validations = opts.clone
-        validations[:type] ||= Array if block
-        validates(attrs, validations)
+      def validate_attributes(attrs, **opts, &block)
+        opts[:type] ||= Array if block
+        validates(attrs, opts)
       end
 
       # Returns a new parameter scope, subordinate to the current one and nested
-      # under the parameter corresponding to `attrs.first`.
-      # @param attrs [Array] the attributes passed to the `requires` or
-      #   `optional` invocation that opened this scope.
-      # @param optional [Boolean] whether the parameter this are nested under
+      # under the given element.
+      # @param element [Symbol] the parameter name under which this scope is nested
+      # @param type [Class] the type governing this scope
+      # @param as [Symbol, nil] optional renamed name for the element
+      # @param optional [Boolean] whether the parameter this scope is nested under
       #   is optional or not (and hence, whether this block's params will be).
       # @yield parameter scope
-      def new_scope(attrs, opts, optional = false, &)
+      def new_scope(element, type:, as:, optional: false, &)
         # if required params are grouped and no type or unsupported type is provided, raise an error
-        type = opts[:type]
-        if attrs.first && !optional
+        if element && !optional
           raise Grape::Exceptions::MissingGroupType if type.nil?
           raise Grape::Exceptions::UnsupportedGroupType unless Grape::Validations::Types.group?(type)
         end
 
         self.class.new(
           api: @api,
-          element: attrs.first,
-          element_renamed: opts[:as],
+          element: element,
+          element_renamed: as,
           parent: self,
           optional: optional,
           type: type || Array,
@@ -291,30 +292,26 @@ module Grape
 
       # Returns a new parameter scope, not nested under any current-level param
       # but instead at the same level as the current scope.
-      # @param options [Hash] options to control how this new scope behaves
-      # @option options :dependent_on [Symbol] if given, specifies that this
-      #   scope should only validate if this parameter from the above scope is
-      #   present
+      # @param dependent_on [Symbol] if given, specifies that this scope should
+      #   only validate if this parameter from the above scope is present
       # @yield parameter scope
-      def new_lateral_scope(options, &)
+      def new_lateral_scope(dependent_on:, &)
         self.class.new(
           api: @api,
-          element: nil,
           parent: self,
-          options: @optional,
+          optional: @optional,
           type: type == Array ? Array : Hash,
-          dependent_on: options[:dependent_on],
+          dependent_on:,
           &
         )
       end
 
-      # Returns a new parameter scope, subordinate to the current one and nested
-      # under the parameter corresponding to `attrs.first`.
-      # @param attrs [Array] the attributes passed to the `requires` or
-      #   `optional` invocation that opened this scope.
+      # Returns a new parameter scope, subordinate to the current one, sharing
+      # the given group options with all parameters defined within.
+      # @param group [Hash] common options to merge into each parameter in the scope
       # @yield parameter scope
-      def new_group_scope(attrs, &)
-        self.class.new(api: @api, parent: self, group: attrs.first, &)
+      def new_group_scope(group, &)
+        self.class.new(api: @api, parent: self, group: group, &)
       end
 
       # Pushes declared params to parent or settings

--- a/spec/grape/dsl/parameters_spec.rb
+++ b/spec/grape/dsl/parameters_spec.rb
@@ -37,15 +37,15 @@ describe Grape::DSL::Parameters do
         @validates
       end
 
-      def new_scope(args, _opts, _, &block)
+      def new_scope(element, **_opts, &block)
         nested_scope = self.class.new
-        nested_scope.new_group_scope(args, &block)
+        nested_scope.new_group_scope(element, &block)
         nested_scope
       end
 
-      def new_group_scope(args)
+      def new_group_scope(group)
         prev_group = @group
-        @group = args.clone.first
+        @group = group
         yield
         @group = prev_group
       end


### PR DESCRIPTION
## Summary

- Replace positional/hash-based method signatures with named keyword arguments throughout `ParamsScope` and `Parameters` DSL
- `ParamsScope#initialize` now uses `api:, element: nil, element_renamed: nil, parent: nil, optional: false, type: nil, group: nil, dependent_on: nil`
- `new_scope`, `new_lateral_scope`, `push_declared_params`, `validate_attributes` all converted to named kwargs
- `new_scope` first argument renamed from `attrs` to `element` — callers now pass `attrs.first` directly, removing the double `attrs.first` lookup inside the method
- `new_group_scope` first argument renamed from `attrs` to `group` — callers now pass the group hash directly instead of wrapping it in an array
- `require_required_and_optional_fields` and `require_optional_fields` now declare `using:, except: nil` explicitly instead of accepting an opaque `opts` hash — callers pass only the relevant keys
- `with` converted from a positional hash to `**opts` keyword arguments — passing an explicit hash literal `with({...})` will now raise `ArgumentError` (see UPGRADING.md)
- Method comments updated to reflect new signatures throughout

## Benefits

- Method interfaces are self-documenting — required vs optional params are clear from the signature
- Eliminates implicit hash contracts where callers had to know which keys were consumed
- Prevents accidental passing of unrelated keys into methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)