### PR TITLE
Fix Style/OptionalBooleanParameter and remove from rubocop_todo

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,11 @@ Style/RaiseArgs:
 Style/RedundantArrayConstructor:
   Enabled: false  # doesn't work well with params definition
 
+Style/OptionalBooleanParameter:
+  AllowedMethods:
+    - respond_to_missing?
+    - respond_to?
+
 Style/Send:
   Enabled: true
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -140,16 +140,3 @@ RSpec/VoidExpect:
 Style/CombinableLoops:
   Exclude:
     - 'spec/grape/endpoint_spec.rb'
-
-# Offense count: 9
-# Configuration parameters: AllowedMethods.
-# AllowedMethods: respond_to_missing?
-Style/OptionalBooleanParameter:
-  Exclude:
-    - 'lib/grape/dsl/parameters.rb'
-    - 'lib/grape/serve_stream/sendfile_response.rb'
-    - 'lib/grape/validations/types/array_coercer.rb'
-    - 'lib/grape/validations/types/custom_type_collection_coercer.rb'
-    - 'lib/grape/validations/types/dry_type_coercer.rb'
-    - 'lib/grape/validations/types/primitive_coercer.rb'
-    - 'lib/grape/validations/types/set_coercer.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -147,7 +147,6 @@ Style/CombinableLoops:
 Style/OptionalBooleanParameter:
   Exclude:
     - 'lib/grape/dsl/parameters.rb'
-    - 'lib/grape/endpoint.rb'
     - 'lib/grape/serve_stream/sendfile_response.rb'
     - 'lib/grape/validations/types/array_coercer.rb'
     - 'lib/grape/validations/types/custom_type_collection_coercer.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * [#2679](https://github.com/ruby-grape/grape/pull/2679): Extract entity dsl and refactor :with to keyword argument - [@ericproulx](https://github.com/ericproulx).
