### PR TITLE
Tidy up Grape::DeclaredParamsHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#2706](https://github.com/ruby-grape/grape/pull/2706): Refactor `ParamsScope#validates` and `ParamsDocumentation` around a frozen `Grape::Validations::ValidationsSpec` value object; the validations hash supplied by the DSL is no longer mutated and the helper chain becomes pure - [@ericproulx](https://github.com/ericproulx).
 * [#2707](https://github.com/ruby-grape/grape/pull/2707): Tighten six guard conditions in `lib/` via De Morgan and `blank?`/`present?`/`include?` rewrites; no behaviour change - [@ericproulx](https://github.com/ericproulx).
 * [#2709](https://github.com/ruby-grape/grape/pull/2709): Lift trailing `if/else` into guard clauses; tighten `Util::Lazy::ValueEnumerable` - [@ericproulx](https://github.com/ericproulx).
+* [#2710](https://github.com/ruby-grape/grape/pull/2710): Tidy up `Grape::DeclaredParamsHandler` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/declared_params_handler.rb
+++ b/lib/grape/declared_params_handler.rb
@@ -50,69 +50,67 @@ module Grape
     end
 
     def declared_hash_attr(passed_params, declared_param:, params_nested_path:, memo:, renamed_params:, route_params:)
-      if declared_param.is_a?(Hash)
-        declared_param.each_pair do |declared_parent_param, declared_children_params|
-          next unless @include_missing || passed_params.key?(declared_parent_param)
+      return declare_leaf(passed_params, declared_param:, params_nested_path:, memo:, renamed_params:, route_params:) unless declared_param.is_a?(Hash)
 
-          memo_key = build_memo_key(params_nested_path, declared_parent_param, renamed_params)
-          passed_children_params = passed_params[declared_parent_param] || passed_params.class.new
+      declared_param.each_pair do |parent, children|
+        declare_nested(passed_params, parent:, children:, params_nested_path:, memo:, renamed_params:, route_params:)
+      end
+    end
 
-          params_nested_path_dup = params_nested_path.dup
-          params_nested_path_dup << declared_parent_param.to_s
+    def declare_nested(passed_params, parent:, children:, params_nested_path:, memo:, renamed_params:, route_params:)
+      return unless @include_missing || passed_params.key?(parent)
 
-          memo[memo_key] = handle_passed_param(params_nested_path_dup, route_params:, has_passed_children: passed_children_params.any?) do
-            recursive_declared(
-              passed_children_params,
-              declared_params: declared_children_params,
-              params_nested_path: params_nested_path_dup,
-              renamed_params:,
-              route_params:
-            )
-          end
-        end
-      else
-        # If it is not a Hash then it does not have children.
-        # Find its value or set it to nil.
-        return unless @include_missing || (passed_params.respond_to?(:key?) && passed_params.key?(declared_param))
+      memo_key = build_memo_key(params_nested_path, parent, renamed_params)
+      passed_children = passed_params[parent] || passed_params.class.new
+      nested_path = nested_path_for(params_nested_path, parent)
 
-        memo_key = build_memo_key(params_nested_path, declared_param, renamed_params)
-        passed_param = passed_params[declared_param]
+      memo[memo_key] = handle_passed_param(nested_path, route_params:, has_passed_children: passed_children.any?) do
+        recursive_declared(
+          passed_children,
+          declared_params: children,
+          params_nested_path: nested_path,
+          renamed_params:,
+          route_params:
+        )
+      end
+    end
 
-        params_nested_path_dup = params_nested_path.dup
-        params_nested_path_dup << declared_param.to_s
+    # The declared param has no children. Find its value or set it to nil.
+    def declare_leaf(passed_params, declared_param:, params_nested_path:, memo:, renamed_params:, route_params:)
+      return unless @include_missing || (passed_params.respond_to?(:key?) && passed_params.key?(declared_param))
 
-        memo[memo_key] = passed_param || handle_passed_param(params_nested_path_dup, route_params:) do
-          passed_param
-        end
+      memo_key = build_memo_key(params_nested_path, declared_param, renamed_params)
+      passed_param = passed_params[declared_param]
+
+      memo[memo_key] = passed_param || handle_passed_param(nested_path_for(params_nested_path, declared_param), route_params:) do
+        passed_param
       end
     end
 
     def build_memo_key(params_nested_path, declared_param, renamed_params)
-      rename_path = params_nested_path + [declared_param.to_s]
-      renamed_param_name = renamed_params[rename_path]
-
+      renamed_param_name = renamed_params[nested_path_for(params_nested_path, declared_param)]
       param = renamed_param_name || declared_param
       @stringify ? param.to_s : param.to_sym
     end
 
-    def handle_passed_param(params_nested_path, route_params:, has_passed_children: false, &_block)
+    def nested_path_for(parent_path, key)
+      parent_path + [key.to_s]
+    end
+
+    def handle_passed_param(params_nested_path, route_params:, has_passed_children: false)
       return yield if has_passed_children
 
-      key = params_nested_path[0]
+      key = params_nested_path.first
       key += "[#{params_nested_path[1..].join('][')}]" if params_nested_path.size > 1
 
       type = route_params.dig(key, :type)
-      has_children = route_params.keys.any? { |k| k != key && k.start_with?("#{key}[") }
+      return yield if type.nil?
 
-      if type == 'Hash' && !has_children
-        {}
-      elsif type == 'Array' || (type&.start_with?('[') && !type.include?(','))
-        []
-      elsif type == 'Set' || type&.start_with?('#<Set', 'Set')
-        Set.new
-      else
-        yield
-      end
+      return {} if type == 'Hash' && route_params.keys.none? { |k| k != key && k.start_with?("#{key}[") }
+      return [] if type == 'Array' || (type.start_with?('[') && !type.include?(','))
+      return Set.new if type == 'Set' || type.start_with?('#<Set', 'Set')
+
+      yield
     end
   end
 end


### PR DESCRIPTION
## Summary

Readability pass over `Grape::DeclaredParamsHandler`. No behaviour change.

- **`declared_hash_attr`**: the body was a two-arm `if declared_param.is_a?(Hash)` that inlined both the recursive-children case and the terminal leaf case. Split into two named helpers (`declare_nested` and `declare_leaf`) and lifted the `Hash` check into a guard so the main flow stays at top indentation.
- **`nested_path_for(parent_path, key)`**: extracted the `path.dup << key.to_s` idiom into a single non-mutating helper, now used by both branches and by `build_memo_key`.
- **`handle_passed_param`**:
  - Lifted the type-nil short-circuit into a guard (`return yield if type.nil?`) so the subsequent guards can assume `type` is non-nil and drop the `&.` operators.
  - Folded the `has_children` predicate inline into the `Hash` branch using `route_params.keys.none? { ... }` so the lone-use local isn't introduced.
  - Rewrote the `if/elsif/elsif/else` ladder as three early-return guards.
  - Dropped the unused `&_block` parameter — the method already uses an implicit `yield`.

## Test plan

- [ ] `bundle exec rspec`
- [ ] CI green
- [x] `bundle exec rspec spec/grape/endpoint/declared_spec.rb` (53 examples, 0 failures locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)