### PR TITLE
Lift trailing if/else into guard clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#2691](https://github.com/ruby-grape/grape/pull/2691): Precompute the prefix list in `Middleware::Versioner::Path` - [@ericproulx](https://github.com/ericproulx).
 * [#2692](https://github.com/ruby-grape/grape/pull/2692): Replace per-request `Proc` allocation in `Router#transaction` with a `halt?` helper - [@ericproulx](https://github.com/ericproulx).
 * [#2694](https://github.com/ruby-grape/grape/pull/2694): Split `Versioner::Base#available_media_types` into an `attr_reader` plus `build_available_media_types` - [@ericproulx](https://github.com/ericproulx).
+* [#2695](https://github.com/ruby-grape/grape/pull/2695): Lift trailing `if/else` into guard clauses - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -56,12 +56,10 @@ module Grape
       # `configuration` as normal.
       def configure
         config = @base_instance.configuration
-        if block_given?
-          yield config
-          self
-        else
-          config
-        end
+        return config unless block_given?
+
+        yield config
+        self
       end
 
       # The remountable class can have a configuration hash to provide some dynamic class-level variables.

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -126,12 +126,10 @@ module Grape
         opts[:presence] = { value: true, message: opts[:message] }
         opts = @group.deep_merge(opts) if @group
 
-        if opts[:using]
-          require_required_and_optional_fields(attrs.first, using: opts[:using], except: opts[:except])
-        else
-          validate_attributes(attrs, **opts, &block)
-          block ? new_scope(attrs.first, type: opts[:type], as: opts[:as], &block) : push_declared_params(attrs, as: opts[:as])
-        end
+        return require_required_and_optional_fields(attrs.first, using: opts[:using], except: opts[:except]) if opts[:using]
+
+        validate_attributes(attrs, **opts, &block)
+        block ? new_scope(attrs.first, type: opts[:type], as: opts[:as], &block) : push_declared_params(attrs, as: opts[:as])
       end
 
       # Allow, but don't require, one or more parameters for the current
@@ -148,13 +146,10 @@ module Grape
           raise Grape::Exceptions::UnsupportedGroupType unless Grape::Validations::Types.group?(type)
         end
 
-        if opts[:using]
-          require_optional_fields(attrs.first, using: opts[:using], except: opts[:except])
-        else
-          validate_attributes(attrs, **opts, &block)
+        return require_optional_fields(attrs.first, using: opts[:using], except: opts[:except]) if opts[:using]
 
-          block ? new_scope(attrs.first, type: opts[:type], as: opts[:as], optional: true, &block) : push_declared_params(attrs, as: opts[:as])
-        end
+        validate_attributes(attrs, **opts, &block)
+        block ? new_scope(attrs.first, type: opts[:type], as: opts[:as], optional: true, &block) : push_declared_params(attrs, as: opts[:as])
       end
 
       # Define common settings for one or more parameters
@@ -190,15 +185,13 @@ module Grape
       # block yet.
       # @return [Boolean] whether the parameter has been defined
       def declared_param?(param)
-        if lateral?
-          # Elements of @declared_params of lateral scope are pushed in @parent. So check them in @parent.
-          @parent.declared_param?(param)
-        else
-          # @declared_params also includes hashes of options and such, but those
-          # won't be flattened out.
-          @declared_params.flatten.any? do |declared_param_attr|
-            first_hash_key_or_param(declared_param_attr.key) == param
-          end
+        # Elements of @declared_params of lateral scope are pushed in @parent. So check them in @parent.
+        return @parent.declared_param?(param) if lateral?
+
+        # @declared_params also includes hashes of options and such, but those
+        # won't be flattened out.
+        @declared_params.flatten.any? do |declared_param_attr|
+          first_hash_key_or_param(declared_param_attr.key) == param
         end
       end
 


### PR DESCRIPTION
## Summary

Four methods ended in an `if/else` where one branch was a one-line special-case detour and the other was the main flow. The `else` existed only as a syntactic counterpart to `if`, pushing multi-line main paths down an extra indentation level. Each now uses a `return … if …` guard, leaving the main flow at the method's top indentation.

- `Grape::DSL::Parameters#requires` — `if opts[:using]` is the shortcut form; main flow is `validate_attributes` + scope/push.
- `Grape::DSL::Parameters#optional` — same shape.
- `Grape::DSL::Parameters#declared_param?` — `if lateral?` delegates to `@parent`; main flow is the `.any?` check.
- `Grape::API.configure` — `unless block_given?` returns the config reader; main flow yields and returns `self`.

Pure refactor; no behavior change.

## Test plan
- [x] `bundle exec rspec` — 2,236 examples, 0 failures.
- [x] `bundle exec rubocop lib/grape/dsl/parameters.rb lib/grape/api.rb` — clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)