### PR TITLE
Detect the MultiXML constant to avoid the multi_xml deprecation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,9 @@ jobs:
           - ruby: '4.0'
             gemfile: gemfiles/multi_xml.gemfile
             specs: 'spec/integration/multi_xml'
+          - ruby: '4.0'
+            gemfile: gemfiles/multi_xml_0_8.gemfile
+            specs: 'spec/integration/multi_xml'
     runs-on: ubuntu-latest
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 * [#2706](https://github.com/ruby-grape/grape/pull/2706): Fix `optional :foo, message: 'oops'` raising `UnknownValidator` - [@ericproulx](https://github.com/ericproulx).
 * [#2751](https://github.com/ruby-grape/grape/pull/2751): Fix structured error messages leaking the raw i18n key for an undefined optional step such as `summary` (closes #2748) - [@ericproulx](https://github.com/ericproulx).
 * [#2759](https://github.com/ruby-grape/grape/pull/2759): Use `create_additions: false` in `Grape::Json.load` to prevent object instantiation via the `json_class` key when using the stdlib JSON fallback - [@dblock](https://github.com/dblock).
+* [#2765](https://github.com/ruby-grape/grape/pull/2765): Detect the `MultiXML` constant to avoid the multi_xml 0.9 `MultiXml` deprecation - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.2.1 (2026-04-16)

--- a/gemfiles/multi_xml_0_8.gemfile
+++ b/gemfiles/multi_xml_0_8.gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-gem 'multi_xml', '>= 0.9'
+gem 'multi_xml', '< 0.9'
 
 eval_gemfile '../Gemfile'

--- a/lib/grape/xml.rb
+++ b/lib/grape/xml.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
 module Grape
-  if defined?(::MultiXml)
+  # Since multi_xml 0.9.0 the canonical constant is MultiXML; MultiXml is a
+  # deprecated alias (removed in v1.0) that warns on use. Prefer MultiXML so
+  # Grape::Xml.parse doesn't trip the deprecation, falling back to the legacy
+  # constant and then ActiveSupport::XmlMini.
+  # https://github.com/sferik/multi_xml/blob/v0.9.1/CHANGELOG.md
+  if defined?(::MultiXML)
+    Xml = ::MultiXML
+  elsif defined?(::MultiXml)
     Xml = ::MultiXml
   else
     Xml = ::ActiveSupport::XmlMini

--- a/spec/integration/multi_xml/xml_spec.rb
+++ b/spec/integration/multi_xml/xml_spec.rb
@@ -1,7 +1,23 @@
 # frozen_string_literal: true
 
 describe Grape::Xml, if: defined?(MultiXml) do
-  subject { described_class }
+  # Exercise the full request stack: a Grape API parses an XML body through the
+  # active multi_xml backend (MultiXML on >= 0.9, the legacy MultiXml alias on
+  # < 0.9). Calling parse through the deprecated MultiXml constant would raise
+  # via the suite's deprecation handler (see spec/support/deprecated_warning_handlers.rb).
+  let(:app) do
+    Class.new(Grape::API) do
+      post '/request_body' do
+        params[:user]
+      end
+    end
+  end
 
-  it { is_expected.to eq(MultiXml) }
+  it 'parses an XML request body into params' do
+    env = Rack::MockRequest.env_for('/request_body', method: Rack::POST, input: '<user>Bobby T.</user>', 'CONTENT_TYPE' => 'application/xml')
+    response = Rack::MockResponse[*app.call(env)]
+
+    expect(response.status).to eq(201)
+    expect(response.body).to eq('Bobby T.')
+  end
 end


### PR DESCRIPTION
## Background

multi_xml **0.9.0** renamed its constant from `MultiXml` to `MultiXML` (same modernization as multi_json 1.21.0, by the same author). `MultiXml` is now a deprecated alias, removed in v1.0, that emits a one-time warning on constant access or method call:

```
The MultiXml constant is deprecated and will be removed in v1.0. Use MultiXML instead.
```

`lib/grape/xml.rb` detected the backend via `::MultiXml` and `Grape::Xml.parse` resolved to `MultiXml.parse`, so users on multi_xml >= 0.9 would hit the deprecation.

## What this PR does

Detect `::MultiXML` first, then fall back to the legacy `::MultiXml` constant, then `ActiveSupport::XmlMini`:

| Backend | `Grape::Xml` |
| --- | --- |
| multi_xml >= 0.9 | `::MultiXML` |
| multi_xml < 0.9 | `::MultiXml` |
| no multi_xml | `::ActiveSupport::XmlMini` |

**Unlike the multi_json counterpart (#2764), no facade is needed.** multi_xml's only method-level deprecation is `load` → `parse`, and Grape calls only `parse`, which is canonical (not renamed) on every backend — so a direct constant alias suffices.

### CI covers both multi_xml lines

`gemfiles/multi_xml.gemfile` is pinned to `>= 0.9` and a new `gemfiles/multi_xml_0_8.gemfile` pins `< 0.9`; both run the `spec/integration/multi_xml` suite, exercising the `MultiXML` and legacy-`MultiXml` paths. The integration spec now drives a real Grape API that parses an XML request body through `Grape::Xml.parse` (rather than a static constant-equality check), so a regression onto the deprecated constant surfaces via the suite's deprecation handler.

## Testing

- `BUNDLE_GEMFILE=gemfiles/multi_xml.gemfile bundle exec rspec spec/integration/multi_xml` (>= 0.9, resolves to 0.9.1): 1 example, 0 failures
- `BUNDLE_GEMFILE=gemfiles/multi_xml_0_8.gemfile bundle exec rspec spec/integration/multi_xml` (< 0.9, resolves to 0.8.1): 1 example, 0 failures
- `bundle exec rspec` (no multi_xml, `XmlMini` fallback): 2322 examples, 0 failures
- Verified the integration spec fails against the pre-fix `lib/grape/xml.rb` under multi_xml 0.9.1 (the deprecation surfaces), confirming it guards the regression.
- RuboCop clean.

This is the multi_xml counterpart to #2764 (multi_json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)