### PR TITLE
Normalize == / eql? aliasing across value-like classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#2706](https://github.com/ruby-grape/grape/pull/2706): Refactor `ParamsScope#validates` and `ParamsDocumentation` around a frozen `Grape::Validations::ValidationsSpec` value object; the validations hash supplied by the DSL is no longer mutated and the helper chain becomes pure - [@ericproulx](https://github.com/ericproulx).
 * [#2707](https://github.com/ruby-grape/grape/pull/2707): Tighten six guard conditions in `lib/` via De Morgan and `blank?`/`present?`/`include?` rewrites; no behaviour change - [@ericproulx](https://github.com/ericproulx).
 * [#2709](https://github.com/ruby-grape/grape/pull/2709): Lift trailing `if/else` into guard clauses; tighten `Util::Lazy::ValueEnumerable` - [@ericproulx](https://github.com/ericproulx).
+* [#2715](https://github.com/ruby-grape/grape/pull/2715): Normalize `==` / `eql?` aliasing across value-like classes - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -131,7 +131,7 @@ module Grape
     def ==(other)
       other.is_a?(self.class) &&
         options == other.options &&
-        inheritable_setting.to_hash == other.inheritable_setting.to_hash
+        inheritable_setting == other.inheritable_setting
     end
     alias eql? ==
 

--- a/lib/grape/exceptions/error_response.rb
+++ b/lib/grape/exceptions/error_response.rb
@@ -22,10 +22,6 @@ module Grape
       end
 
       def ==(other)
-        eql?(other)
-      end
-
-      def eql?(other)
         self.class == other.class &&
           other.status == status &&
           other.message == message &&
@@ -33,6 +29,7 @@ module Grape
           other.backtrace == backtrace &&
           other.original_exception == original_exception
       end
+      alias eql? ==
 
       def hash
         [self.class, status, message, headers, backtrace, original_exception].hash

--- a/lib/grape/middleware/stack.rb
+++ b/lib/grape/middleware/stack.rb
@@ -28,6 +28,7 @@ module Grape
             klass == other || (name.nil? && klass.superclass == other)
           end
         end
+        alias eql? ==
 
         def inspect
           klass.to_s

--- a/lib/grape/namespace.rb
+++ b/lib/grape/namespace.rb
@@ -23,13 +23,13 @@ module Grape
       settings&.map(&:space)
     end
 
-    def eql?(other)
+    def ==(other)
       other.class == self.class &&
         other.space == space &&
         other.requirements == requirements &&
         other.options == options
     end
-    alias == eql?
+    alias eql? ==
 
     def hash
       [self.class, space, requirements, options].hash

--- a/lib/grape/serve_stream/file_body.rb
+++ b/lib/grape/serve_stream/file_body.rb
@@ -31,6 +31,7 @@ module Grape
       def ==(other)
         path == other.path
       end
+      alias eql? ==
     end
   end
 end

--- a/lib/grape/serve_stream/stream_response.rb
+++ b/lib/grape/serve_stream/stream_response.rb
@@ -18,6 +18,7 @@ module Grape
       def ==(other)
         stream == other.stream
       end
+      alias eql? ==
     end
   end
 end

--- a/lib/grape/util/inheritable_setting.rb
+++ b/lib/grape/util/inheritable_setting.rb
@@ -5,7 +5,7 @@ module Grape
     # A branchable, inheritable settings object which can store both stackable
     # and inheritable values (see InheritableValues and StackableValues).
     class InheritableSetting
-      attr_accessor :route, :api_class, :namespace, :namespace_inheritable, :namespace_stackable, :namespace_reverse_stackable, :parent, :point_in_time_copies
+      attr_reader :route, :api_class, :namespace, :namespace_inheritable, :namespace_stackable, :namespace_reverse_stackable, :parent, :point_in_time_copies
 
       # Retrieve global settings.
       def self.global
@@ -23,17 +23,15 @@ module Grape
       # instance can then be set to inherit from an existing instance (see
       # #inherit_from).
       def initialize
-        self.route = {}
-        self.api_class = {}
-        self.namespace = InheritableValues.new # only inheritable from a parent when
+        @route = {}
+        @api_class = {}
+        @namespace = InheritableValues.new # only inheritable from a parent when
         # used with a mount, or should every API::Class be a separate namespace by default?
-        self.namespace_inheritable = InheritableValues.new
-        self.namespace_stackable = StackableValues.new
-        self.namespace_reverse_stackable = ReverseStackableValues.new
-
-        self.point_in_time_copies = []
-
-        self.parent = nil
+        @namespace_inheritable = InheritableValues.new
+        @namespace_stackable = StackableValues.new
+        @namespace_reverse_stackable = ReverseStackableValues.new
+        @point_in_time_copies = []
+        @parent = nil
       end
 
       # Return the class-level global properties.
@@ -48,12 +46,12 @@ module Grape
       def inherit_from(parent)
         return if parent.nil?
 
-        self.parent = parent
+        @parent = parent
 
         namespace_inheritable.inherited_values = parent.namespace_inheritable
         namespace_stackable.inherited_values = parent.namespace_stackable
         namespace_reverse_stackable.inherited_values = parent.namespace_reverse_stackable
-        self.route = parent.route.merge(route)
+        @route = parent.route.merge(route)
 
         point_in_time_copies.each { |cloned_one| cloned_one.inherit_from parent }
       end
@@ -65,15 +63,7 @@ module Grape
       def point_in_time_copy
         new_setting = self.class.new
         point_in_time_copies << new_setting
-        new_setting.point_in_time_copies = []
-
-        new_setting.namespace = namespace.clone
-        new_setting.namespace_inheritable = namespace_inheritable.clone
-        new_setting.namespace_stackable = namespace_stackable.clone
-        new_setting.namespace_reverse_stackable = namespace_reverse_stackable.clone
-        new_setting.route = route.clone
-        new_setting.api_class = api_class
-
+        new_setting.copy_state_from(self)
         new_setting.inherit_from(parent)
         new_setting
       end
@@ -96,11 +86,29 @@ module Grape
         }
       end
 
+      def ==(other)
+        other.is_a?(self.class) && to_hash == other.to_hash
+      end
+      alias eql? ==
+
       def namespace_stackable_with_hash(key)
         data = namespace_stackable[key]
         return if data.blank?
 
         data.each_with_object({}) { |value, result| result.deep_merge!(value) }
+      end
+
+      protected
+
+      # Used by +point_in_time_copy+ to populate a freshly-built instance
+      # with cloned state from another instance of the same class.
+      def copy_state_from(source)
+        @namespace = source.namespace.clone
+        @namespace_inheritable = source.namespace_inheritable.clone
+        @namespace_stackable = source.namespace_stackable.clone
+        @namespace_reverse_stackable = source.namespace_reverse_stackable.clone
+        @route = source.route.clone
+        @api_class = source.api_class
       end
     end
   end

--- a/lib/grape/util/media_type.rb
+++ b/lib/grape/util/media_type.rb
@@ -20,10 +20,6 @@ module Grape
       end
 
       def ==(other)
-        eql?(other)
-      end
-
-      def eql?(other)
         self.class == other.class &&
           other.type == type &&
           other.subtype == subtype &&
@@ -31,6 +27,7 @@ module Grape
           other.version == version &&
           other.format == format
       end
+      alias eql? ==
 
       def hash
         [self.class, type, subtype, vendor, version, format].hash


### PR DESCRIPTION
## Summary

`Endpoint` already followed the canonical Ruby pattern (`def ==` then `alias eql? ==`), but several value-like classes either defined `==` without an `eql?` alias (so they wouldn't compare correctly as hash keys / set members), or defined the two as separate methods that drifted. Normalizing every one to the same shape:

```ruby
def ==(other)
  ...
end
alias eql? ==
```

### Equality changes

- `Grape::Middleware::Stack::Middleware` — add `alias eql? ==`.
- `Grape::ServeStream::StreamResponse` — same.
- `Grape::ServeStream::FileBody` — same.
- `Grape::Util::MediaType` — collapse the `def ==(other); eql?(other); end` trampoline + separate `def eql?` into a single `==` body with `alias eql? ==`. Same behaviour, one fewer dispatch.
- `Grape::Exceptions::ErrorResponse` — same collapse.
- `Grape::Namespace` — flip from `def eql? ... alias == eql?` to `def == ... alias eql? ==` so the codebase is consistent on one direction.
- `Grape::Util::InheritableSetting` — add `def ==(other)` (compares via `to_hash` internally) and `alias eql? ==`. The class previously had no equality at all, so `Endpoint#==` had to call `inheritable_setting.to_hash == other.inheritable_setting.to_hash` to compare. With this in place:
- `Grape::Endpoint#==` simplifies from `inheritable_setting.to_hash == other.inheritable_setting.to_hash` to plain `inheritable_setting == other.inheritable_setting`.

`Grape::Endpoint`'s own `==` was already canonical and remains so.

### Encapsulation cleanup in `InheritableSetting`

While in the file, tightened the public surface — none of `route`, `api_class`, `namespace`, `namespace_inheritable`, `namespace_stackable`, `namespace_reverse_stackable`, `parent`, `point_in_time_copies` is written from outside the class anywhere in `lib/` or `spec/`. They were `attr_accessor` but only ever needed `attr_reader`.

- Switched `attr_accessor` → `attr_reader` for all eight.
- `initialize` and `inherit_from` now write to `@ivar` directly instead of the awkward `self.foo = …` setter syntax (matching `route_end`'s existing `@route = {}`).
- `point_in_time_copy` previously mutated the new instance by calling its public setters from the outside. Replaced that with a single `protected` `copy_state_from(source)` helper on `InheritableSetting` itself — the new instance pulls its state from `source` from inside the class, with no public writers required.

### Why it matters

Without the alias, `[obj1].include?(obj2)` and `Set#include?` use `eql?` (which falls back to `equal?` / object identity) instead of the custom `==`, producing surprising `false` results when two value-equal instances are compared by hash-based collections. The `InheritableSetting` encapsulation cleanup is a related-but-separate readability win — the class no longer leaks writable state, and internal mutations go through the canonical `@ivar = …` form.

## Test plan

- [x] `bundle exec rspec` — 2292 examples, 0 failures
- [x] RuboCop clean on touched files
- [ ] CI green across Gemfile variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)