### PR TITLE
Convert Grape::Exceptions::ErrorResponse to a Data value object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#2709](https://github.com/ruby-grape/grape/pull/2709): Lift trailing `if/else` into guard clauses; tighten `Util::Lazy::ValueEnumerable` - [@ericproulx](https://github.com/ericproulx).
 * [#2715](https://github.com/ruby-grape/grape/pull/2715): Normalize `==` / `eql?` aliasing across value-like classes - [@ericproulx](https://github.com/ericproulx).
 * [#2710](https://github.com/ruby-grape/grape/pull/2710): Tidy up `Grape::DeclaredParamsHandler` - [@ericproulx](https://github.com/ericproulx).
+* [#2717](https://github.com/ruby-grape/grape/pull/2717): Convert `Grape::Exceptions::ErrorResponse` to a `Data` value object - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/exceptions/error_response.rb
+++ b/lib/grape/exceptions/error_response.rb
@@ -6,33 +6,13 @@ module Grape
     # and consumed by `Middleware::Error#error_response`. Replaces the
     # implicit-schema Hash that previously circulated between throw sites
     # and the error middleware.
-    class ErrorResponse
-      attr_reader :status, :message, :headers, :backtrace, :original_exception
-
+    ErrorResponse = Data.define(:status, :message, :headers, :backtrace, :original_exception) do
       def initialize(status: nil, message: nil, headers: nil, backtrace: nil, original_exception: nil)
-        @status = status
-        @message = message
-        @headers = headers
-        @backtrace = backtrace
-        @original_exception = original_exception
+        super
       end
 
       def to_s
         "#<#{self.class.name} status=#{status.inspect} message=#{message.inspect} headers=#{headers.inspect}>"
-      end
-
-      def ==(other)
-        self.class == other.class &&
-          other.status == status &&
-          other.message == message &&
-          other.headers == headers &&
-          other.backtrace == backtrace &&
-          other.original_exception == original_exception
-      end
-      alias eql? ==
-
-      def hash
-        [self.class, status, message, headers, backtrace, original_exception].hash
       end
 
       def self.from_exception(exception)


### PR DESCRIPTION
## Summary

`Grape::Exceptions::ErrorResponse` is already structured as a value object — five readers, kwarg-only constructor, hand-written `==` / `eql?` / `hash`. Swap the hand-rolled class for `Data.define` and let Ruby provide equality, hashing, and field accessors for free.

```ruby
ErrorResponse = Data.define(:status, :message, :headers, :backtrace, :original_exception) do
  def initialize(status: nil, message: nil, headers: nil, backtrace: nil, original_exception: nil)
    super
  end

  def to_s
    "#<#{self.class.name} status=#{status.inspect} message=#{message.inspect} headers=#{headers.inspect}>"
  end

  def self.from_exception(exception)
    new(...)
  end

  def self.coerce(input)
    ...
  end
end
```

What changes:

- The ivar-setting constructor and the `==` / `eql?` / `hash` trio (~12 lines of boilerplate) collapse into the `Data.define` declaration. Defaults stay on `#initialize` for `coerce`'s Hash-slice branch and for `default_rescue_handler`-style callers that build instances without supplying `status`/`headers`.
- `to_s`, `from_exception`, and `coerce` move into the Data block unchanged.

What does not change:

- Public surface — every accessor, `from_exception`, `coerce`, the `Hash` / `Grape::Exceptions::Base` / `ErrorResponse` branches in `coerce`, and the `==` semantics (Data's default field-equality matches the prior hand-written one).
- Production behaviour.

## Test plan

- [x] Full suite: `bundle exec rspec` — 2292 examples, 0 failures
- [x] RuboCop clean
- [ ] CI green across Gemfile variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)