### PR TITLE
Build the cookie jar only on use and drop its deferral Proc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * [#2754](https://github.com/ruby-grape/grape/pull/2754): Merge routing args in place in `Router#process_route` instead of allocating a new Hash via `merge` - [@ericproulx](https://github.com/ericproulx).
 * [#2753](https://github.com/ruby-grape/grape/pull/2753): Lazy-allocate `Grape::Validations::ParamScopeTracker`'s identity-keyed hashes so validating requests that never use the index / qualifying-params trackers allocate no hash - [@ericproulx](https://github.com/ericproulx).
 * [#2752](https://github.com/ruby-grape/grape/pull/2752): Skip per-request `ActiveSupport::Notifications` payload and dispatch when no subscriber is listening, via private `instrument_<event>` guards on `Endpoint`/`Middleware::Formatter` - [@ericproulx](https://github.com/ericproulx).
+* [#2757](https://github.com/ruby-grape/grape/pull/2757): Build the `Grape::Cookies` jar only when a cookie is read or written (via a new `Grape::Request#cookies?` predicate gating response-cookie flushing), and drop the jar's now-redundant lazy-parse `Proc` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/cookies.rb
+++ b/lib/grape/cookies.rb
@@ -13,7 +13,7 @@ module Grape
     def_delegators :cookies, :[], :each
 
     def initialize(rack_cookies)
-      @cookies = rack_cookies
+      @cookies = ActiveSupport::HashWithIndifferentAccess.new(rack_cookies)
       @send_cookies = nil
     end
 
@@ -37,11 +37,7 @@ module Grape
 
     private
 
-    def cookies
-      return @cookies unless @cookies.is_a?(Proc)
-
-      @cookies = ActiveSupport::HashWithIndifferentAccess.new(@cookies.call)
-    end
+    attr_reader :cookies
 
     def send_cookies
       @send_cookies ||= Set.new

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -385,6 +385,8 @@ module Grape
     end
 
     def build_response_cookies
+      return unless request.cookies?
+
       response_cookies do |name, value|
         cookie_value = value.is_a?(Hash) ? value : { value: }
         Rack::Utils.set_cookie_header! header, name, cookie_value

--- a/lib/grape/request.rb
+++ b/lib/grape/request.rb
@@ -153,7 +153,15 @@ module Grape
     end
 
     def cookies
-      @cookies ||= Grape::Cookies.new(-> { rack_cookies })
+      @cookies ||= Grape::Cookies.new(rack_cookies)
+    end
+
+    # True once the cookie jar has been materialized (a cookie was read or
+    # written this request). Lets the endpoint skip response-cookie flushing,
+    # and the Grape::Cookies allocation it triggers, when no cookie was
+    # touched on the request.
+    def cookies?
+      !@cookies.nil?
     end
 
     private


### PR DESCRIPTION
Makes the response-cookie path lazy at the request boundary, in two related steps.

### 1. Build the jar only when a cookie is touched

`Grape::Endpoint#build_response_cookies` runs on **every** request and delegated `response_cookies` → `cookies` → `request.cookies`, materializing the `Grape::Cookies` jar even when the handler never touched a cookie (the jar's `response_cookies` then immediately no-ops). Gate it on a new `Grape::Request#cookies?` predicate, true only once the jar exists:

```ruby
def build_response_cookies
  return unless request.cookies?
  ...
end
```

A `Set-Cookie` is only ever emitted after a `cookies[...] =` write, which always materializes the jar first — so `cookies?` is true exactly when there could be something to flush. Behaviour is unchanged; a cookie-free request now allocates no jar.

### 2. Drop the jar's deferral `Proc`

The `-> { rack_cookies }` Proc existed (since #2549) to defer the request-cookie parse, because the jar used to be built on every request. Now that step 1 only builds it when a cookie is actually read or written — and any access forces the parse immediately (a write via `[]=` always did) — the Proc no longer earns its keep. Parse `rack_cookies` eagerly in the constructor and replace the `is_a?(Proc)` lazy reader with a plain `attr_reader`, dropping the closure allocation and a per-access branch.

The `ActiveSupport::HashWithIndifferentAccess` wrapping is **unchanged** — it backs Grape's string/symbol-indifferent cookie access (`set_cookie username=…` is read back as `cookies[:username]`).

### Result

A request that never touches a cookie now allocates **zero** `Grape::Cookies`/`Proc` objects (was ~10 on the flush path); a cookie-using request loses the extra `Proc` closure and the per-access `is_a?(Proc)` check.

### Tests

`spec/grape/endpoint_spec.rb` `#cookies` — 5 examples, 0 failures (set / update / delete / symbol-keyed read / "does not set response cookies"). Rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)