### PR TITLE
Lift trailing if/else into guard clauses; tighten Lazy::ValueEnumerable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#2705](https://github.com/ruby-grape/grape/pull/2705): Add `Grape.config.warn_on_helper_overrides` (off by default) to emit a warning when a helper method masks a `Grape::Endpoint` instance method - [@ericproulx](https://github.com/ericproulx).
 * [#2706](https://github.com/ruby-grape/grape/pull/2706): Refactor `ParamsScope#validates` and `ParamsDocumentation` around a frozen `Grape::Validations::ValidationsSpec` value object; the validations hash supplied by the DSL is no longer mutated and the helper chain becomes pure - [@ericproulx](https://github.com/ericproulx).
 * [#2707](https://github.com/ruby-grape/grape/pull/2707): Tighten six guard conditions in `lib/` via De Morgan and `blank?`/`present?`/`include?` rewrites; no behaviour change - [@ericproulx](https://github.com/ericproulx).
+* [#2709](https://github.com/ruby-grape/grape/pull/2709): Lift trailing `if/else` into guard clauses; tighten `Util::Lazy::ValueEnumerable` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -73,11 +73,7 @@ module Grape
           if request.post?
             201
           elsif request.delete?
-            if @body.present?
-              200
-            else
-              204
-            end
+            @body.present? ? 200 : 204
           else
             200
           end
@@ -88,11 +84,9 @@ module Grape
 
       # Set response content-type
       def content_type(val = nil)
-        if val
-          header(Rack::CONTENT_TYPE, val)
-        else
-          header[Rack::CONTENT_TYPE]
-        end
+        return header(Rack::CONTENT_TYPE, val) if val
+
+        header[Rack::CONTENT_TYPE]
       end
 
       # Allows you to define the response body as something other than the

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -137,13 +137,10 @@ module Grape
           return redispatch(e, endpoint, redispatched)
         end
 
-        if error?(response)
-          error_response(response)
-        elsif response.is_a?(Rack::Response)
-          response
-        else
-          run_rescue_handler(method(:default_rescue_handler), Grape::Exceptions::InvalidResponse.new, endpoint)
-        end
+        return error_response(response) if error?(response)
+        return response if response.is_a?(Rack::Response)
+
+        run_rescue_handler(method(:default_rescue_handler), Grape::Exceptions::InvalidResponse.new, endpoint)
       end
 
       # Route an exception raised inside a +rescue_from+ block.

--- a/lib/grape/middleware/versioner/header.rb
+++ b/lib/grape/middleware/versioner/header.rb
@@ -41,11 +41,9 @@ module Grape
 
           strict_header_checks!
           media_type = Grape::Util::MediaType.best_quality(accept_header, available_media_types)
-          if media_type
-            yield media_type
-          else
-            fail!
-          end
+          return yield media_type if media_type
+
+          fail!
         end
 
         def accept_header

--- a/lib/grape/path.rb
+++ b/lib/grape/path.rb
@@ -21,13 +21,10 @@ module Grape
     private
 
     def build_suffix(raw_path, raw_namespace, settings)
-      if uses_specific_format?(settings)
-        "(.#{settings[:format]})"
-      elsif !uses_path_versioning?(settings) || (valid_part?(raw_namespace) || valid_part?(raw_path))
-        NO_VERSIONING_WITH_VALID_PATH_FORMAT_SEGMENT
-      else
-        DEFAULT_FORMAT_SEGMENT
-      end
+      return "(.#{settings[:format]})" if uses_specific_format?(settings)
+      return NO_VERSIONING_WITH_VALID_PATH_FORMAT_SEGMENT if !uses_path_versioning?(settings) || valid_part?(raw_namespace) || valid_part?(raw_path)
+
+      DEFAULT_FORMAT_SEGMENT
     end
 
     def build_parts(raw_path, raw_namespace, settings)

--- a/lib/grape/util/lazy/value_enumerable.rb
+++ b/lib/grape/util/lazy/value_enumerable.rb
@@ -5,28 +5,25 @@ module Grape
     module Lazy
       class ValueEnumerable < Value
         def [](key)
-          if @value_hash[key].nil?
-            Value.new(nil).reached_by(access_keys, key)
-          else
-            @value_hash[key].reached_by(access_keys, key)
-          end
+          return Value.new(nil).reached_by(access_keys, key) if @value_hash[key].nil?
+
+          @value_hash[key].reached_by(access_keys, key)
         end
 
         def fetch(access_keys)
-          fetched_keys = access_keys.dup
-          value = self[fetched_keys.shift]
-          fetched_keys.any? ? value.fetch(fetched_keys) : value
+          access_keys.reduce(self) { |node, key| node[key] }
         end
 
         def []=(key, value)
-          @value_hash[key] = case value
-                             when Hash
-                               ValueHash.new(value)
-                             when Array
-                               ValueArray.new(value)
-                             else
-                               Value.new(value)
-                             end
+          value_class = case value
+                        when Hash
+                          ValueHash
+                        when Array
+                          ValueArray
+                        else
+                          Value
+                        end
+          @value_hash[key] = value_class.new(value)
         end
       end
     end

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -197,13 +197,10 @@ module Grape
       private
 
       def build_full_path
-        if nested?
-          @parent.full_path + [@element]
-        elsif lateral?
-          @parent.full_path
-        else
-          []
-        end
+        return @parent.full_path + [@element] if nested?
+        return @parent.full_path if lateral?
+
+        []
       end
 
       # Add a new parameter which should be renamed when using the +#declared+


### PR DESCRIPTION
## Summary

Style cleanup — lift trailing `if`/`elsif`/`else` blocks into early-return guard clauses (matches the project's existing direction; see #2695), plus a few small simplifications in `Grape::Util::Lazy::ValueEnumerable`.

**Guard-clause lifts (no behaviour change):**
- `DSL::InsideRoute#content_type`: `if val; …; else; …; end` → `return … if val` guard.
- `DSL::InsideRoute` default status (delete branch): collapse the inner `if @body.present?` into a ternary.
- `Middleware::Error#run_rescue_handler`: three-arm `if/elsif/else` on `response` → two early-return guards.
- `Middleware::Versioner::Header#strict_accept_header_negotiation`: `if media_type; yield…; else; fail!; end` → `return yield media_type if media_type`.
- `Path#build_suffix`: three-arm `if/elsif/else` → guards; inlined `!a || (b || c)` as `!a || b || c`.
- `Validations::ParamsScope#build_full_path`: three-arm `if/elsif/else` → guards.

**`Util::Lazy::ValueEnumerable`:**
- `[]`: `if @value_hash[key].nil?; … else; … end` → guard clause.
- `fetch`: replace the `dup` + `shift` + recursive call with a flat `access_keys.reduce(self) { |node, key| node[key] }`.
- `[]=`: pull the `Hash`/`Array`/else case dispatch into a `value_class` local so there is a single `@value_hash[key] = value_class.new(value)` assignment site.

## Test plan

- [ ] `bundle exec rspec`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)