### PR TITLE
Add oneof: option for polymorphic Hash parameters (#2385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#2706](https://github.com/ruby-grape/grape/pull/2706): Refactor `ParamsScope#validates` and `ParamsDocumentation` around a frozen `Grape::Validations::ValidationsSpec` value object; the validations hash supplied by the DSL is no longer mutated and the helper chain becomes pure - [@ericproulx](https://github.com/ericproulx).
 * [#2707](https://github.com/ruby-grape/grape/pull/2707): Tighten six guard conditions in `lib/` via De Morgan and `blank?`/`present?`/`include?` rewrites; no behaviour change - [@ericproulx](https://github.com/ericproulx).
 * [#2709](https://github.com/ruby-grape/grape/pull/2709): Lift trailing `if/else` into guard clauses; tighten `Util::Lazy::ValueEnumerable` - [@ericproulx](https://github.com/ericproulx).
+* [#2702](https://github.com/ruby-grape/grape/pull/2702): Add `oneof:` option for `requires`/`optional` to accept a Hash parameter matching one of several variant schemas (resolves [#2385](https://github.com/ruby-grape/grape/issues/2385)) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -1335,6 +1335,56 @@ end
 client.get('/', status_codes: %w(1 two)) # => [1, "two"]
 ```
 
+### Multiple Hash Schemas with `oneof`
+
+A Hash parameter that may take one of several different shapes can be declared with the `oneof:` option. Each variant is a `Proc` that uses the normal `params` DSL — so the full validator surface (`requires`, `optional`, `regexp:`, `values:`, `allow_blank:`, nested `Hash`/`Array`, etc.) is available inside.
+
+```ruby
+params do
+  requires :value, type: Hash, oneof: [
+    proc { requires :fixed_price, type: Float },
+    proc do
+      requires :time_unit, type: String
+      requires :rate, type: Float
+    end
+  ]
+end
+post '/pricing' do
+  params[:value]
+end
+```
+
+Both of these requests succeed:
+
+```bash
+curl -d '{"value":{"fixed_price":100.0}}' -H 'Content-Type: application/json' /pricing
+curl -d '{"value":{"time_unit":"hour","rate":50.0}}' -H 'Content-Type: application/json' /pricing
+```
+
+A request that doesn't match any variant returns `400` with `value does not match any of the allowed schemas`.
+
+Variants are tried in declaration order; the first variant that validates without errors wins, and any coercions it performed (e.g. `"150.5"` → `150.5`) are applied to the request params. Nested hash structures inside variants work the same as elsewhere in Grape:
+
+```ruby
+params do
+  requires :options, type: Hash, oneof: [
+    proc do
+      requires :form, type: Hash do
+        requires :colour, type: String
+        optional :size, type: Integer
+      end
+    end,
+    proc do
+      requires :api, type: Hash do
+        requires :authenticated, type: Grape::API::Boolean
+      end
+    end
+  ]
+end
+```
+
+`oneof:` requires `type: Hash`. The variants array must be non-empty and each entry must be a `Proc`; violating either raises an `ArgumentError` at definition time.
+
 ### Validation of Nested Parameters
 
 Parameters can be nested using `group` or by calling `requires` or `optional` with a block.

--- a/lib/grape/locale/en.yml
+++ b/lib/grape/locale/en.yml
@@ -43,6 +43,7 @@ en:
           resolution: 'eg: version ''v1'', using: :header, vendor: ''twitter'''
           summary: 'when version using header, you must specify :vendor option'
         mutual_exclusion: 'are mutually exclusive'
+        oneof: 'does not match any of the allowed schemas'
         presence: 'is missing'
         regexp: 'is invalid'
         same_as: 'is not the same as %{parameter}'

--- a/lib/grape/validations/oneof_collector.rb
+++ b/lib/grape/validations/oneof_collector.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Grape
+  module Validations
+    # Stand-in for the +@api+ object that {ParamsScope} normally writes to.
+    # Used when evaluating a single variant block of a +oneof:+ schema so that
+    # the variant's validators are captured locally rather than registered on
+    # the real API. Exposes only the slice of the API surface that
+    # ParamsScope and its helpers touch during definition.
+    class OneofCollector
+      attr_reader :inheritable_setting
+
+      def initialize
+        @inheritable_setting = Grape::Util::InheritableSetting.new
+        @inheritable_setting.namespace_inheritable[:do_not_document] = true
+      end
+
+      def configuration
+        nil
+      end
+
+      def validators
+        inheritable_setting.namespace_stackable[:validations]
+      end
+
+      def declared_params
+        inheritable_setting.namespace_stackable[:declared_params]
+      end
+
+      # Evaluate +variant_block+ in a fresh +ParamsScope+ backed by a new
+      # collector and return the validators that the block registered.
+      def self.collect(variant_block)
+        collector = new
+        ParamsScope.new(api: collector, type: Hash, &variant_block)
+        collector.validators
+      end
+    end
+  end
+end

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -331,6 +331,7 @@ module Grape
       end
 
       def validates(attrs, validations)
+        process_oneof!(validations) if validations.key?(:oneof)
         spec = ValidationsSpec.from(validations)
 
         check_incompatible_option_values(spec.default, spec.values, spec.except_values)
@@ -387,6 +388,22 @@ module Grape
         return unless except_values && !except_values.is_a?(Proc) && Array(default).any? { |def_val| except_values.include?(def_val) }
 
         raise Grape::Exceptions::IncompatibleOptionValues.new(:default, default, :except, except_values)
+      end
+
+      # Translate a `oneof: [proc, proc, ...]` declaration into a list of
+      # captured validator arrays — one array per variant. Each variant's
+      # block is evaluated in its own +ParamsScope+ backed by an
+      # {OneofCollector} so the full params DSL is available inside variants
+      # and the resulting validators are kept out of the real API's
+      # registration list.
+      def process_oneof!(validations)
+        raise ArgumentError, 'oneof: requires type: Hash' unless validations[:type] == Hash
+
+        variants = validations[:oneof]
+        raise ArgumentError, 'oneof: must be a non-empty Array of blocks' unless variants.is_a?(Array) && variants.any?
+        raise ArgumentError, 'oneof: each variant must be a Proc' unless variants.all?(Proc)
+
+        validations[:oneof] = variants.map { |block| OneofCollector.collect(block) }
       end
 
       def validate(type, options, attrs, required, opts)

--- a/lib/grape/validations/validators/oneof_validator.rb
+++ b/lib/grape/validations/validators/oneof_validator.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Grape
+  module Validations
+    module Validators
+      # Validates that a Hash parameter matches at least one of a set of
+      # variant schemas. Each variant is a list of pre-built validators
+      # captured by evaluating the variant's block in a {Grape::Validations::OneofCollector}-backed
+      # {ParamsScope}. At request time we try each variant in order against
+      # a deep-dup of the value; the first variant that produces no errors
+      # wins and its (possibly coerced) hash replaces the original.
+      class OneofValidator < Base
+        default_message_key :oneof
+
+        def initialize(attrs, options, required, scope, opts)
+          super
+          @variants = Array(options)
+        end
+
+        def validate_param!(attr_name, params)
+          value = params[attr_name]
+          return if value.nil? && !@required
+
+          winning_candidate = nil
+          @variants.each do |variant_validators|
+            candidate = value.deep_dup
+            if variant_matches?(variant_validators, candidate)
+              winning_candidate = candidate
+              break
+            end
+          end
+
+          return params[attr_name] = winning_candidate if winning_candidate
+
+          validation_error!(attr_name)
+        end
+
+        private
+
+        def variant_matches?(variant_validators, candidate)
+          variant_validators.each { |v| v.validate!(candidate) }
+          true
+        rescue Grape::Exceptions::Validation, Grape::Exceptions::ValidationArrayErrors
+          false
+        end
+      end
+    end
+  end
+end

--- a/spec/grape/validations/validators/oneof_validator_spec.rb
+++ b/spec/grape/validations/validators/oneof_validator_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+describe Grape::Validations::Validators::OneofValidator do
+  describe 'definition-time validation' do
+    it 'raises when type: Hash is missing' do
+      expect do
+        Class.new(Grape::API) do
+          params do
+            requires :value, oneof: [proc { requires :a, type: Integer }]
+          end
+          post('/') {}
+        end
+      end.to raise_error(ArgumentError, /requires type: Hash/)
+    end
+
+    it 'raises when oneof is not an array' do
+      expect do
+        Class.new(Grape::API) do
+          params do
+            requires :value, type: Hash, oneof: proc { requires :a }
+          end
+          post('/') {}
+        end
+      end.to raise_error(ArgumentError, /non-empty Array of blocks/)
+    end
+
+    it 'raises when oneof is empty' do
+      expect do
+        Class.new(Grape::API) do
+          params do
+            requires :value, type: Hash, oneof: []
+          end
+          post('/') {}
+        end
+      end.to raise_error(ArgumentError, /non-empty Array of blocks/)
+    end
+
+    it 'raises when a variant is not a Proc' do
+      expect do
+        Class.new(Grape::API) do
+          params do
+            requires :value, type: Hash, oneof: ['not a proc']
+          end
+          post('/') {}
+        end
+      end.to raise_error(ArgumentError, /each variant must be a Proc/)
+    end
+  end
+
+  describe 'request-time validation with two flat variants' do
+    let(:app) do
+      Class.new(Grape::API) do
+        format :json
+        params do
+          requires :value, type: Hash, oneof: [
+            proc { requires :fixed_price, type: Float },
+            proc do
+              requires :time_unit, type: String
+              requires :rate, type: Float
+            end
+          ]
+        end
+        post('/pricing') { params[:value] }
+      end
+    end
+
+    it 'matches the first variant' do
+      post '/pricing', { value: { fixed_price: 100.0 } }.to_json, 'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(201)
+      expect(JSON.parse(last_response.body)).to eq('fixed_price' => 100.0)
+    end
+
+    it 'matches the second variant' do
+      post '/pricing', { value: { time_unit: 'hour', rate: 50.0 } }.to_json, 'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(201)
+      expect(JSON.parse(last_response.body)).to eq('time_unit' => 'hour', 'rate' => 50.0)
+    end
+
+    it 'coerces values inside the winning variant' do
+      post '/pricing', { value: { fixed_price: '150.5' } }.to_json, 'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(201)
+      expect(JSON.parse(last_response.body)).to eq('fixed_price' => 150.5)
+    end
+
+    it 'rejects values that do not match any variant' do
+      post '/pricing', { value: { time_unit: 'hour', rate: 'not-a-number' } }.to_json, 'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(400)
+      expect(JSON.parse(last_response.body)['error']).to match(/does not match any of the allowed schemas/)
+    end
+
+    it 'rejects values with no matching keys' do
+      post '/pricing', { value: { something_else: 1 } }.to_json, 'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(400)
+      expect(JSON.parse(last_response.body)['error']).to match(/does not match any of the allowed schemas/)
+    end
+
+    it 'rejects when the value key is missing entirely' do
+      post '/pricing', '{}', 'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(400)
+      expect(JSON.parse(last_response.body)['error']).to match(/value is missing/)
+    end
+  end
+
+  describe 'optional :value' do
+    let(:app) do
+      Class.new(Grape::API) do
+        format :json
+        params do
+          optional :value, type: Hash, oneof: [
+            proc { requires :a, type: Integer }
+          ]
+        end
+        post('/') { { value: params[:value] } }
+      end
+    end
+
+    it 'accepts a missing value' do
+      post '/', '{}', 'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(201)
+    end
+
+    it 'still validates when the value is provided' do
+      post '/', { value: { a: 'oops' } }.to_json, 'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(400)
+    end
+  end
+
+  describe 'full DSL inside a variant' do
+    let(:app) do
+      Class.new(Grape::API) do
+        format :json
+        params do
+          requires :value, type: Hash, oneof: [
+            proc { requires :state, type: Symbol, values: %i[active inactive] },
+            proc { requires :name, type: String, regexp: /\A[a-z]+\z/ }
+          ]
+        end
+        post('/') { params[:value] }
+      end
+    end
+
+    it 'enforces values: inside a variant' do
+      post '/', { value: { state: 'unknown' } }.to_json, 'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(400)
+    end
+
+    it 'accepts a value that matches the values: constraint' do
+      post '/', { value: { state: 'active' } }.to_json, 'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(201)
+    end
+
+    it 'falls through to the second variant when the first fails' do
+      post '/', { value: { name: 'alice' } }.to_json, 'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(201)
+    end
+
+    it 'enforces regexp: inside a variant' do
+      post '/', { value: { name: 'NoCaps' } }.to_json, 'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(400)
+    end
+  end
+
+  describe 'nested hash inside a variant' do
+    let(:app) do
+      Class.new(Grape::API) do
+        format :json
+        params do
+          requires :options, type: Hash, oneof: [
+            proc do
+              requires :form, type: Hash do
+                requires :colour, type: String
+                optional :size, type: Integer
+              end
+            end,
+            proc do
+              requires :api, type: Hash do
+                requires :authenticated, type: Grape::API::Boolean
+              end
+            end
+          ]
+        end
+        post('/') { params[:options] }
+      end
+    end
+
+    it 'matches a deeply nested first variant' do
+      post '/', { options: { form: { colour: 'red', size: 12 } } }.to_json, 'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(201)
+      expect(JSON.parse(last_response.body)).to eq('form' => { 'colour' => 'red', 'size' => 12 })
+    end
+
+    it 'matches a deeply nested second variant' do
+      post '/', { options: { api: { authenticated: 'true' } } }.to_json, 'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(201)
+      expect(JSON.parse(last_response.body)).to eq('api' => { 'authenticated' => true })
+    end
+
+    it 'rejects when a required nested field is missing' do
+      post '/', { options: { form: {} } }.to_json, 'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(400)
+    end
+  end
+end


### PR DESCRIPTION
Resolves #2385. Adds an `oneof:` option for `requires`/`optional` so a Hash parameter can accept one of several variant schemas without the `optional + mutually_exclusive + given` workaround the issue describes.

## API

```ruby
params do
  requires :value, type: Hash, oneof: [
    proc { requires :fixed_price, type: Float },
    proc do
      requires :time_unit, type: String
      requires :rate, type: Float
    end
  ]
end
post '/pricing' do
  params[:value]
end
```

Both `{"value":{"fixed_price":100.0}}` and `{"value":{"time_unit":"hour","rate":50.0}}` succeed. A request that doesn't match any variant returns `400` with `value does not match any of the allowed schemas`.

Each variant is a `Proc` that uses the normal Grape `params` DSL — so `requires`, `optional`, `regexp:`, `values:`, `allow_blank:`, nested `Hash`/`Array`, `Grape::API::Boolean`, custom types, etc. all work inside variants without re-implementation. Coercion through the winning variant is applied to the parent params (e.g. `"150.5"` → `150.5`).

Variants are tried in declaration order; the first variant whose validators raise no exceptions wins (deterministic).

## Why a separate `oneof:` and not `types: [hash_schema {...}]`

I considered overloading `types:` per @dblock's note in the issue thread, but kept `oneof:` distinct because:

- `types:` already drives `MultipleTypeCoercer` for primitive variants (`types: [Integer, String]`).
- Mixing primitives and hash schemas in one array — `types: [Integer, hash_schema { ... }]` — produces a non-obvious dispatch.
- `oneof:` aligns with JSON Schema vocabulary and makes the user's intent explicit.

If the maintainers prefer the `types:` overload, the validator and collector machinery in this PR are reusable — only `infer_coercion`/`process_oneof!` would need to change.

## Implementation

| File | What |
|---|---|
| `lib/grape/validations/oneof_collector.rb` | Minimal `@api`-compatible shim. Exposes `OneofCollector.collect(block)` which evaluates the variant block in a fresh `ParamsScope` and returns the captured validators. |
| `lib/grape/validations/validators/oneof_validator.rb` | `OneofValidator < Base`. At request time deep-dups the candidate hash, runs each variant's validators against the dup, takes the first variant that produces no exceptions, and replaces `params[attr_name]` with the (possibly coerced) result. Raises `Validation` with i18n key `oneof` if no variant matches. |
| `lib/grape/validations/params_scope.rb` | `validates` calls `process_oneof!` when `:oneof` is in the validations hash; the helper validates shape (non-empty Array of Procs, `type: Hash`) and replaces each Proc with its `OneofCollector.collect`-built validator list before the standard `validate` loop instantiates `OneofValidator`. |
| `lib/grape/locale/en.yml` | New `oneof: 'does not match any of the allowed schemas'` key. |
| `README.md` | New §"Multiple Hash Schemas with `oneof`" between "Multiple Allowed Types" and "Validation of Nested Parameters". |
| `CHANGELOG.md` | Features entry referencing #2385. |

## Definition-time guards

- `oneof:` requires `type: Hash` (raises `ArgumentError`)
- Variants array must be non-empty (raises `ArgumentError`)
- Every entry must be a `Proc` (raises `ArgumentError`)

## Tests

19 new examples in `spec/grape/validations/validators/oneof_validator_spec.rb`:

- Definition-time errors (4 cases)
- Two-flat-variants matching/coercion/rejection (6 cases)
- `optional :value` with missing/invalid (2 cases)
- Full DSL inside variants — `values:`, `regexp:` (4 cases)
- Deeply nested `Hash` inside variants (3 cases)

## Test plan

- [x] `bundle exec rspec spec/grape/validations/validators/oneof_validator_spec.rb` — 19 examples, 0 failures
- [x] `bundle exec rspec` — full suite green (2,273 examples, up from 2,254)
- [x] `bundle exec rubocop lib/ spec/` — clean

## Credits

Same feature requested as in #2661 by @jcagarcia and @mia-n. This PR re-implements from scratch using the existing `ParamsScope` infrastructure (instead of a parallel mini-DSL) so all Grape validators work inside variants by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
