### PR TITLE
Fix: VariantCollectionCoercer#to_s returns "Array[Type, ...]" notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 * [#2678](https://github.com/ruby-grape/grape/pull/2678): Update rubocop to 1.86.0 and autocorrect offenses - [@ericproulx](https://github.com/ericproulx).
 * [#2682](https://github.com/ruby-grape/grape/pull/2682): Fix `Style/OptionalBooleanParameter` offenses - [@ericproulx](https://github.com/ericproulx).
 * [#2699](https://github.com/ruby-grape/grape/pull/2699): Fix `Grape::Validations::Types::CustomTypeCoercer` dropping symbolized hash keys for `Array`/`Set` types; refactor the class for readability - [@ericproulx](https://github.com/ericproulx).
+* [#2758](https://github.com/ruby-grape/grape/pull/2758): Fix `VariantCollectionCoercer#to_s` to return `"Array[Type, ...]"` notation instead of a raw object string - [@bogdan](https://github.com/bogdan).
 * [#2700](https://github.com/ruby-grape/grape/pull/2700): Fix README typos, remove obsolete Ruby 2.4 / Fixnum section, and replace incorrect `requires + values + allow_blank` note with a correct one covering `optional + values` semantics (closes #2631) - [@ericproulx](https://github.com/ericproulx).
 * [#2703](https://github.com/ruby-grape/grape/pull/2703): Catch exceptions raised inside `rescue_from` blocks; new `rescue_from :internal_grape_exceptions` opt-in for unrecognised internal errors (resolves [#2482](https://github.com/ruby-grape/grape/issues/2482)) - [@ericproulx](https://github.com/ericproulx).
 * [#2706](https://github.com/ruby-grape/grape/pull/2706): Fix `optional :foo, message: 'oops'` raising `UnknownValidator` - [@ericproulx](https://github.com/ericproulx).

--- a/lib/grape/validations/types/variant_collection_coercer.rb
+++ b/lib/grape/validations/types/variant_collection_coercer.rb
@@ -26,6 +26,14 @@ module Grape
           @member_coercer = MultipleTypeCoercer.new types, method
         end
 
+        # Returns the Grape DSL notation for this coercer, e.g. "Array[Integer, String]".
+        # Distinct from the plain-array string "[Integer, String]" produced by the
+        # +types:+ keyword, which lets documentation tools tell the two apart.
+        def to_s
+          container = @types.is_a?(Set) ? 'Set' : 'Array'
+          "#{container}[#{@types.join(', ')}]"
+        end
+
         # Coerce the given value.
         #
         # @param value [Array<String>] collection of values to be coerced

--- a/spec/grape/endpoint/declared_spec.rb
+++ b/spec/grape/endpoint/declared_spec.rb
@@ -40,6 +40,7 @@ describe Grape::Endpoint do
         optional :empty_hash_two, type: Hash
         optional :empty_set, type: Set
         optional :empty_typed_set, type: Set[String]
+        optional :empty_variant_set, type: Set[Integer, String]
       end
     end
 
@@ -108,7 +109,7 @@ describe Grape::Endpoint do
       end
       get '/declared?first=present'
       expect(last_response).to be_successful
-      expect(JSON.parse(last_response.body).keys.size).to eq(12)
+      expect(JSON.parse(last_response.body).keys.size).to eq(13)
     end
 
     it 'has a optional param with default value all the time' do
@@ -203,6 +204,14 @@ describe Grape::Endpoint do
         expect(body['empty_typed_set']).to eq(json_empty_set)
         expect(body['nested']['empty_set']).to eq(json_empty_set)
         expect(body['nested']['empty_typed_set']).to eq(json_empty_set)
+      end
+
+      it 'sets objects with type=Set[Integer, String] (variant collection) to be a set' do
+        get '/declared?first=present'
+        expect(last_response).to be_successful
+
+        body = JSON.parse(last_response.body)
+        expect(body['empty_variant_set']).to eq(JSON.parse(Set.new.to_json))
       end
 
       it 'sets objects with type=Array to be an array' do

--- a/spec/grape/validations/validations_spec_spec.rb
+++ b/spec/grape/validations/validations_spec_spec.rb
@@ -36,12 +36,21 @@ describe Grape::Validations::ValidationsSpec do
     it 'wraps a multiple type from :type in a VariantCollectionCoercer' do
       multi_spec = described_class.from(type: [Integer, String])
       expect(multi_spec.coerce_type).to be_a(Grape::Validations::Types::VariantCollectionCoercer)
+      expect(multi_spec.coerce_type.to_s).to eq('Array[Integer, String]')
+      expect(multi_spec.coerce_method).to be_nil
+    end
+
+    it 'wraps a Set multiple type from :type in a VariantCollectionCoercer' do
+      multi_spec = described_class.from(type: Set[Integer, String])
+      expect(multi_spec.coerce_type).to be_a(Grape::Validations::Types::VariantCollectionCoercer)
+      expect(multi_spec.coerce_type.to_s).to eq('Set[Integer, String]')
       expect(multi_spec.coerce_method).to be_nil
     end
 
     it 'extracts :types as a plain coerce list' do
       spec = described_class.from(types: [Integer, String])
       expect(spec.coerce_type).to eq([Integer, String])
+      expect(spec.coerce_type.to_s).to eq('[Integer, String]')
     end
   end
 


### PR DESCRIPTION
## Problem

`type: [Integer, String]` and `types: [Integer, String]` have different semantics:

- `types: [Integer, String]` — the parameter itself can be Integer **or** String (variant types)
- `type: [Integer, String]` / `type: Array[Integer, String]` — the parameter is always an Array whose **members** can be Integer or String (variant-member-type collection)

However, `VariantCollectionCoercer` had no custom `to_s`, so `route.params[:type]` for the `type:` form serialised to a garbage object string (`"#<Grape::Validations::Types::VariantCollectionCoercer:0x...>"`). Documentation tools such as grape-swagger and grape-oas could not distinguish it from the plain `"[Integer, String]"` produced by `types:`, and could not generate a correct schema for either case.

## Fix

Add `VariantCollectionCoercer#to_s` returning the Grape DSL notation:

- `type: [Integer, String]` → `"Array[Integer, String]"`
- `type: Set[Integer, String]` → `"Set[Integer, String]"`
- `types: [Integer, String]` → `"[Integer, String]"` (unchanged)

This matches the notation users write in the DSL and gives documentation tools an unambiguous signal to emit `{type: array, items: {oneOf: [...]}}` rather than a plain `oneOf`.

## Compatibility

- `declared_params_handler.rb` reads `route.params[:type]` but only matches `'Array'`, `'Hash'`, and the single-type `[Type]` pattern — `"Array[Integer, String]"` does not collide with any of those branches.
- For the Set form: `"Set[Integer, String]"` **does** match line 111's `start_with?('Set')` check, so a `type: Set[Integer, String]` param now gets `Set.new` as its declared default. This is correct and consistent with how `type: Set` and `type: Set[String]` already behave; a spec has been added to pin it down.
- grape-swagger's type-parsing regexes (`/\[(.*)\\]$/`, `/\A\[.*\]\z/`) are unaffected.