### PR TITLE
Parse request bodies with JSON.parse in the stdlib fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 * [#2752](https://github.com/ruby-grape/grape/pull/2752): Skip per-request `ActiveSupport::Notifications` payload and dispatch when no subscriber is listening, via private `instrument_<event>` guards on `Endpoint`/`Middleware::Formatter` - [@ericproulx](https://github.com/ericproulx).
 * [#2757](https://github.com/ruby-grape/grape/pull/2757): Build the `Grape::Cookies` jar only when a cookie is read or written (via a new `Grape::Request#cookies?` predicate gating response-cookie flushing), and drop the jar's now-redundant lazy-parse `Proc` - [@ericproulx](https://github.com/ericproulx).
 * [#2756](https://github.com/ruby-grape/grape/pull/2756): Tighten dependency lower bounds to their compatibility floors (`rack >= 2.2.4`, `zeitwerk >= 2.6`, `dry-configurable >= 1.0`) - [@ericproulx](https://github.com/ericproulx).
+* [#2762](https://github.com/ruby-grape/grape/pull/2762): Parse request bodies with `JSON.parse` in the stdlib JSON fallback, dropping the `create_additions: false` wrapper from #2759 (`JSON.parse` never honours `json_class`) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/json.rb
+++ b/lib/grape/json.rb
@@ -4,16 +4,7 @@ module Grape
   if defined?(::MultiJson)
     Json = ::MultiJson
   else
-    module Json
-      ParseError = ::JSON::ParserError
-
-      def self.load(str)
-        ::JSON.load(str, nil, create_additions: false)
-      end
-
-      def self.dump(obj, *)
-        ::JSON.dump(obj, *)
-      end
-    end
+    Json = ::JSON
+    Json::ParseError = Json::ParserError
   end
 end

--- a/lib/grape/parser/json.rb
+++ b/lib/grape/parser/json.rb
@@ -4,7 +4,7 @@ module Grape
   module Parser
     class Json < Base
       def self.call(object, _env)
-        ::Grape::Json.load(object)
+        ::Grape::Json.parse(object)
       rescue ::Grape::Json::ParseError
         # handle JSON parsing errors via the rescue handlers or provide error message
         raise Grape::Exceptions::InvalidMessageBody.new('application/json')

--- a/spec/grape/parser/json_spec.rb
+++ b/spec/grape/parser/json_spec.rb
@@ -14,7 +14,8 @@ describe Grape::Parser::Json, if: !defined?(MultiJson) do
   end
 
   # Verify that json_class payloads are treated as plain data and do not
-  # trigger Ruby object instantiation via JSON.load's create_additions mechanism.
+  # trigger Ruby object instantiation. JSON.parse never honours the json_class
+  # additions mechanism (unlike JSON.load), so the named class is never built.
   context 'when the request body contains a json_class key' do
     let(:triggered) { [] }
 


### PR DESCRIPTION
## What

Follow-up to #2759. This achieves the same security guarantee with a smaller, simpler change by fixing the `json_class` deserialization vector at its source — the parser — instead of wrapping the JSON fallback.

Two parts:

1. **`lib/grape/json.rb` returns to its pre-#2759 shape.** The original stdlib fallback was simply `Grape::Json = ::JSON` (with `Json::ParseError = Json::ParserError`). #2759 replaced that with a wrapper module so it could pass `create_additions: false` to `JSON.load`. With the parser fixed (below), that wrapper is unnecessary, so this reverts to the original.

2. **`lib/grape/parser/json.rb` parses with `JSON.parse` instead of `JSON.load`.** This is the only genuinely new line.

```diff
 module Grape
   if defined?(::MultiJson)
     Json = ::MultiJson
   else
-    module Json
-      ParseError = ::JSON::ParserError
-
-      def self.load(str)
-        ::JSON.load(str, nil, create_additions: false)
-      end
-
-      def self.dump(obj, *)
-        ::JSON.dump(obj, *)
-      end
-    end
+    Json = ::JSON
+    Json::ParseError = Json::ParserError
   end
 end
```

```diff
-        ::Grape::Json.load(object)
+        ::Grape::Json.parse(object)
```

## Why this is a better fix than #2759

#2759 closed the `json_class` hole by wrapping the stdlib fallback in a module whose `load` delegated to `JSON.load(str, nil, create_additions: false)`.

The cleaner observation is that **`JSON.parse` never honours the `json_class` additions mechanism in the first place** — it ignores `create_additions` unless you explicitly opt in. Parsing request bodies with `JSON.parse` therefore gives the exact same safety guarantee without the wrapper, the explicit option, or a per-call delegating method:

- **Smaller diff / no new wrapper.** `lib/grape/json.rb` goes back to the form it had for years before #2759; `Grape::Json` is just `::JSON` again, with no extra `self.load`/`self.dump` indirection on the parse hot path.
- **Same security posture.** `json_class` payloads are returned as plain hashes and never instantiate Ruby objects — verified by the regression specs added in #2759 (kept here; comment updated to reflect that it is `JSON.parse`, not `create_additions: false`, that keeps them inert).
- **Not coupled to `JSON.load`'s shifting defaults.** `load` is the "rich, trusting" entry point (object additions, accepts `IO`/`nil`, etc.); since `json` 2.8.0 it warns when `create_additions` is unset and `json` 3.0 will default it to `false`. `JSON.parse` already behaves that way today, so using it sidesteps the deprecation entirely. Request bodies are plain data, and `parse` is the plain-data decoder.

## Both adapters stay correct

| Path | `Grape::Json` | `.parse` | `Grape::Json::ParseError` |
|------|---------------|----------|---------------------------|
| stdlib (`require 'json'`) | `::JSON` | `JSON.parse` (additions off by default) | `::JSON::ParserError` (aliased, as before #2759) |
| `MultiJson` present | `::MultiJson` | `MultiJson.parse` (plain data, no additions) | `MultiJson::ParseError` (autoloaded) |

`MultiJson` responds to `.parse` and returns plain data, so the `MultiJson` branch keeps working unchanged.

## Empty bodies

`JSON.parse("")` raises where `JSON.load("")` returns `nil`, but this is a non-issue: `Grape::Middleware::Formatter#read_rack_input` returns early on an empty body (`return if body.empty?`) and never calls the parser, so the parser only ever sees a non-empty body.

## Changes

- `lib/grape/json.rb`: revert #2759's wrapper module; restore the original `Grape::Json = ::JSON` stdlib fallback.
- `lib/grape/parser/json.rb`: parse with `JSON.parse` instead of `JSON.load`.
- `spec/grape/parser/json_spec.rb`: update the regression spec comment to reflect that `JSON.parse` (not `JSON.load` + `create_additions: false`) is what keeps `json_class` payloads inert. The existing assertions are unchanged and still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
