### PR TITLE
Make rescue_from reject meta selectors mixed with exception classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [#2733](https://github.com/ruby-grape/grape/pull/2733): Drop the dead `active_support/core_ext/hash/reverse_merge` require; call `ActiveSupport::HashWithIndifferentAccess.new(...)` directly at call sites - [@ericproulx](https://github.com/ericproulx).
 * [#2734](https://github.com/ruby-grape/grape/pull/2734): Extract `options_route_enabled` from the Endpoint options Hash into a dedicated `attr_accessor` - [@ericproulx](https://github.com/ericproulx).
 * [#2736](https://github.com/ruby-grape/grape/pull/2736): Collapse `Endpoint#run_validators` rescue branches via `ValidationErrors` flatten; `ValidationErrors#initialize` keyword renamed `errors:` → `exceptions:` - [@ericproulx](https://github.com/ericproulx).
+* [#2737](https://github.com/ruby-grape/grape/pull/2737): `rescue_from` raises `ArgumentError` when a meta selector (`:all`, `:grape_exceptions`, `:internal_grape_exceptions`) is mixed with exception classes instead of silently dropping the classes - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -15,6 +15,22 @@ Grape::Exceptions::ValidationErrors.new(errors: [validation, validation_array_er
 Grape::Exceptions::ValidationErrors.new(exceptions: [validation, validation_array_errors], headers:)
 ```
 
+#### `rescue_from` rejects meta selectors mixed with exception classes
+
+`rescue_from` used to silently drop additional exception classes when its first argument was a meta selector (`:all`, `:grape_exceptions`, `:internal_grape_exceptions`). It now raises `ArgumentError` so the misuse is caught at definition time:
+
+```ruby
+# previously: MyError was silently dropped — only :all took effect
+rescue_from :all, MyError, with: :handler
+
+# now: ArgumentError ("rescue_from :all does not accept additional arguments")
+# split into two declarations instead:
+rescue_from :all, with: :handler
+rescue_from MyError, with: :other_handler
+```
+
+Calls that only use one meta selector or only use exception classes (the documented forms) are unaffected.
+
 #### `auth`, `http_basic` and `http_digest` now take keyword arguments
 
 `Grape::Middleware::Auth::DSL#auth`, `#http_basic` and `#http_digest` now accept their options as keyword arguments instead of a positional `Hash`. Calls using bare keyword syntax or a block are unaffected:

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -79,9 +79,14 @@ module Grape
       #       rescue_from CustomError
       #     end
       #
+      META_RESCUE_SELECTORS = %i[all grape_exceptions internal_grape_exceptions].freeze
+      private_constant :META_RESCUE_SELECTORS
+
       # @overload rescue_from(*exception_classes, **options)
       #   @param [Array] exception_classes A list of classes that you want to rescue, or
-      #     the symbol :all to rescue from all exceptions.
+      #     one of the meta selectors +:all+, +:grape_exceptions+,
+      #     +:internal_grape_exceptions+. Meta selectors must be used alone;
+      #     mixing with exception classes raises +ArgumentError+.
       #   @param [Block] block Execution block to handle the given exception.
       #   @param [Proc] with Execution proc to handle the given exception as an alternative
       #     to passing a block.
@@ -93,19 +98,30 @@ module Grape
       #     in the rescue response body.
       def rescue_from(*args, with: nil, rescue_subclasses: true, backtrace: false, original_exception: false, &block)
         handler = extract_handler(args, with:, block:)
+        meta_selector = (args & META_RESCUE_SELECTORS).first
+        raise ArgumentError, "rescue_from #{meta_selector.inspect} does not accept additional arguments" if meta_selector && args.size > 1
 
-        if args.include?(:all)
-          inheritable_setting.namespace_inheritable[:rescue_all] = true
-          inheritable_setting.namespace_inheritable[:all_rescue_handler] = handler
-        elsif args.include?(:grape_exceptions)
-          inheritable_setting.namespace_inheritable[:rescue_all] = true
-          inheritable_setting.namespace_inheritable[:rescue_grape_exceptions] = true
-          inheritable_setting.namespace_inheritable[:grape_exceptions_rescue_handler] = handler
-        elsif args.include?(:internal_grape_exceptions)
-          inheritable_setting.namespace_inheritable[:internal_grape_exceptions_rescue_handler] = handler
+        namespace_inheritable = nil
+        arg = nil
+
+        if args.one?
+          arg = args.first
+          namespace_inheritable = inheritable_setting.namespace_inheritable
+        end
+
+        case arg
+        when :all
+          namespace_inheritable[:rescue_all] = true
+          namespace_inheritable[:all_rescue_handler] = handler
+        when :grape_exceptions
+          namespace_inheritable[:rescue_all] = true
+          namespace_inheritable[:rescue_grape_exceptions] = true
+          namespace_inheritable[:grape_exceptions_rescue_handler] = handler
+        when :internal_grape_exceptions
+          namespace_inheritable[:internal_grape_exceptions_rescue_handler] = handler
         else
           handler_type = rescue_subclasses ? :rescue_handlers : :base_only_rescue_handlers
-          inheritable_setting.namespace_reverse_stackable[handler_type] = args.to_h { |arg| [arg, handler] }
+          inheritable_setting.namespace_reverse_stackable[handler_type] = args.to_h { |klass| [klass, handler] }
         end
 
         inheritable_setting.namespace_stackable[:rescue_options] = RescueOptions.new(backtrace:, original_exception:)

--- a/spec/grape/dsl/request_response_spec.rb
+++ b/spec/grape/dsl/request_response_spec.rb
@@ -198,6 +198,23 @@ describe Grape::DSL::RequestResponse do
       end
     end
 
+    describe 'meta selector mixed with exception classes' do
+      it 'raises ArgumentError for :all + exception class' do
+        expect { subject.rescue_from :all, StandardError }
+          .to raise_error(ArgumentError, 'rescue_from :all does not accept additional arguments')
+      end
+
+      it 'raises ArgumentError for :grape_exceptions + exception class' do
+        expect { subject.rescue_from :grape_exceptions, StandardError }
+          .to raise_error(ArgumentError, 'rescue_from :grape_exceptions does not accept additional arguments')
+      end
+
+      it 'raises ArgumentError for :internal_grape_exceptions + exception class' do
+        expect { subject.rescue_from :internal_grape_exceptions, StandardError }
+          .to raise_error(ArgumentError, 'rescue_from :internal_grape_exceptions does not accept additional arguments')
+      end
+    end
+
     describe 'list of exceptions is passed' do
       let(:default_rescue_options) { [Grape::DSL::RescueOptions.new] }
 


### PR DESCRIPTION
## Summary

- `rescue_from` previously accepted `*args` and short-circuited on `if args.include?(:all)` (and the same for `:grape_exceptions` / `:internal_grape_exceptions`), silently dropping any exception classes passed alongside the meta selector. `rescue_from :all, MyError, with: :h` would only register the `:all` handler — `MyError` never bound.
- Keep the existing `*args` signature, add a single guard above the dispatch: if any meta selector is present and `args.size > 1`, raise `ArgumentError`.
- Valid forms unchanged: `rescue_from :all`, `rescue_from :all, with: :h`, `rescue_from :all, &block`, `rescue_from MyError, OtherError, with: :h`, etc.

## Contract change

Mixing a meta selector with exception classes now raises `ArgumentError` instead of silently ignoring the classes. UPGRADING entry added.

## Test plan

- [x] `bundle exec rspec` — 2316 examples, 0 failures (3 new ArgumentError specs)
- [x] `bundle exec rubocop` — clean on touched files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)