### PR TITLE
Introduce Grape::Validations::CoerceOptions value object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#2710](https://github.com/ruby-grape/grape/pull/2710): Tidy up `Grape::DeclaredParamsHandler` - [@ericproulx](https://github.com/ericproulx).
 * [#2714](https://github.com/ruby-grape/grape/pull/2714): Drop unused `Grape::Middleware::Globals` and its `grape.request*` env constants - [@ericproulx](https://github.com/ericproulx).
 * [#2717](https://github.com/ruby-grape/grape/pull/2717): Convert `Grape::Exceptions::ErrorResponse` to a `Data` value object - [@ericproulx](https://github.com/ericproulx).
+* [#2722](https://github.com/ruby-grape/grape/pull/2722): Introduce `Grape::Validations::CoerceOptions` value object for the internal coerce options - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/validations/coerce_options.rb
+++ b/lib/grape/validations/coerce_options.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Grape
+  module Validations
+    # Immutable value object describing how a parameter is coerced. Assembled
+    # by {ValidationsSpec#coerce_options} from the parsed +type+/+coerce_with+/
+    # +coerce_message+ declaration — never written by the user — and consumed
+    # by {ParamsScope#check_coerce_with} / {ParamsScope#validate_coerce} and by
+    # {Validators::Validators::CoerceValidator} (which receives it as its
+    # +options+ argument).
+    #
+    # All three fields may be +nil+ (e.g. a remountable API evaluated on its
+    # base instance has no resolved +type+ yet).
+    # +coerce_method+ (not +method+) avoids shadowing +Object#method+.
+    CoerceOptions = Data.define(:type, :coerce_method, :message) do
+      def initialize(type: nil, coerce_method: nil, message: nil)
+        super
+      end
+    end
+  end
+end

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -350,13 +350,13 @@ module Grape
         end
       end
 
-      # Enforce correct usage of :coerce_with on a coerce_options hash.
+      # Enforce correct usage of :coerce_with on a CoerceOptions.
       # We do not allow coercion without a type, nor with +JSON+ as a type
       # since that defines its own coercion method.
       def check_coerce_with(coerce_options)
-        return unless coerce_options[:method]
-        raise ArgumentError, 'must supply type for coerce_with' unless coerce_options[:type]
-        return unless SPECIAL_JSON.include?(coerce_options[:type])
+        return unless coerce_options.coerce_method
+        raise ArgumentError, 'must supply type for coerce_with' unless coerce_options.type
+        return unless SPECIAL_JSON.include?(coerce_options.type)
 
         raise ArgumentError, 'coerce_with disallowed for type: JSON'
       end
@@ -375,7 +375,7 @@ module Grape
         # configuration[:some_type] evaluates to nil. Skipping instantiation
         # here is correct — the real mounted instance will replay this step
         # with the actual type value.
-        return unless coerce_options[:type]
+        return unless coerce_options.type
 
         validate('coerce', coerce_options, attrs, spec.required?, spec.shared_opts)
       end

--- a/lib/grape/validations/validations_spec.rb
+++ b/lib/grape/validations/validations_spec.rb
@@ -63,7 +63,7 @@ module Grape
       end
 
       def coerce_options
-        { type: @coerce_type, method: @coerce_method, message: @coerce_message }
+        CoerceOptions.new(type: @coerce_type, coerce_method: @coerce_method, message: @coerce_message)
       end
 
       private

--- a/lib/grape/validations/validators/coerce_validator.rb
+++ b/lib/grape/validations/validators/coerce_validator.rb
@@ -9,13 +9,18 @@ module Grape
         def initialize(attrs, options, required, scope, opts)
           super
 
-          raw_type = @options[:type]
+          # +@options+ is a Grape::Validations::CoerceOptions. +Base#message+
+          # can't see a custom message off a Data (it probes Hash-like
+          # +key?+), so restore it here to preserve `type: { value:, message: }`.
+          @exception_message = @options.message unless @options.message.nil?
+
+          raw_type = @options.type
           type = hash_like?(raw_type) ? raw_type[:value] : raw_type
           @converter =
             if type.is_a?(Grape::Validations::Types::VariantCollectionCoercer)
               type
             else
-              Types.build_coercer(type, method: @options[:method])
+              Types.build_coercer(type, method: @options.coerce_method)
             end
         end
 


### PR DESCRIPTION
## Summary

`ValidationsSpec#coerce_options` returned an ad-hoc `{ type:, method:, message: }` Hash that flowed (deep-frozen) into `CoerceValidator` as its `options` argument and was poked at by `ParamsScope#check_coerce_with` / `#validate_coerce`.

Unlike most validator options (which are a genuine union — bare value, `{ value:, message: }` envelope, or structured Hash, depending on what the user wrote), this one is **never written by the user**. It's assembled internally from the parsed `type:` / `coerce_with:` / `coerce_message` declaration, so it has a fixed shape and no public contract to preserve — the cleanest possible `Data.define` candidate.

Replace it with `Grape::Validations::CoerceOptions`:

```ruby
CoerceOptions = Data.define(:type, :coerce_method, :message) do
  def initialize(type: nil, coerce_method: nil, message: nil)
    super
  end
end
```

The member is `coerce_method`, not `method` — defining `:method` would shadow `Object#method` (`Lint/DataDefineOverride`), and `coerce_method` already matches `ValidationsSpec`'s existing accessor name.

### Changes

- `ValidationsSpec#coerce_options` builds the value object.
- `ParamsScope#check_coerce_with` / `#validate_coerce` read `.type` / `.coerce_method` instead of `[:type]` / `[:method]`.
- `CoerceValidator` reads `@options.type` / `@options.coerce_method`. `Base#message` resolves a custom message by probing a Hash-like `key?`, which a Data doesn't answer, so `CoerceValidator#initialize` restores `@exception_message` from `@options.message` — preserving `type: { value: Integer, message: 'bad' }` behaviour (covered by existing specs).

### Why it's safe

- `Grape::Util::DeepFreeze` returns the Data via its `else` branch unchanged; `Base.new` already freezes the whole validator instance, and Data is structurally immutable.
- No user-facing contract change: users never construct or read this Hash; no spec hand-builds a `CoerceValidator` with it (the validator specs go through the full `Grape::API` DSL).
- The remountable-API `return unless coerce_options.type` guard in `validate_coerce` is preserved (a base instance with no resolved type still skips).

## Test plan

- [x] `bundle exec rspec` — 2307 examples, 0 failures (incl. `coerce_validator_spec` 97/0, custom-message path)
- [x] RuboCop clean (incl. `Lint/DataDefineOverride`)
- [ ] CI green across Gemfile variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)