### PR TITLE
Return frozen EMPTY array from StackableValues on miss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#2687](https://github.com/ruby-grape/grape/pull/2687): Skip backtrace capture on internal validation exceptions - [@ericproulx](https://github.com/ericproulx).
 * [#2688](https://github.com/ruby-grape/grape/pull/2688): Consolidate user-registered rescue handler lookup into `Middleware::Error#registered_rescue_handler` backed by a shared `rescue_handler_from` primitive - [@ericproulx](https://github.com/ericproulx).
 * [#2689](https://github.com/ruby-grape/grape/pull/2689): Avoid empty-hash merges on request hot paths - [@ericproulx](https://github.com/ericproulx).
+* [#2690](https://github.com/ruby-grape/grape/pull/2690): Avoid allocating an empty array on every `StackableValues#[]` miss - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -46,7 +46,7 @@ module Grape
       # this endpoint and its parents, but later it will be cleaned up,
       # see +reset_validations!+ in lib/grape/dsl/validations.rb
       inheritable_setting.route[:declared_params] = inheritable_setting.namespace_stackable[:declared_params].flatten
-      inheritable_setting.route[:saved_validations] = inheritable_setting.namespace_stackable[:validations]
+      inheritable_setting.route[:saved_validations] = inheritable_setting.namespace_stackable[:validations].dup
 
       inheritable_setting.namespace_stackable[:representations] ||= []
       inheritable_setting.namespace_inheritable[:default_error_status] ||= 500

--- a/lib/grape/util/stackable_values.rb
+++ b/lib/grape/util/stackable_values.rb
@@ -3,12 +3,14 @@
 module Grape
   module Util
     class StackableValues < BaseInheritable
-      # Even if there is no value, an empty array will be returned.
+      EMPTY = [].freeze
+
+      # Even if there is no value, an empty (frozen) array will be returned.
       def [](name)
         inherited_value = inherited_values[name]
         new_value = new_values[name]
 
-        return new_value || [] unless inherited_value
+        return new_value || EMPTY unless inherited_value
 
         concat_values(inherited_value, new_value)
       end


### PR DESCRIPTION
## Summary

`StackableValues#[]` is the accessor behind `namespace_stackable[key]` — called multiple times per request (five filter phases plus ad-hoc settings lookups). When neither `inherited_values` nor `new_values` have an entry, the old `return new_value || []` allocated a fresh empty array on every miss.

Introduce a frozen `EMPTY = [].freeze` and return it instead. Eliminates 2–5 short-lived empty-array allocations per request depending on how many filter phases are in use.

## Backward compatibility

One internal caller — `Endpoint#initialize` — stored `namespace_stackable[:validations]` by reference into `route[:saved_validations]`, then `.concat`'d parent validations into it via `inherit_settings`. With a frozen `EMPTY` in play, that mutation would `FrozenError` on endpoints with no validations that later inherit some. Fix: `.dup` at capture, so the route keeps its own mutable list. Hardens the existing shared-state footgun regardless of this PR.

No public API change.

## Perf / Benchmarks

1,000-iteration 5-key probe:

| Scenario | current | variant | speedup | allocations |
|---|---|---|---|---|
| Realistic (3 populated, 2 absent) | 2.01 M i/s | 2.19 M i/s | within noise | **80B → 0** (2 arrays saved) |
| Worst case (all 5 absent) | 2.18 M i/s | 2.49 M i/s | **1.14x** | **200B → 0** (5 arrays saved) |

Raw-speed win is modest; allocation win is consistent and free.

## Test plan
- [x] `bundle exec rspec` — 2,236 examples, 0 failures.
- [x] `bundle exec rubocop lib/grape/util/stackable_values.rb lib/grape/endpoint.rb` — clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)