### PR TITLE
Lazy-allocate @new_values in Grape::Util::BaseInheritable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [#2733](https://github.com/ruby-grape/grape/pull/2733): Drop the dead `active_support/core_ext/hash/reverse_merge` require; call `ActiveSupport::HashWithIndifferentAccess.new(...)` directly at call sites - [@ericproulx](https://github.com/ericproulx).
 * [#2734](https://github.com/ruby-grape/grape/pull/2734): Extract `options_route_enabled` from the Endpoint options Hash into a dedicated `attr_accessor` - [@ericproulx](https://github.com/ericproulx).
 * [#2736](https://github.com/ruby-grape/grape/pull/2736): Collapse `Endpoint#run_validators` rescue branches via `ValidationErrors` flatten; `ValidationErrors#initialize` keyword renamed `errors:` → `exceptions:` - [@ericproulx](https://github.com/ericproulx).
+* [#2739](https://github.com/ruby-grape/grape/pull/2739): Lazy-allocate `@new_values` in `Grape::Util::BaseInheritable` so settings layers that only inherit never carry an empty Hash; readers in `InheritableValues`/`StackableValues` handle nil - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/util/base_inheritable.rb
+++ b/lib/grape/util/base_inheritable.rb
@@ -4,6 +4,9 @@ module Grape
   module Util
     # Base for classes which need to operate with own values kept
     # in the hash and inherited values kept in a Hash-like object.
+    #
+    # +@new_values+ is lazily allocated on first write so settings layers
+    # that only inherit (never override) don't carry an empty Hash each.
     class BaseInheritable
       attr_accessor :inherited_values, :new_values
 
@@ -11,30 +14,29 @@ module Grape
       #   of the Hash class.
       def initialize(inherited_values = nil)
         @inherited_values = inherited_values || {}
-        @new_values = {}
+        # @new_values stays nil until the first write.
       end
 
       def delete(*keys)
-        keys.map do |key|
-          # since delete returns the deleted value, seems natural to `map` the result
-          new_values.delete key
-        end
+        return [] unless @new_values
+
+        keys.map { |key| @new_values.delete(key) }
       end
 
       def initialize_copy(other)
         super
-        self.inherited_values = other.inherited_values
-        self.new_values = other.new_values.dup
+        @inherited_values = other.inherited_values
+        @new_values = other.new_values&.dup
       end
 
       def keys
-        return inherited_values.keys if new_values.empty?
+        return @inherited_values.keys if @new_values.nil? || @new_values.empty?
 
-        (inherited_values.keys + new_values.keys).uniq
+        (@inherited_values.keys + @new_values.keys).uniq
       end
 
       def key?(name)
-        inherited_values.key?(name) || new_values.key?(name)
+        @inherited_values.key?(name) || @new_values&.key?(name) || false
       end
     end
   end

--- a/lib/grape/util/inheritable_values.rb
+++ b/lib/grape/util/inheritable_values.rb
@@ -4,11 +4,13 @@ module Grape
   module Util
     class InheritableValues < BaseInheritable
       def [](name)
+        return @inherited_values[name] unless @new_values
+
         @new_values.fetch(name) { @inherited_values[name] }
       end
 
       def []=(name, value)
-        new_values[name] = value
+        (@new_values ||= {})[name] = value
       end
 
       def merge(new_hash)
@@ -22,7 +24,9 @@ module Grape
       protected
 
       def values
-        @inherited_values.merge(@new_values)
+        return @inherited_values.merge(@new_values) if @new_values && !@new_values.empty?
+
+        @inherited_values.is_a?(Hash) ? @inherited_values.dup : @inherited_values.to_hash
       end
     end
   end

--- a/lib/grape/util/stackable_values.rb
+++ b/lib/grape/util/stackable_values.rb
@@ -7,8 +7,8 @@ module Grape
 
       # Even if there is no value, an empty (frozen) array will be returned.
       def [](name)
-        inherited_value = inherited_values[name]
-        new_value = new_values[name]
+        inherited_value = @inherited_values[name]
+        new_value = @new_values && @new_values[name]
 
         return new_value || EMPTY unless inherited_value
 
@@ -16,8 +16,9 @@ module Grape
       end
 
       def []=(name, value)
-        new_values[name] ||= []
-        new_values[name].push value
+        @new_values ||= {}
+        @new_values[name] ||= []
+        @new_values[name].push value
       end
 
       def to_hash


### PR DESCRIPTION
## Summary

- `BaseInheritable#initialize` used to eagerly allocate an empty `@new_values = {}` per instance. Most settings layers in a typical API only inherit from a parent and never write any *new* values of their own, so the empty Hash was just retained dead weight.
- Defer the allocation: `@new_values` starts `nil`, `[]=` writers do `(@new_values ||= {})[...] = ...`, and the readers in `InheritableValues#[]` / `StackableValues#[]` short-circuit on nil instead of touching an empty Hash.
- `initialize_copy` skips the `.dup` when the source has no own values.

## Benchmarks

Measured against master with `MemoryProfiler.report`:

| Scenario | Before | After | Delta |
|---|---|---|---|
| `Grape::Util::InheritableSetting.new × 100` | 1600 objects / 183.6 kB | 1200 objects / 121.1 kB | **−34%** |
| `parent.point_in_time_copy × 100` | 2500 objects / 277.3 kB | 1700 objects / 152.3 kB | **−45%** |

The bigger `point_in_time_copy` win matches the `base_inheritable.rb:27` (`new_values.dup`) hot spot in the boot-time memory profile — that line used to dup four empty Hashes per copy and now skips them entirely.

## Test plan

- [x] `bundle exec rspec` — 2313 examples, 0 failures
- [x] `bundle exec rubocop` — clean on touched files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)