### PR TITLE
Readability: case/when, guard clauses, small cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#2686](https://github.com/ruby-grape/grape/pull/2686): Add `Grape::Middleware::PrecomputedContentTypes` to warm content-type caches on the parent middleware instance (opt-in via `include`); short-circuit `Middleware::Base#merge_headers` when no headers were set - [@ericproulx](https://github.com/ericproulx).
 * [#2683](https://github.com/ruby-grape/grape/pull/2683): Introduce `Grape::Util::Lazy::Base` for unified lazy-type dispatch - [@ericproulx](https://github.com/ericproulx).
 * [#2685](https://github.com/ruby-grape/grape/pull/2685): Skip `run_filters` and `endpoint_run_filters.grape` instrumentation when the filter list is empty - [@ericproulx](https://github.com/ericproulx).
+* [#2684](https://github.com/ruby-grape/grape/pull/2684): Readability refactors: case/when, guard clauses, small cleanups - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -142,14 +142,12 @@ module Grape
       #
       #   GET /file # => "contents of file"
       def sendfile(value = nil)
-        if value.is_a?(String)
-          file_body = Grape::ServeStream::FileBody.new(value)
-          @stream = Grape::ServeStream::StreamResponse.new(file_body)
-        elsif !value.is_a?(NilClass)
-          raise ArgumentError, 'Argument must be a file path'
-        else
-          stream
-        end
+        return stream if value.nil?
+
+        raise ArgumentError, 'Argument must be a file path' unless value.is_a?(String)
+
+        file_body = Grape::ServeStream::FileBody.new(value)
+        @stream = Grape::ServeStream::StreamResponse.new(file_body)
       end
 
       # Allows you to define the response as a streamable object.
@@ -173,16 +171,19 @@ module Grape
         header Rack::CONTENT_LENGTH, nil
         header 'Transfer-Encoding', nil
         header Rack::CACHE_CONTROL, 'no-cache' # Skips ETag generation (reading the response up front)
-        if value.is_a?(String)
-          file_body = Grape::ServeStream::FileBody.new(value)
-          @stream = Grape::ServeStream::StreamResponse.new(file_body)
-        elsif value.respond_to?(:each)
-          @stream = Grape::ServeStream::StreamResponse.new(value)
-        elsif !value.is_a?(NilClass)
-          raise ArgumentError, 'Stream object must respond to :each.'
-        else
-          @stream
-        end
+
+        return @stream if value.nil?
+
+        stream_body =
+          if value.is_a?(String)
+            Grape::ServeStream::FileBody.new(value)
+          elsif value.respond_to?(:each)
+            value
+          else
+            raise ArgumentError, 'Stream object must respond to :each.'
+          end
+
+        @stream = Grape::ServeStream::StreamResponse.new(stream_body)
       end
 
       # Returns route information for the current request.

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -204,21 +204,7 @@ module Grape
 
       alias group requires
 
-      class EmptyOptionalValue; end # rubocop:disable Lint/EmptyClass
-
-      def map_params(params, element, is_array: false)
-        if params.is_a?(Array)
-          params.map do |el|
-            map_params(el, element, is_array: true)
-          end
-        elsif params.is_a?(Hash)
-          params[element] || (@optional && is_array ? EmptyOptionalValue : {})
-        elsif params == EmptyOptionalValue
-          EmptyOptionalValue
-        else
-          {}
-        end
-      end
+      EmptyOptionalValue = Object.new.freeze
 
       # @param params [Hash] initial hash of parameters
       # @return hash of parameters relevant for the current scope
@@ -233,6 +219,21 @@ module Grape
 
       def first_hash_key_or_param(parameter)
         parameter.is_a?(Hash) ? parameter.keys.first : parameter
+      end
+
+      def map_params(params, element, is_array: false)
+        case params
+        when Array
+          params.map do |el|
+            map_params(el, element, is_array: true)
+          end
+        when Hash
+          params[element] || (@optional && is_array ? EmptyOptionalValue : {})
+        when EmptyOptionalValue
+          EmptyOptionalValue
+        else
+          {}
+        end
       end
     end
   end

--- a/lib/grape/error_formatter/json.rb
+++ b/lib/grape/error_formatter/json.rb
@@ -11,10 +11,14 @@ module Grape
         private
 
         def wrap_message(message)
-          return message if message.is_a?(Hash)
-          return message.as_json if message.is_a?(Exceptions::ValidationErrors)
-
-          { error: ensure_utf8(message) }
+          case message
+          when Hash
+            message
+          when Exceptions::ValidationErrors
+            message.as_json
+          else
+            { error: ensure_utf8(message) }
+          end
         end
 
         def ensure_utf8(message)

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -41,7 +41,7 @@ module Grape
           # Allow content-type to be explicitly overwritten
           formatter = fetch_formatter(headers, options)
           bodymap = ActiveSupport::Notifications.instrument('format_response.grape', formatter:, env:) do
-            bodies.collect { |body| formatter.call(body, env) }
+            bodies.map { |body| formatter.call(body, env) }
           end
           Rack::Response.new(bodymap, status, headers)
         end
@@ -59,11 +59,9 @@ module Grape
       # @param headers [Hash]
       # @return [Hash]
       def ensure_content_type(headers)
-        if headers[Rack::CONTENT_TYPE]
-          headers
-        else
-          headers.merge(Rack::CONTENT_TYPE => content_type_for(env[Grape::Env::API_FORMAT]))
-        end
+        return headers if headers[Rack::CONTENT_TYPE]
+
+        headers.merge(Rack::CONTENT_TYPE => content_type_for(env[Grape::Env::API_FORMAT]))
       end
 
       def read_body_input
@@ -90,24 +88,22 @@ module Grape
 
         throw :error, status: 415, message: "The provided content-type '#{media_type}' is not supported." unless content_type_for(fmt)
         parser = Grape::Parser.parser_for fmt, options[:parsers]
-        if parser
-          begin
-            body = (env[Grape::Env::API_REQUEST_BODY] = parser.call(body, env))
-            if body.is_a?(Hash)
-              env[Rack::RACK_REQUEST_FORM_HASH] = if env.key?(Rack::RACK_REQUEST_FORM_HASH)
-                                                    env[Rack::RACK_REQUEST_FORM_HASH].merge(body)
-                                                  else
-                                                    body
-                                                  end
-              env[Rack::RACK_REQUEST_FORM_INPUT] = env[Rack::RACK_INPUT]
-            end
-          rescue Grape::Exceptions::Base => e
-            raise e
-          rescue StandardError => e
-            throw :error, status: 400, message: e.message, backtrace: e.backtrace, original_exception: e
+        return env[Grape::Env::API_REQUEST_BODY] = body unless parser
+
+        begin
+          body = (env[Grape::Env::API_REQUEST_BODY] = parser.call(body, env))
+          if body.is_a?(Hash)
+            env[Rack::RACK_REQUEST_FORM_HASH] = if env.key?(Rack::RACK_REQUEST_FORM_HASH)
+                                                  env[Rack::RACK_REQUEST_FORM_HASH].merge(body)
+                                                else
+                                                  body
+                                                end
+            env[Rack::RACK_REQUEST_FORM_INPUT] = env[Rack::RACK_INPUT]
           end
-        else
-          env[Grape::Env::API_REQUEST_BODY] = body
+        rescue Grape::Exceptions::Base => e
+          raise e
+        rescue StandardError => e
+          throw :error, status: 400, message: e.message, backtrace: e.backtrace, original_exception: e
         end
       end
 

--- a/lib/grape/validations/types.rb
+++ b/lib/grape/validations/types.rb
@@ -75,7 +75,7 @@ module Grape
       # @return [Boolean] +true+ if the given value will be treated as
       #   a list of types.
       def multiple?(type)
-        (type.is_a?(Array) || type.is_a?(Set)) && type.size > 1
+        array_or_set?(type) && type.size > 1
       end
 
       # Does Grape provide special coercion and validation
@@ -98,17 +98,18 @@ module Grape
         GROUPS.include? type
       end
 
+      def array_or_set?(type)
+        type.is_a?(Array) || type.is_a?(Set)
+      end
+
       # A valid custom type must implement a class-level `parse` method, taking
       # one String argument and returning the parsed value in its correct type.
       #
       # @param type [Class] type to check
       # @return [Boolean] whether or not the type can be used as a custom type
       def custom?(type)
-        !primitive?(type) &&
-          !structure?(type) &&
-          !multiple?(type) &&
-          type.respond_to?(:parse) &&
-          type.method(:parse).arity == 1
+        !(primitive?(type) || structure?(type) || multiple?(type)) &&
+          type.respond_to?(:parse) && type.method(:parse).arity == 1
       end
 
       # Is the declared type an +Array+ or +Set+ of a {#custom?} type?
@@ -117,9 +118,7 @@ module Grape
       # @return [Boolean] true if +type+ is a collection of a type that implements
       #   its own +#parse+ method.
       def collection_of_custom?(type)
-        (type.is_a?(Array) || type.is_a?(Set)) &&
-          type.length == 1 &&
-          (custom?(type.first) || special?(type.first))
+        array_or_set?(type) && type.length == 1 && (custom?(type.first) || special?(type.first))
       end
 
       def map_special(type)
@@ -162,27 +161,21 @@ module Grape
       end
 
       def create_coercer_instance(type, method, strict)
-        # Maps a custom type provided by Grape, it doesn't map types wrapped by collections!!!
-        type = Types.map_special(type)
+        # map_special doesn't recurse into collections — applied only to the top-level type here.
+        type = map_special(type)
 
-        # Use a special coercer for multiply-typed parameters.
-        if Types.multiple?(type)
-          MultipleTypeCoercer.new(type, method)
+        # Multiply-typed parameters, e.g. types: [Integer, String].
+        return MultipleTypeCoercer.new(type, method) if multiple?(type)
 
-          # Use a special coercer for custom types and coercion methods.
-        elsif method || Types.custom?(type)
-          CustomTypeCoercer.new(type, method)
+        # User-supplied coercion method, or a custom type with its own #parse.
+        return CustomTypeCoercer.new(type, method) if method || custom?(type)
 
-          # Special coercer for collections of types that implement a parse method.
-          # CustomTypeCoercer (above) already handles such types when an explicit coercion
-          # method is supplied.
-        elsif Types.collection_of_custom?(type)
-          Types::CustomTypeCollectionCoercer.new(
-            Types.map_special(type.first), set: type.is_a?(Set)
-          )
-        else
-          DryTypeCoercer.coercer_instance_for(type, strict:)
-        end
+        # Array/Set of a custom type — CustomTypeCoercer already handles single
+        # custom types when an explicit coercion method is supplied.
+        return CustomTypeCollectionCoercer.new(map_special(type.first), set: type.is_a?(Set)) if collection_of_custom?(type)
+
+        # Fallback: let dry-types handle primitives, structures, and known specials.
+        DryTypeCoercer.coercer_instance_for(type, strict:)
       end
 
       class CoercerCache < Grape::Util::Cache

--- a/lib/grape/validations/types/primitive_coercer.rb
+++ b/lib/grape/validations/types/primitive_coercer.rb
@@ -29,9 +29,14 @@ module Grape
         # but Virtus wouldn't accept it. So, this method only exists to not introduce
         # breaking changes.
         def reject?(val)
-          (val.is_a?(Array) && type == String) ||
-            (val.is_a?(String) && type == Hash) ||
-            (val.is_a?(Hash) && type == String)
+          case val
+          when Array, Hash
+            type == String
+          when String
+            type == Hash
+          else
+            false
+          end
         end
 
         # Dry-Types treats an empty string as invalid. However, Grape considers an empty string as

--- a/lib/grape/validations/validators/except_values_validator.rb
+++ b/lib/grape/validations/validators/except_values_validator.rb
@@ -9,11 +9,12 @@ module Grape
         def initialize(attrs, options, required, scope, opts)
           super
           except = option_value
-          raise ArgumentError, 'except_values Proc must have arity of zero (use values: with a one-arity predicate for per-element checks)' if except.is_a?(Proc) && !except.arity.zero?
+          except_proc = except.is_a?(Proc)
+          raise ArgumentError, 'except_values Proc must have arity of zero (use values: with a one-arity predicate for per-element checks)' if except_proc && !except.arity.zero?
 
           # Zero-arity procs (e.g. -> { User.pluck(:role) }) must be called per-request,
           # not at definition time, so they are wrapped in a lambda to defer execution.
-          @excepts_call = except.is_a?(Proc) ? except : -> { except }
+          @excepts_call = except_proc ? except : -> { except }
         end
 
         def validate_param!(attr_name, params)


### PR DESCRIPTION
## Summary
Mechanical readability refactors across validators, DSLs, and formatters. No behavior change.

- `dsl/inside_route.rb`: `sendfile` dispatched via `case`/`when` on value type.
- `dsl/parameters.rb`: `map_params` switched to `case`/`when`; `EmptyOptionalValue` simplified to a frozen `Object.new`; public/private method order tidied.
- `error_formatter/json.rb`: `wrap_message` dispatched via `case`/`when`.
- `middleware/formatter.rb`: guard-clause returns in `ensure_content_type` and `read_rack_input`; `bodies.collect` → `bodies.map`.
- `validations/types.rb`: `create_coercer_instance` rewritten as a priority-list of guards with comments above each branch; shared `array_or_set?` predicate extracted; redundant `Types.` prefixes dropped inside `module_function Types`.
- `validations/types/primitive_coercer.rb`: `reject?` rewritten as `case`/`when` dispatching on the value's class.
- `validators/except_values_validator.rb`: lift `except.is_a?(Proc)` to a local so it isn't recomputed.

## Test plan
- [x] Full RSpec suite passes locally (2236 examples, 0 failures).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)