### PR TITLE
Split Versioner::Base#available_media_types into attr_reader + builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#2690](https://github.com/ruby-grape/grape/pull/2690): Avoid allocating an empty array on every `StackableValues#[]` miss - [@ericproulx](https://github.com/ericproulx).
 * [#2691](https://github.com/ruby-grape/grape/pull/2691): Precompute the prefix list in `Middleware::Versioner::Path` - [@ericproulx](https://github.com/ericproulx).
 * [#2692](https://github.com/ruby-grape/grape/pull/2692): Replace per-request `Proc` allocation in `Router#transaction` with a `halt?` helper - [@ericproulx](https://github.com/ericproulx).
+* [#2694](https://github.com/ruby-grape/grape/pull/2694): Split `Versioner::Base#available_media_types` into an `attr_reader` plus `build_available_media_types` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/middleware/versioner/base.rb
+++ b/lib/grape/middleware/versioner/base.rb
@@ -37,13 +37,13 @@ module Grape
           Versioner.register(klass)
         end
 
-        attr_reader :error_headers, :versions
+        attr_reader :error_headers, :versions, :available_media_types
 
         def initialize(app, **options)
           super
           @error_headers = cascade ? CASCADE_PASS_HEADER : {}
           @versions = options[:versions]&.map(&:to_s) # making sure versions are strings to ease potential match
-          available_media_types # warm on parent instance so per-request dups inherit it
+          @available_media_types = build_available_media_types
         end
 
         def potential_version_match?(potential_version)
@@ -56,22 +56,20 @@ module Grape
 
         private
 
-        def available_media_types
-          @available_media_types ||= begin
-            media_types = []
-            base_media_type = "application/vnd.#{vendor}"
-            content_types.each_key do |extension|
-              versions&.reverse_each do |version|
-                media_types << "#{base_media_type}-#{version}+#{extension}"
-                media_types << "#{base_media_type}-#{version}"
-              end
-              media_types << "#{base_media_type}+#{extension}"
+        def build_available_media_types
+          media_types = []
+          base_media_type = "application/vnd.#{vendor}"
+          content_types.each_key do |extension|
+            versions&.reverse_each do |version|
+              media_types << "#{base_media_type}-#{version}+#{extension}"
+              media_types << "#{base_media_type}-#{version}"
             end
-
-            media_types << base_media_type
-            media_types.concat(content_types.values.flatten)
-            media_types
+            media_types << "#{base_media_type}+#{extension}"
           end
+
+          media_types << base_media_type
+          media_types.concat(content_types.values.flatten)
+          media_types
         end
       end
     end


### PR DESCRIPTION
## Summary

The lazy `||=` memoization in `Versioner::Base#available_media_types` was effectively dead — `initialize` already called the method to warm the cache on the parent instance, so per-request dups always inherited a populated value. Replace it with an explicit `attr_reader :available_media_types` plus a private `build_available_media_types` method assigned in `initialize`.

The construction-time intent is now visible at the constructor, the accessor is a one-liner, and the build logic gets a name. Same `build_*` shape used elsewhere in Grape.

No behavior change.

## Test plan
- [x] `bundle exec rspec` — 2,236 examples, 0 failures.
- [x] `bundle exec rubocop lib/grape/middleware/versioner/base.rb` — clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)