### PR TITLE
Pass http_methods to Grape::Endpoint as a keyword instead of via options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#2768](https://github.com/ruby-grape/grape/pull/2768): Remove Guard - [@ericproulx](https://github.com/ericproulx).
 * [#2774](https://github.com/ruby-grape/grape/pull/2774): Make `forward_match` an internal kwarg instead of a route option - [@ericproulx](https://github.com/ericproulx).
+* [#2775](https://github.com/ruby-grape/grape/pull/2775): Pass `http_methods` to `Grape::Endpoint` as a keyword instead of via options - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -9,6 +9,20 @@ Upgrading Grape
 
 As a result it is no longer readable through `route.options[:forward_match]` or the `route.forward_match` reader — both previously returned the flag. Nothing in Grape consumed either, so this only affects code that introspected routes directly; there is no replacement, as the value is now purely internal.
 
+#### `Grape::Endpoint.new` takes `http_methods:` instead of `method:`
+
+`Grape::Endpoint.new` now receives the HTTP verb(s) under the `http_methods:` keyword instead of `method:`, matching the name used everywhere else. If you build endpoints directly (uncommon — this is an internal API normally driven by the routing DSL), rename the keyword:
+
+```ruby
+# before
+Grape::Endpoint.new(settings, method: :get, path: '/foo', for: self)
+
+# after
+Grape::Endpoint.new(settings, http_methods: :get, path: '/foo', for: self)
+```
+
+Relatedly, an endpoint's public `options` Hash no longer carries `:method` (`endpoint.options[:method]`). Nothing in Grape read it, and downstream gems such as grape-swagger already read the verb from `route.request_method`, which is unchanged.
+
 ### Upgrading to >= 3.3
 
 #### Minimum required Ruby is now 3.3

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -156,7 +156,7 @@ module Grape
 
           endpoints << Grape::Endpoint.new(
             in_setting,
-            method: :any,
+            http_methods: :any,
             path:,
             app:,
             route_options: { anchor: false },
@@ -178,7 +178,7 @@ module Grape
       #     end
       #   end
       def route(methods, paths = ['/'], route_options = {}, &)
-        method = methods == :any ? '*' : methods
+        http_methods = methods == :any ? '*' : methods
         endpoint_params = inheritable_setting.namespace_stackable_with_hash(:params) || {}
         endpoint_description = inheritable_setting.route[:description]
         all_route_options = { params: endpoint_params }
@@ -187,7 +187,7 @@ module Grape
 
         new_endpoint = Grape::Endpoint.new(
           inheritable_setting,
-          method:,
+          http_methods:,
           path: paths,
           for: self,
           route_options: all_route_options,

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -38,17 +38,17 @@ module Grape
     # Create a new endpoint.
     # @param new_settings [InheritableSetting] settings to determine the params,
     #   validations, and other properties from.
+    # @param http_methods [String or Array] which HTTP method(s) can be used to
+    #   reach this endpoint.
     # @param options [Hash] attributes of this endpoint, normalized into a
     #   +Grape::Endpoint::Options+ value object.
     # @option options path [String or Array] the path to this endpoint, within
     #   the current scope.
-    # @option options method [String or Array] which HTTP method(s) can be used
-    #   to reach this endpoint.
     # @option options route_options [Hash]
     # @note This happens at the time of API definition, so in this context the
     # endpoint does not know if it will be mounted under a different endpoint.
     # @yield a block defining what your API should do when this endpoint is hit
-    def initialize(new_settings, **options, &block)
+    def initialize(new_settings, http_methods:, **options, &block)
       self.inheritable_setting = new_settings.point_in_time_copy
 
       # now +namespace_stackable(:declared_params)+ contains all params defined for
@@ -63,8 +63,7 @@ module Grape
       @options = options
       @options[:path] = Array(@options[:path])
       @options[:path] << '/' if @options[:path].empty?
-      @options[:method] = Array(@options[:method])
-      @config = Options.new(**options)
+      @config = Options.new(http_methods:, **options)
 
       @status = nil
       @stream = nil

--- a/lib/grape/endpoint/options.rb
+++ b/lib/grape/endpoint/options.rb
@@ -6,13 +6,12 @@ module Grape
     # +Grape::Endpoint.new+. Internal to {Grape::Endpoint}, which builds it
     # from the +**options+ Hash in #initialize so the public +options+ reader
     # stays a plain Hash for downstream gems (e.g. grape-swagger).
-    # +:method+ is renamed to +:http_methods+ on the value object to avoid
-    # shadowing +Object#method+ via the generated Data accessor.
     Options = Data.define(:path, :http_methods, :for, :route_options, :app, :format) do
-      def initialize(path:, method:, route_options: {}, app: nil, format: nil, **rest)
+      def initialize(path:, http_methods:, route_options: {}, app: nil, format: nil, **rest)
         path = Array(path)
         path << '/' if path.empty?
-        super(path:, http_methods: Array(method), route_options:, app:, format:, **rest)
+        http_methods = Array(http_methods)
+        super
       end
     end
   end

--- a/spec/grape/dsl/routing_spec.rb
+++ b/spec/grape/dsl/routing_spec.rb
@@ -155,7 +155,7 @@ describe Grape::DSL::Routing do
       subject.inheritable_setting.namespace_stackable[:params] = { nuz: 'naz' }
 
       expect(Grape::Endpoint).to receive(:new) do |_inheritable_setting, endpoint_options|
-        expect(endpoint_options[:method]).to eq :get
+        expect(endpoint_options[:http_methods]).to eq :get
         expect(endpoint_options[:path]).to eq '/foo'
         expect(endpoint_options[:for]).to eq subject
         expect(endpoint_options[:route_options]).to eq(foo: 'bar', fiz: 'baz', params: { nuz: 'naz' })

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -1030,7 +1030,7 @@ describe Grape::Endpoint do
 
     let(:options) do
       {
-        method: :path,
+        http_methods: :path,
         path: '/path',
         app: {},
         route_options: { anchor: false },


### PR DESCRIPTION
> Stacked on #2774 — review/merge that one first. The base will auto-retarget to `master` once #2774 merges.

### Summary

`method` was threaded through `Grape::Endpoint.new`'s `**options` Hash, normalized in place (`@options[:method] = Array(...)`), and renamed to `http_methods` on the `Options` value object solely to avoid the `Object#method` shadow on the generated `Data` accessor.

This exposes it as an explicit, required `http_methods:` keyword on `Grape::Endpoint#initialize` and passes it straight into `Options` — whose field is now genuinely named `http_methods`, so the rename hack (and its comment) disappear and `options.method(:x)` no longer shadows `Object#method`.

### Changes

- `Grape::Endpoint#initialize` takes `http_methods:` instead of reading `method` from `**options`.
- `Grape::Endpoint::Options` accepts `http_methods:` directly (no `method:` → `http_methods:` rename).
- The routing DSL (`route`, `mount`) passes `http_methods:`.
- Dropped the dead `@options[:method]` normalization — the endpoint's public `options` Hash no longer carries `:method`.

### Why it stays in `config`

`http_methods` remains part of the `Options` value object because `Endpoint#==`/`eql?` compares `config == other.config`, which is what keeps same-path/different-verb endpoints (e.g. `post '/x'` + `put '/x'`) distinct. Keeping it there means no extra equality term, ivar, or reader.

### Upgrading

`Grape::Endpoint.new` now takes `http_methods:` instead of `method:`, and `endpoint.options[:method]` is gone (grape-swagger and others read the verb from `route.request_method`). Documented in `UPGRADING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)