### PR TITLE
Move declaration-coherence checks into ValidationsSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [#2721](https://github.com/ruby-grape/grape/pull/2721): Use an internal `Grape::Validations::SharedOptions` value object in `Validators::Base` (public `opts` Hash contract unchanged) - [@ericproulx](https://github.com/ericproulx).
 * [#2719](https://github.com/ruby-grape/grape/pull/2719): Move content-type helpers from `Middleware::Base` into `PrecomputedContentTypes` - [@ericproulx](https://github.com/ericproulx).
 * [#2716](https://github.com/ruby-grape/grape/pull/2716): Refactor `DSL::Routing#version`: guard clause, explicit kwargs in place of `**options`, and a `Grape::DSL::VersionOptions` value object stored internally - [@ericproulx](https://github.com/ericproulx).
+* [#2720](https://github.com/ruby-grape/grape/pull/2720): Move declaration-coherence checks into `Grape::Validations::ValidationsSpec` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -334,8 +334,6 @@ module Grape
         process_oneof!(validations) if validations.key?(:oneof)
         spec = ValidationsSpec.from(validations)
 
-        check_incompatible_option_values(spec.default, spec.values, spec.except_values)
-        validate_value_coercion(spec.coerce_type, spec.values, spec.except_values)
         document_params(attrs, spec)
 
         # Presence runs first — `required` is forwarded to every subsequent
@@ -380,16 +378,6 @@ module Grape
         validate('coerce', coerce_options, attrs, spec.required?, spec.shared_opts)
       end
 
-      def check_incompatible_option_values(default, values, except_values)
-        return if default.nil? || default.is_a?(Proc)
-
-        raise Grape::Exceptions::IncompatibleOptionValues.new(:default, default, :values, values) if values && !values.is_a?(Proc) && Array(default).any? { |def_val| !values.include?(def_val) }
-
-        return unless except_values && !except_values.is_a?(Proc) && Array(default).any? { |def_val| except_values.include?(def_val) }
-
-        raise Grape::Exceptions::IncompatibleOptionValues.new(:default, default, :except, except_values)
-      end
-
       # Translate a `oneof: [proc, proc, ...]` declaration into a list of
       # captured validator arrays — one array per variant. Each variant's
       # block is evaluated in its own +ParamsScope+ backed by an
@@ -416,19 +404,6 @@ module Grape
           opts
         )
         @api.inheritable_setting.namespace_stackable[:validations] = validator_instance
-      end
-
-      def validate_value_coercion(coerce_type, *values_list)
-        return unless coerce_type
-
-        coerce_type = coerce_type.first if coerce_type.is_a?(Enumerable)
-        values_list.each do |values|
-          next if !values || values.is_a?(Proc)
-
-          value_types = values.is_a?(Range) ? [values.begin, values.end].compact : values
-          value_types = value_types.map { |type| Grape::API::Boolean.build(type) } if coerce_type == Grape::API::Boolean
-          raise Grape::Exceptions::IncompatibleOptionValues.new(:type, coerce_type, :values, values) unless value_types.all?(coerce_type)
-        end
       end
 
       def all_element_blank?(scoped_params)

--- a/lib/grape/validations/validations_spec.rb
+++ b/lib/grape/validations/validations_spec.rb
@@ -55,6 +55,8 @@ module Grape
         @shared_opts = { allow_blank: @allow_blank, fail_fast: @fail_fast }.freeze
         @validator_entries = build_validator_entries(raw)
 
+        validate!
+
         freeze
       end
 
@@ -67,6 +69,38 @@ module Grape
       end
 
       private
+
+      # Cross-field consistency checks on the parsed declaration. Run at
+      # construction so an incoherent spec (e.g. a +default+ outside +values+,
+      # or +values+ whose elements don't match +type+) can never exist —
+      # callers no longer have to remember to invoke these separately.
+      def validate!
+        check_incompatible_option_values(@default, @values, @except_values)
+        validate_value_coercion(@coerce_type, @values, @except_values)
+      end
+
+      def check_incompatible_option_values(default, values, except_values)
+        return if default.nil? || default.is_a?(Proc)
+
+        raise Grape::Exceptions::IncompatibleOptionValues.new(:default, default, :values, values) if values && !values.is_a?(Proc) && Array(default).any? { |def_val| !values.include?(def_val) }
+
+        return unless except_values && !except_values.is_a?(Proc) && Array(default).any? { |def_val| except_values.include?(def_val) }
+
+        raise Grape::Exceptions::IncompatibleOptionValues.new(:default, default, :except, except_values)
+      end
+
+      def validate_value_coercion(coerce_type, *values_list)
+        return unless coerce_type
+
+        coerce_type = coerce_type.first if coerce_type.is_a?(Enumerable)
+        values_list.each do |values|
+          next if !values || values.is_a?(Proc)
+
+          value_types = values.is_a?(Range) ? [values.begin, values.end].compact : values
+          value_types = value_types.map { |type| Grape::API::Boolean.build(type) } if coerce_type == Grape::API::Boolean
+          raise Grape::Exceptions::IncompatibleOptionValues.new(:type, coerce_type, :values, values) unless value_types.all?(coerce_type)
+        end
+      end
 
       def build_validator_entries(raw)
         raw.reject do |k, _|

--- a/spec/grape/validations/params_documentation_spec.rb
+++ b/spec/grape/validations/params_documentation_spec.rb
@@ -35,7 +35,7 @@ describe Grape::Validations::ParamsDocumentation do
       validations = {
         presence: true,
         type: Integer,
-        default: 42,
+        default: 1,
         length: { min: 1, max: 10 },
         desc: 'A foo',
         documentation: { note: 'doc' },
@@ -50,7 +50,7 @@ describe Grape::Validations::ParamsDocumentation do
         type: 'Integer',
         values: [1, 2, 3],
         except_values: [4, 5, 6],
-        default: 42,
+        default: 1,
         min_length: 1,
         max_length: 10,
         desc: 'A foo',


### PR DESCRIPTION
## Summary

`check_incompatible_option_values` and `validate_value_coercion` were private methods on `ParamsScope`, invoked from `#validates` immediately after building the `ValidationsSpec`. Both are **pure cross-field invariants** computed entirely from fields the spec already owns (`default`, `values`, `except_values`, `coerce_type`).

`ValidationsSpec` already enforced one construction-time invariant — the `:type` + `:types` mutual-exclusion `ArgumentError` in `#initialize`. Concentrating the rest there makes *"you cannot construct an incoherent spec"* true by definition: the invariant no longer depends on a caller remembering to run the checks after `.from(...)`. `ParamsScope#validates` collapses to build-spec → document → dispatch.

### Changes

- Moved `check_incompatible_option_values` and `validate_value_coercion` into `ValidationsSpec` as private methods.
- New private `ValidationsSpec#validate!` runs them from `#initialize`, before `freeze`.
- Deleted both methods from `ParamsScope` and removed the two call sites in `#validates`.

### Deliberately left behind: `check_coerce_with`

It looks similar but isn't a pure construction-time invariant. It's invoked from `ParamsScope#validate_coerce`, **gated on the remountable-API skip** (`return unless coerce_options[:type]` — a base instance has no resolved type until the mounted instance replays). Moving it into `ValidationsSpec#initialize` would make a remountable API raise on the base instance before its type resolves. It stays in `validate_coerce`.

### Behaviour change

Constructing a `ValidationsSpec` with an incoherent combination (e.g. `default: 42, values: [1, 2, 3]`) now raises `Grape::Exceptions::IncompatibleOptionValues` at construction instead of only when `ParamsScope#validates` reached the check. For real APIs this is identical (the spec is always built inside `#validates`). One documentation spec built such a deliberately-incompatible spec just to exercise `document_params`; its fixture now uses a coherent `default: 1`.

`ValidationsSpec` gains a dependency on `Grape::Exceptions::IncompatibleOptionValues` — acceptable since it already raises `ArgumentError` and is Grape-internal.

## Test plan

- [x] `bundle exec rspec` — 2307 examples, 0 failures
- [x] RuboCop clean
- [ ] CI green across Gemfile variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)