### PR TITLE
Update rubocop to 1.88.0 and rubocop-rspec to 3.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#2767](https://github.com/ruby-grape/grape/pull/2767): Update rubocop to 1.88.0 and rubocop-rspec to 3.10.2 - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.0 (2026-06-20)

--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,9 @@ group :development, :test do
   gem 'builder', require: false
   gem 'bundler'
   gem 'rake'
-  gem 'rubocop', '1.86.0', require: false
+  gem 'rubocop', '1.88.0', require: false
   gem 'rubocop-performance', '1.26.1', require: false
-  gem 'rubocop-rspec', '3.9.0', require: false
+  gem 'rubocop-rspec', '3.10.2', require: false
 end
 
 group :development do

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3691,8 +3691,8 @@ describe Grape::API do
           mount app
         end
         expect(subject.routes.size).to eq(2)
-        expect(subject.routes.first.path).to match(%r{/cool/awesome})
-        expect(subject.routes.last.path).to match(%r{/cool/sauce})
+        expect(subject.routes.first.path).to include('/cool/awesome')
+        expect(subject.routes.last.path).to include('/cool/sauce')
       end
 
       it 'mounts on a path' do

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -39,7 +39,7 @@ describe Grape::Validations::ParamsScope do
 
       get '/types', foo: 'invalid'
       expect(last_response.status).to eq(400)
-      expect(last_response.body).to match(/foo is invalid/)
+      expect(last_response.body).to include('foo is invalid')
     end
   end
 

--- a/spec/grape/validations/validators/oneof_validator_spec.rb
+++ b/spec/grape/validations/validators/oneof_validator_spec.rb
@@ -85,19 +85,19 @@ describe Grape::Validations::Validators::OneofValidator do
     it 'rejects values that do not match any variant' do
       post '/pricing', { value: { time_unit: 'hour', rate: 'not-a-number' } }.to_json, 'CONTENT_TYPE' => 'application/json'
       expect(last_response.status).to eq(400)
-      expect(JSON.parse(last_response.body)['error']).to match(/does not match any of the allowed schemas/)
+      expect(JSON.parse(last_response.body)['error']).to include('does not match any of the allowed schemas')
     end
 
     it 'rejects values with no matching keys' do
       post '/pricing', { value: { something_else: 1 } }.to_json, 'CONTENT_TYPE' => 'application/json'
       expect(last_response.status).to eq(400)
-      expect(JSON.parse(last_response.body)['error']).to match(/does not match any of the allowed schemas/)
+      expect(JSON.parse(last_response.body)['error']).to include('does not match any of the allowed schemas')
     end
 
     it 'rejects when the value key is missing entirely' do
       post '/pricing', '{}', 'CONTENT_TYPE' => 'application/json'
       expect(last_response.status).to eq(400)
-      expect(JSON.parse(last_response.body)['error']).to match(/value is missing/)
+      expect(JSON.parse(last_response.body)['error']).to include('value is missing')
     end
   end
 

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -1253,8 +1253,8 @@ describe Grape::Validations do
       it 'throws the validation errors' do
         get '/two_required'
         expect(last_response.status).to eq(400)
-        expect(last_response.body).to match(/yolo is missing/)
-        expect(last_response.body).to match(/swag is missing/)
+        expect(last_response.body).to include('yolo is missing')
+        expect(last_response.body).to include('swag is missing')
       end
     end
 


### PR DESCRIPTION
Bump RuboCop to 1.88.0 and rubocop-rspec to 3.10.2.

Fixes the spec offenses the new versions flag by preferring `include` over `match` for plain-string matchers (`RSpec/MatchArray`-style guidance / `Style/StringMatch`). No production code changes; `bundle exec rubocop` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)