+* [#2681](https://github.com/ruby-grape/grape/pull/2681): Extract `Grape::Endpoint.before_each` into `Grape::Testing` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Fixes
 
 * [#2678](https://github.com/ruby-grape/grape/pull/2678): Update rubocop to 1.86.0 and autocorrect offenses - [@ericproulx](https://github.com/ericproulx).
+* [#2682](https://github.com/ruby-grape/grape/pull/2682): Fix `Style/OptionalBooleanParameter` offenses - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.2.1 (2026-04-16)

--- a/README.md
+++ b/README.md
@@ -3968,7 +3968,15 @@ end
 
 ### Stubbing Helpers
 
-Because helpers are mixed in based on the context when an endpoint is defined, it can be difficult to stub or mock them for testing. The `Grape::Endpoint.before_each` method can help by allowing you to define behavior on the endpoint that will run before every request.
+Because helpers are mixed in based on the context when an endpoint is defined, it can be difficult to stub or mock them for testing. `Grape::Endpoint.before_each` allows you to define behavior on the endpoint that will run before every request.
+
+This feature is provided by `Grape::Testing`, a standalone module intended for test environments only. Add it to your test helper:
+
+```ruby
+require 'grape/testing'
+```
+
+Then use it in your tests:
 
 ```ruby
 describe 'an endpoint that needs helpers stubbed' do
@@ -3979,7 +3987,7 @@ describe 'an endpoint that needs helpers stubbed' do
   end
 
   after do
-    Grape::Endpoint.before_each nil
+    Grape::Endpoint.reset_before_each
   end
 
   it 'stubs the helper' do

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,28 @@
 Upgrading Grape
 ===============
 
+### Upgrading to >= 3.3
+
+#### `Grape::Endpoint.before_each` moved to `Grape::Testing`
+
+`Grape::Endpoint.before_each` and `Grape::Endpoint.reset_before_each` are now only available after requiring `grape/testing`. This module is intended for test environments only and is not loaded by default.
+
+Add the following to your test helper:
+
+```ruby
+require 'grape/testing'
+```
+
+The `before_each` method now always requires a block — calling it without one raises `ArgumentError`. To clear registered hooks, use the new dedicated `reset_before_each` method:
+
+```ruby
+# Before
+after { Grape::Endpoint.before_each nil }
+
+# After
+after { Grape::Endpoint.reset_before_each }
+```
+
 ### Upgrading to >= 3.2
 
 #### Rack parameter parsing errors now raise `Grape::Exceptions::RequestError`

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -206,10 +206,10 @@ module Grape
 
       class EmptyOptionalValue; end # rubocop:disable Lint/EmptyClass
 
-      def map_params(params, element, is_array = false)
+      def map_params(params, element, is_array: false)
         if params.is_a?(Array)
           params.map do |el|
-            map_params(el, element, true)
+            map_params(el, element, is_array: true)
           end
         elsif params.is_a?(Hash)
           params[element] || (@optional && is_array ? EmptyOptionalValue : {})

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -17,24 +17,6 @@ module Grape
     def_delegator :cookies, :response_cookies
 
     class << self
-      def before_each(new_setup = false, &block)
-        @before_each ||= []
-        if new_setup == false
-          return @before_each unless block
-
-          @before_each << block
-        elsif new_setup
-          @before_each = [new_setup]
-        else
-          @before_each.clear
-        end
-      end
-
-      def run_before_each(endpoint)
-        superclass.run_before_each(endpoint) unless self == Endpoint
-        before_each.each { |blk| blk.call(endpoint) }
-      end
-
       def block_to_unbound_method(block)
         return unless block
 
@@ -161,7 +143,6 @@ module Grape
       ActiveSupport::Notifications.instrument('endpoint_run.grape', endpoint: self, env:) do
         @request = Grape::Request.new(env, build_params_with: inheritable_setting.namespace_inheritable[:build_params_with])
         begin
-          self.class.run_before_each(self)
           run_filters befores, :before
           @before_filter_passed = true
 

--- a/lib/grape/testing.rb
+++ b/lib/grape/testing.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Grape
+  module Testing
+    module RunBeforeEach
+      def run
+        self.class.run_before_each(self)
+        super
+      end
+    end
+
+    module ClassMethods
+      def before_each(&block)
+        raise ArgumentError, 'a block is required' unless block
+
+        @before_each ||= []
+        @before_each << block
+      end
+
+      def reset_before_each
+        @before_each&.clear
+      end
+
+      def run_before_each(endpoint)
+        superclass.run_before_each(endpoint) unless self == Grape::Endpoint
+        @before_each&.each { |blk| blk.call(endpoint) }
+      end
+    end
+
+    Grape::Endpoint.prepend(RunBeforeEach)
+    Grape::Endpoint.extend(ClassMethods)
+  end
+end

--- a/lib/grape/validations/types.rb
+++ b/lib/grape/validations/types.rb
@@ -178,10 +178,10 @@ module Grape
           # method is supplied.
         elsif Types.collection_of_custom?(type)
           Types::CustomTypeCollectionCoercer.new(
-            Types.map_special(type.first), type.is_a?(Set)
+            Types.map_special(type.first), set: type.is_a?(Set)
           )
         else
-          DryTypeCoercer.coercer_instance_for(type, strict)
+          DryTypeCoercer.coercer_instance_for(type, strict:)
         end
       end
 

--- a/lib/grape/validations/types/array_coercer.rb
+++ b/lib/grape/validations/types/array_coercer.rb
@@ -12,7 +12,7 @@ module Grape
       # behavior of Virtus which was used earlier, a `Grape::Validations::Types::PrimitiveCoercer`
       # maintains Virtus behavior in coercing.
       class ArrayCoercer < DryTypeCoercer
-        def initialize(type, strict = false)
+        def initialize(type, strict: false)
           super
           @coercer = strict ? DryTypes::Strict::Array : DryTypes::Params::Array
           @subtype = type.first
@@ -52,7 +52,7 @@ module Grape
         end
 
         def elem_coercer
-          @elem_coercer ||= DryTypeCoercer.coercer_instance_for(subtype, strict)
+          @elem_coercer ||= DryTypeCoercer.coercer_instance_for(subtype, strict:)
         end
       end
     end

--- a/lib/grape/validations/types/custom_type_collection_coercer.rb
+++ b/lib/grape/validations/types/custom_type_collection_coercer.rb
@@ -29,7 +29,7 @@ module Grape
         # @param set [Boolean]
         #   when true, a +Set+ will be returned by {#call} instead
         #   of an +Array+ and duplicate items will be discarded.
-        def initialize(type, set = false)
+        def initialize(type, set: false)
           super(type)
           @set = set
         end

--- a/lib/grape/validations/types/dry_type_coercer.rb
+++ b/lib/grape/validations/types/dry_type_coercer.rb
@@ -26,13 +26,13 @@ module Grape
           end
 
           # Returns an instance of a coercer for a given type
-          def coercer_instance_for(type, strict = false)
+          def coercer_instance_for(type, strict: false)
             klass = type.instance_of?(Class) ? PrimitiveCoercer : collection_coercer_for(type)
-            klass.new(type, strict)
+            klass.new(type, strict:)
           end
         end
 
-        def initialize(type, strict = false)
+        def initialize(type, strict: false)
           @type = type
           @strict = strict
           @cache_coercer = strict ? DryTypes::StrictCache : DryTypes::ParamsCache

--- a/lib/grape/validations/types/primitive_coercer.rb
+++ b/lib/grape/validations/types/primitive_coercer.rb
@@ -7,7 +7,7 @@ module Grape
       # initialization. When +strict+ is true, it doesn't coerce a value but check
       # that it has the proper type.
       class PrimitiveCoercer < DryTypeCoercer
-        def initialize(type, strict = false)
+        def initialize(type, strict: false)
           super
 
           @coercer = cache_coercer[type]

--- a/lib/grape/validations/types/set_coercer.rb
+++ b/lib/grape/validations/types/set_coercer.rb
@@ -6,7 +6,7 @@ module Grape
       # Takes the given array and converts it to a set. Every element of the set
       # is also coerced.
       class SetCoercer < ArrayCoercer
-        def initialize(type, strict = false)
+        def initialize(type, strict: false)
           super
 
           @coercer = nil

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -7,59 +7,6 @@ describe Grape::Endpoint do
     subject
   end
 
-  describe '.before_each' do
-    after { described_class.before_each.clear }
-
-    it 'is settable via block' do
-      block = ->(_endpoint) { 'noop' }
-      described_class.before_each(&block)
-      expect(described_class.before_each.first).to eq(block)
-    end
-
-    it 'is settable via reference' do
-      block = ->(_endpoint) { 'noop' }
-      described_class.before_each block
-      expect(described_class.before_each.first).to eq(block)
-    end
-
-    it 'is able to override a helper' do
-      subject.get('/') { current_user }
-      expect { get '/' }.to raise_error(NameError, /undefined local variable or method [`']current_user'/)
-
-      described_class.before_each do |endpoint|
-        allow(endpoint).to receive(:current_user).and_return('Bob')
-      end
-
-      get '/'
-      expect(last_response.body).to eq('Bob')
-
-      described_class.before_each(nil)
-      expect { get '/' }.to raise_error(NameError, /undefined local variable or method [`']current_user'/)
-    end
-
-    it 'is able to stack helper' do
-      subject.get('/') do
-        authenticate_user!
-        current_user
-      end
-      expect { get '/' }.to raise_error(NoMethodError, /undefined method [`']authenticate_user!' for/)
-
-      described_class.before_each do |endpoint|
-        allow(endpoint).to receive(:current_user).and_return('Bob')
-      end
-
-      described_class.before_each do |endpoint|
-        allow(endpoint).to receive(:authenticate_user!).and_return(true)
-      end
-
-      get '/'
-      expect(last_response.body).to eq('Bob')
-
-      described_class.before_each(nil)
-      expect { get '/' }.to raise_error(NoMethodError, /undefined method [`']authenticate_user!' for/)
-    end
-  end
-
   it 'sets itself in the env upon call' do
     subject.get('/') { 'Hello world.' }
     get '/'

--- a/spec/grape/testing_spec.rb
+++ b/spec/grape/testing_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'grape/testing'
+
+describe Grape::Testing do
+  subject { Class.new(Grape::API) }
+
+  let(:app) { subject }
+
+  describe 'Grape::Endpoint.before_each' do
+    after { Grape::Endpoint.reset_before_each }
+
+    it 'is able to override a helper' do
+      subject.get('/') { current_user }
+      expect { get '/' }.to raise_error(NameError, /undefined local variable or method [`']current_user'/)
+
+      Grape::Endpoint.before_each do |endpoint|
+        allow(endpoint).to receive(:current_user).and_return('Bob')
+      end
+
+      get '/'
+      expect(last_response.body).to eq('Bob')
+
+      Grape::Endpoint.reset_before_each
+      expect { get '/' }.to raise_error(NameError, /undefined local variable or method [`']current_user'/)
+    end
+
+    it 'is able to stack helpers' do
+      subject.get('/') do
+        authenticate_user!
+        current_user
+      end
+      expect { get '/' }.to raise_error(NoMethodError, /undefined method [`']authenticate_user!' for/)
+
+      Grape::Endpoint.before_each do |endpoint|
+        allow(endpoint).to receive_messages(current_user: 'Bob', authenticate_user!: true)
+      end
+
+      get '/'
+      expect(last_response.body).to eq('Bob')
+
+      Grape::Endpoint.reset_before_each
+      expect { get '/' }.to raise_error(NoMethodError, /undefined method [`']authenticate_user!' for/)
+    end
+  end
+end

--- a/spec/grape/validations/types/primitive_coercer_spec.rb
+++ b/spec/grape/validations/types/primitive_coercer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Grape::Validations::Types::PrimitiveCoercer do
-  subject { described_class.new(type, strict) }
+  subject { described_class.new(type, strict:) }
 
   let(:strict) { false }
 


### PR DESCRIPTION
## Summary

- Convert boolean positional parameters to keyword arguments in coercers (`DryTypeCoercer`, `ArrayCoercer`, `PrimitiveCoercer`, `SetCoercer`, `CustomTypeCollectionCoercer`) and `map_params` in DSL parameters
- Add `respond_to?` to `AllowedMethods` in `.rubocop.yml` — it overrides Ruby's built-in method signature and must stay positional
- Remove the entire `Style/OptionalBooleanParameter` block from `.rubocop_todo.yml`

## Test plan

- [ ] `bundle exec rspec spec/grape/validations/types/ spec/grape/dsl/parameters_spec.rb`
- [ ] `bundle exec rubocop --only Style/OptionalBooleanParameter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)