### PR TITLE
Introduce Grape::Util::Lazy::Base for unified lazy-type dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#2679](https://github.com/ruby-grape/grape/pull/2679): Extract entity dsl and refactor :with to keyword argument - [@ericproulx](https://github.com/ericproulx).
 * [#2681](https://github.com/ruby-grape/grape/pull/2681): Extract `Grape::Endpoint.before_each` into `Grape::Testing` - [@ericproulx](https://github.com/ericproulx).
 * [#2686](https://github.com/ruby-grape/grape/pull/2686): Add `Grape::Middleware::PrecomputedContentTypes` to warm content-type caches on the parent middleware instance (opt-in via `include`); short-circuit `Middleware::Base#merge_headers` when no headers were set - [@ericproulx](https://github.com/ericproulx).
+* [#2683](https://github.com/ruby-grape/grape/pull/2683): Introduce `Grape::Util::Lazy::Base` for unified lazy-type dispatch - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -126,11 +126,10 @@ module Grape
         eval_args = evaluate_arguments(instance.configuration, *args)
         eval_kwargs = kwargs.deep_transform_values { |v| evaluate_arguments(instance.configuration, v).first }
         response = instance.__send__(method, *eval_args, **eval_kwargs, &block)
-        if skip_immediate_run?(instance, [response], kwargs)
-          response
-        else
-          evaluate_arguments(instance.configuration, response).first
-        end
+
+        return response if skip_immediate_run?(instance, [response], kwargs)
+
+        evaluate_arguments(instance.configuration, response).first
       end
 
       # Skips steps that contain arguments to be lazily executed (on re-mount time)
@@ -140,25 +139,22 @@ module Grape
       end
 
       def any_lazy?(args)
-        args.any? { |argument| argument_lazy?(argument) }
+        args.any?(Grape::Util::Lazy::Base)
       end
 
       def evaluate_arguments(configuration, *args)
         args.map do |argument|
-          if argument_lazy?(argument)
+          case argument
+          when Grape::Util::Lazy::Base
             argument.evaluate_from(configuration)
-          elsif argument.is_a?(Hash)
+          when Hash
             argument.transform_values { |value| evaluate_arguments(configuration, value).first }
-          elsif argument.is_a?(Array)
+          when Array
             evaluate_arguments(configuration, *argument)
           else
             argument
           end
         end
-      end
-
-      def argument_lazy?(argument)
-        argument.respond_to?(:lazy?) && argument.lazy?
       end
     end
   end

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -260,28 +260,24 @@ module Grape
       # of settings stack pushes.
       def nest(*blocks, &block)
         blocks.compact!
-        if blocks.any?
-          evaluate_as_instance_with_configuration(block) if block
-          blocks.each { |b| evaluate_as_instance_with_configuration(b) }
-          reset_validations!
-        else
-          instance_eval(&block)
-        end
+        return instance_eval(&block) if blocks.empty?
+
+        evaluate_as_instance_with_configuration(block) if block
+        blocks.each { |b| evaluate_as_instance_with_configuration(b) }
+        reset_validations!
       end
 
       def evaluate_as_instance_with_configuration(block, lazy: false)
         lazy_block = Grape::Util::Lazy::Block.new do |configuration|
           value_for_configuration = configuration
-          self.configuration = value_for_configuration.evaluate if value_for_configuration.respond_to?(:lazy?) && value_for_configuration.lazy?
+          self.configuration = value_for_configuration.evaluate if value_for_configuration.is_a?(Grape::Util::Lazy::Base)
           response = instance_eval(&block)
           self.configuration = value_for_configuration
           response
         end
-        if @base && base_instance? && lazy
-          lazy_block
-        else
-          lazy_block.evaluate_from(configuration)
-        end
+        return lazy_block if @base && base_instance? && lazy
+
+        lazy_block.evaluate_from(configuration)
       end
     end
   end

--- a/lib/grape/util/lazy/base.rb
+++ b/lib/grape/util/lazy/base.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Grape
+  module Util
+    module Lazy
+      # Abstract parent for lazy wrappers used by the remount/configuration
+      # machinery. Call sites can type-check with +is_a?(Grape::Util::Lazy::Base)+
+      # instead of enumerating the concrete subclasses.
+      class Base
+        def to_s
+          evaluate.to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/grape/util/lazy/block.rb
+++ b/lib/grape/util/lazy/block.rb
@@ -3,8 +3,9 @@
 module Grape
   module Util
     module Lazy
-      class Block
+      class Block < Base
         def initialize(&new_block)
+          super()
           @block = new_block
         end
 
@@ -14,14 +15,6 @@ module Grape
 
         def evaluate
           @block.call({})
-        end
-
-        def lazy?
-          true
-        end
-
-        def to_s
-          evaluate.to_s
         end
       end
     end

--- a/lib/grape/util/lazy/value.rb
+++ b/lib/grape/util/lazy/value.rb
@@ -3,10 +3,11 @@
 module Grape
   module Util
     module Lazy
-      class Value
+      class Value < Base
         attr_reader :access_keys
 
         def initialize(value, access_keys = [])
+          super()
           @value = value
           @access_keys = access_keys
         end
@@ -20,17 +21,9 @@ module Grape
           @value
         end
 
-        def lazy?
-          true
-        end
-
         def reached_by(parent_access_keys, access_key)
           @access_keys = parent_access_keys + [access_key]
           self
-        end
-
-        def to_s
-          evaluate.to_s
         end
       end
     end

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -38,9 +38,10 @@ module Grape
         end
 
         def self.attr_key(declared_param_attr)
-          return attr_key(declared_param_attr.key) if declared_param_attr.is_a?(self)
-
-          if declared_param_attr.is_a?(Hash)
+          case declared_param_attr
+          when self
+            attr_key(declared_param_attr.key)
+          when Hash
             declared_param_attr.transform_values { |value| attrs_keys(value) }
           else
             declared_param_attr
@@ -86,7 +87,8 @@ module Grape
       end
 
       def configuration
-        (@api.configuration.respond_to?(:evaluate) && @api.configuration.evaluate) || @api.configuration
+        config = @api.configuration
+        config.is_a?(Grape::Util::Lazy::Base) ? config.evaluate : config
       end
 
       # @return [Boolean] whether or not this entire scope needs to be


### PR DESCRIPTION
## Summary
- Adds `Grape::Util::Lazy::Base` as a shared abstract parent for `Grape::Util::Lazy::Value` and `Grape::Util::Lazy::Block`, so call sites can type-check with a single `is_a?(Grape::Util::Lazy::Base)` instead of duck-typing on `respond_to?(:lazy?)` / `respond_to?(:evaluate)` or enumerating the concrete subclasses.
- Collapses `Grape::API::evaluate_arguments` into a single `case`/`when` on `Lazy::Base` / `Hash` / `Array`; removes the `argument_lazy?` indirection and uses `Array#any?(Base)` in `any_lazy?` for a C-level class match.
- Swaps the duck checks in `Grape::DSL::Routing#evaluate_as_instance_with_configuration` and `Grape::Validations::ParamsScope#configuration` for explicit `is_a?(Lazy::Base)`.
- Removes the now-dead internal `#lazy?` methods on `Value` and `Block`; the single `#to_s` is lifted onto `Base` (dedup).

No behavior change — the set of objects classified as lazy is unchanged (every `lazy?`/`evaluate` responder in the codebase is already a `Lazy::Base` descendant, including `Grape::Util::EndpointConfiguration < Lazy::ValueHash < Value`).

## Test plan
- [x] Full RSpec suite passes locally (2236 examples, 0 failures).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)