### PR TITLE
fix: remove redundant code patterns

### DIFF
--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -141,7 +141,7 @@ module Grape
         opts = @group.deep_merge(opts) if @group
 
         # check type for optional parameter group
-        if attrs && block
+        if block
           raise Grape::Exceptions::MissingGroupType if type.nil?
           raise Grape::Exceptions::UnsupportedGroupType unless Grape::Validations::Types.group?(type)
         end

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -135,7 +135,7 @@ module Grape
     end
 
     def default_response
-      [404, DEFAULT_RESPONSE_HEADERS.dup, DEFAULT_RESPONSE_BODY.dup]
+      [404, DEFAULT_RESPONSE_HEADERS.dup, DEFAULT_RESPONSE_BODY]
     end
 
     def match?(input, method)


### PR DESCRIPTION
## Summary
Remove redundant code patterns in Ruby code.

## Changes
- lib/grape/router.rb: Remove redundant .dup call
- lib/grape/dsl/parameters.rb: Remove redundant attrs check

## Motivation
Clean up unnecessary operations for better performance.
