### PR TITLE
Skip per-request instrumentation work when no subscribers are listening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * [#2739](https://github.com/ruby-grape/grape/pull/2739): Lazy-allocate `@new_values` in `Grape::Util::BaseInheritable` so settings layers that only inherit never carry an empty Hash; readers in `InheritableValues`/`StackableValues` handle nil - [@ericproulx](https://github.com/ericproulx).
 * [#2737](https://github.com/ruby-grape/grape/pull/2737): `rescue_from` raises `ArgumentError` when a meta selector (`:all`, `:grape_exceptions`, `:internal_grape_exceptions`) is mixed with exception classes instead of silently dropping the classes - [@ericproulx](https://github.com/ericproulx).
 * [#2735](https://github.com/ruby-grape/grape/pull/2735): Normalize `Grape::Endpoint#options` into an immutable `Grape::Endpoint::Options` `Data` value object; Hash-style `[]` reads kept for back-compat - [@ericproulx](https://github.com/ericproulx).
+* [#2752](https://github.com/ruby-grape/grape/pull/2752): Skip per-request `ActiveSupport::Notifications` payload and dispatch when no subscriber is listening, via private `instrument_<event>` guards on `Endpoint`/`Middleware::Formatter` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -150,7 +150,7 @@ module Grape
     protected
 
     def run
-      ActiveSupport::Notifications.instrument('endpoint_run.grape', endpoint: self, env:) do
+      instrument_run do
         @request = Grape::Request.new(env, build_params_with: @build_params_with)
         begin
           run_filters befores, :before
@@ -188,7 +188,7 @@ module Grape
     def execute
       return unless source
 
-      ActiveSupport::Notifications.instrument('endpoint_render.grape', endpoint: self) do
+      instrument_render do
         source.bind_call(self)
       end
     end
@@ -200,7 +200,7 @@ module Grape
       validation_exceptions = nil
 
       Grape::Validations::ParamScopeTracker.track do
-        ActiveSupport::Notifications.instrument('endpoint_run_validators.grape', endpoint: self, validators:, request:) do
+        instrument_run_validators(validators, request) do
           validators.each do |validator|
             validator.validate(request)
           rescue Grape::Exceptions::Validation, Grape::Exceptions::ValidationArrayErrors => e
@@ -216,7 +216,7 @@ module Grape
     def run_filters(filters, type = :other)
       return if filters.blank?
 
-      ActiveSupport::Notifications.instrument('endpoint_run_filters.grape', endpoint: self, filters:, type:) do
+      instrument_run_filters(filters, type) do
         filters.each { |filter| instance_eval(&filter) }
       end
     end
@@ -230,6 +230,34 @@ module Grape
     private
 
     attr_reader :before_filter_passed
+
+    # Instrument helpers. Each guards on +listening?+ so that with no subscriber
+    # the payload Hash and notification machinery are skipped and the block runs
+    # directly (no added allocations); the block is forwarded anonymously so
+    # nothing is allocated unless a subscriber is present.
+    def instrument_run(&)
+      return yield unless ActiveSupport::Notifications.notifier.listening?('endpoint_run.grape')
+
+      ActiveSupport::Notifications.instrument('endpoint_run.grape', endpoint: self, env:, &)
+    end
+
+    def instrument_render(&)
+      return yield unless ActiveSupport::Notifications.notifier.listening?('endpoint_render.grape')
+
+      ActiveSupport::Notifications.instrument('endpoint_render.grape', endpoint: self, &)
+    end
+
+    def instrument_run_validators(validators, request, &)
+      return yield unless ActiveSupport::Notifications.notifier.listening?('endpoint_run_validators.grape')
+
+      ActiveSupport::Notifications.instrument('endpoint_run_validators.grape', endpoint: self, validators:, request:, &)
+    end
+
+    def instrument_run_filters(filters, type, &)
+      return yield unless ActiveSupport::Notifications.notifier.listening?('endpoint_run_filters.grape')
+
+      ActiveSupport::Notifications.instrument('endpoint_run_filters.grape', endpoint: self, filters:, type:, &)
+    end
 
     def compile!
       @app = config.app || build_stack

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -49,13 +49,22 @@ module Grape
         else
           # Allow content-type to be explicitly overwritten
           formatter = fetch_formatter(headers)
-          bodymap = ActiveSupport::Notifications.instrument('format_response.grape', formatter:, env:) do
+          bodymap = instrument_format_response(formatter) do
             bodies.map { |body| formatter.call(body, env) }
           end
           Rack::Response.new(bodymap, status, headers)
         end
       rescue Grape::Exceptions::InvalidFormatter => e
         throw :error, Grape::Exceptions::ErrorResponse.new(status: 500, message: e.message, backtrace: e.backtrace, original_exception: e)
+      end
+
+      # Guards on +listening?+ so that with no subscriber the payload Hash and
+      # notification machinery are skipped and the block runs directly (no added
+      # allocations); the block is forwarded anonymously.
+      def instrument_format_response(formatter, &)
+        return yield unless ActiveSupport::Notifications.notifier.listening?('format_response.grape')
+
+        ActiveSupport::Notifications.instrument('format_response.grape', formatter:, env:, &)
       end
 
       def fetch_formatter(headers)


### PR DESCRIPTION
## Summary

Grape emits up to **six** `ActiveSupport::Notifications.instrument` events per request — `endpoint_run`, `endpoint_render`, `endpoint_run_validators`, `endpoint_run_filters` (once per filter type) and `format_response`. Each one builds a payload `Hash` and enters the notification machinery on **every request**, even when nothing is subscribed to the event — the common case in production.

This guards each emission behind `ActiveSupport::Notifications.notifier.listening?`, so when there's no subscriber the block runs directly and neither the payload `Hash` nor the instrument dispatch is paid for.

## Approach

A small private `instrument_<event>` method on each owning class (`Grape::Endpoint`, `Grape::Middleware::Formatter`):

```ruby
def instrument_run(&)
  return yield unless ActiveSupport::Notifications.notifier.listening?('endpoint_run.grape')

  ActiveSupport::Notifications.instrument('endpoint_run.grape', endpoint: self, env:, &)
end
```

Call sites become a one-line wrap; the original method bodies are untouched:

```ruby
def run
  instrument_run do
    # ... unchanged
  end
end
```

As instance methods they read `self`/`env` directly (no arguments to pass). The block is forwarded anonymously (`&`) so no `Proc` is allocated unless a subscriber is present, and the payload `Hash` is only built past the guard.

## Results

Microbenchmark on Ruby 4.0.3 (+YJIT) — a single endpoint with `before`/`after` filters and a `params` block (6 events/request), `BenchAPI.call(env)` in a tight loop, allocations counted deterministically and throughput taken best-of-5:

| | allocations / request | throughput (YJIT) |
|---|--:|--:|
| **before** | 71 | 89,455 i/s |
| **after** | 65 | 93,568 i/s |

−6 allocations/request (one `Hash` per emitted event) and **~+4.6%** median throughput. The gain scales with the number of events emitted per request; a bare endpoint (3 events, no filters/params) sees a smaller, noisier gain.

## Behaviour

Unchanged when a subscriber exists — same events, same payloads. The block-forwarding path only runs once a subscriber is present, so subscribed apps pay just one extra `listening?` check (a hash lookup). Verified by the existing instrumentation spec (which subscribes via a `/grape/` regex) and the full suite (**2320 examples, 0 failures**). RuboCop clean, no new disables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
