### PR TITLE
Deprecate positional options Hash for `desc`; add grape-swagger integration spec

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,11 +33,14 @@ jobs:
           - gemfiles/rails_7_2.gemfile
           - gemfiles/rails_8_0.gemfile
           - gemfiles/rails_8_1.gemfile
-        specs: ['spec --exclude-pattern=spec/integration/{grape_entity,hashie,dry_validation,multi_*}/*_spec.rb']
+        specs: ['spec --exclude-pattern=spec/integration/{grape_entity,grape_swagger,hashie,dry_validation,multi_*}/*_spec.rb']
         include:
           - ruby: '4.0'
             gemfile: gemfiles/grape_entity.gemfile
             specs: 'spec/integration/grape_entity'
+          - ruby: '4.0'
+            gemfile: gemfiles/grape_swagger.gemfile
+            specs: 'spec/integration/grape_swagger'
           - ruby: '4.0'
             gemfile: gemfiles/hashie.gemfile
             specs: 'spec/integration/hashie'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#2710](https://github.com/ruby-grape/grape/pull/2710): Tidy up `Grape::DeclaredParamsHandler` - [@ericproulx](https://github.com/ericproulx).
 * [#2714](https://github.com/ruby-grape/grape/pull/2714): Drop unused `Grape::Middleware::Globals` and its `grape.request*` env constants - [@ericproulx](https://github.com/ericproulx).
 * [#2717](https://github.com/ruby-grape/grape/pull/2717): Convert `Grape::Exceptions::ErrorResponse` to a `Data` value object - [@ericproulx](https://github.com/ericproulx).
+* [#2723](https://github.com/ruby-grape/grape/pull/2723): Deprecate passing a positional options Hash to `Grape::DSL::Desc#desc`; pass options as keyword arguments. Add a grape-swagger integration spec - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/gemfiles/grape_swagger.gemfile
+++ b/gemfiles/grape_swagger.gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+eval_gemfile '../Gemfile'
+
+gem 'grape-swagger'

--- a/lib/grape/dsl/desc.rb
+++ b/lib/grape/dsl/desc.rb
@@ -9,7 +9,8 @@ module Grape
       # @param description [String] descriptive string for this endpoint
       #   or namespace
       # @param options [Hash] other properties you can set to describe the
-      #   endpoint or namespace. Optional.
+      #   endpoint or namespace. Optional. Pass these as keyword arguments;
+      #   passing a positional options Hash is deprecated.
       # @option options :detail [String] additional detail about this endpoint
       # @option options :summary [String] summary for this endpoint
       # @option options :params [Hash] param types and info. normally, you set
@@ -49,7 +50,12 @@ module Grape
       #       # ...
       #     end
       #
-      def desc(description, options = {}, &config_block)
+      def desc(description, *legacy_options, **options, &config_block)
+        if legacy_options.any?
+          Grape.deprecator.warn('Passing a positional options Hash to `desc` is deprecated. Pass keyword arguments instead.')
+          options = legacy_options.first.merge(options)
+        end
+
         settings =
           if config_block
             endpoint_config = defined?(configuration) ? configuration : nil

--- a/spec/grape/dsl/desc_spec.rb
+++ b/spec/grape/dsl/desc_spec.rb
@@ -14,9 +14,26 @@ describe Grape::DSL::Desc do
     it 'sets a description' do
       desc_text = 'The description'
       options = { message: 'none' }
-      subject.desc desc_text, options
+      subject.desc desc_text, **options
       expect(subject.namespace_setting(:description)).to eq(options.merge(description: desc_text))
       expect(subject.route_setting(:description)).to eq(options.merge(description: desc_text))
+    end
+
+    context 'when a positional options Hash is passed' do
+      let(:desc_text) { 'The description' }
+      let(:options) { { message: 'none' } }
+
+      it 'is deprecated' do
+        expect { subject.desc desc_text, options }.to raise_error(ActiveSupport::DeprecationException)
+      end
+
+      it 'still sets the description when deprecations are silenced' do
+        Grape.deprecator.silence do
+          subject.desc desc_text, options
+        end
+        expect(subject.namespace_setting(:description)).to eq(options.merge(description: desc_text))
+        expect(subject.route_setting(:description)).to eq(options.merge(description: desc_text))
+      end
     end
 
     context 'when a block is passed' do

--- a/spec/integration/grape_swagger/grape_swagger_spec.rb
+++ b/spec/integration/grape_swagger/grape_swagger_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+describe 'GrapeSwagger', if: defined?(GrapeSwagger) do
+  # grape-swagger 2.1.4 still calls `desc 'text', options_hash` with a
+  # positional Hash. Grape now deprecates that form, and the test suite
+  # raises on deprecations, so the documentation class has to be built
+  # with the deprecator silenced. The integration value is in asserting
+  # that the generated OpenAPI document is still correct.
+  let(:app) do
+    Grape.deprecator.silence do
+      Class.new(Grape::API) do
+        format :json
+
+        desc 'Get all widgets', success: { code: 200, message: 'widgets found' }
+        params do
+          optional :q, type: String, desc: 'search term'
+        end
+        get '/widgets' do
+          [{ id: 1, name: 'gear' }]
+        end
+
+        desc 'Create a widget'
+        params do
+          requires :name, type: String, desc: 'widget name'
+        end
+        post '/widgets' do
+          { id: 2, name: params[:name] }
+        end
+
+        add_swagger_documentation info: { title: 'Widget API', version: '1.0' }
+      end
+    end
+  end
+
+  describe 'GET /swagger_doc' do
+    let(:swagger) do
+      get '/swagger_doc'
+      JSON.parse(last_response.body)
+    end
+
+    it 'returns a successful Swagger 2.0 document' do
+      expect(swagger).to include('swagger' => '2.0')
+      expect(last_response).to be_successful
+      expect(last_response.content_type).to eq('application/json')
+    end
+
+    it 'documents both routes from the mounted API' do
+      expect(swagger['paths'].keys).to contain_exactly('/widgets')
+      expect(swagger['paths']['/widgets'].keys).to contain_exactly('get', 'post')
+    end
+
+    it 'carries the descriptions set via Grape::DSL::Desc' do
+      expect(swagger['paths']['/widgets']['get']['description']).to eq('Get all widgets')
+      expect(swagger['paths']['/widgets']['post']['description']).to eq('Create a widget')
+    end
+
+    it 'translates the success: option into a documented response' do
+      expect(swagger['paths']['/widgets']['get']['responses']).to include('200')
+    end
+
+    it 'documents the declared query parameter' do
+      param = swagger['paths']['/widgets']['get']['parameters'].first
+      expect(param).to include('name' => 'q', 'in' => 'query', 'type' => 'string', 'required' => false)
+    end
+  end
+
+  describe 'GET /swagger_doc/:name' do
+    let(:swagger) do
+      get '/swagger_doc/widgets'
+      JSON.parse(last_response.body)
+    end
+
+    it 'returns the documentation scoped to a single resource' do
+      expect(swagger['paths']).to have_key('/widgets')
+      expect(last_response).to be_successful
+      expect(swagger.dig('definitions', 'postWidgets', 'required')).to eq(['name'])
+    end
+  end
+
+  describe 'add_swagger_documentation' do
+    it 'relies on the deprecated positional Hash form of `desc`' do
+      expect do
+        Class.new(Grape::API) { add_swagger_documentation }
+      end.to raise_error(ActiveSupport::DeprecationException, /positional options Hash to `desc`/)
+    end
+  end
+end


### PR DESCRIPTION
#### Summary

`Grape::DSL::Desc#desc` now accepts its options as **keyword arguments**. Passing a positional options Hash still works but emits a deprecation warning via `Grape.deprecator`, so downstream callers keep functioning through the deprecation cycle.

```ruby
# preferred
desc 'Create a user', detail: 'creates a user', tags: %w[users]

# still works, now deprecated
desc 'Create a user', { detail: 'creates a user', tags: %w[users] }
```

#### grape-swagger integration coverage

Adds `spec/integration/grape_swagger/grape_swagger_spec.rb`, a `gemfiles/grape_swagger.gemfile`, and a dedicated CI matrix entry (mirroring the existing `grape_entity` / `dry_validation` integration jobs).

The spec stands up a real API with `add_swagger_documentation` and asserts the generated OpenAPI 2.0 document (paths, descriptions carried from `desc`, `success:` responses, declared params, per-resource `/swagger_doc/:name`).

It also documents why the shim matters: grape-swagger 2.1.4 still calls `desc 'text', options_hash` internally (`lib/grape-swagger/doc_methods.rb`), so without the compatibility path the latest grape-swagger would break outright under the keyword-only signature. An upstream issue has been opened on `ruby-grape/grape-swagger` to migrate to keyword arguments.

#### Tests

- New grape-swagger integration spec: green under `gemfiles/grape_swagger.gemfile`
- `spec/grape/dsl/desc_spec.rb`: covers the keyword form and the deprecated positional form (warns + still works when silenced)
- All `desc`-exercising specs pass under the default gemfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)