### PR TITLE
Move content-type helpers from Middleware::Base into PrecomputedContentTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#2710](https://github.com/ruby-grape/grape/pull/2710): Tidy up `Grape::DeclaredParamsHandler` - [@ericproulx](https://github.com/ericproulx).
 * [#2714](https://github.com/ruby-grape/grape/pull/2714): Drop unused `Grape::Middleware::Globals` and its `grape.request*` env constants - [@ericproulx](https://github.com/ericproulx).
 * [#2717](https://github.com/ruby-grape/grape/pull/2717): Convert `Grape::Exceptions::ErrorResponse` to a `Data` value object - [@ericproulx](https://github.com/ericproulx).
+* [#2719](https://github.com/ruby-grape/grape/pull/2719): Move content-type helpers from `Middleware::Base` into `PrecomputedContentTypes` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/middleware/base.rb
+++ b/lib/grape/middleware/base.rb
@@ -61,22 +61,6 @@ module Grape
         @app_response = Rack::Response[*@app_response]
       end
 
-      def content_types
-        @content_types ||= Grape::ContentTypes.content_types_for(options[:content_types])
-      end
-
-      def mime_types
-        @mime_types ||= Grape::ContentTypes.mime_types_for(content_types)
-      end
-
-      def content_type_for(format)
-        content_types_indifferent_access[format]
-      end
-
-      def content_type
-        content_type_for(env[Grape::Env::API_FORMAT] || options[:format]) || 'text/html'
-      end
-
       def query_params
         rack_request.GET
       rescue *Grape::RACK_ERRORS
@@ -84,10 +68,6 @@ module Grape
       end
 
       private
-
-      def content_types_indifferent_access
-        @content_types_indifferent_access ||= content_types.with_indifferent_access
-      end
 
       def merge_headers(response)
         return if @header.blank?

--- a/lib/grape/middleware/precomputed_content_types.rb
+++ b/lib/grape/middleware/precomputed_content_types.rb
@@ -2,20 +2,43 @@
 
 module Grape
   module Middleware
-    # Include in a middleware subclass to warm the content-type caches on the
-    # parent instance at initialization. Per-request dups inherit the cached
-    # values via +dup+'s ivar copy, avoiding ~1 µs per request of
-    # +with_indifferent_access+ recomputation.
+    # Include in a middleware subclass that needs content-type negotiation.
+    # Provides +content_types+ / +mime_types+ / +content_type_for+ /
+    # +content_type+ resolved from +options[:content_types]+ and
+    # +options[:format]+, and warms those caches on the parent instance at
+    # initialization so per-request +dup+s inherit them (avoiding
+    # ~1 µs/request of +with_indifferent_access+ recomputation).
     #
-    # Opt-in: plain +Grape::Middleware::Base+ subclasses continue to compute
-    # +content_types+ / +mime_types+ / +content_type_for+ lazily on first
-    # access.
+    # Opt-in: plain +Grape::Middleware::Base+ subclasses that don't need
+    # content-type-aware helpers don't pay for them.
     module PrecomputedContentTypes
       def initialize(app, **options)
         super
         content_types
         mime_types
         content_types_indifferent_access
+      end
+
+      def content_types
+        @content_types ||= Grape::ContentTypes.content_types_for(options[:content_types])
+      end
+
+      def mime_types
+        @mime_types ||= Grape::ContentTypes.mime_types_for(content_types)
+      end
+
+      def content_type_for(format)
+        content_types_indifferent_access[format]
+      end
+
+      def content_type
+        content_type_for(env[Grape::Env::API_FORMAT] || options[:format]) || 'text/html'
+      end
+
+      private
+
+      def content_types_indifferent_access
+        @content_types_indifferent_access ||= content_types.with_indifferent_access
       end
     end
   end


### PR DESCRIPTION
## Summary

`Middleware::Base#content_types` / `#mime_types` / `#content_type_for` / `#content_type` / `#content_types_indifferent_access` are only consumed by middleware that `include Grape::Middleware::PrecomputedContentTypes` — namely `Formatter`, `Error`, and `Versioner::Base`. The other concrete middlewares (`Filter`, `Auth::Base`) never call them.

Move the five methods into `PrecomputedContentTypes`. `Base` keeps the storage layer (`@options` / `@env` / `@app` / `Rack::Request` wrapper / header merge / `query_params`); the content-type concern lives with the mixin that already takes responsibility for warming its caches.

### Why

Currently `Base` reaches into the options Hash twice — `options[:content_types]` and `options[:format]` — to compute helpers that not every subclass needs. That coupling makes it impossible to migrate a subclass's options to a typed value object without also retrofitting Hash semantics onto that value object, just to keep `Base` happy.

After this move, `Base` doesn't touch its options hash at all. The mixin still uses `options[:…]` — but now only middleware that opted in by including the mixin pay for that coupling, and a follow-up can replace the `[]` access inside the mixin without rippling through `Base`.

### Scope

- `lib/grape/middleware/base.rb` — five methods removed.
- `lib/grape/middleware/precomputed_content_types.rb` — same five methods added, identical bodies, ivar caching preserved.

No call sites moved or renamed; `PrecomputedContentTypes` is currently `include`d in exactly the three middlewares that called these helpers, so behaviour is unchanged.

## Test plan

- [x] Full suite: `bundle exec rspec` — 2307 examples, 0 failures
- [x] RuboCop clean
- [ ] CI green across Gemfile variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)