### PR TITLE
Extract Grape::Util::PathNormalizer from Grape::Router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#2692](https://github.com/ruby-grape/grape/pull/2692): Replace per-request `Proc` allocation in `Router#transaction` with a `halt?` helper - [@ericproulx](https://github.com/ericproulx).
 * [#2694](https://github.com/ruby-grape/grape/pull/2694): Split `Versioner::Base#available_media_types` into an `attr_reader` plus `build_available_media_types` - [@ericproulx](https://github.com/ericproulx).
 * [#2695](https://github.com/ruby-grape/grape/pull/2695): Lift trailing `if/else` into guard clauses - [@ericproulx](https://github.com/ericproulx).
+* [#2697](https://github.com/ruby-grape/grape/pull/2697): Extract `Grape::Util::PathNormalizer` from `Grape::Router`; `Grape::Router.normalize_path` is now a deprecated alias - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -113,7 +113,7 @@ module Grape
           in_setting = inheritable_setting
 
           if app.respond_to?(:inheritable_setting, true)
-            mount_path = Grape::Router.normalize_path(path)
+            mount_path = Grape::Util::PathNormalizer.call(path)
             app.top_level_setting.namespace_stackable[:mount_path] = mount_path
 
             app.inherit_settings(inheritable_setting)

--- a/lib/grape/middleware/versioner/path.rb
+++ b/lib/grape/middleware/versioner/path.rb
@@ -19,11 +19,11 @@ module Grape
       class Path < Base
         def initialize(app, **options)
           super
-          @prefixes = [mount_path, Grape::Router.normalize_path(prefix)].select { |p| p.present? && p != '/' }.freeze
+          @prefixes = [mount_path, Grape::Util::PathNormalizer.call(prefix)].select { |p| p.present? && p != '/' }.freeze
         end
 
         def before
-          path_info = Grape::Router.normalize_path(env[Rack::PATH_INFO])
+          path_info = Grape::Util::PathNormalizer.call(env[Rack::PATH_INFO])
           return if path_info == '/'
 
           path_info = @prefixes.reduce(path_info) do |pi, path|

--- a/lib/grape/namespace.rb
+++ b/lib/grape/namespace.rb
@@ -45,7 +45,7 @@ module Grape
       def initialize
         super
         @cache = Hash.new do |h, joined_space|
-          h[joined_space] = Grape::Router.normalize_path(joined_space.join('/'))
+          h[joined_space] = Grape::Util::PathNormalizer.call(joined_space.join('/'))
         end
       end
     end

--- a/lib/grape/path.rb
+++ b/lib/grape/path.rb
@@ -68,7 +68,7 @@ module Grape
       def initialize
         super
         @cache = Hash.new do |h, parts|
-          h[parts] = Grape::Router.normalize_path(parts.join('/'))
+          h[parts] = Grape::Util::PathNormalizer.call(parts.join('/'))
         end
       end
     end

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -2,31 +2,12 @@
 
 module Grape
   class Router
-    # Taken from Rails
-    #     normalize_path("/foo")  # => "/foo"
-    #     normalize_path("/foo/") # => "/foo"
-    #     normalize_path("foo")   # => "/foo"
-    #     normalize_path("")      # => "/"
-    #     normalize_path("/%ab")  # => "/%AB"
-    # https://github.com/rails/rails/blob/00cc4ff0259c0185fe08baadaa40e63ea2534f6e/actionpack/lib/action_dispatch/journey/router/utils.rb#L19
+    # @deprecated Use {Grape::Util::PathNormalizer.call} instead.
     def self.normalize_path(path)
-      return '/' unless path
-      return path if path == '/'
-
-      # Fast path for the overwhelming majority of paths that don't need to be normalized
-      return path if path.start_with?('/') && !(path.end_with?('/') || path.match?(%r{%|//}))
-
-      # Slow path
-      encoding = path.encoding
-      path = "/#{path}"
-      path.squeeze!('/')
-
-      unless path == '/'
-        path.delete_suffix!('/')
-        path.gsub!(/(%[a-f0-9]{2})/) { ::Regexp.last_match(1).upcase }
-      end
-
-      path.force_encoding(encoding)
+      Grape.deprecator.warn(
+        '`Grape::Router.normalize_path` is deprecated. Use `Grape::Util::PathNormalizer.call` instead.'
+      )
+      Grape::Util::PathNormalizer.call(path)
     end
 
     def initialize
@@ -62,7 +43,7 @@ module Grape
 
     def call(env)
       with_optimization do
-        input = Router.normalize_path(env[Rack::PATH_INFO])
+        input = Grape::Util::PathNormalizer.call(env[Rack::PATH_INFO])
         method = env[Rack::REQUEST_METHOD]
         response, route = identity(input, method, env)
         response || rotation(input, method, env, route)

--- a/lib/grape/util/path_normalizer.rb
+++ b/lib/grape/util/path_normalizer.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Grape
+  module Util
+    module PathNormalizer
+      # Taken from Rails
+      #     call("/foo")  # => "/foo"
+      #     call("/foo/") # => "/foo"
+      #     call("foo")   # => "/foo"
+      #     call("")      # => "/"
+      #     call("/%ab")  # => "/%AB"
+      # https://github.com/rails/rails/blob/00cc4ff0259c0185fe08baadaa40e63ea2534f6e/actionpack/lib/action_dispatch/journey/router/utils.rb#L19
+      def self.call(path)
+        return '/' unless path
+        return path if path == '/'
+
+        # Fast path for the overwhelming majority of paths that don't need to be normalized
+        return path if path.start_with?('/') && !(path.end_with?('/') || path.match?(%r{%|//}))
+
+        # Slow path
+        encoding = path.encoding
+        path = "/#{path}"
+        path.squeeze!('/')
+
+        unless path == '/'
+          path.delete_suffix!('/')
+          path.gsub!(/(%[a-f0-9]{2})/) { ::Regexp.last_match(1).upcase }
+        end
+
+        path.force_encoding(encoding)
+      end
+    end
+  end
+end

--- a/spec/grape/router_spec.rb
+++ b/spec/grape/router_spec.rb
@@ -2,56 +2,10 @@
 
 describe Grape::Router do
   describe '.normalize_path' do
-    subject { described_class.normalize_path(path) }
-
-    context 'when no leading slash' do
-      let(:path) { 'foo%20bar%20baz' }
-
-      it { is_expected.to eq '/foo%20bar%20baz' }
-    end
-
-    context 'when path ends with slash' do
-      let(:path) { '/foo%20bar%20baz/' }
-
-      it { is_expected.to eq '/foo%20bar%20baz' }
-    end
-
-    context 'when path has recurring slashes' do
-      let(:path) { '////foo%20bar%20baz' }
-
-      it { is_expected.to eq '/foo%20bar%20baz' }
-    end
-
-    context 'when not greedy' do
-      let(:path) { '/foo%20bar%20baz' }
-
-      it { is_expected.to eq '/foo%20bar%20baz' }
-    end
-
-    context 'when encoded string in lowercase' do
-      let(:path) { '/foo%aabar%aabaz' }
-
-      it { is_expected.to eq '/foo%AAbar%AAbaz' }
-    end
-
-    context 'when nil' do
-      let(:path) { nil }
-
-      it { is_expected.to eq '/' }
-    end
-
-    context 'when empty string' do
-      let(:path) { '' }
-
-      it { is_expected.to eq '/' }
-    end
-
-    context 'when encoding is different' do
-      subject { described_class.normalize_path(path).encoding }
-
-      let(:path) { '/foo%AAbar%AAbaz'.b }
-
-      it { is_expected.to eq(Encoding::BINARY) }
+    it 'is deprecated and delegates to Grape::Util::PathNormalizer' do
+      expect { described_class.normalize_path('/foo/') }.to raise_error(
+        ActiveSupport::DeprecationException, /Grape::Util::PathNormalizer/
+      )
     end
   end
 end

--- a/spec/grape/util/path_normalizer_spec.rb
+++ b/spec/grape/util/path_normalizer_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+describe Grape::Util::PathNormalizer do
+  describe '.call' do
+    subject { described_class.call(path) }
+
+    context 'when no leading slash' do
+      let(:path) { 'foo%20bar%20baz' }
+
+      it { is_expected.to eq '/foo%20bar%20baz' }
+    end
+
+    context 'when path ends with slash' do
+      let(:path) { '/foo%20bar%20baz/' }
+
+      it { is_expected.to eq '/foo%20bar%20baz' }
+    end
+
+    context 'when path has recurring slashes' do
+      let(:path) { '////foo%20bar%20baz' }
+
+      it { is_expected.to eq '/foo%20bar%20baz' }
+    end
+
+    context 'when not greedy' do
+      let(:path) { '/foo%20bar%20baz' }
+
+      it { is_expected.to eq '/foo%20bar%20baz' }
+    end
+
+    context 'when encoded string in lowercase' do
+      let(:path) { '/foo%aabar%aabaz' }
+
+      it { is_expected.to eq '/foo%AAbar%AAbaz' }
+    end
+
+    context 'when nil' do
+      let(:path) { nil }
+
+      it { is_expected.to eq '/' }
+    end
+
+    context 'when empty string' do
+      let(:path) { '' }
+
+      it { is_expected.to eq '/' }
+    end
+
+    context 'when encoding is different' do
+      subject { described_class.call(path).encoding }
+
+      let(:path) { '/foo%AAbar%AAbaz'.b }
+
+      it { is_expected.to eq(Encoding::BINARY) }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`Grape::Router.normalize_path` is a pure string utility — 5 of its 6 callers already live outside `Grape::Router` (`Grape::Path`, `Grape::Namespace`, `Grape::Middleware::Versioner::Path`, `Grape::DSL::Routing`). Move it to `Grape::Util::PathNormalizer` next to the other utility-style modules (`Header`, `Translation`, `Cache`, etc.); the function has no dependency on `Router` state, so the placement was historical.

## Backwards compatibility

`Grape::Router.normalize_path` is preserved as a deprecated class-method alias that delegates to `Grape::Util::PathNormalizer.call` and emits a warning via `Grape.deprecator`. It will be removed in a future release.

## Test plan
- [x] `bundle exec rspec` — green (moved spec to `spec/grape/util/path_normalizer_spec.rb`, kept a deprecation spec on `Grape::Router`).
- [x] `bundle exec rubocop` on touched files — clean.
- [x] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)