### PR TITLE
Reuse one AttributesIterator per validator; drop Enumerable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [#2716](https://github.com/ruby-grape/grape/pull/2716): Refactor `DSL::Routing#version`: guard clause, explicit kwargs in place of `**options`, and a `Grape::DSL::VersionOptions` value object stored internally - [@ericproulx](https://github.com/ericproulx).
 * [#2720](https://github.com/ruby-grape/grape/pull/2720): Move declaration-coherence checks into `Grape::Validations::ValidationsSpec` - [@ericproulx](https://github.com/ericproulx).
 * [#2725](https://github.com/ruby-grape/grape/pull/2725): Encapsulate `Grape::Validations::Validators::Base` state behind readers; add `required?`/`allow_blank?` predicates - [@ericproulx](https://github.com/ericproulx).
+* [#2726](https://github.com/ruby-grape/grape/pull/2726): Reuse one `AttributesIterator` per validator and drop the unused `Enumerable` mixin - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/validations/attributes_iterator.rb
+++ b/lib/grape/validations/attributes_iterator.rb
@@ -3,37 +3,37 @@
 module Grape
   module Validations
     class AttributesIterator
-      include Enumerable
-
-      attr_reader :scope
-
-      def initialize(attrs, scope, params)
+      # +attrs+ and +scope+ are static per validator; only +params+ varies
+      # per request, so an instance can be built once and reused (it keeps
+      # no request-derived state). Reused instances are shared across
+      # threads, so +each+ must stay free of mutable instance state.
+      def initialize(attrs, scope)
         @attrs = attrs
         @scope = scope
-        @original_params = scope.params(params)
-        @params = Array.wrap(@original_params)
       end
 
-      def each(&)
-        do_each(@params, &) # because we need recursion for nested arrays
+      def each(params, &)
+        original_params = @scope.params(params)
+        # because we need recursion for nested arrays
+        do_each(Array.wrap(original_params), original_params, &)
       end
 
       private
 
-      def do_each(params_to_process, parent_indices = [], &block)
+      def do_each(params_to_process, original_params, parent_indices = [], &block)
         params_to_process.each_with_index do |resource_params, index|
           # when we get arrays of arrays it means that target element located inside array
           # we need this because we want to know parent arrays indices
           if resource_params.is_a?(Array)
-            do_each(resource_params, [index] + parent_indices, &block)
+            do_each(resource_params, original_params, [index] + parent_indices, &block)
             next
           end
 
           if @scope.type == Array
-            next unless @original_params.is_a?(Array) # do not validate content of array if it isn't array
+            next unless original_params.is_a?(Array) # do not validate content of array if it isn't array
 
             store_indices(@scope, index, parent_indices)
-          elsif @original_params.is_a?(Array)
+          elsif original_params.is_a?(Array)
             # Lateral scope (no @element) whose params resolved to an array —
             # delegate index tracking to the nearest array-typed ancestor so
             # that full_name produces the correct bracketed index.

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -72,6 +72,7 @@ module Grape
           @scope = scope
           @opts = SharedOptions.new(**opts.slice(:allow_blank, :fail_fast))
           @exception_message = message(self.class.default_message_key) if self.class.default_message_key
+          @iterator = iterator_class.new(@attrs, @scope).freeze
         end
 
         # Validates a given request.
@@ -92,12 +93,11 @@ module Grape
         # @raise [Grape::Exceptions::Validation] if validation failed
         # @return [void]
         def validate!(params)
-          attributes = SingleAttributeIterator.new(attrs, scope, params)
           # we collect errors inside array because
           # there may be more than one error per field
           array_errors = nil
 
-          attributes.each do |val, attr_name, empty_val|
+          @iterator.each(params) do |val, attr_name, empty_val|
             next if !scope.required? && empty_val
             next unless scope.meets_dependency?(val, params)
 
@@ -125,6 +125,12 @@ module Grape
         attr_reader :options, :scope, :required, :exception_message
 
         alias required? required
+
+        # The AttributesIterator subclass used to walk this validator's
+        # attributes. Built once in #initialize and reused across requests.
+        def iterator_class
+          SingleAttributeIterator
+        end
 
         def validation_error!(attr_name_or_params, message = exception_message)
           params = attr_name_or_params.is_a?(Array) ? attr_name_or_params : scope.full_name(attr_name_or_params)

--- a/lib/grape/validations/validators/default_validator.rb
+++ b/lib/grape/validations/validators/default_validator.rb
@@ -18,8 +18,7 @@ module Grape
         end
 
         def validate!(params)
-          attributes = SingleAttributeIterator.new(attrs, scope, params)
-          attributes.each do |resource_params, attr_name|
+          @iterator.each(params) do |resource_params, attr_name|
             next unless scope.meets_dependency?(resource_params, params)
 
             resource_params[attr_name] = @default_call.call(resource_params) if hash_like?(resource_params) && resource_params[attr_name].nil?

--- a/lib/grape/validations/validators/multiple_params_base.rb
+++ b/lib/grape/validations/validators/multiple_params_base.rb
@@ -5,19 +5,22 @@ module Grape
     module Validators
       class MultipleParamsBase < Base
         def validate!(params)
-          attributes = MultipleAttributesIterator.new(attrs, scope, params)
-          array_errors = []
+          array_errors = nil
 
-          attributes.each do |resource_params|
+          @iterator.each(params) do |resource_params|
             validate_params!(resource_params)
           rescue Grape::Exceptions::Validation => e
-            array_errors << e
+            (array_errors ||= []) << e
           end
 
-          raise Grape::Exceptions::ValidationArrayErrors.new(array_errors) if array_errors.any?
+          raise Grape::Exceptions::ValidationArrayErrors.new(array_errors) if array_errors
         end
 
         private
+
+        def iterator_class
+          MultipleAttributesIterator
+        end
 
         def keys_in_common(resource_params, known_keys = all_keys)
           return [] unless hash_like?(resource_params)

--- a/spec/grape/validations/multiple_attributes_iterator_spec.rb
+++ b/spec/grape/validations/multiple_attributes_iterator_spec.rb
@@ -2,7 +2,7 @@
 
 describe Grape::Validations::MultipleAttributesIterator do
   describe '#each' do
-    subject(:iterator) { described_class.new(validator, scope, params) }
+    subject(:iterator) { described_class.new(validator, scope) }
 
     let(:scope) { Grape::Validations::ParamsScope.new(api: Class.new(Grape::API)) }
     let(:validator) { double(attrs: %i[first second third]) }
@@ -13,7 +13,7 @@ describe Grape::Validations::MultipleAttributesIterator do
       end
 
       it 'yields the whole params hash without the list of attrs' do
-        expect { |b| iterator.each(&b) }.to yield_with_args(params)
+        expect { |b| iterator.each(params, &b) }.to yield_with_args(params)
       end
     end
 
@@ -23,7 +23,7 @@ describe Grape::Validations::MultipleAttributesIterator do
       end
 
       it 'yields each element of the array without the list of attrs' do
-        expect { |b| iterator.each(&b) }.to yield_successive_args(params[0], params[1])
+        expect { |b| iterator.each(params, &b) }.to yield_successive_args(params[0], params[1])
       end
     end
 
@@ -31,7 +31,7 @@ describe Grape::Validations::MultipleAttributesIterator do
       let(:params) { [Grape::DSL::Parameters::EmptyOptionalValue] }
 
       it 'does not yield it' do
-        expect { |b| iterator.each(&b) }.to yield_successive_args
+        expect { |b| iterator.each(params, &b) }.to yield_successive_args
       end
     end
   end

--- a/spec/grape/validations/single_attribute_iterator_spec.rb
+++ b/spec/grape/validations/single_attribute_iterator_spec.rb
@@ -2,7 +2,7 @@
 
 describe Grape::Validations::SingleAttributeIterator do
   describe '#each' do
-    subject(:iterator) { described_class.new(%i[first second], scope, params) }
+    subject(:iterator) { described_class.new(%i[first second], scope) }
 
     let(:scope) { Grape::Validations::ParamsScope.new(api: Class.new(Grape::API)) }
 
@@ -12,7 +12,7 @@ describe Grape::Validations::SingleAttributeIterator do
       end
 
       it 'yields params and every single attribute from the list' do
-        expect { |b| iterator.each(&b) }
+        expect { |b| iterator.each(params, &b) }
           .to yield_successive_args([params, :first, false], [params, :second, false])
       end
     end
@@ -23,7 +23,7 @@ describe Grape::Validations::SingleAttributeIterator do
       end
 
       it 'yields every single attribute from the list for each of the array elements' do
-        expect { |b| iterator.each(&b) }.to yield_successive_args(
+        expect { |b| iterator.each(params, &b) }.to yield_successive_args(
           [params[0], :first, false], [params[0], :second, false],
           [params[1], :first, false], [params[1], :second, false]
         )
@@ -33,7 +33,7 @@ describe Grape::Validations::SingleAttributeIterator do
         let(:params) { [{}, '', 10] }
 
         it 'marks params with empty values' do
-          expect { |b| iterator.each(&b) }.to yield_successive_args(
+          expect { |b| iterator.each(params, &b) }.to yield_successive_args(
             [params[0], :first, true], [params[0], :second, true],
             [params[1], :first, true], [params[1], :second, true],
             [params[2], :first, false], [params[2], :second, false]
@@ -45,7 +45,7 @@ describe Grape::Validations::SingleAttributeIterator do
         let(:params) { [Grape::DSL::Parameters::EmptyOptionalValue, 10] }
 
         it 'does not yield skipped values' do
-          expect { |b| iterator.each(&b) }.to yield_successive_args(
+          expect { |b| iterator.each(params, &b) }.to yield_successive_args(
             [params[1], :first, false], [params[1], :second, false]
           )
         end


### PR DESCRIPTION
#### Summary

`AttributesIterator`'s `attrs`/`scope` are **static per validator**; only `params` varies per request. Yet a fresh iterator was allocated *per validator per request* in `validate!`, with the request-derived state (`@original_params`/`@params`) computed in the constructor.

This builds the iterator **once** in `Base#initialize` (frozen) and threads `params` through `#each`, so the instance carries no per-request state and can be reused. It also drops the unused `Enumerable` mixin.

#### What changed

- **`AttributesIterator`**
  - Removed `include Enumerable` — dead and misleading: `#each` never returned an `Enumerator` (no `enum_for` fallback) and nothing in the codebase used `map`/`select`/`to_a`/etc. Only `#each` is ever called.
  - Removed `attr_reader :scope` — zero callers in lib/ or spec/.
  - Constructor is now `(attrs, scope)`. `params` flows through `each(params)` → `do_each(..., original_params, ...)` as an argument instead of the `@original_params`/`@params` ivars.
- **`Base`** — overridable private `iterator_class` (default `SingleAttributeIterator`); `@iterator = iterator_class.new(@attrs, @scope).freeze` built in `#initialize`; `#validate!` uses `@iterator.each(params)`.
- **`MultipleParamsBase`** — overrides `iterator_class` → `MultipleAttributesIterator`; `#validate!` now builds `array_errors` lazily (`nil` → `||= []`) like `Base`, avoiding an empty-array allocation on the no-error path.
- **`DefaultValidator`** — uses the shared `@iterator`.
- Iterator specs updated to `new(attrs, scope)` + `each(params, &b)`.

The reused instance holds only the static, frozen `@attrs`/`@scope` and writes no ivars during traversal — safe under Grape's frozen, thread-shared validators.

#### Benchmark

Real pre-change implementation (from `master`, identical `do_each` machinery) vs. the new one, one validator traversal:

| | i/s | memory | objects |
|---|---|---|---|
| before: new per request | 1.22M | 280 B | 6 |
| after: reuse instance | 1.31M | **200 B** | **5** |

**Speed is neutral** (ips delta within noise — `scope.params`/`Array.wrap` still run per request, just in `each` instead of the ctor). The reliable win is **one fewer object (~80 B) per validator per request** — a GC-pressure reduction that scales with `#validators × throughput`, in the spirit of #2689/#2690. This is an allocation/clarity refactor, not a throughput optimization.

#### Testing

- `spec/grape/validations` + `spec/grape/endpoint_spec.rb` + `spec/grape/api_spec.rb`: **0 failures**
- RuboCop: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)