### PR TITLE
Catch exceptions raised inside rescue_from blocks (#2482)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [#2682](https://github.com/ruby-grape/grape/pull/2682): Fix `Style/OptionalBooleanParameter` offenses - [@ericproulx](https://github.com/ericproulx).
 * [#2699](https://github.com/ruby-grape/grape/pull/2699): Fix `Grape::Validations::Types::CustomTypeCoercer` dropping symbolized hash keys for `Array`/`Set` types; refactor the class for readability - [@ericproulx](https://github.com/ericproulx).
 * [#2700](https://github.com/ruby-grape/grape/pull/2700): Fix README typos, remove obsolete Ruby 2.4 / Fixnum section, and replace incorrect `requires + values + allow_blank` note with a correct one covering `optional + values` semantics (closes #2631) - [@ericproulx](https://github.com/ericproulx).
+* [#2703](https://github.com/ruby-grape/grape/pull/2703): Catch exceptions raised inside `rescue_from` blocks; new `rescue_from :internal_grape_exceptions` opt-in for unrecognised internal errors (resolves [#2482](https://github.com/ruby-grape/grape/issues/2482)) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.2.1 (2026-04-16)

--- a/README.md
+++ b/README.md
@@ -2734,6 +2734,41 @@ class Twitter::API < Grape::API
 end
 ```
 
+#### Re-raising from inside a `rescue_from` block
+
+A `rescue_from` block can re-raise an exception to invoke a different handler. This is useful for translating one exception class into another:
+
+```ruby
+class Twitter::API < Grape::API
+  rescue_from Grape::Exceptions::ValidationErrors do |e|
+    raise Api::Exceptions::InvalidValueError, e.full_messages
+  end
+
+  rescue_from Api::Exceptions::InvalidValueError do |e|
+    error!({ errors: e.message }, 422)
+  end
+end
+```
+
+The first handler re-raises; the second handler runs against the new exception.
+
+If the re-raised exception has no registered `rescue_from` and is a `Grape::Exceptions::Base` subclass, it is rendered through the default Grape error path (using its own `status` and `message`). Anything else — typos, `NoMethodError`, an unrelated `StandardError` — is treated as an internal error: it is exposed on `env['grape.exception']` for upstream Rack middleware to observe, and rendered to the API consumer as a generic `500 Internal Server Error`. This avoids leaking internal detail in the response body.
+
+You can take control of the internal-error path by opting in with `rescue_from :internal_grape_exceptions`:
+
+```ruby
+class Twitter::API < Grape::API
+  rescue_from :internal_grape_exceptions do |e|
+    Sentry.capture_exception(e)
+    error!({ message: 'Something went wrong' }, 500)
+  end
+end
+```
+
+When this handler is registered the framework hands the original exception to you, and you own the response shape and any logging. The framework deliberately does not log internal errors itself — it has no way to know your preferred format or destination.
+
+A second raise inside the redispatched handler is not redispatched again — it goes straight to the framework's generic 500. This bounds the chain at one redispatch and prevents loops.
+
 You can also rescue all exceptions with a code block and handle the Rack response at the lowest level.
 
 ```ruby

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -92,6 +92,36 @@ end
 
 **Behaviour change for code that didn't define a helper.** If your code references `logger` inside an endpoint context *without* a corresponding `helpers` definition, that call previously raised `NoMethodError` and now returns the API's configured logger. This is almost always the intended behaviour, but if you were relying on the `NoMethodError` (for instance to short-circuit logging in test environments via `rescue NoMethodError`), update your code to check `respond_to?(:logger)` or to gate logging on a feature flag.
 
+#### Exceptions raised inside `rescue_from` blocks are now caught
+
+Previously, an exception raised inside a `rescue_from` block was uncaught and bubbled up to Rack, producing the Rack default 500 page. The framework now catches and routes it:
+
+1. If the re-raised exception's class has a registered `rescue_from` handler, that handler runs (one redispatch only — a second raise stops the chain).
+2. If the re-raised exception is a `Grape::Exceptions::Base` subclass, it is rendered via the default Grape error path with its own `status` and `message`.
+3. Otherwise, the original exception is exposed on `env['grape.exception']` for upstream Rack middleware to observe, and the response is a generic `Grape::Exceptions::InternalServerError` (`500 Internal Server Error`) — the original exception's message is **not** rendered to the API consumer.
+
+This means deliberate re-raises in a `rescue_from` block (e.g. translating one exception class into another) now compose with the rest of your `rescue_from` configuration, and accidental crashes (typos, `NoMethodError`, …) no longer leak internal detail to API consumers.
+
+The framework deliberately does **not** log unhandled internal exceptions itself — formatting and destination are application concerns. To log, forward to an error tracker, or customize the response shape for these errors, register a `rescue_from :internal_grape_exceptions` handler:
+
+```ruby
+rescue_from :internal_grape_exceptions do |e|
+  Sentry.capture_exception(e)
+  error!({ message: 'Something went wrong' }, 500)
+end
+```
+
+When this handler is registered, the framework hands the original exception to you and you own the response shape entirely.
+
+If you relied on the old behaviour and want raw exception messages exposed in development, register a catch-all handler:
+
+```ruby
+rescue_from StandardError do |e|
+  error!({ message: e.message, class: e.class.name }, 500)
+end
+```
+
+
 ### Upgrading to >= 3.2
 
 #### Rack parameter parsing errors now raise `Grape::Exceptions::RequestError`

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -98,6 +98,8 @@ module Grape
           inheritable_setting.namespace_inheritable[:rescue_all] = true
           inheritable_setting.namespace_inheritable[:rescue_grape_exceptions] = true
           inheritable_setting.namespace_inheritable[:grape_exceptions_rescue_handler] = handler
+        elsif args.include?(:internal_grape_exceptions)
+          inheritable_setting.namespace_inheritable[:internal_grape_exceptions_rescue_handler] = handler
         else
           handler_type =
             case options[:rescue_subclasses]

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -305,19 +305,7 @@ module Grape
 
       stack.use Rack::Head
       stack.use Rack::Lint if lint?
-      stack.use Grape::Middleware::Error,
-                format:,
-                content_types:,
-                default_status: inheritable_setting.namespace_inheritable[:default_error_status],
-                rescue_all: inheritable_setting.namespace_inheritable[:rescue_all],
-                rescue_grape_exceptions: inheritable_setting.namespace_inheritable[:rescue_grape_exceptions],
-                default_error_formatter: inheritable_setting.namespace_inheritable[:default_error_formatter],
-                error_formatters: inheritable_setting.namespace_stackable_with_hash(:error_formatters),
-                rescue_options: inheritable_setting.namespace_stackable_with_hash(:rescue_options),
-                rescue_handlers:,
-                base_only_rescue_handlers: inheritable_setting.namespace_stackable_with_hash(:base_only_rescue_handlers),
-                all_rescue_handler: inheritable_setting.namespace_inheritable[:all_rescue_handler],
-                grape_exceptions_rescue_handler: inheritable_setting.namespace_inheritable[:grape_exceptions_rescue_handler]
+      stack.use Grape::Middleware::Error, **error_middleware_options(format, content_types)
 
       stack.concat inheritable_setting.namespace_stackable[:middleware]
 
@@ -339,6 +327,26 @@ module Grape
       builder = stack.build
       builder.run ->(env) { env[Grape::Env::API_ENDPOINT].run }
       builder.to_app
+    end
+
+    def error_middleware_options(format, content_types)
+      ns_inh = inheritable_setting.namespace_inheritable
+      ns_stack = inheritable_setting
+      {
+        format:,
+        content_types:,
+        default_status: ns_inh[:default_error_status],
+        rescue_all: ns_inh[:rescue_all],
+        rescue_grape_exceptions: ns_inh[:rescue_grape_exceptions],
+        default_error_formatter: ns_inh[:default_error_formatter],
+        error_formatters: ns_stack.namespace_stackable_with_hash(:error_formatters),
+        rescue_options: ns_stack.namespace_stackable_with_hash(:rescue_options),
+        rescue_handlers:,
+        base_only_rescue_handlers: ns_stack.namespace_stackable_with_hash(:base_only_rescue_handlers),
+        all_rescue_handler: ns_inh[:all_rescue_handler],
+        grape_exceptions_rescue_handler: ns_inh[:grape_exceptions_rescue_handler],
+        internal_grape_exceptions_rescue_handler: ns_inh[:internal_grape_exceptions_rescue_handler]
+      }
     end
 
     def build_helpers

--- a/lib/grape/env.rb
+++ b/lib/grape/env.rb
@@ -16,5 +16,6 @@ module Grape
     GRAPE_REQUEST_PARAMS = 'grape.request.params'
     GRAPE_ROUTING_ARGS = 'grape.routing_args'
     GRAPE_ALLOWED_METHODS = 'grape.allowed_methods'
+    GRAPE_EXCEPTION = 'grape.exception'
   end
 end

--- a/lib/grape/exceptions/internal_server_error.rb
+++ b/lib/grape/exceptions/internal_server_error.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Grape
+  module Exceptions
+    # Raised internally when a +rescue_from+ handler itself raises an
+    # unrecognised exception. The framework substitutes the original
+    # exception with this safe stand-in for rendering, while preserving
+    # the original on +env[Grape::Env::GRAPE_EXCEPTION]+ for upstream
+    # observability (loggers, error trackers, etc.).
+    class InternalServerError < Base
+      def initialize
+        super(status: 500, message: compose_message(:internal_server_error))
+      end
+    end
+  end
+end

--- a/lib/grape/locale/en.yml
+++ b/lib/grape/locale/en.yml
@@ -11,6 +11,7 @@ en:
         exactly_one: 'are missing, exactly one parameter must be provided'
         except_values: 'has a value not allowed'
         incompatible_option_values: '%{option1}: %{value1} is incompatible with %{option2}: %{value2}'
+        internal_server_error: 'Internal Server Error'
         invalid_accept_header:
           problem: 'invalid accept header'
           resolution: '%{message}'

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -14,6 +14,7 @@ module Grape
         error_formatters: nil,
         format: :txt,
         grape_exceptions_rescue_handler: nil,
+        internal_grape_exceptions_rescue_handler: nil,
         rescue_all: false,
         rescue_grape_exceptions: false,
         rescue_handlers: nil,
@@ -25,8 +26,8 @@ module Grape
 
       attr_reader :all_rescue_handler, :base_only_rescue_handlers, :default_error_formatter,
                   :default_message, :default_status, :error_formatters, :format,
-                  :grape_exceptions_rescue_handler, :rescue_all, :rescue_grape_exceptions,
-                  :rescue_handlers
+                  :grape_exceptions_rescue_handler, :internal_grape_exceptions_rescue_handler,
+                  :rescue_all, :rescue_grape_exceptions, :rescue_handlers
 
       def initialize(app, **options)
         super
@@ -38,6 +39,7 @@ module Grape
         @error_formatters = @options[:error_formatters]
         @format = @options[:format]
         @grape_exceptions_rescue_handler = @options[:grape_exceptions_rescue_handler]
+        @internal_grape_exceptions_rescue_handler = @options[:internal_grape_exceptions_rescue_handler]
         @rescue_all = @options[:rescue_all]
         @rescue_grape_exceptions = @options[:rescue_grape_exceptions]
         @rescue_handlers = @options[:rescue_handlers]
@@ -127,10 +129,12 @@ module Grape
         all_rescue_handler || method(:default_rescue_handler)
       end
 
-      def run_rescue_handler(handler, error, endpoint)
+      def run_rescue_handler(handler, error, endpoint, redispatched: false)
         handler = endpoint.public_method(handler) if handler.is_a?(Symbol)
         response = catch(:error) do
           handler.arity.zero? ? endpoint.instance_exec(&handler) : endpoint.instance_exec(error, &handler)
+        rescue StandardError => e
+          return redispatch(e, endpoint, redispatched)
         end
 
         if error?(response)
@@ -140,6 +144,49 @@ module Grape
         else
           run_rescue_handler(method(:default_rescue_handler), Grape::Exceptions::InvalidResponse.new, endpoint)
         end
+      end
+
+      # Route an exception raised inside a +rescue_from+ block.
+      #
+      # * If we have already redispatched once (the redispatched handler
+      #   itself raised), go straight to {#framework_default} — bounds the
+      #   chain at one redispatch.
+      # * Else if the exception has a registered +rescue_from+ handler,
+      #   run it.
+      # * Else if it's a +Grape::Exceptions::Base+ subclass, render it
+      #   through +error_response+ with its own +status+ and +message+.
+      # * Else fall through to {#safe_default}, which lets the user opt
+      #   in via +rescue_from :internal_grape_exceptions+ or, failing
+      #   that, applies the framework default.
+      def redispatch(error, endpoint, already_redispatched)
+        return framework_default(endpoint) if already_redispatched
+
+        if (registered = registered_rescue_handler(error.class))
+          run_rescue_handler(registered, error, endpoint, redispatched: true)
+        elsif error.is_a?(Grape::Exceptions::Base)
+          run_rescue_handler(method(:error_response), error, endpoint, redispatched: true)
+        else
+          safe_default(error, endpoint)
+        end
+      end
+
+      # The unrecognised-error path. Exposes the original exception on
+      # the rack env so upstream Rack middleware (loggers, error
+      # trackers) can observe it. If the user registered a
+      # +rescue_from :internal_grape_exceptions+ handler, that handler
+      # runs and owns the response. Otherwise the framework renders the
+      # generic +InternalServerError+ — never the original exception's
+      # message. The framework deliberately does no logging of its own
+      # here; that's the application's call.
+      def safe_default(error, endpoint)
+        env[Grape::Env::GRAPE_EXCEPTION] = error
+        return run_rescue_handler(internal_grape_exceptions_rescue_handler, error, endpoint, redispatched: true) if internal_grape_exceptions_rescue_handler
+
+        framework_default(endpoint)
+      end
+
+      def framework_default(endpoint)
+        run_rescue_handler(method(:default_rescue_handler), Grape::Exceptions::InternalServerError.new, endpoint)
       end
 
       def error!(message, status = default_status, headers = {}, backtrace = [], original_exception = nil)

--- a/spec/grape/middleware/error_spec.rb
+++ b/spec/grape/middleware/error_spec.rb
@@ -98,4 +98,208 @@ describe Grape::Middleware::Error do
       )
     end
   end
+
+  describe 'when a rescue_from block raises' do
+    subject(:response) do
+      get '/'
+      last_response
+    end
+
+    context 'and the re-raised exception has a registered rescue_from' do
+      let(:app) do
+        Class.new(Grape::API) do
+          format :txt
+
+          custom_error_class = Class.new(StandardError)
+          const_set(:CustomError, custom_error_class)
+
+          rescue_from custom_error_class do |e|
+            error!("custom-handled: #{e.message}", 422)
+          end
+
+          rescue_from :all do |e|
+            raise custom_error_class, "wrapped(#{e.message})"
+          end
+
+          get('/') { raise ArgumentError, 'oops' }
+        end
+      end
+
+      it 'redispatches to the registered handler' do
+        expect(response.status).to eq(422)
+        expect(response.body).to eq('custom-handled: wrapped(oops)')
+      end
+    end
+
+    context 'and the re-raised exception is a Grape::Exceptions::Base subclass' do
+      let(:app) do
+        Class.new(Grape::API) do
+          format :txt
+
+          teapot_class = Class.new(Grape::Exceptions::Base) do
+            def initialize
+              super(status: 418, message: 'teapot')
+            end
+          end
+          const_set(:TeapotError, teapot_class)
+
+          rescue_from :all do
+            raise teapot_class
+          end
+
+          get('/') { raise StandardError, 'first' }
+        end
+      end
+
+      it 'renders the exception via the default Grape error path with its own status' do
+        expect(response.status).to eq(418)
+        expect(response.body).to eq('teapot')
+      end
+    end
+
+    context 'and the re-raised exception is an unrecognised StandardError' do
+      let(:app) do
+        Class.new(Grape::API) do
+          format :txt
+
+          rescue_from :all do
+            raise NoMethodError, "undefined method 'foo' for nil"
+          end
+
+          get('/') { raise StandardError, 'first' }
+        end
+      end
+
+      it 'renders the generic Internal Server Error response' do
+        expect(response.status).to eq(500)
+        expect(response.body).to eq('Internal Server Error')
+      end
+
+      it "exposes the original exception via env['grape.exception']" do
+        captured = nil
+        original_call = app.method(:call)
+        allow(app).to receive(:call) do |env|
+          result = original_call.call(env)
+          captured = env[Grape::Env::GRAPE_EXCEPTION]
+          result
+        end
+
+        response
+
+        expect(captured).to be_a(NoMethodError)
+        expect(captured.message).to include("undefined method 'foo'")
+      end
+    end
+
+    context 'and a redispatched handler also raises' do
+      let(:app) do
+        Class.new(Grape::API) do
+          format :txt
+
+          inner_class = Class.new(StandardError)
+          outer_class = Class.new(StandardError)
+          const_set(:InnerError, inner_class)
+          const_set(:OuterError, outer_class)
+
+          rescue_from inner_class do
+            raise outer_class, 'second-level'
+          end
+
+          rescue_from outer_class do |e|
+            error!("would-handle: #{e.message}", 422)
+          end
+
+          rescue_from :all do
+            raise inner_class, 'first-level'
+          end
+
+          get('/') { raise StandardError, 'route' }
+        end
+      end
+
+      it 'stops at the safe default after one redispatch' do
+        expect(response.status).to eq(500)
+        expect(response.body).to eq('Internal Server Error')
+      end
+    end
+
+    context 'and the user has opted into rescue_from :internal_grape_exceptions' do
+      let(:app) do
+        Class.new(Grape::API) do
+          format :txt
+
+          rescue_from :internal_grape_exceptions do |e|
+            error!("internal: #{e.class}: #{e.message}", 503)
+          end
+
+          rescue_from :all do
+            raise NoMethodError, "undefined method 'foo' for nil"
+          end
+
+          get('/') { raise StandardError, 'first' }
+        end
+      end
+
+      it 'invokes the user handler with the original exception' do
+        expect(response.status).to eq(503)
+        expect(response.body).to eq("internal: NoMethodError: undefined method 'foo' for nil")
+      end
+
+      it "still exposes the original exception via env['grape.exception']" do
+        captured = nil
+        original_call = app.method(:call)
+        allow(app).to receive(:call) do |env|
+          result = original_call.call(env)
+          captured = env[Grape::Env::GRAPE_EXCEPTION]
+          result
+        end
+
+        response
+
+        expect(captured).to be_a(NoMethodError)
+      end
+
+      context 'and the user handler also raises' do
+        let(:app) do
+          Class.new(Grape::API) do
+            format :txt
+
+            rescue_from :internal_grape_exceptions do
+              raise 'handler bug'
+            end
+
+            rescue_from :all do
+              raise NoMethodError, 'first internal'
+            end
+
+            get('/') { raise StandardError, 'route' }
+          end
+        end
+
+        it 'falls through to the framework safe default (loop bounded)' do
+          expect(response.status).to eq(500)
+          expect(response.body).to eq('Internal Server Error')
+        end
+      end
+    end
+
+    context 'and the handler returns a non-Response, non-error value' do
+      let(:app) do
+        Class.new(Grape::API) do
+          format :txt
+
+          rescue_from :all do
+            'not a Rack response'
+          end
+
+          get('/') { raise StandardError, 'boom' }
+        end
+      end
+
+      it 'falls through to the InvalidResponse path (existing behaviour preserved)' do
+        expect(response.status).to eq(500)
+        expect(response.body).to eq('Invalid response')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves #2482. Catches exceptions raised inside `rescue_from` blocks and routes them through one of three paths instead of letting them bubble up to Rack as a default 500 page.

## Behavior

| The re-raised exception is… | What happens |
|---|---|
| A class with a registered `rescue_from` handler | That handler runs (one redispatch only — a second raise from inside it stops the chain at the framework default, bounding loops) |
| A `Grape::Exceptions::Base` subclass with no registered handler | Rendered via the default Grape error path using its own `status` and `message` |
| Anything else (vanilla `StandardError`, `NoMethodError`, etc.) | Exposed on `env['grape.exception']`. If the user opted into `rescue_from :internal_grape_exceptions`, their handler runs and owns the response. Otherwise framework renders a generic `Grape::Exceptions::InternalServerError` (500). **The original exception's message is never surfaced to the API consumer in this branch.** |

The third bucket is the safety property the issue thread was missing — neither the workaround in the issue body nor PR #2483 have it. A typo in a `rescue_from` block (e.g. `rescue_from :all do; foo; end` where `foo` is undefined) used to bubble up as a Rack 500 and now becomes a Grape `500 Internal Server Error` with the actual `NoMethodError` observable in `env['grape.exception']`, but never rendered.

## New `rescue_from :internal_grape_exceptions` opt-in

Mirrors the existing `rescue_from :grape_exceptions` keyword. When registered, the handler is invoked for any unrecognised internal error — typically what you want for forwarding to error trackers, custom logging, request-id correlation, etc.:

```ruby
class TwitterAPI < Grape::API
  rescue_from :internal_grape_exceptions do |e|
    MyLogger.error("[#{env['x-request-id']}] #{e.class}: #{e.message}")
    Sentry.capture_exception(e)
    error!({ message: 'Something went wrong' }, 500)
  end
end
```

The framework hands you the original exception and steps out of the way. **The framework does no logging of its own** — formatting and destination are application concerns; `:internal_grape_exceptions` is where you opt in to whatever observability you want.

## Why this resolves the issue

@ngernert's actual code in #2482 was:

```ruby
rescue_from Grape::Exceptions::ValidationErrors do |e|
  begin
    raise Api::Exceptions::InvalidValueError, e.full_messages
  rescue Api::Exceptions::InvalidValueError => invalid_value_error
    run_rescue_handler(:error_response, invalid_value_error)
  end
end
```

After this PR, that simplifies to:

```ruby
rescue_from Grape::Exceptions::ValidationErrors do |e|
  raise Api::Exceptions::InvalidValueError, e.full_messages
end

rescue_from Api::Exceptions::InvalidValueError do |e|
  error!({ errors: e.message }, 422)
end
```

The first handler re-raises; the second handler is invoked through the redispatch.

## How this differs from PR #2483

PR #2483 catches `StandardError` and forwards the caught exception to `default_rescue_handler`, which renders `exception.message` as the response body. That fixes the issue author's specific use case but:

- **Leaks internal detail** for unrecognised exceptions. A typo (`NoMethodError`) ends up rendered as `"undefined method 'foo' for nil:NilClass"` to the API consumer.
- **Bypasses the user's rescue chain.** A re-raised exception with a registered `rescue_from` handler is sent to the default handler, not the user's handler.
- **No application-controlled hook.** The user can't intercept the unrecognised-error path to forward to Sentry, customize the response, etc.
- **Conflates two failure modes** via the `handler_exception || InvalidResponse` fallback.

This PR addresses all of that: redispatch through the user's chain when applicable, render only Grape-aware exceptions with their own message, expose unrecognised exceptions in env, and let the application opt in to owning the unrecognised-error path entirely.

## Files

| File | What |
|---|---|
| `lib/grape/middleware/error.rb` | `run_rescue_handler` gains `redispatched:` kwarg; new private `redispatch`, `safe_default`, `framework_default`. New `internal_grape_exceptions_rescue_handler` option. |
| `lib/grape/dsl/request_response.rb` | `rescue_from :internal_grape_exceptions` recognized as a keyword and stored in `namespace_inheritable[:internal_grape_exceptions_rescue_handler]`. |
| `lib/grape/endpoint.rb` | Pipes the new option through to the middleware. Extracted `error_middleware_options` helper since the kwarg list grew. |
| `lib/grape/exceptions/internal_server_error.rb` | New `Grape::Exceptions::InternalServerError < Grape::Exceptions::Base` — status 500, i18n-backed generic message. |
| `lib/grape/env.rb` | New `Grape::Env::GRAPE_EXCEPTION = 'grape.exception'` — exposed for upstream Rack middleware (also relevant to #2610). |
| `lib/grape/locale/en.yml` | `internal_server_error: 'Internal Server Error'` i18n entry. |
| `spec/grape/middleware/error_spec.rb` | 9 new examples covering all three buckets, the redispatch loop limit, the opt-in handler, the opt-in handler also raising, the InvalidResponse path preservation, and `env['grape.exception']` exposure. |
| `README.md` | New paragraph in the `rescue_from` section documenting re-raise semantics and the opt-in. |
| `UPGRADING.md` | Note documenting the behaviour change and the opt-in. |

## Test plan

- [x] `bundle exec rspec spec/grape/middleware/error_spec.rb` — 16 examples, 0 failures (9 new + 7 existing)
- [x] `bundle exec rspec` — full suite green (2,263 examples, up from 2,254)
- [x] `bundle exec rubocop lib/ spec/` — clean

## Note on observability

Stashing the original exception on `env['grape.exception']` overlaps with the request in #2610 (Rails-style `action_dispatch.exception` equivalent). It's a free side-effect of the safe-default path here. If maintainers want full #2610 coverage — exposing the original exception in env for *every* swallowed exception, not just re-raises from `rescue_from` blocks — that's a separate small change in `error_response` / `call!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
