### PR TITLE
Fix middleware build crash when a top-level ::Options constant is in scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 #### Fixes
 
 * [#2767](https://github.com/ruby-grape/grape/pull/2767): Update rubocop to 1.88.0 and rubocop-rspec to 3.10.2 - [@ericproulx](https://github.com/ericproulx).
+* [#2773](https://github.com/ruby-grape/grape/pull/2773): Fix middleware build crash when a top-level `::Options` constant is in scope - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.1 (2026-06-28)

--- a/lib/grape/middleware/base.rb
+++ b/lib/grape/middleware/base.rb
@@ -16,10 +16,8 @@ module Grape
       #   subclass's `DEFAULT_OPTIONS` Hash (legacy path) and frozen.
       def initialize(app, **options)
         @app = app
-        if self.class.const_defined?(:Options)
-          # Search ancestors so subclasses (e.g. Versioner::Path → Versioner::Base)
-          # inherit their parent's Options Data class without redeclaring it.
-          @config = self.class::Options.new(**options)
+        if (config_class = options_data_class)
+          @config = config_class.new(**options)
           @options = @config.to_h.freeze
         else
           @options = merge_default_options(options).freeze
@@ -92,9 +90,25 @@ module Grape
 
       def merge_default_options(options)
         return default_options.deep_merge(options) if respond_to?(:default_options)
-        return self.class::DEFAULT_OPTIONS.deep_merge(options) if self.class.const_defined?(:DEFAULT_OPTIONS)
 
-        options
+        default_options_constant&.deep_merge(options) || options
+      end
+
+      # self.class::Options honours middleware inheritance (e.g. Versioner::Path
+      # → Versioner::Base) and, unlike const_defined?, never resolves a
+      # top-level ::Options on Object. Absent an own/inherited Options class,
+      # the lookup raises NameError and we fall back to the legacy path.
+      def options_data_class
+        self.class::Options
+      rescue NameError
+        nil
+      end
+
+      # Same idea as {#options_data_class} for the legacy DEFAULT_OPTIONS Hash.
+      def default_options_constant
+        self.class::DEFAULT_OPTIONS
+      rescue NameError
+        nil
       end
 
       def try_scrub(obj)

--- a/spec/grape/middleware/base_spec.rb
+++ b/spec/grape/middleware/base_spec.rb
@@ -153,6 +153,74 @@ describe Grape::Middleware::Base do
         expect(example_ware.new(blank_app, monkey: false).options[:monkey]).to be false
       end
     end
+
+    context 'when an unrelated top-level ::Options constant is in scope' do
+      # The `options` gem (a transitive dep of e.g. progress_bar) defines a
+      # global ::Options. const_defined?(:Options) reaches it through Object,
+      # but `self.class::Options` does not, so the naive guard raised NameError.
+      before { stub_const('Options', Module.new) }
+
+      let(:example_ware) do
+        Class.new(Grape::Middleware::Base) do
+          const_set(:DEFAULT_OPTIONS, { monkey: true }.freeze)
+        end
+      end
+
+      it 'builds without resolving the global ::Options' do
+        expect { example_ware.new(blank_app) }.not_to raise_error
+      end
+
+      it 'falls back to the legacy DEFAULT_OPTIONS path' do
+        expect(example_ware.new(blank_app).options[:monkey]).to be true
+      end
+
+      it 'does not expose a config object' do
+        expect(example_ware.new(blank_app).config).to be_nil
+      end
+    end
+
+    context 'when an unrelated top-level ::DEFAULT_OPTIONS constant is in scope' do
+      before { stub_const('DEFAULT_OPTIONS', { monkey: true }.freeze) }
+
+      let(:example_ware) { Class.new(described_class) }
+
+      it 'ignores the global ::DEFAULT_OPTIONS' do
+        expect(example_ware.new(blank_app).options).not_to have_key(:monkey)
+      end
+    end
+
+    context 'when a middleware declares its own Options Data class' do
+      let(:example_ware) do
+        Class.new(Grape::Middleware::Base) do
+          self::Options = Data.define(:monkey)
+        end
+      end
+
+      it 'routes options through the Options value object' do
+        instance = example_ware.new(blank_app, monkey: true)
+        expect(instance.config.monkey).to be true
+        expect(instance.options[:monkey]).to be true
+      end
+
+      it 'still resolves its own Options when a global ::Options is in scope' do
+        stub_const('Options', Module.new)
+        expect(example_ware.new(blank_app, monkey: true).config.monkey).to be true
+      end
+    end
+
+    context 'when a middleware inherits its parent Options Data class' do
+      let(:parent_ware) do
+        Class.new(Grape::Middleware::Base) do
+          self::Options = Data.define(:monkey)
+        end
+      end
+
+      let(:child_ware) { Class.new(parent_ware) }
+
+      it 'inherits the ancestor Options without redeclaring it' do
+        expect(child_ware.new(blank_app, monkey: true).config.monkey).to be true
+      end
+    end
   end
 
   context 'header' do


### PR DESCRIPTION
Fixes #2772.

### Problem

Since 3.3.0, `Grape::Middleware::Base#initialize` routes options through a per-class `Options` `Data` value object when the subclass declares one:

```ruby
if self.class.const_defined?(:Options)
  @config = self.class::Options.new(**options)
  ...
```

`const_defined?(:Options)` defaults to `inherit: true`, so the lookup also walks up to **top-level constants on `Object`**. If anything in the process defines a global `::Options`, the guard returns `true` for *every* middleware subclass — even ones that never declare their own `Options`. The subsequent `self.class::Options` then raises `NameError`, because the `::` resolution operator does **not** fall back to `Object`. The whole middleware stack fails to build.

This is not hypothetical: the [`options`](https://rubygems.org/gems/options) gem defines a top-level `::Options` module on load and is a transitive dependency of common gems (e.g. `progress_bar`). With it loaded, every third-party middleware that subclasses `Grape::Middleware::Base` without its own `Options` (e.g. `grape_logging`'s `RequestLogger`) crashes:

```
NameError: uninitialized constant GrapeLogging::Middleware::RequestLogger::Options
```

The `DEFAULT_OPTIONS` path in `merge_default_options` had the **identical** defect (`self.class.const_defined?(:DEFAULT_OPTIONS)` → `self.class::DEFAULT_OPTIONS`), so a global `::DEFAULT_OPTIONS` would crash the same way.

### Fix

Drop the `const_defined?` guard entirely and resolve through `self.class::Options` directly:

```ruby
def options_data_class
  self.class::Options
rescue NameError
  nil
end
```

The `::` resolution operator already does exactly what we need: it honours middleware inheritance (e.g. `Versioner::Path` → `Versioner::Base`) **and**, unlike `const_defined?`, it never falls back to a top-level `::Options` on `Object`. So a global `::Options` is no longer matched, and a middleware that declares none cleanly yields the legacy `DEFAULT_OPTIONS` path. The same treatment is applied to the `DEFAULT_OPTIONS` lookup.

This came down to a quirk of Ruby's reflection API: no predicate method matches the `::` operator's "inherit through ancestors but skip `Object`" semantics — `const_defined?(:X)`/`const_get(:X)` include `Object` (the bug), while their `inherit: false` forms drop inheritance (which would break `Versioner::Path`). Letting `::` raise and rescuing is the most direct way to mirror its behaviour.

### Tests

Added regression specs to `spec/grape/middleware/base_spec.rb` (using `stub_const` for the global constant, auto-cleaned per example):

- A middleware without its own `Options` builds and takes the legacy `DEFAULT_OPTIONS` path even with a global `::Options` in scope (the crash repro), and exposes no `config`.
- A global `::DEFAULT_OPTIONS` is ignored by the legacy merge path.
- A middleware that declares its own `Options` still routes through it, including when a global `::Options` is present.
- A subclass still inherits its parent's `Options` `Data` class without redeclaring it.

### Benchmark

`#initialize` runs once per middleware at app-build time, not per request (`call` does `dup.call!`, which doesn't re-run `initialize`), so this is a boot-path concern only. Comparing the `::`-and-rescue approach against the alternative (walking `self.class.ancestors` with `const_defined?(name, false)`), measured on Ruby 4.0.5 with `benchmark-ips`:

| middleware shape | `::` + rescue | ancestor walk | |
|---|---|---|---|
| declares own `Options` (`Formatter`, `Error`, `Versioner::Base`) | **49 ns** | 212 ns | rescue 4.3× faster |
| inherits `Options` (`Versioner::Path`) | **50 ns** | 306 ns | rescue 6.1× faster |
| no `Options` (most third-party middleware) | 549 ns | **297 ns** | walk 1.85× faster |

`::`-and-rescue is faster in exactly the shapes Grape ships (everything internal declares or inherits `Options`); it is slower only for no-`Options` middleware, where it pays the `NameError` cost — and that ~250 ns delta is boot-only and dwarfed by the rest of construction (a full `ThirdParty.new` with no `Options` is ~1.33 µs, still faster than `Formatter.new` at ~2.02 µs).

### Verification

- `bundle exec rspec spec/grape/middleware/` — all green.
- `bundle exec rubocop lib/grape/middleware/base.rb spec/grape/middleware/base_spec.rb` — no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
