### PR TITLE
Bump minimum required Ruby to 3.3

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -6,11 +6,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2', '3.3', '3.4', '4.0', ruby-head, truffleruby-head, jruby-head]
+        ruby: ['3.3', '3.4', '4.0', ruby-head, truffleruby-head, jruby-head]
         gemfile: [rails_edge, rack_edge]
-        exclude:
-          - ruby: '3.2'
-            gemfile: rails_edge
     runs-on: ubuntu-latest
     continue-on-error: true
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2', '3.3', '3.4', '4.0']
+        ruby: ['3.3', '3.4', '4.0']
         gemfile:
           - Gemfile
           - gemfiles/rack_2_2.gemfile

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   SuggestExtensions: false
   Exclude:
     - vendor/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * [#2734](https://github.com/ruby-grape/grape/pull/2734): Extract `options_route_enabled` from the Endpoint options Hash into a dedicated `attr_accessor` - [@ericproulx](https://github.com/ericproulx).
 * [#2736](https://github.com/ruby-grape/grape/pull/2736): Collapse `Endpoint#run_validators` rescue branches via `ValidationErrors` flatten; `ValidationErrors#initialize` keyword renamed `errors:` → `exceptions:` - [@ericproulx](https://github.com/ericproulx).
 * [#2746](https://github.com/ruby-grape/grape/pull/2746): Hoist `using:` / `except:` from `**opts` to explicit kwargs on `DSL::Parameters#requires` and `#optional` - [@ericproulx](https://github.com/ericproulx).
+* [#2750](https://github.com/ruby-grape/grape/pull/2750): Bump minimum required Ruby to 3.3 - [@ericproulx](https://github.com/ericproulx).
 * [#2742](https://github.com/ruby-grape/grape/pull/2742): Prune unused requires in `lib/grape.rb`; narrow `active_support/inflector` to `core_ext/string/inflections` - [@ericproulx](https://github.com/ericproulx).
 * [#2741](https://github.com/ruby-grape/grape/pull/2741): Readability pass: guard clauses and small extractions across `lib/` - [@ericproulx](https://github.com/ericproulx).
 * [#2740](https://github.com/ruby-grape/grape/pull/2740): Lazy-allocate `@api_class` and `@point_in_time_copies` on `Grape::Util::InheritableSetting` so unused settings layers don't carry an empty Hash and empty Array each - [@ericproulx](https://github.com/ericproulx).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The maintainers of Grape are working with Tidelift to deliver commercial support
 
 ## Installation
 
-Ruby 3.2 or newer is required.
+Ruby 3.3 or newer is required.
 
 Grape is available as a gem, to install it run:
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,10 @@ Upgrading Grape
 
 ### Upgrading to >= 3.3
 
+#### Minimum required Ruby is now 3.3
+
+Grape no longer supports Ruby 3.2; 3.3 is now the minimum (`required_ruby_version = '>= 3.3'`). Upgrade your runtime to Ruby 3.3 or newer before bumping Grape.
+
 #### `Grape::Exceptions::ValidationErrors.new` keyword renamed `errors:` → `exceptions:`
 
 `Grape::Exceptions::ValidationErrors#initialize` now takes its input array under the `exceptions:` keyword instead of `errors:`. The kwarg accepts a mix of `Grape::Exceptions::Validation` and `Grape::Exceptions::ValidationArrayErrors` instances; `ValidationArrayErrors` wrappers are flattened internally via `flat_map(&:errors)`. The `errors` reader on the constructed instance (the grouped `{params => [Validation, ...]}` Hash) is unchanged.

--- a/grape.gemspec
+++ b/grape.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |s|
 
   s.files = Dir['lib/**/*', 'CHANGELOG.md', 'CONTRIBUTING.md', 'README.md', 'grape.png', 'UPGRADING.md', 'LICENSE', 'grape.gemspec']
   s.require_paths = ['lib']
-  s.required_ruby_version = '>= 3.2'
+  s.required_ruby_version = '>= 3.3'
 end


### PR DESCRIPTION
## Summary

Drops Ruby 3.2 support; minimum is now Ruby 3.3.

### What changed

- **`grape.gemspec`** — `required_ruby_version = '>= 3.3'`.
- **`.rubocop.yml`** — `TargetRubyVersion: 3.3` (no new offenses on tracked sources).
- **`.github/workflows/test.yml`** — removed `'3.2'` from the matrix; `'3.3'`, `'3.4'`, `'4.0'` remain.
- **`.github/workflows/edge.yml`** — removed `'3.2'` from the matrix and the now-empty `rails_edge` exclude entry.
- **`README.md`** — install note updated to "Ruby 3.3 or newer".
- **`UPGRADING.md`** — added a contract-break entry under the next `>= 3.3` section.

### Why

Ruby 3.2 will reach end-of-life within the next release cycle of Grape. Dropping it now keeps the matrix lean and unblocks future use of 3.3+ syntax/standard-library improvements.

## Test plan

- [x] `bundle exec rubocop` against tracked sources — 303 files, 0 offenses
- [x] No code changes — existing test suites cover Ruby 3.3+ via CI matrix
- [ ] CI: verify `test` + `edge` workflows green on the remaining matrix entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)