### PR TITLE
Lazy-allocate validation_exceptions and unify rescue branches via ValidationErrors flatten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [#2726](https://github.com/ruby-grape/grape/pull/2726): Reuse one `AttributesIterator` per validator and drop the unused `Enumerable` mixin - [@ericproulx](https://github.com/ericproulx).
 * [#2728](https://github.com/ruby-grape/grape/pull/2728): Deprecate passing a positional options Hash to `auth`/`http_basic`/`http_digest`; pass keyword arguments instead - [@ericproulx](https://github.com/ericproulx).
 * [#2733](https://github.com/ruby-grape/grape/pull/2733): Drop the dead `active_support/core_ext/hash/reverse_merge` require; call `ActiveSupport::HashWithIndifferentAccess.new(...)` directly at call sites - [@ericproulx](https://github.com/ericproulx).
+* [#2736](https://github.com/ruby-grape/grape/pull/2736): Collapse `Endpoint#run_validators` rescue branches via `ValidationErrors` flatten; `ValidationErrors#initialize` keyword renamed `errors:` → `exceptions:` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,18 @@ Upgrading Grape
 
 ### Upgrading to >= 3.3
 
+#### `Grape::Exceptions::ValidationErrors.new` keyword renamed `errors:` → `exceptions:`
+
+`Grape::Exceptions::ValidationErrors#initialize` now takes its input array under the `exceptions:` keyword instead of `errors:`. The kwarg accepts a mix of `Grape::Exceptions::Validation` and `Grape::Exceptions::ValidationArrayErrors` instances; `ValidationArrayErrors` wrappers are flattened internally via `flat_map(&:errors)`. The `errors` reader on the constructed instance (the grouped `{params => [Validation, ...]}` Hash) is unchanged.
+
+```ruby
+# before
+Grape::Exceptions::ValidationErrors.new(errors: [validation, validation_array_errors], headers:)
+
+# after
+Grape::Exceptions::ValidationErrors.new(exceptions: [validation, validation_array_errors], headers:)
+```
+
 #### `auth`, `http_basic` and `http_digest` now take keyword arguments
 
 `Grape::Middleware::Auth::DSL#auth`, `#http_basic` and `#http_digest` now accept their options as keyword arguments instead of a positional `Hash`. Calls using bare keyword syntax or a block are unaffected:

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -192,25 +192,22 @@ module Grape
 
     def run_validators(request:)
       validators = inheritable_setting.route[:saved_validations]
-      return if validators.empty?
+      return if validators.blank?
 
-      validation_errors = []
+      validation_exceptions = nil
 
       Grape::Validations::ParamScopeTracker.track do
         ActiveSupport::Notifications.instrument('endpoint_run_validators.grape', endpoint: self, validators:, request:) do
           validators.each do |validator|
             validator.validate(request)
-          rescue Grape::Exceptions::Validation => e
-            validation_errors << e
-            break if validator.fail_fast?
-          rescue Grape::Exceptions::ValidationArrayErrors => e
-            validation_errors.concat e.errors
+          rescue Grape::Exceptions::Validation, Grape::Exceptions::ValidationArrayErrors => e
+            (validation_exceptions ||= []) << e
             break if validator.fail_fast?
           end
         end
       end
 
-      raise(Grape::Exceptions::ValidationErrors.new(errors: validation_errors, headers: header)) if validation_errors.any?
+      raise Grape::Exceptions::ValidationErrors.new(exceptions: validation_exceptions, headers: header) if validation_exceptions
     end
 
     def run_filters(filters, type = :other)

--- a/lib/grape/exceptions/validation.rb
+++ b/lib/grape/exceptions/validation.rb
@@ -29,6 +29,14 @@ module Grape
       def as_json(*_args)
         to_s
       end
+
+      # Returns +self+ so callers (e.g. +ValidationErrors#initialize+) can treat
+      # a single +Validation+ and a +ValidationArrayErrors+ wrapper uniformly via
+      # +flat_map(&:errors)+ — Array returns flatten in, non-Array returns
+      # (i.e. this +self+) append as one element.
+      def errors
+        self
+      end
     end
   end
 end

--- a/lib/grape/exceptions/validation_errors.rb
+++ b/lib/grape/exceptions/validation_errors.rb
@@ -7,8 +7,8 @@ module Grape
 
       attr_reader :errors
 
-      def initialize(errors: [], headers: {})
-        @errors = errors.group_by(&:params)
+      def initialize(exceptions: [], headers: {})
+        @errors = exceptions.flat_map(&:errors).group_by(&:params)
         super(message: full_messages.join(', '), status: 400, headers:)
       end
 

--- a/spec/grape/exceptions/validation_errors_spec.rb
+++ b/spec/grape/exceptions/validation_errors_spec.rb
@@ -2,11 +2,15 @@
 
 describe Grape::Exceptions::ValidationErrors do
   let(:validation_message) { 'FooBar is invalid' }
-  let(:validation_error) { instance_double Grape::Exceptions::Validation, params: [validation_message], message: '' }
+  let(:validation_error) do
+    instance_double(Grape::Exceptions::Validation, params: [validation_message], message: '').tap do |dbl|
+      allow(dbl).to receive(:errors).and_return(dbl)
+    end
+  end
 
   context 'initialize' do
     subject do
-      described_class.new(errors: [validation_error], headers:)
+      described_class.new(exceptions: [validation_error], headers:)
     end
 
     let(:headers) do
@@ -25,7 +29,7 @@ describe Grape::Exceptions::ValidationErrors do
       subject(:message) { error.message.split(',').map(&:strip) }
 
       let(:error) do
-        described_class.new(errors: [validation_error, validation_error])
+        described_class.new(exceptions: [validation_error, validation_error])
       end
 
       it { expect(message).to include validation_message }
@@ -35,7 +39,7 @@ describe Grape::Exceptions::ValidationErrors do
 
   describe '#full_messages' do
     context 'with errors' do
-      subject { described_class.new(errors: [validation_error_1, validation_error_2]).full_messages }
+      subject { described_class.new(exceptions: [validation_error_1, validation_error_2]).full_messages }
 
       let(:validation_error_1) { Grape::Exceptions::Validation.new(params: ['id'], message: :presence) }
       let(:validation_error_2) { Grape::Exceptions::Validation.new(params: ['name'], message: :presence) }
@@ -46,7 +50,7 @@ describe Grape::Exceptions::ValidationErrors do
     end
 
     context 'when attributes is an array of symbols' do
-      subject { described_class.new(errors: [validation_error]).full_messages }
+      subject { described_class.new(exceptions: [validation_error]).full_messages }
 
       let(:validation_error) { Grape::Exceptions::Validation.new(params: [:admin_field], message: 'Can not set admin-only field') }
 


### PR DESCRIPTION
## Summary

- `Grape::Endpoint#run_validators` lazy-allocates the exceptions array (starts at `nil`, `(validation_exceptions ||= []) << e`) so the happy path skips the empty-Array allocation. Local renamed from `validation_errors` → `validation_exceptions` since it holds raw exception objects.
- The two rescue branches collapse into one: `rescue Grape::Exceptions::Validation, Grape::Exceptions::ValidationArrayErrors => e`. The unwrapping of `ValidationArrayErrors → [Validation, ...]` moves into `ValidationErrors#initialize` via `flat_map(&:errors)`, which is the right home — the aggregator knows how to digest the raised shapes.
- `Grape::Exceptions::Validation#errors` returns `self` so `flat_map(&:errors)` works uniformly: Validation appends as one element (non-Array return), ValidationArrayErrors's Array flattens in.

## Contract change

`Grape::Exceptions::ValidationErrors#initialize` keyword renamed `errors:` → `exceptions:` (the input is a list of exception objects, not the grouped `{params => [Validation, ...]}` Hash exposed by `#errors`). UPGRADING entry added.

## Test plan

- [x] `bundle exec rspec` — 2313 examples, 0 failures
- [x] `bundle exec rubocop` — clean on touched files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)