### PR TITLE
Make forward_match an internal kwarg instead of a route option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * [#2768](https://github.com/ruby-grape/grape/pull/2768): Remove Guard - [@ericproulx](https://github.com/ericproulx).
+* [#2774](https://github.com/ruby-grape/grape/pull/2774): Make `forward_match` an internal kwarg instead of a route option - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,14 @@
 Upgrading Grape
 ===============
 
+### Upgrading to >= 4.0.0
+
+#### `forward_match` is no longer exposed on routes
+
+`forward_match` is an internal, construction-time detail that decides how a route matches incoming paths (a prefix match for mounted Rack apps, the compiled pattern otherwise). It is now passed to `Grape::Router::Route` as a keyword argument and derived from the mounted app instead of being carried in the route's options.
+
+As a result it is no longer readable through `route.options[:forward_match]` or the `route.forward_match` reader — both previously returned the flag. Nothing in Grape consumed either, so this only affects code that introspected routes directly; there is no replacement, as the value is now purely internal.
+
 ### Upgrading to >= 3.3
 
 #### Minimum required Ruby is now 3.3

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -160,7 +160,6 @@ module Grape
             path:,
             app:,
             route_options: { anchor: false },
-            forward_match: !app.respond_to?(:inheritable_setting),
             for: self
           )
         end

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -276,6 +276,7 @@ module Grape
       default_route_options = prepare_default_route_attributes(route_options)
       complete_route_options = route_options.merge(default_route_options)
       path_settings = prepare_default_path_settings
+      forward_match = config.app && !config.app.respond_to?(:inheritable_setting)
 
       config.http_methods.flat_map do |method|
         config.path.map do |path|
@@ -289,7 +290,7 @@ module Grape
             version: default_route_options[:version],
             requirements: default_route_options[:requirements]
           )
-          Grape::Router::Route.new(self, method, pattern, complete_route_options)
+          Grape::Router::Route.new(self, method, pattern, complete_route_options, forward_match:)
         end
       end
     end
@@ -301,8 +302,7 @@ module Grape
         requirements: prepare_routes_requirements(route_options[:requirements]),
         prefix: inheritable_setting.namespace_inheritable[:root_prefix],
         anchor: route_options.fetch(:anchor, true),
-        settings: inheritable_setting.route.except(:declared_params, :saved_validations),
-        forward_match: config.forward_match
+        settings: inheritable_setting.route.except(:declared_params, :saved_validations)
       }
     end
 

--- a/lib/grape/endpoint/options.rb
+++ b/lib/grape/endpoint/options.rb
@@ -8,11 +8,11 @@ module Grape
     # stays a plain Hash for downstream gems (e.g. grape-swagger).
     # +:method+ is renamed to +:http_methods+ on the value object to avoid
     # shadowing +Object#method+ via the generated Data accessor.
-    Options = Data.define(:path, :http_methods, :for, :route_options, :app, :format, :forward_match) do
-      def initialize(path:, method:, route_options: {}, app: nil, format: nil, forward_match: nil, **rest)
+    Options = Data.define(:path, :http_methods, :for, :route_options, :app, :format) do
+      def initialize(path:, method:, route_options: {}, app: nil, format: nil, **rest)
         path = Array(path)
         path << '/' if path.empty?
-        super(path:, http_methods: Array(method), route_options:, app:, format:, forward_match:, **rest)
+        super(path:, http_methods: Array(method), route_options:, app:, format:, **rest)
       end
     end
   end

--- a/lib/grape/router/base_route.rb
+++ b/lib/grape/router/base_route.rb
@@ -10,7 +10,7 @@ module Grape
       attr_reader :options, :pattern
 
       def_delegators :@pattern, :path, :origin
-      def_delegators :@options, :description, :version, :requirements, :prefix, :anchor, :settings, :forward_match, *Grape::Util::ApiDescription::DSL_METHODS
+      def_delegators :@options, :description, :version, :requirements, :prefix, :anchor, :settings, *Grape::Util::ApiDescription::DSL_METHODS
 
       def initialize(pattern, options = {})
         @pattern = pattern

--- a/lib/grape/router/route.rb
+++ b/lib/grape/router/route.rb
@@ -12,11 +12,11 @@ module Grape
 
       def_delegators :@app, :call
 
-      def initialize(endpoint, method, pattern, options)
+      def initialize(endpoint, method, pattern, options, forward_match:)
         super(pattern, options)
         @app = endpoint
         @request_method = upcase_method(method)
