### PR TITLE
Avoid empty-hash merges on request hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#2684](https://github.com/ruby-grape/grape/pull/2684): Readability refactors: case/when, guard clauses, small cleanups - [@ericproulx](https://github.com/ericproulx).
 * [#2687](https://github.com/ruby-grape/grape/pull/2687): Skip backtrace capture on internal validation exceptions - [@ericproulx](https://github.com/ericproulx).
 * [#2688](https://github.com/ruby-grape/grape/pull/2688): Consolidate user-registered rescue handler lookup into `Middleware::Error#registered_rescue_handler` backed by a shared `rescue_handler_from` primitive - [@ericproulx](https://github.com/ericproulx).
+* [#2689](https://github.com/ruby-grape/grape/pull/2689): Avoid empty-hash merges on request hot paths - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,10 @@ Upgrading Grape
 
 ### Upgrading to >= 3.3
 
+#### `Grape::Request#grape_routing_args` has been removed
+
+`grape_routing_args` was previously public to support third-party `params_builder` extensions, which have since been removed. With no remaining callers, the method has been removed. If you were calling it externally, read `env[Grape::Env::GRAPE_ROUTING_ARGS]` directly.
+
 #### `endpoint_run_filters.grape` notification no longer fired for empty filter lists
 
 `ActiveSupport::Notifications` subscribers listening to `endpoint_run_filters.grape` will no longer receive an event when the filter list for a given phase (`:before`, `:before_validation`, `:after_validation`, `:after`, `:finally`) is empty. Previously every phase emitted an event on every request regardless of whether any filters were registered. If you relied on these events to infer per-phase timing, subscribe to `endpoint_run.grape` (which always fires once per request) or register a no-op filter to keep the phase instrumented.

--- a/lib/grape/dsl/entity.rb
+++ b/lib/grape/dsl/entity.rb
@@ -32,7 +32,7 @@ module Grape
         representation = { root => representation } if root
 
         if key
-          representation = (body || {}).merge(key => representation)
+          representation = body&.merge(key => representation) || { key => representation }
         elsif entity_class.present? && body
           raise ArgumentError, "Representation of type #{representation.class} cannot be merged." unless representation.respond_to?(:merge)
 

--- a/lib/grape/request.rb
+++ b/lib/grape/request.rb
@@ -156,16 +156,12 @@ module Grape
       @cookies ||= Grape::Cookies.new(-> { rack_cookies })
     end
 
-    # needs to be public until extensions param_builder are removed
-    def grape_routing_args
-      # preserve version from query string parameters
-      env[Grape::Env::GRAPE_ROUTING_ARGS]&.except(:version, :route_info) || {}
-    end
-
     private
 
     def make_params
-      @params_builder.call(rack_params).deep_merge!(grape_routing_args)
+      params = @params_builder.call(rack_params)
+      routing_args = env[Grape::Env::GRAPE_ROUTING_ARGS]&.except(:version, :route_info)&.presence
+      routing_args ? params.deep_merge!(routing_args) : params
     rescue *Grape::RACK_ERRORS
       raise Grape::Exceptions::RequestError
     end

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -137,8 +137,7 @@ module Grape
     def process_route(route, input, env, include_allow_header: false)
       args = env[Grape::Env::GRAPE_ROUTING_ARGS] || { route_info: route }
       route_params = route.params(input)
-      routing_args = args.merge(route_params || {})
-      env[Grape::Env::GRAPE_ROUTING_ARGS] = routing_args
+      env[Grape::Env::GRAPE_ROUTING_ARGS] = route_params.blank? ? args : args.merge(route_params)
       env[Grape::Env::GRAPE_ALLOWED_METHODS] = route.allow_header if include_allow_header
       route.call(env)
     end


### PR DESCRIPTION
## Summary

Three `|| {}` sites on the per-request path allocated an empty Hash and handed it to a merge that produced a shallow copy of the left-hand side — pure waste. Guard the merge when the right-hand side is absent or empty.

- **`Router#process_route`** — `args.merge(route_params || {})` → `route_params.blank? ? args : args.merge(route_params)`. On every static route (no path placeholders), this saves both the `{}` allocation and the identical-copy hash from `merge`.
- **`Request#make_params`** — `deep_merge!` on an empty routing-args hash walked nothing but still paid the call cost; skip it entirely when empty.
- **`DSL::Entity#present`** (keyed form) — `(body || {}).merge(key => representation)` → ternary that builds the one-key hash directly when `body` is nil.

No behavior change.

## Perf / Benchmarks

Microbenchmark of the `process_route` merge shape, 1,000 calls per run:

| Scenario | old | new | speedup | allocations (old → new) |
|---|---|---|---|---|
| `route_params` nil (common) | 4.48 M i/s | 8.31 M i/s | **1.85x** | 3000 → 1000 (3x fewer) |
| `route_params` empty `{}` | 5.16 M i/s | 8.02 M i/s | **1.55x** | 2000 → 1000 (2x fewer) |
| `route_params` real | 4.58 M i/s | 4.67 M i/s | within noise | unchanged |

## Test plan
- [x] `bundle exec rspec` — 2,236 examples, 0 failures.
- [x] `bundle exec rubocop lib/grape/router.rb lib/grape/request.rb lib/grape/dsl/entity.rb` — clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)