### PR TITLE
Expose public schema reader on ContractScopeValidator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 #### Fixes
 
 * [#2678](https://github.com/ruby-grape/grape/pull/2678): Update rubocop to 1.86.0 and autocorrect offenses - [@ericproulx](https://github.com/ericproulx).
+* [#2680](https://github.com/ruby-grape/grape/pull/2680): Restore public `schema` reader on ContractScope validator - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.2.0 (2026-04-08)

--- a/lib/grape/validations/validators/contract_scope_validator.rb
+++ b/lib/grape/validations/validators/contract_scope_validator.rb
@@ -4,6 +4,8 @@ module Grape
   module Validations
     module Validators
       class ContractScopeValidator
+        attr_reader :schema
+
         def initialize(schema:)
           @schema = schema
           freeze
@@ -14,7 +16,7 @@ module Grape
         # @raise [Grape::Exceptions::ValidationArrayErrors] if validation failed
         # @return [void]
         def validate(request)
-          res = @schema.call(request.params)
+          res = schema.call(request.params)
 
           if res.success?
             request.params.deep_merge!(res.to_h)


### PR DESCRIPTION
## Summary

- Adds `attr_reader :schema` to `ContractScopeValidator`
- Switches `validate` method from `@schema` ivar access to `schema` reader
- Consistent with the frozen validator design pattern used across the codebase

## Test plan

- [ ] Existing `ContractScopeValidator` specs pass
- [ ] `bundle exec rspec spec/grape/validations/validators/contract_scope_validator_spec.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)