### PR TITLE
Use an internal Grape::Validations::SharedOptions value object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#2710](https://github.com/ruby-grape/grape/pull/2710): Tidy up `Grape::DeclaredParamsHandler` - [@ericproulx](https://github.com/ericproulx).
 * [#2714](https://github.com/ruby-grape/grape/pull/2714): Drop unused `Grape::Middleware::Globals` and its `grape.request*` env constants - [@ericproulx](https://github.com/ericproulx).
 * [#2717](https://github.com/ruby-grape/grape/pull/2717): Convert `Grape::Exceptions::ErrorResponse` to a `Data` value object - [@ericproulx](https://github.com/ericproulx).
+* [#2721](https://github.com/ruby-grape/grape/pull/2721): Use an internal `Grape::Validations::SharedOptions` value object in `Validators::Base` (public `opts` Hash contract unchanged) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/validations/shared_options.rb
+++ b/lib/grape/validations/shared_options.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Grape
+  module Validations
+    # Immutable value object holding the two options every validator reads at
+    # construction time: +allow_blank+ and +fail_fast+. Internal to
+    # {Validators::Base}, which builds it from the +opts+ Hash so the public
+    # 5th-argument contract stays a plain Hash — not part of any wire contract.
+    #
+    # Defaults mirror the prior +opts.values_at+ behaviour: +allow_blank+ is
+    # +nil+ when the declaration didn't supply it (validators treat nil as
+    # "not set"), +fail_fast+ defaults to +false+.
+    SharedOptions = Data.define(:allow_blank, :fail_fast) do
+      def initialize(allow_blank: nil, fail_fast: false)
+        super
+      end
+    end
+  end
+end

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -12,9 +12,16 @@ module Grape
       # from them are frozen by construction. Lazy ivar assignment
       # (e.g. +memoize+, <tt>||=</tt>) will raise +FrozenError+ at request time.
       class Base
+        extend Forwardable
         include Grape::Util::Translation
 
         attr_reader :attrs
+
+        # +allow_blank+ / +fail_fast+ are read straight off the internal
+        # {Grape::Validations::SharedOptions} value object; no per-validator
+        # ivars. The object is built from the +opts+ Hash in #initialize, so
+        # the public 5th-argument contract stays a plain Hash.
+        def_delegators :@opts, :allow_blank, :fail_fast
 
         class << self
           # Declares the default I18n message key used by +validation_error!+.
@@ -52,14 +59,15 @@ module Grape
         # @param options [Object] implementation-dependent Validator options; deep-frozen on assignment
         # @param required [Boolean] attribute(s) are required or optional
         # @param scope [ParamsScope] parent scope for this Validator
-        # @param opts [Hash] additional validation options
+        # @param opts [Hash] shared validator options; only +:allow_blank+ and
+        #   +:fail_fast+ are consulted (other keys ignored, as before)
         def initialize(attrs, options, required, scope, opts)
           @attrs = Array(attrs).freeze
           @options = Grape::Util::DeepFreeze.deep_freeze(options)
           @option = @options # TODO: remove in next major release
           @required = required
           @scope = scope
-          @fail_fast, @allow_blank = opts.values_at(:fail_fast, :allow_blank)
+          @opts = SharedOptions.new(**opts.slice(:allow_blank, :fail_fast))
           @exception_message = message(self.class.default_message_key) if self.class.default_message_key
         end
 
@@ -75,7 +83,7 @@ module Grape
         end
 
         def fail_fast?
-          @fail_fast
+          fail_fast
         end
 
         # Validates a given parameter hash.

--- a/lib/grape/validations/validators/values_validator.rb
+++ b/lib/grape/validations/validators/values_validator.rb
@@ -28,7 +28,7 @@ module Grape
           val = scrub(params[attr_name])
 
           return if val.nil? && !required_for_root_scope?
-          return if val != false && val.blank? && @allow_blank
+          return if val != false && val.blank? && allow_blank
           return if check_values?(val, attr_name)
 
           validation_error!(attr_name)


### PR DESCRIPTION
## Summary

`Validators::Base#initialize` consumed the shared `opts` via `opts.values_at(:fail_fast, :allow_blank)` and copied both into per-validator ivars (`@fail_fast` / `@allow_blank`), with `ValuesValidator` reaching into `@allow_blank` directly.

Introduce `Grape::Validations::SharedOptions` — `Data.define(:allow_blank, :fail_fast)` with defaults mirroring the prior `values_at` behaviour — as a **purely internal** representation:

```ruby
@opts = SharedOptions.new(**opts.slice(:allow_blank, :fail_fast))
```

and expose the fields via `extend Forwardable; def_delegators :@opts, :allow_blank, :fail_fast`. `#fail_fast?` delegates; `ValuesValidator` switches to the `allow_blank` reader.

## No contract change

The public 5th argument of `Validators::Base#initialize` stays a plain **Hash**. The Hash → value-object conversion happens *inside* `Base`, so:

- Custom validators that subclass and `super` the args through — unaffected.
- Custom validators / user specs that hand-construct with a literal Hash 5th arg — **unaffected** (the original concern from the earlier revision of this PR is gone).
- `opts.slice(:allow_blank, :fail_fast)` preserves the historical tolerance of silently ignoring any other keys (matching the old `values_at`).
- `ValidationsSpec#shared_opts` keeps emitting the frozen `{ allow_blank:, fail_fast: }` Hash — its (internal) surface is unchanged.

No `UPGRADING.md` entry needed — there is no behaviour or contract change, just an internal cleanup that removes the scattered ivars in favour of one delegated value object.

## Test plan

- [x] `bundle exec rspec` — 2307 examples, 0 failures
- [x] RuboCop clean on `lib/grape/validations/`
- [ ] CI green across Gemfile variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)