### PR TITLE
Use create_additions: false in Grape::Json.load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 * [#2703](https://github.com/ruby-grape/grape/pull/2703): Catch exceptions raised inside `rescue_from` blocks; new `rescue_from :internal_grape_exceptions` opt-in for unrecognised internal errors (resolves [#2482](https://github.com/ruby-grape/grape/issues/2482)) - [@ericproulx](https://github.com/ericproulx).
 * [#2706](https://github.com/ruby-grape/grape/pull/2706): Fix `optional :foo, message: 'oops'` raising `UnknownValidator` - [@ericproulx](https://github.com/ericproulx).
 * [#2751](https://github.com/ruby-grape/grape/pull/2751): Fix structured error messages leaking the raw i18n key for an undefined optional step such as `summary` (closes #2748) - [@ericproulx](https://github.com/ericproulx).
+* [#2759](https://github.com/ruby-grape/grape/pull/2759): Use `create_additions: false` in `Grape::Json.load` to prevent object instantiation via the `json_class` key when using the stdlib JSON fallback - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 3.2.1 (2026-04-16)

--- a/lib/grape/json.rb
+++ b/lib/grape/json.rb
@@ -4,7 +4,16 @@ module Grape
   if defined?(::MultiJson)
     Json = ::MultiJson
   else
-    Json = ::JSON
-    Json::ParseError = Json::ParserError
+    module Json
+      ParseError = ::JSON::ParserError
+
+      def self.load(str)
+        ::JSON.load(str, nil, create_additions: false)
+      end
+
+      def self.dump(obj, *)
+        ::JSON.dump(obj, *)
+      end
+    end
   end
 end

--- a/spec/grape/parser/json_spec.rb
+++ b/spec/grape/parser/json_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+describe Grape::Parser::Json, if: !defined?(MultiJson) do
+  include Rack::Test::Methods
+
+  let(:app) do
+    Class.new(Grape::API) do
+      format :json
+
+      post '/data' do
+        params.to_h
+      end
+    end
+  end
+
+  # Verify that json_class payloads are treated as plain data and do not
+  # trigger Ruby object instantiation via JSON.load's create_additions mechanism.
+  context 'when the request body contains a json_class key' do
+    let(:triggered) { [] }
+
+    before do
+      t = triggered
+      stub_const('JsonClassTarget', Class.new do
+        define_singleton_method(:json_create) do |_data|
+          t << true
+          new
+        end
+      end)
+    end
+
+    it 'does not instantiate the named class' do
+      body = JSON.dump('json_class' => 'JsonClassTarget', 'data' => { 'x' => 1 })
+      post '/data', body, 'CONTENT_TYPE' => 'application/json'
+
+      expect(triggered).to be_empty
+    end
+
+    it 'returns the payload as a plain hash' do
+      body = JSON.dump('json_class' => 'JsonClassTarget', 'data' => { 'x' => 1 })
+      post '/data', body, 'CONTENT_TYPE' => 'application/json'
+
+      expect(last_response.status).to eq(201)
+      parsed = JSON.parse(last_response.body)
+      expect(parsed['json_class']).to eq('JsonClassTarget')
+    end
+  end
+end


### PR DESCRIPTION
## What

When `MultiJson` is not available, `Grape::Json` falls back to stdlib `::JSON`. `Grape::Parser::Json` calls `Grape::Json.load` to parse incoming request bodies.

`JSON.load` (unlike `JSON.parse`) honours the `json_class` magic key: it looks up the named constant and calls `.json_create` on it, passing all decoded data. This allows a remote caller to instantiate arbitrary Ruby objects that are already loaded in the process.

This PR wraps the stdlib fallback in a thin module and passes `create_additions: false` to `JSON.load`, which disables that dispatch. The `MultiJson` path is untouched.

## Why this is not a CVE

- **Zero default attack surface.** No classes expose `json_create` with a bare `require 'json'`. The dangerous `json/add/core` (which does add `json_create` to `Regexp`, `Exception`, `Symbol`, etc.) is not loaded by Grape, Rack, or Rails.
- **No known RCE gadget chain.** The stdlib classes that do define `json_create` do not lead to code execution. This is fundamentally different from the Rails YAML/Psych CVEs (e.g. CVE-2013-0156) where RCE was achievable via common library classes.
- **The reporter agreed.** The original security report explicitly stated they would claim it is not worthy of a CVE assignment.
- **Upstream is already fixing it.** Since `json` gem 2.8.0, `JSON.load` emits a deprecation warning when `create_additions` is not explicitly set, and `json` 3.0 will default it to `false`.

The real concern is the information-disclosure angle: `JSON.load` calls `const_get` on the class name, so an attacker can probe what constants are loaded in the process by observing whether they get a 500 vs. a normal response. That alone is enough reason to apply this fix.

## Changes

- `lib/grape/json.rb`: wrap the stdlib JSON fallback in a `Grape::Json` module whose `load` delegates to `JSON.load(..., create_additions: false)`
- `spec/grape/parser/json_spec.rb`: regression spec verifying `json_class` payloads are not deserialized