### PR TITLE
Drop dead reverse_merge require; call HWIA constructor directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [#2725](https://github.com/ruby-grape/grape/pull/2725): Encapsulate `Grape::Validations::Validators::Base` state behind readers; add `required?`/`allow_blank?` predicates - [@ericproulx](https://github.com/ericproulx).
 * [#2726](https://github.com/ruby-grape/grape/pull/2726): Reuse one `AttributesIterator` per validator and drop the unused `Enumerable` mixin - [@ericproulx](https://github.com/ericproulx).
 * [#2728](https://github.com/ruby-grape/grape/pull/2728): Deprecate passing a positional options Hash to `auth`/`http_basic`/`http_digest`; pass keyword arguments instead - [@ericproulx](https://github.com/ericproulx).
+* [#2733](https://github.com/ruby-grape/grape/pull/2733): Drop the dead `active_support/core_ext/hash/reverse_merge` require; call `ActiveSupport::HashWithIndifferentAccess.new(...)` directly at call sites - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -10,7 +10,7 @@ require 'active_support/core_ext/hash/conversions' # to_xml
 require 'active_support/core_ext/hash/deep_merge'
 require 'active_support/core_ext/hash/deep_transform_values'
 require 'active_support/core_ext/hash/indifferent_access'
-require 'active_support/core_ext/hash/reverse_merge'
+require 'active_support/hash_with_indifferent_access'
 require 'active_support/core_ext/module/delegation' # delegate_missing_to
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/object/deep_dup'

--- a/lib/grape/cookies.rb
+++ b/lib/grape/cookies.rb
@@ -40,7 +40,7 @@ module Grape
     def cookies
       return @cookies unless @cookies.is_a?(Proc)
 
-      @cookies = @cookies.call.with_indifferent_access
+      @cookies = ActiveSupport::HashWithIndifferentAccess.new(@cookies.call)
     end
 
     def send_cookies

--- a/lib/grape/middleware/auth/dsl.rb
+++ b/lib/grape/middleware/auth/dsl.rb
@@ -9,7 +9,7 @@ module Grape
           return namespace_inheritable[:auth] unless type
 
           options = merge_legacy_auth_options(:auth, legacy_options, options)
-          namespace_inheritable[:auth] = options.reverse_merge(type: type.to_sym, proc: block)
+          namespace_inheritable[:auth] = { type: type.to_sym, proc: block }.merge!(options)
           use Grape::Middleware::Auth::Base, namespace_inheritable[:auth]
         end
 

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -195,7 +195,7 @@ module Grape
 
       def error!(message, status = default_status, headers = {}, backtrace = [], original_exception = nil)
         env[Grape::Env::API_ENDPOINT].status(status) # not error! inside route
-        merged_headers = headers.reverse_merge(Rack::CONTENT_TYPE => content_type)
+        merged_headers = { Rack::CONTENT_TYPE => content_type }.merge!(headers)
         error = Grape::Exceptions::ErrorResponse.new(
           status:, message:, headers: merged_headers, backtrace:, original_exception:
         )

--- a/lib/grape/middleware/precomputed_content_types.rb
+++ b/lib/grape/middleware/precomputed_content_types.rb
@@ -38,7 +38,7 @@ module Grape
       private
 
       def content_types_indifferent_access
-        @content_types_indifferent_access ||= content_types.with_indifferent_access
+        @content_types_indifferent_access ||= ActiveSupport::HashWithIndifferentAccess.new(content_types)
       end
     end
   end

--- a/lib/grape/params_builder/hash_with_indifferent_access.rb
+++ b/lib/grape/params_builder/hash_with_indifferent_access.rb
@@ -4,7 +4,7 @@ module Grape
   module ParamsBuilder
     class HashWithIndifferentAccess < Base
       def self.call(params)
-        params.with_indifferent_access
+        ActiveSupport::HashWithIndifferentAccess.new(params)
       end
     end
   end

--- a/lib/grape/util/registry.rb
+++ b/lib/grape/util/registry.rb
@@ -20,7 +20,7 @@ module Grape
       end
 
       def registry
-        @registry ||= {}.with_indifferent_access
+        @registry ||= ActiveSupport::HashWithIndifferentAccess.new
       end
     end
   end


### PR DESCRIPTION
## Summary

- Removes the now-dead `active_support/core_ext/hash/reverse_merge` require (no remaining call sites in `lib/`); the two `reverse_merge` usages become explicit `{ defaults }.merge!(other)` literals.
- Swaps `.with_indifferent_access` call sites for `ActiveSupport::HashWithIndifferentAccess.new(...)` and adds an explicit `require 'active_support/hash_with_indifferent_access'`, so the class dependency is documented at the top of `lib/grape.rb` rather than implicit via the core_ext. The `core_ext/hash/indifferent_access` require is intentionally kept — `HWIA#convert_value` invokes `Hash#nested_under_indifferent_access` internally when wrapping nested hash values.

No behavior change; same semantics in all touched paths.

## Test plan

- [x] `bundle exec rspec spec/grape/params_builder spec/grape/middleware spec/grape/util/registry_spec.rb spec/grape/endpoint_spec.rb spec/grape/request_spec.rb` (488 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)