### PR TITLE
Skip absent optional steps when composing structured error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 * [#2700](https://github.com/ruby-grape/grape/pull/2700): Fix README typos, remove obsolete Ruby 2.4 / Fixnum section, and replace incorrect `requires + values + allow_blank` note with a correct one covering `optional + values` semantics (closes #2631) - [@ericproulx](https://github.com/ericproulx).
 * [#2703](https://github.com/ruby-grape/grape/pull/2703): Catch exceptions raised inside `rescue_from` blocks; new `rescue_from :internal_grape_exceptions` opt-in for unrecognised internal errors (resolves [#2482](https://github.com/ruby-grape/grape/issues/2482)) - [@ericproulx](https://github.com/ericproulx).
 * [#2706](https://github.com/ruby-grape/grape/pull/2706): Fix `optional :foo, message: 'oops'` raising `UnknownValidator` - [@ericproulx](https://github.com/ericproulx).
+* [#2751](https://github.com/ruby-grape/grape/pull/2751): Fix structured error messages leaking the raw i18n key for an undefined optional step such as `summary` (closes #2748) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.2.1 (2026-04-16)

--- a/lib/grape/exceptions/base.rb
+++ b/lib/grape/exceptions/base.rb
@@ -5,7 +5,7 @@ module Grape
     class Base < StandardError
       include Grape::Util::Translation
 
-      MESSAGE_STEPS = %w[problem summary resolution].to_h { |s| [s, s.capitalize] }.freeze
+      MESSAGE_STEPS = %w[problem summary resolution].to_h { |s| [s.to_sym, s.capitalize] }.freeze
 
       attr_reader :status, :headers
 
@@ -27,6 +27,8 @@ module Grape
         return short_message unless short_message.is_a?(Hash)
 
         MESSAGE_STEPS.filter_map do |step, label|
+          next unless short_message.key?(step)
+
           detail = translate_message(:"#{key}.#{step}", **)
           "\n#{label}:\n  #{detail}" if detail.present?
         end.join

--- a/spec/grape/exceptions/base_spec.rb
+++ b/spec/grape/exceptions/base_spec.rb
@@ -109,5 +109,31 @@ describe Grape::Exceptions::Base do
         end
       end
     end
+
+    context 'when the message defines an optional step' do
+      let(:key) { :missing_vendor_option }
+      let(:attributes) { {} }
+
+      it 'renders every step, including the optional summary' do
+        expect(subject).to include('Problem:', 'Summary:', 'Resolution:')
+      end
+    end
+
+    context 'when the message omits an optional step' do
+      let(:key) { :invalid_message_body }
+      let(:attributes) { { body_format: 'application/json' } }
+
+      it 'does not leak the missing step i18n key into the message' do
+        expect(subject).not_to include('grape.errors.messages')
+      end
+
+      it 'omits the missing step label' do
+        expect(subject).not_to include('Summary:')
+      end
+
+      it 'still renders the steps that are present' do
+        expect(subject).to include('Problem:', 'Resolution:')
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #2748.

### Problem

`Grape::Exceptions::Base#compose_message` loops over every entry in `MESSAGE_STEPS` (`problem`, `summary`, `resolution`) and translates each one individually. For an optional step a message doesn't define — e.g. `summary` on `invalid_message_body` — `Grape::Util::Translation#translate` falls back to returning the scoped key path as a string. That string is non-blank, so it passes the `detail.present?` guard and leaks verbatim into the rendered message:

```
Grape::Exceptions::InvalidMessageBody.new('application/json').message
# Problem:
#   message body does not match declared format
# Summary:
#   grape.errors.messages.invalid_message_body.summary   <- leaked i18n key
# Resolution:
#   when specifying application/json as content-type, ...
```

### Fix

Gate each step on whether the already-resolved message hash defines it (`short_message.key?(step.to_sym)`). The resolved hash already reflects the `:en` fallback, so:

- absent optional steps (e.g. `summary`) are skipped instead of leaking the key path;
- `:en` locale fallback for present steps is preserved (verified under a `:de` locale with no override — still renders Problem + Resolution from `:en`, no leak);
- the intentional key-path behaviour for a *fully unresolvable top-level message* (`spec/grape/exceptions/base_spec.rb` "returns the scoped translation key as a string") is untouched — that path returns before the Hash branch;
- `translate` itself is unchanged, so validators and `ValidationErrors` are unaffected.

### Tests

Added specs in `spec/grape/exceptions/base_spec.rb`: the leak is gone for `invalid_message_body`, while `missing_vendor_option` (which legitimately defines `summary`) still renders all three steps. `spec/grape/exceptions/` is green (96 examples, 0 failures).

Reported by @dcasillano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)