### PR TITLE
Extract options_route_enabled from Endpoint options Hash into a dedicated accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [#2726](https://github.com/ruby-grape/grape/pull/2726): Reuse one `AttributesIterator` per validator and drop the unused `Enumerable` mixin - [@ericproulx](https://github.com/ericproulx).
 * [#2728](https://github.com/ruby-grape/grape/pull/2728): Deprecate passing a positional options Hash to `auth`/`http_basic`/`http_digest`; pass keyword arguments instead - [@ericproulx](https://github.com/ericproulx).
 * [#2733](https://github.com/ruby-grape/grape/pull/2733): Drop the dead `active_support/core_ext/hash/reverse_merge` require; call `ActiveSupport::HashWithIndifferentAccess.new(...)` directly at call sites - [@ericproulx](https://github.com/ericproulx).
+* [#2734](https://github.com/ruby-grape/grape/pull/2734): Extract `options_route_enabled` from the Endpoint options Hash into a dedicated `attr_accessor` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/api/instance.rb
+++ b/lib/grape/api/instance.rb
@@ -168,7 +168,7 @@ module Grape
           allowed_methods |= [Rack::HEAD] if !namespace_inheritable[:do_not_route_head] && allowed_methods.include?(Rack::GET)
 
           allow_header = namespace_inheritable[:do_not_route_options] ? allowed_methods : [Rack::OPTIONS] | allowed_methods
-          last_route.app.options[:options_route_enabled] = true unless namespace_inheritable[:do_not_route_options] || allowed_methods.include?(Rack::OPTIONS)
+          last_route.app.options_route_enabled = true unless namespace_inheritable[:do_not_route_options] || allowed_methods.include?(Rack::OPTIONS)
 
           greedy_route = Grape::Router::GreedyRoute.new(last_route.pattern, endpoint: last_route.app, allow_header:)
           @router.associate_routes(greedy_route)

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -12,6 +12,7 @@ module Grape
     include Grape::DSL::InsideRoute
 
     attr_reader :env, :request, :source, :options, :endpoints
+    attr_accessor :options_route_enabled
 
     def_delegators :request, :params, :headers, :cookies
     def_delegator :cookies, :response_cookies
@@ -69,6 +70,7 @@ module Grape
       @body = nil
       @source = self.class.block_to_unbound_method(block)
       @before_filter_passed = false
+      @options_route_enabled = false
       @endpoints = @options[:app].endpoints if @options[:app].respond_to?(:endpoints)
     end
 
@@ -224,8 +226,7 @@ module Grape
     attr_reader :befores, :before_validations, :after_validations, :afters, :finallies
 
     def options?
-      options[:options_route_enabled] &&
-        env[Rack::REQUEST_METHOD] == Rack::OPTIONS
+      options_route_enabled && env[Rack::REQUEST_METHOD] == Rack::OPTIONS
     end
 
     private


### PR DESCRIPTION
## Summary

- `options_route_enabled` is not a constructor input — `Grape::API::Instance#configure_options_routes` sets it later via `last_route.app.options[:options_route_enabled] = true`. Threading it through the `**options` Hash was the only reason `Endpoint#options` had to remain externally mutable.
- Adds `attr_accessor :options_route_enabled` on `Grape::Endpoint` (initialized to `false`); rewrites `options?` to read the ivar; rewrites the writer in `Grape::API::Instance` to use the setter.
- First step in a planned cleanup of the Endpoint constructor surface (the rest of `**options` can move to explicit kwargs / a frozen value object in follow-ups once this mutable outlier is out of the way).

## Test plan

- [x] `bundle exec rspec` — 2313 examples, 0 failures
- [x] `bundle exec rubocop lib/grape/endpoint.rb lib/grape/api/instance.rb` — no offenses
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)