### PR TITLE
Fix double wrap on json errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 * [#2767](https://github.com/ruby-grape/grape/pull/2767): Update rubocop to 1.88.0 and rubocop-rspec to 3.10.2 - [@ericproulx](https://github.com/ericproulx).
 * [#2770](https://github.com/ruby-grape/grape/pull/2770): Avoid per-entry array allocation in `Request#build_headers` - [@ericproulx](https://github.com/ericproulx).
+* [#2771](https://github.com/ruby-grape/grape/pull/2771): Fix double wrap on json errors - [@MattHall](https://github.com/MattHall).
 * Your contribution here.
 
 ### 3.3.0 (2026-06-20)

--- a/lib/grape/error_formatter/json.rb
+++ b/lib/grape/error_formatter/json.rb
@@ -11,14 +11,16 @@ module Grape
         private
 
         def wrap_message(message)
-          case message
-          when Hash
-            message
-          when Exceptions::ValidationErrors
-            message.as_json
-          else
-            { error: ensure_utf8(message) }
-          end
+          # Use +is_a?+ rather than +case/when+ here. +case/when Hash+ matches via
+          # +Module#===+, a C-level real-class check that ignores delegation, so a
+          # +SimpleDelegator+ wrapping a Hash (e.g. the +OutputBuilder+ returned by
+          # +Grape::Entity#serializable_hash+ when an error is presented via an entity)
+          # would fall through and be wrapped in a spurious +{ error: ... }+ envelope.
+          # +is_a?+ is forwarded by the delegator to the wrapped Hash, so it matches.
+          return message if message.is_a?(Hash)
+          return message.as_json if message.is_a?(Exceptions::ValidationErrors)
+
+          { error: ensure_utf8(message) }
         end
 
         def ensure_utf8(message)

--- a/spec/integration/grape_entity/entity_spec.rb
+++ b/spec/integration/grape_entity/entity_spec.rb
@@ -417,5 +417,27 @@ describe 'Grape::Entity', if: defined?(Grape::Entity) do
         expect(subject.body).to eql({ code: 408, static: 'some static text' }.to_json)
       end
     end
+
+    context 'when the format is :json' do
+      let(:app) do
+        Class.new(Grape::API) do
+          format :json
+
+          desc 'some desc', http_codes: [[408, 'Unauthorized', ErrorPresenter]]
+          get '/exception' do
+            error!({ code: 408 }, 408)
+          end
+        end
+      end
+
+      # Regression: a presented error hash must not be wrapped in an extra
+      # `{ "error": ... }` envelope. `Grape::Entity#serializable_hash` returns a
+      # `SimpleDelegator` around a Hash, which `Json#wrap_message`'s `case/when Hash`
+      # (via `Module#===`) fails to match, so it falls through to the `else` branch.
+      it 'is presented without an extra error envelope' do
+        expect(subject).to be_request_timeout
+        expect(JSON(subject.body)).to eql('code' => 408, 'static' => 'some static text')
+      end
+    end
   end
 end


### PR DESCRIPTION
When an error is presented via an entity, ErrorFormatter::Base#present returns:

```
presenter.represent(message, embeds).serializable_hash
```

`Grape::Entity#serializable_hash` does not return a plain `Hash` - it returns a `Grape::Entity::Exposure::NestingExposure::OutputBuilder`, which is a `SimpleDelegator` wrapping a `Hash` (not a Hash subclass).

3.3.0 refactored `ErrorFormatter::Json#wrap_message` from an `is_a?` check to `case`/`when`:

### 3.2.1
```
return message if message.is_a?(Hash)   # delegated to the wrapped Hash → true → returned unwrapped
```

### 3.3.0
```
case message
when Hash then message                  # Hash === message → C-level real-class check → false
else { error: ensure_utf8(message) }    # OutputBuilder falls here → wrapped
end
```

`obj.is_a?(Hash)` is an ordinary method call, so `SimpleDelegator` forwards it to the wrapped `Hash` (true). But case/when Hash matches via Module#===, a C-level ancestry check that ignores delegation (false) — so the delegator falls through to the else branch and gets wrapped.

## Fix

Restore `is_a?` based matching in `ErrorFormatter::Json#wrap_message`, bringing it back in line with the base class and the pre-3.3.0 behaviour. A comment documents the `Module#===` vs `is_a?` delegation pitfall so it isn't refactored back.
