### PR TITLE
Skip redundant GRAPE_ROUTING_ARGS rewrite when route has no params to merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [#2726](https://github.com/ruby-grape/grape/pull/2726): Reuse one `AttributesIterator` per validator and drop the unused `Enumerable` mixin - [@ericproulx](https://github.com/ericproulx).
 * [#2728](https://github.com/ruby-grape/grape/pull/2728): Deprecate passing a positional options Hash to `auth`/`http_basic`/`http_digest`; pass keyword arguments instead - [@ericproulx](https://github.com/ericproulx).
 * [#2733](https://github.com/ruby-grape/grape/pull/2733): Drop the dead `active_support/core_ext/hash/reverse_merge` require; call `ActiveSupport::HashWithIndifferentAccess.new(...)` directly at call sites - [@ericproulx](https://github.com/ericproulx).
+* [#2738](https://github.com/ruby-grape/grape/pull/2738): Skip the redundant `env[Grape::Env::GRAPE_ROUTING_ARGS]` rewrite in `Router#process_route` when the matched route has no URL params to merge - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -122,9 +122,13 @@ module Grape
     end
 
     def process_route(route, input, env, include_allow_header: false)
-      args = env[Grape::Env::GRAPE_ROUTING_ARGS] || { route_info: route }
       route_params = route.params(input)
-      env[Grape::Env::GRAPE_ROUTING_ARGS] = route_params.blank? ? args : args.merge(route_params)
+      if route_params.present?
+        args = env[Grape::Env::GRAPE_ROUTING_ARGS] || { route_info: route }
+        env[Grape::Env::GRAPE_ROUTING_ARGS] = args.merge(route_params)
+      else
+        env[Grape::Env::GRAPE_ROUTING_ARGS] ||= { route_info: route }
+      end
       env[Grape::Env::GRAPE_ALLOWED_METHODS] = route.allow_header if include_allow_header
       route.call(env)
     end


### PR DESCRIPTION
## Summary

- `Router#process_route` reads `env[GRAPE_ROUTING_ARGS]`, computes `route_params`, then writes the merged Hash back. When `env[GRAPE_ROUTING_ARGS]` was already set and `route_params` was blank, the ternary returned the existing Hash unchanged and we wrote the same value back to env — a no-op assignment on every cascade match through a route with no URL placeholders.
- Use `||=` for the default seed and only re-assign env when there are new params to actually merge.

## Test plan

- [x] `bundle exec rspec` — 2313 examples, 0 failures
- [x] `bundle exec rubocop lib/grape/router.rb` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)