### PR TITLE
Precompute prefix list in Versioner::Path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#2688](https://github.com/ruby-grape/grape/pull/2688): Consolidate user-registered rescue handler lookup into `Middleware::Error#registered_rescue_handler` backed by a shared `rescue_handler_from` primitive - [@ericproulx](https://github.com/ericproulx).
 * [#2689](https://github.com/ruby-grape/grape/pull/2689): Avoid empty-hash merges on request hot paths - [@ericproulx](https://github.com/ericproulx).
 * [#2690](https://github.com/ruby-grape/grape/pull/2690): Avoid allocating an empty array on every `StackableValues#[]` miss - [@ericproulx](https://github.com/ericproulx).
+* [#2691](https://github.com/ruby-grape/grape/pull/2691): Precompute the prefix list in `Middleware::Versioner::Path` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/middleware/versioner/path.rb
+++ b/lib/grape/middleware/versioner/path.rb
@@ -17,12 +17,17 @@ module Grape
       #   env['api.version'] => 'v1'
       #
       class Path < Base
+        def initialize(app, **options)
+          super
+          @prefixes = [mount_path, Grape::Router.normalize_path(prefix)].select { |p| p.present? && p != '/' }.freeze
+        end
+
         def before
           path_info = Grape::Router.normalize_path(env[Rack::PATH_INFO])
           return if path_info == '/'
 
-          [mount_path, Grape::Router.normalize_path(prefix)].each do |path|
-            path_info = path_info.delete_prefix(path) if path.present? && path != '/' && path_info.start_with?(path)
+          path_info = @prefixes.reduce(path_info) do |pi, path|
+            pi.start_with?(path) ? pi.delete_prefix(path) : pi
           end
 
           slash_position = path_info.index('/', 1) # omit the first one


### PR DESCRIPTION
## Summary

`Versioner::Path#before` built `[mount_path, Grape::Router.normalize_path(prefix)]` on every request, then iterated the pair, filtering out `nil`/`''`/`'/'` elements with a guard on each iteration. Both `mount_path` and `prefix` are fixed at mount time — the array, the `normalize_path` call, and the per-element filtering are all per-request waste.

Memoize a pre-filtered frozen `@prefixes` in `initialize`. `Middleware::Base#call` does `dup`, which shallow-copies ivars, so every per-request middleware dup gets the shared frozen array for free. The loop body simplifies to `if path_info.start_with?(path)`.

No behavior change.

## Perf / Benchmarks

1,000-iteration microbenchmark of the `before` workload:

| | ops/sec | allocations |
|---|---|---|
| current | 1.09 M i/s | 80 KB / 2,000 objects |
| memoize normalize only | 1.34 M i/s | 80 KB / 2,000 objects |
| **memoize list (shipped)** | **2.61 M i/s** | **40 KB / 1,000 objects** (2.38x faster, 2x fewer) |

## Test plan
- [x] `bundle exec rspec` — 2,236 examples, 0 failures.
- [x] `bundle exec rubocop lib/grape/middleware/versioner/path.rb` — clean.
- [x] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)