### PR TITLE
Pass path to Grape::Endpoint as a keyword instead of via options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#2768](https://github.com/ruby-grape/grape/pull/2768): Remove Guard - [@ericproulx](https://github.com/ericproulx).
 * [#2774](https://github.com/ruby-grape/grape/pull/2774): Make `forward_match` an internal kwarg instead of a route option - [@ericproulx](https://github.com/ericproulx).
 * [#2775](https://github.com/ruby-grape/grape/pull/2775): Pass `http_methods` to `Grape::Endpoint` as a keyword instead of via options - [@ericproulx](https://github.com/ericproulx).
+* [#2776](https://github.com/ruby-grape/grape/pull/2776): Pass `path` to `Grape::Endpoint` as a keyword instead of via options - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -21,7 +21,7 @@ Grape::Endpoint.new(settings, method: :get, path: '/foo', for: self)
 Grape::Endpoint.new(settings, http_methods: :get, path: '/foo', for: self)
 ```
 
-Relatedly, an endpoint's public `options` Hash no longer carries `:method` (`endpoint.options[:method]`). Nothing in Grape read it, and downstream gems such as grape-swagger already read the verb from `route.request_method`, which is unchanged.
+Relatedly, an endpoint's public `options` Hash no longer carries `:method` or `:path`. Nothing in Grape read `:method`, and the only reader of `:path` was an internal test; both values are available from the route instead — `route.request_method` for the verb and `route.path` for the (compiled) path, which is what grape-swagger and other introspection already use. The raw definition-time path array is no longer exposed on the endpoint.
 
 ### Upgrading to >= 3.3
 

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -40,15 +40,15 @@ module Grape
     #   validations, and other properties from.
     # @param http_methods [String or Array] which HTTP method(s) can be used to
     #   reach this endpoint.
+    # @param path [String or Array] the path to this endpoint, within the
+    #   current scope.
     # @param options [Hash] attributes of this endpoint, normalized into a
     #   +Grape::Endpoint::Options+ value object.
-    # @option options path [String or Array] the path to this endpoint, within
-    #   the current scope.
     # @option options route_options [Hash]
     # @note This happens at the time of API definition, so in this context the
     # endpoint does not know if it will be mounted under a different endpoint.
     # @yield a block defining what your API should do when this endpoint is hit
-    def initialize(new_settings, http_methods:, **options, &block)
+    def initialize(new_settings, http_methods:, path:, **options, &block)
       self.inheritable_setting = new_settings.point_in_time_copy
 
       # now +namespace_stackable(:declared_params)+ contains all params defined for
@@ -61,9 +61,7 @@ module Grape
       inheritable_setting.namespace_inheritable[:default_error_status] ||= 500
 
       @options = options
-      @options[:path] = Array(@options[:path])
-      @options[:path] << '/' if @options[:path].empty?
-      @config = Options.new(http_methods:, **options)
+      @config = Options.new(http_methods:, path:, **options)
 
       @status = nil
       @stream = nil

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3982,7 +3982,7 @@ describe Grape::API do
       subject.format :json
       subject.get '/endpoint/options' do
         {
-          path: options[:path],
+          path: route.path,
           source_location: source.source_location
         }
       end
@@ -3991,7 +3991,7 @@ describe Grape::API do
     it 'path' do
       get '/endpoint/options'
       options = Grape::Json.parse(last_response.body)
-      expect(options['path']).to eq(['/endpoint/options'])
+      expect(options['path']).to eq('/endpoint/options(.json)')
       expect(options['source_location'][0]).to include 'api_spec.rb'
       expect(options['source_location'][1].to_i).to be > 0
     end


### PR DESCRIPTION
> Stacked on #2775 (which is stacked on #2774) — review/merge those first. The base auto-retargets as the stack lands.

### Summary

`path` was threaded through `Grape::Endpoint.new`'s `**options` Hash and normalized in place (`@options[:path] = Array(...)`), duplicating the normalization `Grape::Endpoint::Options` already performs.

This exposes it as an explicit `path:` keyword on `Grape::Endpoint#initialize`, passed straight into `Options` — the single normalized source of truth. Mirrors the `http_methods:` change in #2775.

### Changes

- `Grape::Endpoint#initialize` takes `path:` instead of reading it from `**options`.
- Dropped the in-place `@options[:path]` normalization (removes the double-normalization).
- The endpoint's public `options` Hash no longer carries `:path`.
- Updated the one internal test that read `options[:path]` to use `route.path`.

### Why it stays in `config`

`path` remains part of the `Options` value object because `config.path` builds the routes (`to_routes`) and `Endpoint#==`/`eql?` compares `config == other.config`, which keeps same-path/different-verb endpoints (e.g. `get '/foo'` + `post '/foo'`) distinct.

### Upgrading

`endpoint.options[:path]` is gone. Its only reader was an internal test; `route.path` (the compiled pattern) is the public path API and is what grape-swagger already uses. Documented in `UPGRADING.md` (folded into the existing endpoint-options note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)