### PR TITLE
Prune unused requires in lib/grape.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [#2733](https://github.com/ruby-grape/grape/pull/2733): Drop the dead `active_support/core_ext/hash/reverse_merge` require; call `ActiveSupport::HashWithIndifferentAccess.new(...)` directly at call sites - [@ericproulx](https://github.com/ericproulx).
 * [#2734](https://github.com/ruby-grape/grape/pull/2734): Extract `options_route_enabled` from the Endpoint options Hash into a dedicated `attr_accessor` - [@ericproulx](https://github.com/ericproulx).
 * [#2736](https://github.com/ruby-grape/grape/pull/2736): Collapse `Endpoint#run_validators` rescue branches via `ValidationErrors` flatten; `ValidationErrors#initialize` keyword renamed `errors:` → `exceptions:` - [@ericproulx](https://github.com/ericproulx).
+* [#2742](https://github.com/ruby-grape/grape/pull/2742): Prune unused requires in `lib/grape.rb`; narrow `active_support/inflector` to `core_ext/string/inflections` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -2,21 +2,20 @@
 
 require 'logger'
 require 'active_support'
-require 'active_support/version'
 require 'active_support/isolated_execution_state'
 require 'active_support/core_ext/array/conversions' # to_xml
 require 'active_support/core_ext/array/wrap'
 require 'active_support/core_ext/hash/conversions' # to_xml
 require 'active_support/core_ext/hash/deep_merge'
 require 'active_support/core_ext/hash/deep_transform_values'
-require 'active_support/core_ext/hash/indifferent_access'
+require 'active_support/core_ext/hash/indifferent_access' # nested_under_indifferent_access, required by HashWithIndifferentAccess.new
 require 'active_support/hash_with_indifferent_access'
 require 'active_support/core_ext/module/delegation' # delegate_missing_to
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/object/deep_dup'
 require 'active_support/core_ext/object/duplicable'
+require 'active_support/core_ext/string/inflections' # demodulize, underscore
 require 'active_support/deprecation'
-require 'active_support/inflector'
 require 'active_support/ordered_options'
 require 'active_support/notifications'
 
@@ -28,7 +27,6 @@ require 'dry-configurable'
 require 'forwardable'
 require 'json'
 require 'mustermann/grape'
-require 'pathname'
 require 'rack'
 require 'rack/auth/basic'
 require 'rack/builder'


### PR DESCRIPTION
## Summary

Audit of `lib/grape.rb` requires against actual `lib/` usage:

**Dropped (no callers anywhere in `lib/`):**
- `active_support/version` — redundant; `require 'active_support'` itself loads the version file first.
- `pathname` — no `Pathname` reference.

**Narrowed:**
- `active_support/inflector` → `active_support/core_ext/string/inflections`. Only `String#demodulize` and `String#underscore` are used (`validations.rb`, `util/registry.rb`); the full Inflector class/rule machinery isn't reached.

**Kept after false start (worth flagging):**
- `active_support/core_ext/hash/indifferent_access` looked unused on first pass (we only construct `ActiveSupport::HashWithIndifferentAccess.new(...)` directly, never call `Hash#with_indifferent_access`). But `HashWithIndifferentAccess.new(hash)` internally calls `nested_under_indifferent_access` on its input, which is added by this core_ext. Dropping it broke ~200 specs. Restored with an inline comment.

## Test plan

- [x] `bundle exec rspec` — 2313 examples, 0 failures
- [x] `bundle exec rubocop lib/grape.rb` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)