### PR TITLE
Replace JSON.load with JSON.parse in Grape::Json stdlib fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 * [#2706](https://github.com/ruby-grape/grape/pull/2706): Fix `optional :foo, message: 'oops'` raising `UnknownValidator` - [@ericproulx](https://github.com/ericproulx).
 * [#2751](https://github.com/ruby-grape/grape/pull/2751): Fix structured error messages leaking the raw i18n key for an undefined optional step such as `summary` (closes #2748) - [@ericproulx](https://github.com/ericproulx).
 * [#2759](https://github.com/ruby-grape/grape/pull/2759): Use `create_additions: false` in `Grape::Json.load` to prevent object instantiation via the `json_class` key when using the stdlib JSON fallback - [@dblock](https://github.com/dblock).
+* [#2761](https://github.com/ruby-grape/grape/pull/2761): Replace `JSON.load` with `JSON.parse` in the stdlib `Grape::Json` fallback - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 3.2.1 (2026-04-16)

--- a/lib/grape/json.rb
+++ b/lib/grape/json.rb
@@ -8,7 +8,7 @@ module Grape
       ParseError = ::JSON::ParserError
 
       def self.load(str)
-        ::JSON.load(str, nil, create_additions: false)
+        ::JSON.parse(str)
       end
 
       def self.dump(obj, *)


### PR DESCRIPTION
Follow-up to #2759.

`JSON.parse` is the semantically correct API for parsing untrusted input. `JSON.load` is documented for internal serialization of trusted data (analogous to `Marshal.load`). The previous fix passed `create_additions: false` to neuter `JSON.load` — but that just makes it behave like `JSON.parse`. May as well use the right call directly.

To me it looks strange that we'd overload `load` with `parse`, so I think we don't merge this.