-        @match_function = options[:forward_match] ? FORWARD_MATCH_METHOD : NON_FORWARD_MATCH_METHOD
+        @match_function = forward_match ? FORWARD_MATCH_METHOD : NON_FORWARD_MATCH_METHOD
       end
 
       def convert_to_head_request!

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3708,6 +3708,21 @@ describe Grape::API do
         expect(last_response.body).to eq('sauce')
       end
 
+      it 'does not forward unknown subpaths to a mounted API' do
+        subject.namespace :cool do
+          app = Class.new(Grape::API) # rubocop:disable RSpec/DescribedClass
+          app.get('/awesome') { 'sauce' }
+          mount app
+        end
+
+        get '/cool/awesome'
+        expect(last_response).to be_successful
+        get '/cool/awesome/subpath'
+        expect(last_response).to be_not_found
+        get '/cool/unknown'
+        expect(last_response).to be_not_found
+      end
+
       it 'mounts on a nested path' do
         app1 = Class.new(described_class)
         app2 = Class.new(described_class)

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -1034,7 +1034,6 @@ describe Grape::Endpoint do
         path: '/path',
         app: {},
         route_options: { anchor: false },
-        forward_match: true,
         for: Class.new
       }
     end

--- a/spec/grape/router/route_spec.rb
+++ b/spec/grape/router/route_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+RSpec.describe Grape::Router::Route do
+  let(:instance) { described_class.new(endpoint, :get, pattern, options, forward_match:) }
+  let(:endpoint) { instance_double(Grape::Endpoint) }
+  let(:options) { {} }
+  let(:pattern) do
+    Grape::Router::Pattern.new(
+      origin: '/mounty',
+      suffix: '',
+      anchor: true,
+      params: {},
+      format: nil,
+      version: nil,
+      requirements: {}
+    )
+  end
+
+  describe 'inheritance' do
+    subject { described_class.new(endpoint, :get, pattern, options, forward_match: false) }
+
+    it { is_expected.to be_a(Grape::Router::BaseRoute) }
+  end
+
+  describe '#match?' do
+    subject { instance.match?(input) }
+
+    context 'when forward_match is true' do
+      let(:forward_match) { true }
+
+      context 'with the exact origin' do
+        let(:input) { '/mounty' }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'with a subpath under the origin' do
+        let(:input) { '/mounty/awesome/deep' }
+
+        it 'matches on the origin prefix' do
+          expect(subject).to be_truthy
+        end
+      end
+
+      context 'with a path outside the origin' do
+        let(:input) { '/other' }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context 'with a blank input' do
+        let(:input) { '' }
+
+        it { is_expected.to be(false) }
+      end
+    end
+
+    context 'when forward_match is false' do
+      let(:forward_match) { false }
+
+      context 'with the exact origin' do
+        let(:input) { '/mounty' }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'with a subpath under the origin' do
+        let(:input) { '/mounty/awesome/deep' }
+
+        it 'does not match beyond the anchored pattern' do
+          expect(subject).to be_falsey
+        end
+      end
+
+      context 'with a blank input' do
+        let(:input) { '' }
+
+        it { is_expected.to be(false) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary

`forward_match` was a derived flag threaded from the `mount`/`route` DSL through `Endpoint::Options` and the route options hash, only to be read once in `Route#initialize` to select the match function (prefix match for mounted Rack apps, compiled pattern otherwise).

Since the value it derives from (`config.app`) already lives on the endpoint, this computes it locally in `Endpoint#to_routes` and passes it to `Grape::Router::Route.new` as a keyword argument, removing the round-trip.

### Changes

- `Grape::Router::Route#initialize` now takes `forward_match:` as a keyword argument rather than reading `options[:forward_match]`.
- `Endpoint#to_routes` derives `forward_match` locally: `config.app && !config.app.respond_to?(:inheritable_setting)` — exactly the condition that previously lived in the `mount` DSL.
- Drops `forward_match` from `Endpoint::Options` and from `prepare_default_route_attributes` (no longer carried in the route options hash).
- Removes the now-dead `BaseRoute#forward_match` delegator (no callers in the codebase).
- Adds `spec/grape/router/route_spec.rb` covering `Route#match?` under both forward and non-forward modes, plus a mount-contrast integration test.

### Upgrading

`forward_match` is now internal: it is no longer readable via `route.options[:forward_match]` or `route.forward_match`. Nothing in Grape consumed either path; documented in `UPGRADING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)