### PR TITLE
Consolidate rescue handler lookup in Middleware::Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#2685](https://github.com/ruby-grape/grape/pull/2685): Skip `run_filters` and `endpoint_run_filters.grape` instrumentation when the filter list is empty - [@ericproulx](https://github.com/ericproulx).
 * [#2684](https://github.com/ruby-grape/grape/pull/2684): Readability refactors: case/when, guard clauses, small cleanups - [@ericproulx](https://github.com/ericproulx).
 * [#2687](https://github.com/ruby-grape/grape/pull/2687): Skip backtrace capture on internal validation exceptions - [@ericproulx](https://github.com/ericproulx).
+* [#2688](https://github.com/ruby-grape/grape/pull/2688): Consolidate user-registered rescue handler lookup into `Middleware::Error#registered_rescue_handler` backed by a shared `rescue_handler_from` primitive - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -45,8 +45,7 @@ module Grape
       end
 
       def find_handler(klass)
-        rescue_handler_for_base_only_class(klass) ||
-          rescue_handler_for_class_or_its_ancestor(klass) ||
+        registered_rescue_handler(klass) ||
           rescue_handler_for_grape_exception(klass) ||
           rescue_handler_for_any_class(klass) ||
           raise
@@ -68,16 +67,13 @@ module Grape
         error_response(message: exception.message, backtrace: exception.backtrace, original_exception: exception)
       end
 
-      def rescue_handler_for_base_only_class(klass)
-        error, handler = options[:base_only_rescue_handlers]&.find { |err, _handler| klass == err }
-
-        return unless error
-
-        handler || method(:default_rescue_handler)
+      def registered_rescue_handler(klass)
+        rescue_handler_from(:base_only_rescue_handlers) { |err| klass == err } ||
+          rescue_handler_from(:rescue_handlers) { |err| klass <= err }
       end
 
-      def rescue_handler_for_class_or_its_ancestor(klass)
-        error, handler = options[:rescue_handlers]&.find { |err, _handler| klass <= err }
+      def rescue_handler_from(key)
+        error, handler = options[key]&.find { |err, _handler| yield(err) }
 
         return unless error
 


### PR DESCRIPTION
## Summary

- Collapse `rescue_handler_for_base_only_class` and `rescue_handler_for_class_or_its_ancestor` — which were structurally identical apart from their option key (`:base_only_rescue_handlers` vs `:rescue_handlers`) and match predicate (`klass == err` vs `klass <= err`) — into a single `registered_rescue_handler`.
- Extract the shared lookup scaffolding (`options[key]&.find { ... } || method(:default_rescue_handler)`) into a `rescue_handler_from(key, &matcher)` primitive.
- `find_handler` now reads as a priority list of four named concepts: user-registered handler → Grape exception → catch-all → re-raise. Exact-before-ancestor precedence is properly encapsulated inside `registered_rescue_handler`.

No public API change; behavior is identical.

## Test plan
- [x] `bundle exec rspec spec/grape/middleware/error_spec.rb spec/grape/endpoint_spec.rb spec/grape/api_spec.rb` — 551 examples, 0 failures.
- [x] `bundle exec rubocop lib/grape/middleware/error.rb` — clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)