### PR TITLE
Document style preferences and PR workflow in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,11 +38,11 @@ Update [CHANGELOG.md](CHANGELOG.md) for every user-facing change. Add a line und
 * [#PR](https://github.com/ruby-grape/grape/pull/PR): Description of change - [@username](https://github.com/username).
 ```
 
-Use a placeholder PR number when the PR is not yet open; update it after opening. The entry for "Your contribution here." must remain as the last line in each section.
+Keep the entry to a single short line — one clause naming the change at a high level. Detail belongs in the PR description, not the changelog. Open the PR with no changelog entry first (or with a placeholder), then amend the commit with the real entry once the PR number is assigned. The "Your contribution here." line must remain last in each section.
 
 ## UPGRADING.md
 
-Update [UPGRADING.md](UPGRADING.md) when introducing a **breaking change or behavior change** that users will need to act on when upgrading. Add a subsection under the current version heading (e.g. `### Upgrading to >= 3.2.0`), describing what changed and how to adapt.
+Update [UPGRADING.md](UPGRADING.md) only when introducing a **contract break** — a change in documented behavior or public API that an upgrading user has to act on. Pure refactors, internal cleanups, performance work, and additive options do not need an UPGRADING entry. Add a subsection under the current version heading (e.g. `### Upgrading to >= 3.2.0`), describing what changed and how to adapt.
 
 ## Code Style
 
@@ -51,12 +51,34 @@ Update [UPGRADING.md](UPGRADING.md) when introducing a **breaking change or beha
 - Frozen string literals are required in all files (`# frozen_string_literal: true`).
 - Minimum Ruby version is 3.2.
 
+Beyond what RuboCop enforces, prefer:
+
+- **Guard clauses over trailing `if/else` (and over `if/elsif/elsif/else` ladders).** When a method ends in branching where one or more arms is a short special case, lift each special case to a `return … if …` / `return … unless …` so the main flow sits at top indentation. Reach for guards even when none of the branches are obviously "the special case" — three guards followed by a bare expression is usually clearer than a three-arm `if/elsif/else`.
+- **Don't return from inside a `case/when`.** If a `when` branch should short-circuit the method, lift it to a guard clause above the `case`; the `when` arms then stay as plain expressions evaluating to a value.
+- **Don't use `case/when` for class-identity dispatch.** `when SomeClass` matches with `===`, i.e. `value.is_a?(SomeClass)` — that's correct only when dispatching on an *instance*. When dispatching on a class *value* (e.g. `type` is the class itself), use `if type == X` or `[X, Y].include?(type)` instead.
+- **No comments restating what the code does.** Reserve comments for *why* something non-obvious is happening (hidden constraint, surprising invariant, workaround) — well-named identifiers carry the *what*.
+
 ## Commits and PRs
 
 - Never push directly to master — always work on a branch and open a PR targeting `ruby-grape/grape master`.
-- One logical commit per PR; squash before merging.
+- **One commit per PR**, kept current by amending — don't stack follow-up "address review" or "fix CI" commits on the branch. After amending, force-push with `git push --force-with-lease` (never plain `--force`).
+- Split changes by concern: one logical refactor / feature / fix per PR. When a working tree contains unrelated changes, stash the others and open them separately rather than bundling.
 - PR titles and commit messages should be clear and imperative (e.g. "Fix UnknownAuthStrategy when subclassing Auth::Base").
 - Reference the related issue in the commit message and PR description (e.g. `Fixes #1234`).
+
+## Rebasing Open PRs
+
+When `origin/master` advances and an open branch needs to catch up:
+
+```
+git fetch origin master
+git checkout <branch>
+git rebase origin/master
+# resolve conflicts, run the touched specs
+git push --force-with-lease origin <branch>
+```
+
+CHANGELOG conflicts are common when two open PRs both add entries at the bottom of `#### Features` / `#### Fixes` — resolve by keeping both entries in PR-number order (oldest first). Mixed conflicts in `lib/` should be resolved on their merits: preserve the master version's structural changes and re-apply the branch's intent on top, rather than reverting either side wholesale.
 
 ## Gem Dependencies
 


### PR DESCRIPTION
## Summary

Fill in the gaps the existing `AGENTS.md` left implicit. Documentation only — no code, runtime, or test changes.

- **Code Style** — new subsection capturing the three control-flow rules the project enforces in review (guard clauses over trailing `if/else` and `if/elsif/else` ladders; no `return` inside `case/when`; no `case/when` for class-value dispatch) plus a comment policy ("comment the *why*, not the *what*").
- **Commits and PRs** — make explicit that a PR is one commit amended in place (no stacked "address review" / "fix CI" commits) and that the publish step is always `git push --force-with-lease`. Add the split-by-concern principle (one logical change per PR; stash unrelated diffs).
- **Changelog** — keep entries to a single short line; open the PR first, then amend the commit with the assigned PR number.
- **UPGRADING.md** — tighten the trigger from "breaking or behavior change" to "contract break", listing the cases that do *not* warrant an entry (refactors, internal cleanups, perf work, additive options).
- **Rebasing Open PRs** — new section with the standard fetch / checkout / rebase / re-spec / `--force-with-lease` workflow, and a note on the typical CHANGELOG and `lib/` conflict patterns when two open PRs touch the same area.

## Test plan

- [x] Renders cleanly in GitHub markdown preview locally
- [ ] No CI signal needed (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)