### PR TITLE
Replace per-request Proc in Router#transaction with a helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#2689](https://github.com/ruby-grape/grape/pull/2689): Avoid empty-hash merges on request hot paths - [@ericproulx](https://github.com/ericproulx).
 * [#2690](https://github.com/ruby-grape/grape/pull/2690): Avoid allocating an empty array on every `StackableValues#[]` miss - [@ericproulx](https://github.com/ericproulx).
 * [#2691](https://github.com/ruby-grape/grape/pull/2691): Precompute the prefix list in `Middleware::Versioner::Path` - [@ericproulx](https://github.com/ericproulx).
+* [#2692](https://github.com/ruby-grape/grape/pull/2692): Replace per-request `Proc` allocation in `Router#transaction` with a `halt?` helper - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -103,20 +103,10 @@ module Grape
     end
 
     def transaction(input, method, env)
-      # using a Proc is important since `return` will exit the enclosing function
-      cascade_or_return_response = proc do |response|
-        if response
-          cascade?(response).tap do |cascade|
-            return response unless cascade
-
-            # we need to close the body if possible before dismissing
-            response[2].close if response[2].respond_to?(:close)
-          end
-        end
-      end
-
       response = yield
-      last_response_cascade = cascade_or_return_response.call(response)
+      return response if halt?(response)
+
+      last_response_cascade = !response.nil?
       last_neighbor_route = greedy_match?(input)
 
       # If last_neighbor_route exists and request method is OPTIONS,
@@ -127,11 +117,27 @@ module Grape
 
       return last_neighbor_route.call(env) if last_neighbor_route && last_response_cascade && route
 
-      last_response_cascade = cascade_or_return_response.call(process_route(route, input, env)) if route
+      if route
+        route_response = process_route(route, input, env)
+        return route_response if halt?(route_response)
+
+        last_response_cascade = !route_response.nil?
+      end
 
       return process_route(last_neighbor_route, input, env, include_allow_header: true) if !last_response_cascade && last_neighbor_route
 
       nil
+    end
+
+    # Returns true if `response` should be returned as-is from the enclosing
+    # transaction. Closes the body as a side effect when the response is
+    # cascading so callers can safely try the next match.
+    def halt?(response)
+      return false unless response
+
+      cascade = cascade?(response)
+      response[2].close if cascade && response[2].respond_to?(:close)
+      !cascade
     end
 
     def process_route(route, input, env, include_allow_header: false)


### PR DESCRIPTION
## Summary

`Router#transaction` allocated a `cascade_or_return_response` proc on every request. The proc had to live inside the method because it relied on non-local `return` to exit `transaction` when a non-cascading response arrived — the comment on top of the method calls this out explicitly. That proc was doing two things at once: closing the cascading body as a side effect, and halting transaction processing.

Split them. A plain `halt?(response)` helper answers "should this response halt processing?" — returning `true` for a final (non-cascading) response and `false` when the response is absent or cascading; closing the cascading body happens inside the helper as a side effect. `transaction` then uses explicit early-returns for the halt case and plain assignments for the cascade flag. No proc needed; behavior identical.

## Perf / Benchmarks

Isolated microbenchmark of the cascade-decision shape, 1,000 iterations:

| scenario | current | variant | speedup | allocations |
|---|---|---|---|---|
| cascading response | 3.12 M i/s | 6.88 M i/s | **2.21x** | 1 → 0 objects |
| hit response (final) | 3.07 M i/s | 9.82 M i/s | **3.20x** | 1 → 0 objects |
| nil response | 5.07 M i/s | 15.7 M i/s | **3.10x** | 1 → 0 objects |

One proc allocation saved per request on the router dispatch path.

## Test plan
- [x] `bundle exec rspec` — 2,236 examples, 0 failures.
- [x] `bundle exec rubocop lib/grape/router.rb` — clean.
- [x] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)