### PR TITLE
Collapse extract_handler type-dispatch into case/when

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#2692](https://github.com/ruby-grape/grape/pull/2692): Replace per-request `Proc` allocation in `Router#transaction` with a `halt?` helper - [@ericproulx](https://github.com/ericproulx).
 * [#2694](https://github.com/ruby-grape/grape/pull/2694): Split `Versioner::Base#available_media_types` into an `attr_reader` plus `build_available_media_types` - [@ericproulx](https://github.com/ericproulx).
 * [#2695](https://github.com/ruby-grape/grape/pull/2695): Lift trailing `if/else` into guard clauses - [@ericproulx](https://github.com/ericproulx).
+* [#2698](https://github.com/ruby-grape/grape/pull/2698): Collapse `DSL::RequestResponse#extract_handler` type-dispatch into a `case`/`when` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -146,10 +146,13 @@ module Grape
 
         return args.pop if args.last.is_a?(Proc)
         return block if block
-        return with if with.instance_of?(Proc) || with.instance_of?(Symbol)
-        return with.to_sym if with.instance_of?(String)
+        return unless with
 
-        raise ArgumentError, "with: #{with.class}, expected Symbol, String or Proc" if with
+        case with
+        when Proc, Symbol then with
+        when String       then with.to_sym
+        else raise ArgumentError, "with: #{with.class}, expected Symbol, String or Proc"
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

`DSL::RequestResponse#extract_handler` dispatched on `with`'s type via three `with.instance_of?` predicates on consecutive lines. Lift the dispatch into a single `case`/`when` block. Branches stay as plain expressions (no return inside `when`), with early returns above the `case` to short-circuit the no-`with` paths.

## Behavior note

`case`/`when` uses `===` (i.e. `is_a?`), not `instance_of?`. So a hypothetical `Symbol`/`String`/`Proc` *subclass* now matches where it didn't before. `is_a?` is the more conventional check and handles inheritance correctly; nothing in the codebase or tests relies on the strict-instance behavior.

## Test plan
- [x] `bundle exec rspec` — green (2236 examples).
- [x] `bundle exec rubocop` on touched file — clean.
- [x] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)