### PR TITLE
Expose API logger via Grape::Endpoint#logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#2696](https://github.com/ruby-grape/grape/pull/2696): Reduce per-request allocations on the request hot path; migrate middleware options to `attr_reader` and freeze `@options` post-init - [@ericproulx](https://github.com/ericproulx).
 * [#2693](https://github.com/ruby-grape/grape/pull/2693): Introduce `Grape::Exceptions::ErrorResponse` value object to replace the implicit-schema Hash thrown via `throw` - [@ericproulx](https://github.com/ericproulx).
 * [#2701](https://github.com/ruby-grape/grape/pull/2701): Replace `.tap` usages in `lib/` with explicit local variables - [@ericproulx](https://github.com/ericproulx).
+* [#2704](https://github.com/ruby-grape/grape/pull/2704): Add `Grape::Endpoint#logger` so the API's configured logger is reachable inside route handlers, filters, and `rescue_from` blocks without a helper - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -63,6 +63,35 @@ after { Grape::Endpoint.before_each nil }
 after { Grape::Endpoint.reset_before_each }
 ```
 
+#### `Grape::Endpoint#logger` now returns the API's configured logger
+
+Calling `logger` inside a route handler, filter (`before` / `before_validation` / `after_validation` / `after` / `finally`), or `rescue_from` block previously raised `NoMethodError` unless the application defined a helper:
+
+```ruby
+class MyAPI < Grape::API
+  logger Logger.new($stdout)
+
+  helpers do
+    def logger
+      MyAPI.logger
+    end
+  end
+end
+```
+
+`Grape::Endpoint` now exposes `#logger` directly, so the helper is no longer necessary:
+
+```ruby
+class MyAPI < Grape::API
+  logger Logger.new($stdout)
+  # logger is now reachable inside route handlers, filters, and rescue_from blocks
+end
+```
+
+**Helper override still wins.** Helpers are mixed into the endpoint's singleton class via `singleton_class.include(@helpers)`, and singleton-class methods take precedence over instance methods on `Grape::Endpoint`. If your application already defines `logger` in a `helpers` block (or a module included via `helpers`), that definition continues to override `Endpoint#logger`. You can safely keep the helper or remove it — both paths produce the same result for the canonical `MyAPI.logger` case above.
+
+**Behaviour change for code that didn't define a helper.** If your code references `logger` inside an endpoint context *without* a corresponding `helpers` definition, that call previously raised `NoMethodError` and now returns the API's configured logger. This is almost always the intended behaviour, but if you were relying on the `NoMethodError` (for instance to short-circuit logging in test environments via `rescue NoMethodError`), update your code to check `respond_to?(:logger)` or to gate logging on a feature flag.
+
 ### Upgrading to >= 3.2
 
 #### Rack parameter parsing errors now raise `Grape::Exceptions::RequestError`

--- a/benchmark/remounting.rb
+++ b/benchmark/remounting.rb
@@ -7,12 +7,6 @@ require 'benchmark/memory'
 class VotingApi < Grape::API
   logger Logger.new($stdout)
 
-  helpers do
-    def logger
-      VotingApi.logger
-    end
-  end
-
   namespace 'votes' do
     get do
       logger

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -16,6 +16,13 @@ module Grape
     def_delegators :request, :params, :headers, :cookies
     def_delegator :cookies, :response_cookies
 
+    # The logger configured on the API this endpoint belongs to. Available
+    # inside route handlers, +before+/+after+/+after_validation+/+finally+
+    # filters, and +rescue_from+ blocks.
+    def logger
+      options[:for].logger
+    end
+
     class << self
       def block_to_unbound_method(block)
         return unless block

--- a/spec/grape/endpoint/logger_spec.rb
+++ b/spec/grape/endpoint/logger_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+describe Grape::Endpoint, '#logger' do
+  let(:log_output) { StringIO.new }
+  let(:configured_logger) { Logger.new(log_output) }
+
+  context 'inside a route handler' do
+    let(:app) do
+      logger_instance = configured_logger
+      Class.new(Grape::API) do
+        format :txt
+        logger logger_instance
+        get('/') do
+          logger.error('from-route')
+          'ok'
+        end
+      end
+    end
+
+    it "returns the API's configured logger" do
+      get '/'
+      expect(log_output.string).to include('from-route')
+    end
+  end
+
+  context 'inside a before/after/after_validation/finally filter' do
+    let(:app) do
+      logger_instance = configured_logger
+      Class.new(Grape::API) do
+        format :txt
+        logger logger_instance
+        before              { logger.error('from-before') }
+
+        before_validation   { logger.error('from-before_validation') }
+        after_validation    { logger.error('from-after_validation') }
+        after               { logger.error('from-after') }
+
+        finally             { logger.error('from-finally') }
+        get('/') { 'ok' }
+      end
+    end
+
+    it 'is reachable in every filter' do
+      get '/'
+      log = log_output.string
+      expect(log).to include('from-before')
+      expect(log).to include('from-before_validation')
+      expect(log).to include('from-after_validation')
+      expect(log).to include('from-after')
+      expect(log).to include('from-finally')
+    end
+  end
+
+  context 'inside a rescue_from block' do
+    let(:app) do
+      logger_instance = configured_logger
+      Class.new(Grape::API) do
+        format :txt
+        logger logger_instance
+        rescue_from :all do |e|
+          logger.error("rescued: #{e.class}")
+          error!('handled', 500)
+        end
+        get('/') { raise ArgumentError, 'boom' }
+      end
+    end
+
+    it 'is reachable from the handler' do
+      get '/'
+      expect(log_output.string).to include('rescued: ArgumentError')
+    end
+  end
+
+  context 'when a user-defined helper overrides #logger' do
+    let(:app) do
+      logger_instance = configured_logger
+      Class.new(Grape::API) do
+        format :txt
+        logger logger_instance
+        helpers do
+          def logger
+            'overridden-helper'
+          end
+        end
+        get('/') { logger }
+      end
+    end
+
+    it 'honours the user override (helpers win over endpoint method)' do
+      get '/'
+      expect(last_response.body).to eq('overridden-helper')
+    end
+  end
+end


### PR DESCRIPTION
Adds a `Grape::Endpoint#logger` accessor so the API's configured logger is reachable inside any endpoint context — without writing a helper.

## Before

Calling `logger` inside a route, filter, or `rescue_from` block raised `NoMethodError`. The documented workaround (and the one used in `benchmark/remounting.rb`) was:

```ruby
class VotingApi < Grape::API
  logger Logger.new($stdout)

  helpers do
    def logger
      VotingApi.logger
    end
  end

  get('/votes') { logger.info('hit') }
end
```

## After

```ruby
class VotingApi < Grape::API
  logger Logger.new($stdout)
  get('/votes') { logger.info('hit') }
end
```

`logger` works in every context whose `self` is the endpoint:

- route handlers
- `before` / `before_validation` / `after_validation` / `after` / `finally` filters
- `rescue_from` blocks
- helpers

## Backwards compatibility

A user-defined `helpers do; def logger; …; end` still wins. Helpers are mixed into the endpoint's singleton class (`call!` does `singleton_class.include(@helpers)`), and singleton-class methods take precedence over instance methods on the class. So existing code that overrode `logger` continues to override it.

A spec verifies this: `helpers do; def logger; 'overridden-helper'; end; end` causes `logger` to return the helper's value, not the API's configured logger.

## Files

| File | What |
|---|---|
| `lib/grape/endpoint.rb` | One-line `def logger; options[:for].logger; end`. |
| `benchmark/remounting.rb` | Removes the now-unnecessary `helpers do; def logger; ... end` workaround. |
| `spec/grape/endpoint/logger_spec.rb` | 4 examples — route, all five filter types, `rescue_from`, and the helpers-override-wins case. |
| `CHANGELOG.md` | Features entry. |

## Test plan

- [x] `bundle exec rspec spec/grape/endpoint/logger_spec.rb` — 4 examples, 0 failures
- [x] `bundle exec rspec` — full suite green (2,258 examples, up from 2,254)
- [x] `bundle exec rubocop lib/ spec/` — clean

## Why this is its own PR

Splits cleanly out of #2703 (which catches exceptions inside `rescue_from` blocks). That PR's example wanted to call `logger.error(...)` from inside the user's handler — which doesn't work today, hence this addition. They're independent: #2703 ships the rescue redispatch; this ships the logger accessor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
