### PR TITLE
Lazy-allocate @api_class and @point_in_time_copies on InheritableSetting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [#2733](https://github.com/ruby-grape/grape/pull/2733): Drop the dead `active_support/core_ext/hash/reverse_merge` require; call `ActiveSupport::HashWithIndifferentAccess.new(...)` directly at call sites - [@ericproulx](https://github.com/ericproulx).
 * [#2734](https://github.com/ruby-grape/grape/pull/2734): Extract `options_route_enabled` from the Endpoint options Hash into a dedicated `attr_accessor` - [@ericproulx](https://github.com/ericproulx).
 * [#2736](https://github.com/ruby-grape/grape/pull/2736): Collapse `Endpoint#run_validators` rescue branches via `ValidationErrors` flatten; `ValidationErrors#initialize` keyword renamed `errors:` → `exceptions:` - [@ericproulx](https://github.com/ericproulx).
+* [#2740](https://github.com/ruby-grape/grape/pull/2740): Lazy-allocate `@api_class` and `@point_in_time_copies` on `Grape::Util::InheritableSetting` so unused settings layers don't carry an empty Hash and empty Array each - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/util/inheritable_setting.rb
+++ b/lib/grape/util/inheritable_setting.rb
@@ -5,7 +5,17 @@ module Grape
     # A branchable, inheritable settings object which can store both stackable
     # and inheritable values (see InheritableValues and StackableValues).
     class InheritableSetting
-      attr_reader :route, :api_class, :namespace, :namespace_inheritable, :namespace_stackable, :namespace_reverse_stackable, :parent, :point_in_time_copies
+      attr_reader :route, :namespace, :namespace_inheritable, :namespace_stackable, :namespace_reverse_stackable, :parent
+
+      # Lazy-allocated; +api_class+ and +point_in_time_copies+ are rarely
+      # written on most settings layers, so don't pay for a Hash/Array each.
+      def api_class
+        @api_class ||= {}
+      end
+
+      def point_in_time_copies
+        @point_in_time_copies ||= []
+      end
 
       # Retrieve global settings.
       def self.global
@@ -24,14 +34,13 @@ module Grape
       # #inherit_from).
       def initialize
         @route = {}
-        @api_class = {}
         @namespace = InheritableValues.new # only inheritable from a parent when
         # used with a mount, or should every API::Class be a separate namespace by default?
         @namespace_inheritable = InheritableValues.new
         @namespace_stackable = StackableValues.new
         @namespace_reverse_stackable = ReverseStackableValues.new
-        @point_in_time_copies = []
         @parent = nil
+        # @api_class and @point_in_time_copies stay nil until first access.
       end
 
       # Return the class-level global properties.
@@ -53,7 +62,7 @@ module Grape
         namespace_reverse_stackable.inherited_values = parent.namespace_reverse_stackable
         @route = parent.route.merge(route)
 
-        point_in_time_copies.each { |cloned_one| cloned_one.inherit_from parent }
+        @point_in_time_copies&.each { |cloned_one| cloned_one.inherit_from parent }
       end
 
       # Create a point-in-time copy of this settings instance, with clones of


### PR DESCRIPTION
## Summary

- `InheritableSetting#initialize` used to eagerly allocate `@api_class = {}` and `@point_in_time_copies = []` per instance, even though most settings layers never touch either:
  - `@api_class` is only written by external code (plugins) via `setting.api_class[:k] = v`; nothing in `lib/` writes to it.
  - `@point_in_time_copies` only fills up on settings that get cloned via `point_in_time_copy` — typically the API-class-level setting, not the per-endpoint copies that dominate boot-time allocations.
- Switch both to memoizing readers (`@x ||= …`), drop the eager init, and rewrite the `inherit_from` propagation loop to access the ivar directly with `&.each` so the no-copies path doesn't allocate the Array just to iterate zero elements.

## Benchmarks

| Scenario | Before | After | Delta |
|---|---|---|---|
| `Grape::Util::InheritableSetting.new × 100` | 1600 objects / 183.6 kB | 1400 objects / 164.1 kB | **−11%** |

Smaller absolute win than #2739, but stacks with it for compounded boot-time savings.

## Test plan

- [x] `bundle exec rspec` — 2313 examples, 0 failures
- [x] `bundle exec rubocop` — clean on touched file
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)