### PR TITLE
Tighten dependency lower bounds to their compatibility floors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * [#2754](https://github.com/ruby-grape/grape/pull/2754): Merge routing args in place in `Router#process_route` instead of allocating a new Hash via `merge` - [@ericproulx](https://github.com/ericproulx).
 * [#2753](https://github.com/ruby-grape/grape/pull/2753): Lazy-allocate `Grape::Validations::ParamScopeTracker`'s identity-keyed hashes so validating requests that never use the index / qualifying-params trackers allocate no hash - [@ericproulx](https://github.com/ericproulx).
 * [#2752](https://github.com/ruby-grape/grape/pull/2752): Skip per-request `ActiveSupport::Notifications` payload and dispatch when no subscriber is listening, via private `instrument_<event>` guards on `Endpoint`/`Middleware::Formatter` - [@ericproulx](https://github.com/ericproulx).
+* [#2756](https://github.com/ruby-grape/grape/pull/2756): Tighten dependency lower bounds to their compatibility floors (`rack >= 2.2.4`, `zeitwerk >= 2.6`, `dry-configurable >= 1.0`) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/grape.gemspec
+++ b/grape.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |s|
   }
 
   s.add_dependency 'activesupport', '>= 7.2'
-  s.add_dependency 'dry-configurable'
+  s.add_dependency 'dry-configurable', '>= 1.0'
   s.add_dependency 'dry-types', '>= 1.1'
   s.add_dependency 'mustermann-grape', '~> 1.1.0'
-  s.add_dependency 'rack', '>= 2'
-  s.add_dependency 'zeitwerk'
+  s.add_dependency 'rack', '>= 2.2.4'
+  s.add_dependency 'zeitwerk', '>= 2.6'
 
   s.files = Dir['lib/**/*', 'CHANGELOG.md', 'CONTRIBUTING.md', 'README.md', 'grape.png', 'UPGRADING.md', 'LICENSE', 'grape.gemspec']
   s.require_paths = ['lib']


### PR DESCRIPTION
## What

Tighten Grape's loose dependency floors to the **lowest versions Grape is actually compatible with** — not the latest. Grape is a library (a dependency in other apps' bundles), so a floor should be the minimum compatible version; pinning higher just causes downstream resolution conflicts for no benefit.

| dep | before | after | why |
|---|---|---|---|
| `rack` | `>= 2` | **`>= 2.2.4`** | Rails 7.2's own floor; avoids the rack CVEs fixed in 2.2.4 |
| `zeitwerk` | _(unpinned)_ | **`>= 2.6`** | mirrors Rails 7.2's `zeitwerk ~> 2.6`; Grape uses only long-stable zeitwerk API |
| `dry-configurable` | _(unpinned)_ | **`>= 1.0`** | the release that introduced the `setting …, default:` keyword API Grape relies on (0.x differs) |

`dry-types` is left at `>= 1.1` (unchanged), and `mustermann` is handled separately in #2755.

## Notes

- **Floors only, no upper bounds**, and **resolved versions are unchanged** (rack 3.2.6, zeitwerk 2.8.2, dry-configurable 1.4.0 all already satisfy these) — they're lower bounds, not pins.
- These are deliberately set to *compatibility* minimums rather than each dependency's own Ruby-3.3-aligned release: those newer releases aren't required (the older ones install and run fine on Ruby 3.3), and requiring them would needlessly constrain downstream bundles. Notably `zeitwerk >= 2.6` matches what Rails 7.2/8.0 themselves allow rather than being stricter.
- Full suite **2,320 examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
