### PR TITLE
Readability pass: guard clauses + small refactors across lib/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [#2733](https://github.com/ruby-grape/grape/pull/2733): Drop the dead `active_support/core_ext/hash/reverse_merge` require; call `ActiveSupport::HashWithIndifferentAccess.new(...)` directly at call sites - [@ericproulx](https://github.com/ericproulx).
 * [#2734](https://github.com/ruby-grape/grape/pull/2734): Extract `options_route_enabled` from the Endpoint options Hash into a dedicated `attr_accessor` - [@ericproulx](https://github.com/ericproulx).
 * [#2736](https://github.com/ruby-grape/grape/pull/2736): Collapse `Endpoint#run_validators` rescue branches via `ValidationErrors` flatten; `ValidationErrors#initialize` keyword renamed `errors:` → `exceptions:` - [@ericproulx](https://github.com/ericproulx).
+* [#2741](https://github.com/ruby-grape/grape/pull/2741): Readability pass: guard clauses and small extractions across `lib/` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/api.rb
+++ b/lib/grape/api.rb
@@ -14,7 +14,7 @@ module Grape
       private_constant :VALUES
 
       def self.build(val)
-        return nil unless VALUES.include?(val)
+        return unless VALUES.include?(val)
 
         new
       end

--- a/lib/grape/dsl/entity.rb
+++ b/lib/grape/dsl/entity.rb
@@ -49,28 +49,31 @@ module Grape
       # @param object [Object] the object to locate the Entity class for
       # @return [Class] the located Entity class, or nil if none is found
       def entity_class_for_obj(object)
-        object_class =
-          if object.respond_to?(:klass)
-            object.klass
-          elsif object.respond_to?(:first)
-            object.first.class
-          else
-            object.class
-          end
+        klass = object_class(object)
 
         representations = inheritable_setting.namespace_stackable_with_hash(:representations)
         if representations
-          potential = object_class.ancestors.detect { |potential| representations.key?(potential) }
+          potential = klass.ancestors.detect { |potential| representations.key?(potential) }
           return representations[potential] if potential && representations[potential]
         end
 
-        return unless object_class.const_defined?(:Entity)
+        return unless klass.const_defined?(:Entity)
 
-        entity = object_class.const_get(:Entity)
+        entity = klass.const_get(:Entity)
         entity if entity.respond_to?(:represent)
       end
 
       private
+
+      # Resolves the class used to look up the Entity for +object+.
+      # @param object [Object] the object to represent.
+      # @return [Class] the object's collection element class, wrapped class, or its own class.
+      def object_class(object)
+        return object.klass if object.respond_to?(:klass)
+        return object.first.class if object.respond_to?(:first)
+
+        object.class
+      end
 
       # @param entity_class [Class] the entity class to use for representation.
       # @param object [Object] the object to represent.

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -60,23 +60,11 @@ module Grape
       #
       # @param status [Integer] The HTTP Status Code to return for this request.
       def status(status = nil)
+        return @status || default_status if status.nil?
+
         case status
-        when Symbol
-          raise ArgumentError, "Status code :#{status} is invalid." unless Rack::Utils::SYMBOL_TO_STATUS_CODE.key?(status)
-
+        when Symbol, Integer
           @status = Rack::Utils.status_code(status)
-        when Integer
-          @status = status
-        when nil
-          return @status if @status
-
-          if request.post?
-            201
-          elsif request.delete?
-            @body.present? ? 200 : 204
-          else
-            200
-          end
         else
           raise ArgumentError, 'Status code must be Integer or Symbol.'
         end
@@ -120,7 +108,6 @@ module Grape
       #
       #   DELETE /12 # => 204 No Content, ""
       def return_no_content
-        status 204
         body false
       end
 
@@ -165,16 +152,7 @@ module Grape
 
         return @stream if value.nil?
 
-        stream_body =
-          if value.is_a?(String)
-            Grape::ServeStream::FileBody.new(value)
-          elsif value.respond_to?(:each)
-            value
-          else
-            raise ArgumentError, 'Stream object must respond to :each.'
-          end
-
-        @stream = Grape::ServeStream::StreamResponse.new(stream_body)
+        @stream = Grape::ServeStream::StreamResponse.new(stream_body(value))
       end
 
       # Returns route information for the current request.
@@ -199,6 +177,25 @@ module Grape
 
       def context
         self
+      end
+
+      private
+
+      # Wraps a stream +value+ into a body that responds to +:each+.
+      def stream_body(value)
+        return Grape::ServeStream::FileBody.new(value) if value.is_a?(String)
+
+        raise ArgumentError, 'Stream object must respond to :each.' unless value.respond_to?(:each)
+
+        value
+      end
+
+      # The default HTTP status when none has been set explicitly.
+      def default_status
+        return 201 if request.post?
+        return 204 if request.delete? && @body.blank?
+
+        200
       end
     end
   end

--- a/lib/grape/dsl/logger.rb
+++ b/lib/grape/dsl/logger.rb
@@ -8,11 +8,9 @@ module Grape
       # @param logger [Object] the new logger to use
       def logger(logger = nil)
         global_settings = inheritable_setting.global
-        if logger
-          global_settings[:logger] = logger
-        else
-          global_settings[:logger] || global_settings[:logger] = ::Logger.new($stdout)
-        end
+        return global_settings[:logger] = logger if logger
+
+        global_settings[:logger] || global_settings[:logger] = ::Logger.new($stdout)
       end
     end
   end

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -148,7 +148,7 @@ module Grape
 
         case with
         when Proc, Symbol then with
-        when String       then with.to_sym
+        when String then with.to_sym
         else raise ArgumentError, "with: #{with.class}, expected Symbol, String or Proc"
         end
       end

--- a/lib/grape/exceptions/error_response.rb
+++ b/lib/grape/exceptions/error_response.rb
@@ -30,10 +30,14 @@ module Grape
       # own middleware or `rescue_from` handlers.
       def self.coerce(input)
         case input
-        when ErrorResponse           then input
-        when Grape::Exceptions::Base then from_exception(input)
-        when Hash                    then new(**input.slice(:status, :message, :headers, :backtrace, :original_exception))
-        else                              new
+        when ErrorResponse
+          input
+        when Grape::Exceptions::Base
+          from_exception(input)
+        when Hash
+          new(**input.slice(:status, :message, :headers, :backtrace, :original_exception))
+        else
+          new
         end
       end
     end

--- a/lib/grape/formatter/serializable_hash.rb
+++ b/lib/grape/formatter/serializable_hash.rb
@@ -19,15 +19,11 @@ module Grape
         end
 
         def serialize(object)
-          if object.respond_to? :serializable_hash
-            object.serializable_hash
-          elsif array_serializable?(object)
-            object.map(&:serializable_hash)
-          elsif object.is_a?(Hash)
-            object.transform_values { |v| serialize(v) }
-          else
-            object
-          end
+          return object.serializable_hash if object.respond_to?(:serializable_hash)
+          return object.map(&:serializable_hash) if array_serializable?(object)
+          return object.transform_values { |v| serialize(v) } if object.is_a?(Hash)
+
+          object
         end
 
         def array_serializable?(object)

--- a/lib/grape/middleware/base.rb
+++ b/lib/grape/middleware/base.rb
@@ -79,13 +79,10 @@ module Grape
       end
 
       def merge_default_options(options)
-        if respond_to?(:default_options)
-          default_options.deep_merge(options)
-        elsif self.class.const_defined?(:DEFAULT_OPTIONS)
-          self.class::DEFAULT_OPTIONS.deep_merge(options)
-        else
-          options
-        end
+        return default_options.deep_merge(options) if respond_to?(:default_options)
+        return self.class::DEFAULT_OPTIONS.deep_merge(options) if self.class.const_defined?(:DEFAULT_OPTIONS)
+
+        options
       end
 
       def try_scrub(obj)

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -165,13 +165,12 @@ module Grape
       def redispatch(error, endpoint, already_redispatched)
         return framework_default(endpoint) if already_redispatched
 
-        if (registered = registered_rescue_handler(error.class))
-          run_rescue_handler(registered, error, endpoint, redispatched: true)
-        elsif error.is_a?(Grape::Exceptions::Base)
-          run_rescue_handler(method(:error_response), error, endpoint, redispatched: true)
-        else
-          safe_default(error, endpoint)
-        end
+        registered = registered_rescue_handler(error.class)
+
+        return run_rescue_handler(registered, error, endpoint, redispatched: true) if registered
+        return run_rescue_handler(method(:error_response), error, endpoint, redispatched: true) if error.is_a?(Grape::Exceptions::Base)
+
+        safe_default(error, endpoint)
       end
 
       # The unrecognised-error path. Exposes the original exception on

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -35,11 +35,9 @@ module Grape
 
         status, headers, bodies = *@app_response
 
-        if Rack::Utils::STATUS_WITH_NO_ENTITY_BODY.include?(status)
-          [status, headers, []]
-        else
-          build_formatted_response(status, headers, bodies)
-        end
+        return [status, headers, []] if Rack::Utils::STATUS_WITH_NO_ENTITY_BODY.include?(status)
+
+        build_formatted_response(status, headers, bodies)
       end
 
       private
@@ -136,11 +134,9 @@ module Grape
 
       def negotiate_content_type
         fmt = format_from_extension || query_params['format'] || format || format_from_header || default_format
-        if content_type_for(fmt)
-          env[Grape::Env::API_FORMAT] = fmt.to_sym
-        else
-          throw :error, Grape::Exceptions::ErrorResponse.new(status: 406, message: "The requested format '#{fmt}' is not supported.")
-        end
+        return env[Grape::Env::API_FORMAT] = fmt.to_sym if content_type_for(fmt)
+
+        throw :error, Grape::Exceptions::ErrorResponse.new(status: 406, message: "The requested format '#{fmt}' is not supported.")
       end
 
       def format_from_extension

--- a/lib/grape/router/pattern.rb
+++ b/lib/grape/router/pattern.rb
@@ -39,15 +39,11 @@ module Grape
       end
 
       def build_path_from_pattern(pattern, anchor)
-        if pattern.end_with?('*path')
-          pattern.dup.insert(pattern.rindex('/') + 1, '?')
-        elsif anchor
-          pattern
-        elsif pattern.end_with?('/')
-          "#{pattern}?*path"
-        else
-          "#{pattern}/?*path"
-        end
+        return pattern.dup.insert(pattern.rindex('/') + 1, '?') if pattern.end_with?('*path')
+        return pattern if anchor
+        return "#{pattern}?*path" if pattern.end_with?('/')
+
+        "#{pattern}/?*path"
       end
 
       def map_str(value)

--- a/lib/grape/serve_stream/sendfile_response.rb
+++ b/lib/grape/serve_stream/sendfile_response.rb
@@ -6,11 +6,9 @@ module Grape
     # for using Rack::SendFile middleware
     class SendfileResponse < Rack::Response
       def respond_to?(method_name, include_all = false)
-        if method_name == :to_path
-          @body.respond_to?(:to_path, include_all)
-        else
-          super
-        end
+        return @body.respond_to?(:to_path, include_all) if method_name == :to_path
+
+        super
       end
 
       def to_path

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -314,12 +314,9 @@ module Grape
       # push_declared_params cannot be called on the frozen scope later.
       def configure_declared_params
         push_renamed_param(full_path, @element_renamed) if @element_renamed
+        return @parent.push_declared_params [{ @element => @declared_params }] if nested?
 
-        if nested?
-          @parent.push_declared_params [{ @element => @declared_params }]
-        else
-          @api.inheritable_setting.namespace_stackable[:declared_params] = @declared_params
-        end
+        @api.inheritable_setting.namespace_stackable[:declared_params] = @declared_params
       ensure
         @declared_params = nil
       end

--- a/lib/grape/validations/types/primitive_coercer.rb
+++ b/lib/grape/validations/types/primitive_coercer.rb
@@ -15,7 +15,7 @@ module Grape
 
         def call(val)
           return InvalidValue.new if reject?(val)
-          return nil if val.nil? || treat_as_nil?(val)
+          return if val.nil? || treat_as_nil?(val)
 
           super
         end

--- a/spec/grape/dsl/inside_route_spec.rb
+++ b/spec/grape/dsl/inside_route_spec.rb
@@ -137,7 +137,7 @@ describe Grape::DSL::InsideRoute do
 
     it 'raises error if unknow symbol is passed' do
       expect { subject.status :foo_bar }
-        .to raise_error(ArgumentError, 'Status code :foo_bar is invalid.')
+        .to raise_error(ArgumentError, 'Unrecognized status code :foo_bar')
     end
 
     it 'accepts unknown Integer status codes' do


### PR DESCRIPTION
## Summary

Mostly cosmetic. Lifts if/elsif/else chains into guard clauses across `dsl/`, `middleware/`, `router/`, `formatter/`, and a few small extractions. No behavior change except where noted below.

**Guard-clause lifts** (the short-circuit moves above the `if`, main flow sits at top indentation):

- `DSL::Logger#logger`, `DSL::InsideRoute#stream` / `#return_no_content`
- `Formatter::SerializableHash#serialize`
- `Middleware::Base#merge_default_options`
- `Middleware::Error#redispatch`
- `Middleware::Formatter#call!` / `#negotiate_content_type`
- `Router::Pattern#build_path_from_pattern`
- `ServeStream::SendfileResponse#respond_to?`
- `Validations::ParamsScope#configure_declared_params`
- `Exceptions::ErrorResponse.coerce` (case/when reformatted to multi-line)

**Small extractions:**

- `DSL::Entity#entity_class_for_obj`: extract `object_class(object)` private helper.
- `DSL::InsideRoute#status`: collapse Symbol/Integer branches; extract `default_status` private helper.
- `DSL::InsideRoute#stream`: extract `stream_body(value)` private helper.
- `DSL::InsideRoute#return_no_content`: drop redundant `status 204` — `body false` already sets it via the setter.

**Tiny:** `return nil unless` → `return unless` in `Grape::API::Boolean.build` and `PrimitiveCoercer#call`.

## Behavior note

`DSL::InsideRoute#status` with an unknown symbol now raises with `Rack::Utils.status_code`'s native message (`"Unrecognized status code :foo_bar"`) instead of Grape's pre-validation message (`"Status code :foo_bar is invalid."`). One spec updated to match.

## Test plan

- [x] `bundle exec rspec` — 2313 examples, 0 failures
- [x] `bundle exec rubocop` — clean on touched files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)