### PR TITLE
Extract Grape::Endpoint.before_each into Grape::Testing

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -147,7 +147,6 @@ Style/CombinableLoops:
 Style/OptionalBooleanParameter:
   Exclude:
     - 'lib/grape/dsl/parameters.rb'
-    - 'lib/grape/endpoint.rb'
     - 'lib/grape/serve_stream/sendfile_response.rb'
     - 'lib/grape/validations/types/array_coercer.rb'
     - 'lib/grape/validations/types/custom_type_collection_coercer.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * [#2679](https://github.com/ruby-grape/grape/pull/2679): Extract entity dsl and refactor :with to keyword argument - [@ericproulx](https://github.com/ericproulx).
+* [#2681](https://github.com/ruby-grape/grape/pull/2681): Extract `Grape::Endpoint.before_each` into `Grape::Testing` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -3968,7 +3968,15 @@ end
 
 ### Stubbing Helpers
 
-Because helpers are mixed in based on the context when an endpoint is defined, it can be difficult to stub or mock them for testing. The `Grape::Endpoint.before_each` method can help by allowing you to define behavior on the endpoint that will run before every request.
+Because helpers are mixed in based on the context when an endpoint is defined, it can be difficult to stub or mock them for testing. `Grape::Endpoint.before_each` allows you to define behavior on the endpoint that will run before every request.
+
+This feature is provided by `Grape::Testing`, a standalone module intended for test environments only. Add it to your test helper:
+
+```ruby
+require 'grape/testing'
+```
+
+Then use it in your tests:
 
 ```ruby
 describe 'an endpoint that needs helpers stubbed' do
@@ -3979,7 +3987,7 @@ describe 'an endpoint that needs helpers stubbed' do
   end
 
   after do
-    Grape::Endpoint.before_each nil
+    Grape::Endpoint.reset_before_each
   end
 
   it 'stubs the helper' do

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,28 @@
 Upgrading Grape
 ===============
 
+### Upgrading to >= 3.3
+
+#### `Grape::Endpoint.before_each` moved to `Grape::Testing`
+
+`Grape::Endpoint.before_each` and `Grape::Endpoint.reset_before_each` are now only available after requiring `grape/testing`. This module is intended for test environments only and is not loaded by default.
+
+Add the following to your test helper:
+
+```ruby
+require 'grape/testing'
+```
+
+The `before_each` method now always requires a block — calling it without one raises `ArgumentError`. To clear registered hooks, use the new dedicated `reset_before_each` method:
+
+```ruby
+# Before
+after { Grape::Endpoint.before_each nil }
+
+# After
+after { Grape::Endpoint.reset_before_each }
+```
+
 ### Upgrading to >= 3.2
 
 #### Rack parameter parsing errors now raise `Grape::Exceptions::RequestError`

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -17,24 +17,6 @@ module Grape
     def_delegator :cookies, :response_cookies
 
     class << self
-      def before_each(new_setup = false, &block)
-        @before_each ||= []
-        if new_setup == false
-          return @before_each unless block
-
-          @before_each << block
-        elsif new_setup
-          @before_each = [new_setup]
-        else
-          @before_each.clear
-        end
-      end
-
-      def run_before_each(endpoint)
-        superclass.run_before_each(endpoint) unless self == Endpoint
-        before_each.each { |blk| blk.call(endpoint) }
-      end
-
       def block_to_unbound_method(block)
         return unless block
 
@@ -161,7 +143,6 @@ module Grape
       ActiveSupport::Notifications.instrument('endpoint_run.grape', endpoint: self, env:) do
         @request = Grape::Request.new(env, build_params_with: inheritable_setting.namespace_inheritable[:build_params_with])
         begin
-          self.class.run_before_each(self)
           run_filters befores, :before
           @before_filter_passed = true
 

--- a/lib/grape/testing.rb
+++ b/lib/grape/testing.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Grape
+  module Testing
+    module RunBeforeEach
+      def run
+        self.class.run_before_each(self)
+        super
+      end
+    end
+
+    module ClassMethods
+      def before_each(&block)
+        raise ArgumentError, 'a block is required' unless block
+
+        @before_each ||= []
+        @before_each << block
+      end
+
+      def reset_before_each
+        @before_each&.clear
+      end
+
+      def run_before_each(endpoint)
+        superclass.run_before_each(endpoint) unless self == Grape::Endpoint
+        @before_each&.each { |blk| blk.call(endpoint) }
+      end
+    end
+
+    Grape::Endpoint.prepend(RunBeforeEach)
+    Grape::Endpoint.extend(ClassMethods)
+  end
+end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -7,59 +7,6 @@ describe Grape::Endpoint do
     subject
   end
 
-  describe '.before_each' do
-    after { described_class.before_each.clear }
-
-    it 'is settable via block' do
-      block = ->(_endpoint) { 'noop' }
-      described_class.before_each(&block)
-      expect(described_class.before_each.first).to eq(block)
-    end
-
-    it 'is settable via reference' do
-      block = ->(_endpoint) { 'noop' }
-      described_class.before_each block
-      expect(described_class.before_each.first).to eq(block)
-    end
-
-    it 'is able to override a helper' do
-      subject.get('/') { current_user }
-      expect { get '/' }.to raise_error(NameError, /undefined local variable or method [`']current_user'/)
-
-      described_class.before_each do |endpoint|
-        allow(endpoint).to receive(:current_user).and_return('Bob')
-      end
-
-      get '/'
-      expect(last_response.body).to eq('Bob')
-
-      described_class.before_each(nil)
-      expect { get '/' }.to raise_error(NameError, /undefined local variable or method [`']current_user'/)
-    end
-
-    it 'is able to stack helper' do
-      subject.get('/') do
-        authenticate_user!
-        current_user
-      end
-      expect { get '/' }.to raise_error(NoMethodError, /undefined method [`']authenticate_user!' for/)
-
-      described_class.before_each do |endpoint|
-        allow(endpoint).to receive(:current_user).and_return('Bob')
-      end
-
-      described_class.before_each do |endpoint|
-        allow(endpoint).to receive(:authenticate_user!).and_return(true)
-      end
-
-      get '/'
-      expect(last_response.body).to eq('Bob')
-
-      described_class.before_each(nil)
-      expect { get '/' }.to raise_error(NoMethodError, /undefined method [`']authenticate_user!' for/)
-    end
-  end
-
   it 'sets itself in the env upon call' do
     subject.get('/') { 'Hello world.' }
     get '/'

--- a/spec/grape/testing_spec.rb
+++ b/spec/grape/testing_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'grape/testing'
+
+describe Grape::Testing do
+  subject { Class.new(Grape::API) }
+
+  let(:app) { subject }
+
+  describe 'Grape::Endpoint.before_each' do
+    after { Grape::Endpoint.reset_before_each }
+
+    it 'is able to override a helper' do
+      subject.get('/') { current_user }
+      expect { get '/' }.to raise_error(NameError, /undefined local variable or method [`']current_user'/)
+
+      Grape::Endpoint.before_each do |endpoint|
+        allow(endpoint).to receive(:current_user).and_return('Bob')
+      end
+
+      get '/'
+      expect(last_response.body).to eq('Bob')
+
+      Grape::Endpoint.reset_before_each
+      expect { get '/' }.to raise_error(NameError, /undefined local variable or method [`']current_user'/)
+    end
+
+    it 'is able to stack helpers' do
+      subject.get('/') do
+        authenticate_user!
+        current_user
+      end
+      expect { get '/' }.to raise_error(NoMethodError, /undefined method [`']authenticate_user!' for/)
+
+      Grape::Endpoint.before_each do |endpoint|
+        allow(endpoint).to receive_messages(current_user: 'Bob', authenticate_user!: true)
+      end
+
+      get '/'
+      expect(last_response.body).to eq('Bob')
+
+      Grape::Endpoint.reset_before_each
+      expect { get '/' }.to raise_error(NoMethodError, /undefined method [`']authenticate_user!' for/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Moves `before_each`, `reset_before_each`, and `run_before_each` out of `Grape::Endpoint` into a new opt-in `Grape::Testing` module
- Production requests no longer pay any cost from this testing-only feature — `run_before_each` is only injected into `Endpoint#run` via `prepend` when `require 'grape/testing'` is called
- `before_each` now always requires a block (raises `ArgumentError` otherwise); `reset_before_each` replaces the old `before_each(nil)` pattern
- Removes `lib/grape/endpoint.rb` from `Style/OptionalBooleanParameter` rubocop todo

## Test plan

- [ ] `bundle exec rspec spec/grape/testing_spec.rb` — new dedicated spec for `Grape::Testing`
- [ ] `bundle exec rspec spec/grape/endpoint_spec.rb` — verify no regression on endpoint behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)