### PR TITLE
Route Grape::Json through the non-deprecated MultiJSON API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,9 @@ jobs:
             gemfile: gemfiles/multi_json.gemfile
             specs: 'spec/integration/multi_json'
           - ruby: '4.0'
+            gemfile: gemfiles/multi_json_1_20.gemfile
+            specs: 'spec/integration/multi_json'
+          - ruby: '4.0'
             gemfile: gemfiles/multi_xml.gemfile
             specs: 'spec/integration/multi_xml'
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 * [#2706](https://github.com/ruby-grape/grape/pull/2706): Fix `optional :foo, message: 'oops'` raising `UnknownValidator` - [@ericproulx](https://github.com/ericproulx).
 * [#2751](https://github.com/ruby-grape/grape/pull/2751): Fix structured error messages leaking the raw i18n key for an undefined optional step such as `summary` (closes #2748) - [@ericproulx](https://github.com/ericproulx).
 * [#2759](https://github.com/ruby-grape/grape/pull/2759): Use `create_additions: false` in `Grape::Json.load` to prevent object instantiation via the `json_class` key when using the stdlib JSON fallback - [@dblock](https://github.com/dblock).
+* [#2764](https://github.com/ruby-grape/grape/pull/2764): Route `Grape::Json` through the non-deprecated `MultiJSON` API - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.2.1 (2026-04-16)

--- a/gemfiles/multi_json_1_20.gemfile
+++ b/gemfiles/multi_json_1_20.gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-gem 'multi_json', '>= 1.21'
+gem 'multi_json', '< 1.21'
 
 eval_gemfile '../Gemfile'

--- a/lib/grape/json.rb
+++ b/lib/grape/json.rb
@@ -1,8 +1,44 @@
 # frozen_string_literal: true
 
 module Grape
-  if defined?(::MultiJson)
-    Json = ::MultiJson
+  if defined?(::MultiJSON)
+    # Since multi_json 1.21.0, MultiJSON.dump is deprecated in favor of
+    # MultiJSON.generate (removed in 2.0). Keep Grape's dump surface but route
+    # it to the non-deprecated name — identical output, no deprecation warning.
+    # https://github.com/sferik/multi_json/blob/v1.21.1/CHANGELOG.md#deprecated
+    module Json
+      ParseError = ::MultiJSON::ParseError
+
+      class << self
+        def dump(object)
+          ::MultiJSON.generate(object)
+        end
+
+        # parse is not deprecated; it's re-exposed (not renamed) because this
+        # facade is its own module and no longer inherits MultiJSON's methods.
+        def parse(source)
+          ::MultiJSON.parse(source)
+        end
+      end
+    end
+  elsif defined?(::MultiJson)
+    # Legacy multi_json (< 1.21) predates generate/parse and only exposes
+    # dump/load. Map Grape's surface onto them so the call sites stay
+    # engine-agnostic (these names are not deprecated on < 1.21).
+    module Json
+      # Mutually exclusive with the MultiJSON branch above; only one runs.
+      ParseError = ::MultiJson::ParseError # rubocop:disable Lint/ConstantReassignment
+
+      class << self
+        def dump(object)
+          ::MultiJson.dump(object)
+        end
+
+        def parse(source)
+          ::MultiJson.load(source)
+        end
+      end
+    end
   else
     Json = ::JSON
     Json::ParseError = Json::ParserError

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -2580,7 +2580,7 @@ describe Grape::API do
         raise 'rain!'
       end
       get '/exception'
-      json = Grape::Json.load(last_response.body)
+      json = Grape::Json.parse(last_response.body)
       expect(json['error']).to eql 'rain!'
       expect(json['backtrace'].length).to be > 0
     end
@@ -3975,7 +3975,7 @@ describe Grape::API do
 
     it 'path' do
       get '/endpoint/options'
-      options = Grape::Json.load(last_response.body)
+      options = Grape::Json.parse(last_response.body)
       expect(options['path']).to eq(['/endpoint/options'])
       expect(options['source_location'][0]).to include 'api_spec.rb'
       expect(options['source_location'][1].to_i).to be > 0

--- a/spec/integration/multi_json/json_spec.rb
+++ b/spec/integration/multi_json/json_spec.rb
@@ -1,8 +1,30 @@
 # frozen_string_literal: true
 
 # grape_entity depends on multi-json and it breaks the test.
-describe Grape::Json, if: defined?(MultiJson) && !defined?(Grape::Entity) do
+describe Grape::Json, if: (defined?(MultiJSON) || defined?(MultiJson)) && !defined?(Grape::Entity) do
   subject { described_class }
 
-  it { is_expected.to eq(MultiJson) }
+  # Exercise the full request/response JSON stack (parser + formatter) through
+  # the active multi_json backend (MultiJSON on >= 1.21, the legacy MultiJson
+  # facade on < 1.21); a deprecated call anywhere in the path would raise via
+  # the suite's deprecation handler.
+  context 'with a Grape API that parses and renders JSON' do
+    let(:app) do
+      Class.new(Grape::API) do
+        format :json
+
+        post '/echo' do
+          { received: params[:value] }
+        end
+      end
+    end
+
+    it 'parses the JSON body and renders the JSON response' do
+      env = Rack::MockRequest.env_for('/echo', method: Rack::POST, input: JSON.dump(value: 'hi'), 'CONTENT_TYPE' => 'application/json')
+      response = Rack::MockResponse[*app.call(env)]
+
+      expect(response.status).to eq(201)
+      expect(JSON.parse(response.body)).to eq('received' => 'hi')
+    end
+  end
 end


### PR DESCRIPTION
Fixes #2763.

## Background

multi_json **1.21.0** introduced three deprecations at once (all slated for removal in 2.0):

| Deprecated | Replacement |
| --- | --- |
| `MultiJson` constant | `MultiJSON` |
| `MultiJSON.load` | `MultiJSON.parse` |
| `MultiJSON.dump` | `MultiJSON.generate` |

`lib/grape/json.rb` detected the backend via `::MultiJson` and `Grape::Json.dump` resolved to `MultiJSON.dump`, so anyone on multi_json >= 1.21 saw the deprecation warning reported in #2763:

```
The MultiJson constant is deprecated and will be removed in v2.0. Use MultiJSON instead.
```

Simply swapping the constant (`::MultiJson` → `::MultiJSON`) is **not** enough: `Grape::Json.dump`/`.load` would then resolve to the deprecated *method* names and warn instead. `generate`/`parse` are byte-identical replacements for `dump`/`load` (verified against both a pre-1.21 and a 1.21 build — only the names changed), so the fix is to route Grape's calls to the non-deprecated names.

## What this PR does

### 1. `Grape::Json` becomes a small engine-agnostic facade

Grape keeps its own stable `dump`/`parse` surface; each backend maps it to its non-deprecated methods:

| Backend | `Grape::Json` | `dump` → | `parse` → |
| --- | --- | --- | --- |
| multi_json >= 1.21 (`MultiJSON`) | facade | `MultiJSON.generate` | `MultiJSON.parse` |
| multi_json < 1.21 (`MultiJson`) | facade | `MultiJson.dump` | `MultiJson.load` |
| no multi_json | `= ::JSON` | `JSON.dump` | `JSON.parse` |

Call sites are unchanged and output is identical on every path, so this is behavior-preserving.

### 2. `Grape::Json.load` is removed entirely

Following #2762 (Grape parses request bodies with `JSON.parse`, never `JSON.load`, to avoid the `json_class`/`create_additions` instantiation vector), `load` should not appear in the codebase. The two remaining `Grape::Json.load` test helpers now use `parse`, and the facade no longer defines `load`.

### 3. Legacy multi_json (< 1.21) no longer raises

multi_json < 1.21 has **no `parse` method** (only `dump`/`load`), so after #2762 `Grape::Json.parse` would raise `NoMethodError` on those versions. The legacy branch now maps `parse` → `MultiJson.load`, fixing that while preserving the user's adapter (oj/yajl).

### 4. CI covers both multi_json lines

`gemfiles/multi_json.gemfile` is pinned to `>= 1.21` and a new `gemfiles/multi_json_1_20.gemfile` pins `< 1.21`; both run the `spec/integration/multi_json` suite, so the MultiJSON and legacy-MultiJson facades are each exercised. The integration spec keys off the `MultiJson` constant (defined on both lines) and drives a real Grape API end to end — a JSON request body through the parser into `params`, and a Hash response through the JSON formatter.

## Testing

- Full suite green on every path:
  - `BUNDLE_GEMFILE=gemfiles/multi_json.gemfile bundle exec rspec` (>= 1.21, reproduces #2763): 2323 examples, 0 failures
  - `BUNDLE_GEMFILE=gemfiles/multi_json_1_20.gemfile bundle exec rspec spec/integration/multi_json` (< 1.21, resolves to 1.20.1): 1 example, 0 failures
  - `bundle exec rspec` (stdlib `JSON` fallback): 2322 examples, 0 failures
- RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)