### PR TITLE
Land #2775–#2779 on master (stacked-merge recovery)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#2776](https://github.com/ruby-grape/grape/pull/2776): Pass `path` to `Grape::Endpoint` as a keyword instead of via options - [@ericproulx](https://github.com/ericproulx).
 * [#2777](https://github.com/ruby-grape/grape/pull/2777): Add `Grape::Endpoint#mounted_app` reader and `app:` keyword - [@ericproulx](https://github.com/ericproulx).
 * [#2778](https://github.com/ruby-grape/grape/pull/2778): Rename `Grape::Endpoint`'s `for:` keyword to `api:` and expose `#api` - [@ericproulx](https://github.com/ericproulx).
+* [#2779](https://github.com/ruby-grape/grape/pull/2779): Promote route metadata (`version`, `namespace`, `prefix`, `requirements`, `anchor`, `settings`) to `Grape::Router::Route` keyword arguments - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#2768](https://github.com/ruby-grape/grape/pull/2768): Remove Guard - [@ericproulx](https://github.com/ericproulx).
 * [#2774](https://github.com/ruby-grape/grape/pull/2774): Make `forward_match` an internal kwarg instead of a route option - [@ericproulx](https://github.com/ericproulx).
 * [#2775](https://github.com/ruby-grape/grape/pull/2775): Pass `http_methods` to `Grape::Endpoint` as a keyword instead of via options - [@ericproulx](https://github.com/ericproulx).
+* [#2776](https://github.com/ruby-grape/grape/pull/2776): Pass `path` to `Grape::Endpoint` as a keyword instead of via options - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#2774](https://github.com/ruby-grape/grape/pull/2774): Make `forward_match` an internal kwarg instead of a route option - [@ericproulx](https://github.com/ericproulx).
 * [#2775](https://github.com/ruby-grape/grape/pull/2775): Pass `http_methods` to `Grape::Endpoint` as a keyword instead of via options - [@ericproulx](https://github.com/ericproulx).
 * [#2776](https://github.com/ruby-grape/grape/pull/2776): Pass `path` to `Grape::Endpoint` as a keyword instead of via options - [@ericproulx](https://github.com/ericproulx).
+* [#2777](https://github.com/ruby-grape/grape/pull/2777): Add `Grape::Endpoint#mounted_app` reader and `app:` keyword - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#2775](https://github.com/ruby-grape/grape/pull/2775): Pass `http_methods` to `Grape::Endpoint` as a keyword instead of via options - [@ericproulx](https://github.com/ericproulx).
 * [#2776](https://github.com/ruby-grape/grape/pull/2776): Pass `path` to `Grape::Endpoint` as a keyword instead of via options - [@ericproulx](https://github.com/ericproulx).
 * [#2777](https://github.com/ruby-grape/grape/pull/2777): Add `Grape::Endpoint#mounted_app` reader and `app:` keyword - [@ericproulx](https://github.com/ericproulx).
+* [#2778](https://github.com/ruby-grape/grape/pull/2778): Rename `Grape::Endpoint`'s `for:` keyword to `api:` and expose `#api` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#2768](https://github.com/ruby-grape/grape/pull/2768): Remove Guard - [@ericproulx](https://github.com/ericproulx).
 * [#2774](https://github.com/ruby-grape/grape/pull/2774): Make `forward_match` an internal kwarg instead of a route option - [@ericproulx](https://github.com/ericproulx).
+* [#2775](https://github.com/ruby-grape/grape/pull/2775): Pass `http_methods` to `Grape::Endpoint` as a keyword instead of via options - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -9,6 +9,20 @@ Upgrading Grape
 
 As a result it is no longer readable through `route.options[:forward_match]` or the `route.forward_match` reader — both previously returned the flag. Nothing in Grape consumed either, so this only affects code that introspected routes directly; there is no replacement, as the value is now purely internal.
 
+#### `Grape::Endpoint.new` takes `http_methods:` instead of `method:`
+
+`Grape::Endpoint.new` now receives the HTTP verb(s) under the `http_methods:` keyword instead of `method:`, matching the name used everywhere else. If you build endpoints directly (uncommon — this is an internal API normally driven by the routing DSL), rename the keyword:
+
+```ruby
+# before
+Grape::Endpoint.new(settings, method: :get, path: '/foo', for: self)
+
+# after
+Grape::Endpoint.new(settings, http_methods: :get, path: '/foo', for: self)
+```
+
+Relatedly, an endpoint's public `options` Hash no longer carries `:method` (`endpoint.options[:method]`). Nothing in Grape read it, and downstream gems such as grape-swagger already read the verb from `route.request_method`, which is unchanged.
+
 ### Upgrading to >= 3.3
 
 #### Minimum required Ruby is now 3.3

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -37,6 +37,23 @@ Grape::Endpoint.new(settings, http_methods: :get, path: '/foo', api: my_api)
 
 The owning API is no longer carried on the endpoint's public `options` Hash — `endpoint.options[:for]` is gone. Use the new `endpoint.api` reader instead.
 
+#### Route metadata is exposed through readers, not the `options` Hash
+
+A route's computed metadata — `version`, `namespace`, `prefix`, `requirements`, `anchor` and `settings` — is now passed to `Grape::Router::Route` as explicit keyword arguments and exposed as plain readers, instead of being merged into the route's `options` Hash.
+
+The readers are unchanged — keep using them:
+
+```ruby
+route.version       # => 'v1'
+route.namespace     # => '/things'
+route.prefix        # => 'api'
+route.requirements  # => {}
+route.anchor        # => true
+route.settings      # => { ... }
+```
+
+What changed is the raw bag. `route.options` now holds only what was declared for the route, so it no longer carries the *computed* values for these keys — `route.options[:version]`, `[:namespace]`, `[:prefix]` and `[:settings]` return `nil`. Nothing in Grape or grape-swagger read them that way (grape-swagger uses the `route.prefix` and `route.settings` readers). For `requirements` and `anchor`, which can be supplied as route options (e.g. a mount's `anchor: false`), any explicitly declared value still appears in `route.options`; the effective value always comes from the reader.
+
 ### Upgrading to >= 3.3
 
 #### Minimum required Ruby is now 3.3

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -23,6 +23,20 @@ Grape::Endpoint.new(settings, http_methods: :get, path: '/foo', for: self)
 
 Relatedly, an endpoint's public `options` Hash no longer carries `:method` or `:path`. Nothing in Grape read `:method`, and the only reader of `:path` was an internal test; both values are available from the route instead — `route.request_method` for the verb and `route.path` for the (compiled) path, which is what grape-swagger and other introspection already use. The raw definition-time path array is no longer exposed on the endpoint.
 
+#### `Grape::Endpoint.new` takes `api:` instead of `for:`
+
+The keyword identifying the API an endpoint belongs to has been renamed from `for:` — a reserved word whose value can't be referenced as a local — to `api:`:
+
+```ruby
+# before
+Grape::Endpoint.new(settings, http_methods: :get, path: '/foo', for: my_api)
+
+# after
+Grape::Endpoint.new(settings, http_methods: :get, path: '/foo', api: my_api)
+```
+
+The owning API is no longer carried on the endpoint's public `options` Hash — `endpoint.options[:for]` is gone. Use the new `endpoint.api` reader instead.
+
 ### Upgrading to >= 3.3
 
 #### Minimum required Ruby is now 3.3

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -21,7 +21,7 @@ Grape::Endpoint.new(settings, method: :get, path: '/foo', for: self)
 Grape::Endpoint.new(settings, http_methods: :get, path: '/foo', for: self)
 ```
 
-Relatedly, an endpoint's public `options` Hash no longer carries `:method` (`endpoint.options[:method]`). Nothing in Grape read it, and downstream gems such as grape-swagger already read the verb from `route.request_method`, which is unchanged.
+Relatedly, an endpoint's public `options` Hash no longer carries `:method` or `:path`. Nothing in Grape read `:method`, and the only reader of `:path` was an internal test; both values are available from the route instead — `route.request_method` for the verb and `route.path` for the (compiled) path, which is what grape-swagger and other introspection already use. The raw definition-time path array is no longer exposed on the endpoint.
 
 ### Upgrading to >= 3.3
 

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -15,7 +15,7 @@ module Grape
       end
 
       def configuration
-        config.for.configuration.evaluate
+        config.api.configuration.evaluate
       end
 
       # End the request and display an error to the

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -160,7 +160,7 @@ module Grape
             path:,
             app:,
             route_options: { anchor: false },
-            for: self
+            api: self
           )
         end
       end
@@ -189,7 +189,7 @@ module Grape
           inheritable_setting,
           http_methods:,
           path: paths,
-          for: self,
+          api: self,
           route_options: all_route_options,
           &
         )

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -156,7 +156,7 @@ module Grape
 
           endpoints << Grape::Endpoint.new(
             in_setting,
-            method: :any,
+            http_methods: :any,
             path:,
             app:,
             route_options: { anchor: false },
@@ -178,7 +178,7 @@ module Grape
       #     end
       #   end
       def route(methods, paths = ['/'], route_options = {}, &)
-        method = methods == :any ? '*' : methods
+        http_methods = methods == :any ? '*' : methods
         endpoint_params = inheritable_setting.namespace_stackable_with_hash(:params) || {}
         endpoint_description = inheritable_setting.route[:description]
         all_route_options = { params: endpoint_params }
@@ -187,7 +187,7 @@ module Grape
 
         new_endpoint = Grape::Endpoint.new(
           inheritable_setting,
-          method:,
+          http_methods:,
           path: paths,
           for: self,
           route_options: all_route_options,

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -150,7 +150,7 @@ module Grape
           refresh_already_mounted = opts.any? ? opts.first[:refresh_already_mounted] : false
           if refresh_already_mounted && !endpoints.empty?
             endpoints.delete_if do |endpoint|
-              endpoint.options[:app].to_s == app.to_s
+              endpoint.mounted_app.to_s == app.to_s
             end
           end
 

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -285,37 +285,28 @@ module Grape
 
     def to_routes
       route_options = config.route_options
-      default_route_options = prepare_default_route_attributes(route_options)
-      complete_route_options = route_options.merge(default_route_options)
       path_settings = prepare_default_path_settings
       forward_match = config.app && !config.app.respond_to?(:inheritable_setting)
+      version = prepare_version(inheritable_setting.namespace_inheritable[:version])
+      prefix = inheritable_setting.namespace_inheritable[:root_prefix]
+      requirements = prepare_routes_requirements(route_options[:requirements])
+      anchor = route_options.fetch(:anchor, true)
+      settings = inheritable_setting.route.except(:declared_params, :saved_validations)
 
       config.http_methods.flat_map do |method|
         config.path.map do |path|
-          prepared_path = Path.new(path, default_route_options[:namespace], path_settings)
+          prepared_path = Path.new(path, namespace, path_settings)
           pattern = Grape::Router::Pattern.new(
             origin: prepared_path.origin,
             suffix: prepared_path.suffix,
-            anchor: default_route_options[:anchor],
+            anchor:,
             params: route_options[:params],
-            format: config.format,
-            version: default_route_options[:version],
-            requirements: default_route_options[:requirements]
+            version:,
+            requirements:
           )
-          Grape::Router::Route.new(self, method, pattern, complete_route_options, forward_match:)
+          Grape::Router::Route.new(self, method, pattern, route_options, forward_match:, version:, namespace:, prefix:, requirements:, anchor:, settings:)
         end
       end
-    end
-
-    def prepare_default_route_attributes(route_options)
-      {
-        namespace:,
-        version: prepare_version(inheritable_setting.namespace_inheritable[:version]),
-        requirements: prepare_routes_requirements(route_options[:requirements]),
-        prefix: inheritable_setting.namespace_inheritable[:root_prefix],
-        anchor: route_options.fetch(:anchor, true),
-        settings: inheritable_setting.route.except(:declared_params, :saved_validations)
-      }
     end
 
     def prepare_default_path_settings

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -40,15 +40,15 @@ module Grape
     #   validations, and other properties from.
     # @param http_methods [String or Array] which HTTP method(s) can be used to
     #   reach this endpoint.
+    # @param path [String or Array] the path to this endpoint, within the
+    #   current scope.
     # @param options [Hash] attributes of this endpoint, normalized into a
     #   +Grape::Endpoint::Options+ value object.
-    # @option options path [String or Array] the path to this endpoint, within
-    #   the current scope.
     # @option options route_options [Hash]
     # @note This happens at the time of API definition, so in this context the
     # endpoint does not know if it will be mounted under a different endpoint.
     # @yield a block defining what your API should do when this endpoint is hit
-    def initialize(new_settings, http_methods:, **options, &block)
+    def initialize(new_settings, http_methods:, path:, **options, &block)
       self.inheritable_setting = new_settings.point_in_time_copy
 
       # now +namespace_stackable(:declared_params)+ contains all params defined for
@@ -61,9 +61,7 @@ module Grape
       inheritable_setting.namespace_inheritable[:default_error_status] ||= 500
 
       @options = options
-      @options[:path] = Array(@options[:path])
-      @options[:path] << '/' if @options[:path].empty?
-      @config = Options.new(http_methods:, **options)
+      @config = Options.new(http_methods:, path:, **options)
 
       @status = nil
       @stream = nil

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -38,17 +38,17 @@ module Grape
     # Create a new endpoint.
     # @param new_settings [InheritableSetting] settings to determine the params,
     #   validations, and other properties from.
+    # @param http_methods [String or Array] which HTTP method(s) can be used to
+    #   reach this endpoint.
     # @param options [Hash] attributes of this endpoint, normalized into a
     #   +Grape::Endpoint::Options+ value object.
     # @option options path [String or Array] the path to this endpoint, within
     #   the current scope.
-    # @option options method [String or Array] which HTTP method(s) can be used
-    #   to reach this endpoint.
     # @option options route_options [Hash]
     # @note This happens at the time of API definition, so in this context the
     # endpoint does not know if it will be mounted under a different endpoint.
     # @yield a block defining what your API should do when this endpoint is hit
-    def initialize(new_settings, **options, &block)
+    def initialize(new_settings, http_methods:, **options, &block)
       self.inheritable_setting = new_settings.point_in_time_copy
 
       # now +namespace_stackable(:declared_params)+ contains all params defined for
@@ -63,8 +63,7 @@ module Grape
       @options = options
       @options[:path] = Array(@options[:path])
       @options[:path] << '/' if @options[:path].empty?
-      @options[:method] = Array(@options[:method])
-      @config = Options.new(**options)
+      @config = Options.new(http_methods:, **options)
 
       @status = nil
       @stream = nil

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -24,6 +24,13 @@ module Grape
       config.for.logger
     end
 
+    # The Rack app or Grape API mounted at this endpoint, or +nil+ for a plain
+    # block endpoint. Prefer this over +options[:app]+, which is retained only
+    # for backwards compatibility.
+    def mounted_app
+      config.app
+    end
+
     class << self
       def block_to_unbound_method(block)
         return unless block
@@ -42,13 +49,15 @@ module Grape
     #   reach this endpoint.
     # @param path [String or Array] the path to this endpoint, within the
     #   current scope.
+    # @param app [#call, nil] the Rack app or Grape API mounted at this
+    #   endpoint; +nil+ for a plain block endpoint. Exposed as {#mounted_app}.
     # @param options [Hash] attributes of this endpoint, normalized into a
     #   +Grape::Endpoint::Options+ value object.
     # @option options route_options [Hash]
     # @note This happens at the time of API definition, so in this context the
     # endpoint does not know if it will be mounted under a different endpoint.
     # @yield a block defining what your API should do when this endpoint is hit
-    def initialize(new_settings, http_methods:, path:, **options, &block)
+    def initialize(new_settings, http_methods:, path:, app: nil, **options, &block)
       self.inheritable_setting = new_settings.point_in_time_copy
 
       # now +namespace_stackable(:declared_params)+ contains all params defined for
@@ -61,7 +70,10 @@ module Grape
       inheritable_setting.namespace_inheritable[:default_error_status] ||= 500
 
       @options = options
-      @config = Options.new(http_methods:, path:, **options)
+      @config = Options.new(http_methods:, path:, app:, **options)
+      # +:app+ is still surfaced on the public options Hash for backwards
+      # compatibility (e.g. grape-swagger); prefer the +mounted_app+ reader.
+      @options[:app] = app if app
 
       @status = nil
       @stream = nil

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -17,12 +17,13 @@ module Grape
     def_delegators :request, :params, :headers, :cookies
     def_delegator :cookies, :response_cookies
 
+    # The API (a +Grape::API+ instance) this endpoint belongs to.
+    def_delegator :@config, :api
+
     # The logger configured on the API this endpoint belongs to. Available
     # inside route handlers, +before+/+after+/+after_validation+/+finally+
     # filters, and +rescue_from+ blocks.
-    def logger
-      config.for.logger
-    end
+    def_delegator :api, :logger
 
     # The Rack app or Grape API mounted at this endpoint, or +nil+ for a plain
     # block endpoint. Prefer this over +options[:app]+, which is retained only
@@ -49,6 +50,8 @@ module Grape
     #   reach this endpoint.
     # @param path [String or Array] the path to this endpoint, within the
     #   current scope.
+    # @param api [Grape::API] the API this endpoint belongs to. Exposed as
+    #   {#api}.
     # @param app [#call, nil] the Rack app or Grape API mounted at this
     #   endpoint; +nil+ for a plain block endpoint. Exposed as {#mounted_app}.
     # @param options [Hash] attributes of this endpoint, normalized into a
@@ -57,7 +60,7 @@ module Grape
     # @note This happens at the time of API definition, so in this context the
     # endpoint does not know if it will be mounted under a different endpoint.
     # @yield a block defining what your API should do when this endpoint is hit
-    def initialize(new_settings, http_methods:, path:, app: nil, **options, &block)
+    def initialize(new_settings, http_methods:, path:, api:, app: nil, **options, &block)
       self.inheritable_setting = new_settings.point_in_time_copy
 
       # now +namespace_stackable(:declared_params)+ contains all params defined for
@@ -70,7 +73,7 @@ module Grape
       inheritable_setting.namespace_inheritable[:default_error_status] ||= 500
 
       @options = options
-      @config = Options.new(http_methods:, path:, app:, **options)
+      @config = Options.new(http_methods:, path:, api:, app:, **options)
       # +:app+ is still surfaced on the public options Hash for backwards
       # compatibility (e.g. grape-swagger); prefer the +mounted_app+ reader.
       @options[:app] = app if app

--- a/lib/grape/endpoint/options.rb
+++ b/lib/grape/endpoint/options.rb
@@ -6,13 +6,12 @@ module Grape
     # +Grape::Endpoint.new+. Internal to {Grape::Endpoint}, which builds it
     # from the +**options+ Hash in #initialize so the public +options+ reader
     # stays a plain Hash for downstream gems (e.g. grape-swagger).
-    # +:method+ is renamed to +:http_methods+ on the value object to avoid
-    # shadowing +Object#method+ via the generated Data accessor.
     Options = Data.define(:path, :http_methods, :for, :route_options, :app, :format) do
-      def initialize(path:, method:, route_options: {}, app: nil, format: nil, **rest)
+      def initialize(path:, http_methods:, route_options: {}, app: nil, format: nil, **rest)
         path = Array(path)
         path << '/' if path.empty?
-        super(path:, http_methods: Array(method), route_options:, app:, format:, **rest)
+        http_methods = Array(http_methods)
+        super
       end
     end
   end

--- a/lib/grape/endpoint/options.rb
+++ b/lib/grape/endpoint/options.rb
@@ -6,8 +6,8 @@ module Grape
     # +Grape::Endpoint.new+. Internal to {Grape::Endpoint}, which builds it
     # from the +**options+ Hash in #initialize so the public +options+ reader
     # stays a plain Hash for downstream gems (e.g. grape-swagger).
-    Options = Data.define(:path, :http_methods, :for, :route_options, :app, :format) do
-      def initialize(path:, http_methods:, route_options: {}, app: nil, format: nil, **rest)
+    Options = Data.define(:path, :http_methods, :api, :route_options, :app, :format) do
+      def initialize(path:, http_methods:, api:, route_options: {}, app: nil, format: nil)
         path = Array(path)
         path << '/' if path.empty?
         http_methods = Array(http_methods)

--- a/lib/grape/endpoint/options.rb
+++ b/lib/grape/endpoint/options.rb
@@ -6,8 +6,8 @@ module Grape
     # +Grape::Endpoint.new+. Internal to {Grape::Endpoint}, which builds it
     # from the +**options+ Hash in #initialize so the public +options+ reader
     # stays a plain Hash for downstream gems (e.g. grape-swagger).
-    Options = Data.define(:path, :http_methods, :api, :route_options, :app, :format) do
-      def initialize(path:, http_methods:, api:, route_options: {}, app: nil, format: nil)
+    Options = Data.define(:path, :http_methods, :api, :route_options, :app) do
+      def initialize(path:, http_methods:, api:, route_options: {}, app: nil)
         path = Array(path)
         path << '/' if path.empty?
         http_methods = Array(http_methods)

--- a/lib/grape/router/base_route.rb
+++ b/lib/grape/router/base_route.rb
@@ -7,19 +7,20 @@ module Grape
 
       delegate_missing_to :@options
 
-      attr_reader :options, :pattern
+      attr_reader :options, :pattern, :version, :prefix, :requirements, :anchor, :settings, :namespace
 
       def_delegators :@pattern, :path, :origin
-      def_delegators :@options, :description, :version, :requirements, :prefix, :anchor, :settings, *Grape::Util::ApiDescription::DSL_METHODS
+      def_delegators :@options, :description, *Grape::Util::ApiDescription::DSL_METHODS
 
-      def initialize(pattern, options = {})
+      def initialize(pattern, options = {}, version: nil, namespace: nil, prefix: nil, requirements: nil, anchor: nil, settings: nil)
         @pattern = pattern
         @options = options.is_a?(ActiveSupport::OrderedOptions) ? options : ActiveSupport::OrderedOptions.new.update(options)
-      end
-
-      # see https://github.com/ruby-grape/grape/issues/1348
-      def namespace
-        @namespace ||= @options[:namespace]
+        @version = version
+        @namespace = namespace
+        @prefix = prefix
+        @requirements = requirements
+        @anchor = anchor
+        @settings = settings
       end
 
       def regexp_capture_index

--- a/lib/grape/router/pattern.rb
+++ b/lib/grape/router/pattern.rb
@@ -13,7 +13,7 @@ module Grape
       def_delegators :to_regexp, :===
       alias match? ===
 
-      def initialize(origin:, suffix:, anchor:, params:, format:, version:, requirements:)
+      def initialize(origin:, suffix:, anchor:, params:, version:, requirements:, format: nil)
         @origin = origin
         @path = PatternCache[[build_path_from_pattern(@origin, anchor), suffix]]
         @pattern = MustermannPattern.new(@path, uri_decode: true, params:, capture: extract_capture(format, version, requirements))

--- a/lib/grape/router/route.rb
+++ b/lib/grape/router/route.rb
@@ -12,8 +12,8 @@ module Grape
 
       def_delegators :@app, :call
 
-      def initialize(endpoint, method, pattern, options, forward_match:)
-        super(pattern, options)
+      def initialize(endpoint, method, pattern, options, forward_match:, **route_attributes)
+        super(pattern, options, **route_attributes)
         @app = endpoint
         @request_method = upcase_method(method)
         @match_function = forward_match ? FORWARD_MATCH_METHOD : NON_FORWARD_MATCH_METHOD

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3982,7 +3982,7 @@ describe Grape::API do
       subject.format :json
       subject.get '/endpoint/options' do
         {
-          path: options[:path],
+          path: route.path,
           source_location: source.source_location
         }
       end
@@ -3991,7 +3991,7 @@ describe Grape::API do
     it 'path' do
       get '/endpoint/options'
       options = Grape::Json.parse(last_response.body)
-      expect(options['path']).to eq(['/endpoint/options'])
+      expect(options['path']).to eq('/endpoint/options(.json)')
       expect(options['source_location'][0]).to include 'api_spec.rb'
       expect(options['source_location'][1].to_i).to be > 0
     end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3571,6 +3571,39 @@ describe Grape::API do
       end
     end
 
+    describe 'the mounted endpoint' do
+      it 'exposes the mounted app through #mounted_app' do
+        subject.mount mounted_app => '/mounty'
+        expect(subject.endpoints.last.mounted_app).to be(mounted_app)
+      end
+
+      it 'reports nil #mounted_app for a plain block endpoint' do
+        subject.get('/plain') { 'hi' }
+        expect(subject.endpoints.last.mounted_app).to be_nil
+      end
+
+      it 'still surfaces the mounted app on the options Hash' do
+        subject.mount mounted_app => '/mounty'
+        expect(subject.endpoints.last.options[:app]).to be(mounted_app)
+      end
+    end
+
+    context 'with refresh_already_mounted' do
+      let(:app) { Class.new(described_class) { get('/x') { 'x' } } }
+
+      it 'replaces a previously mounted app instead of duplicating it' do
+        subject.mount app => '/thing'
+        expect { subject.mount({ app => '/thing' }, refresh_already_mounted: true) }
+          .not_to(change { subject.endpoints.count })
+      end
+
+      it 'duplicates the endpoint without the flag' do
+        subject.mount app => '/thing'
+        expect { subject.mount app => '/thing' }
+          .to change { subject.endpoints.count }.by(1)
+      end
+    end
+
     context 'mounting an API' do
       it 'applies the settings of the mounting api' do
         subject.version 'v1', using: :path

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3133,6 +3133,14 @@ describe Grape::API do
       it 'sets prefix' do
         expect(subject.routes[1].prefix).to eq('p')
       end
+
+      it 'does not carry computed attributes in the route options Hash' do
+        route = subject.routes[1]
+        expect(route.options).not_to have_key(:version)
+        expect(route.options).not_to have_key(:namespace)
+        expect(route.options).not_to have_key(:prefix)
+        expect(route.options).not_to have_key(:settings)
+      end
     end
 
     describe 'api structure with additional parameters' do

--- a/spec/grape/dsl/routing_spec.rb
+++ b/spec/grape/dsl/routing_spec.rb
@@ -157,7 +157,7 @@ describe Grape::DSL::Routing do
       expect(Grape::Endpoint).to receive(:new) do |_inheritable_setting, endpoint_options|
         expect(endpoint_options[:http_methods]).to eq :get
         expect(endpoint_options[:path]).to eq '/foo'
-        expect(endpoint_options[:for]).to eq subject
+        expect(endpoint_options[:api]).to eq subject
         expect(endpoint_options[:route_options]).to eq(foo: 'bar', fiz: 'baz', params: { nuz: 'naz' })
       end.and_yield
 

--- a/spec/grape/dsl/routing_spec.rb
+++ b/spec/grape/dsl/routing_spec.rb
@@ -155,7 +155,7 @@ describe Grape::DSL::Routing do
       subject.inheritable_setting.namespace_stackable[:params] = { nuz: 'naz' }
 
       expect(Grape::Endpoint).to receive(:new) do |_inheritable_setting, endpoint_options|
-        expect(endpoint_options[:method]).to eq :get
+        expect(endpoint_options[:http_methods]).to eq :get
         expect(endpoint_options[:path]).to eq '/foo'
         expect(endpoint_options[:for]).to eq subject
         expect(endpoint_options[:route_options]).to eq(foo: 'bar', fiz: 'baz', params: { nuz: 'naz' })

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -1034,7 +1034,7 @@ describe Grape::Endpoint do
         path: '/path',
         app: {},
         route_options: { anchor: false },
-        for: Class.new
+        api: Class.new
       }
     end
     let(:settings) { Grape::Util::InheritableSetting.new }

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -1030,7 +1030,7 @@ describe Grape::Endpoint do
 
     let(:options) do
       {
-        method: :path,
+        http_methods: :path,
         path: '/path',
         app: {},
         route_options: { anchor: false },

--- a/spec/grape/named_api_spec.rb
+++ b/spec/grape/named_api_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Grape::API do
-  subject(:api_name) { NamedAPI.endpoints.last.options[:for].to_s }
+  subject(:api_name) { NamedAPI.endpoints.last.api.to_s }
 
   let(:api) do
     Class.new(Grape::API) do

--- a/spec/grape/router/route_spec.rb
+++ b/spec/grape/router/route_spec.rb
@@ -22,6 +22,42 @@ RSpec.describe Grape::Router::Route do
     it { is_expected.to be_a(Grape::Router::BaseRoute) }
   end
 
+  describe 'route attributes' do
+    subject(:route) do
+      described_class.new(endpoint, :get, pattern, options, forward_match: false,
+                                                            version: 'v1', namespace: '/things', prefix: '/api',
+                                                            requirements: { id: /\d+/ }, anchor: false, settings: { a: 1 })
+    end
+
+    it 'exposes them as readers' do
+      expect(route.version).to eq('v1')
+      expect(route.namespace).to eq('/things')
+      expect(route.prefix).to eq('/api')
+      expect(route.requirements).to eq(id: /\d+/)
+      expect(route.anchor).to be(false)
+      expect(route.settings).to eq(a: 1)
+    end
+
+    it 'does not leak them into the options Hash' do
+      %i[version namespace prefix requirements anchor settings].each do |key|
+        expect(route.options).not_to have_key(key)
+      end
+    end
+
+    context 'when omitted' do
+      subject(:route) { described_class.new(endpoint, :get, pattern, options, forward_match: false) }
+
+      it 'defaults to nil' do
+        expect(route.version).to be_nil
+        expect(route.namespace).to be_nil
+        expect(route.prefix).to be_nil
+        expect(route.requirements).to be_nil
+        expect(route.anchor).to be_nil
+        expect(route.settings).to be_nil
+      end
+    end
+  end
+
   describe '#match?' do
     subject { instance.match?(input) }
 


### PR DESCRIPTION
### Why this PR exists

The stacked series #2774 → #2779 was merged in the right chronological order, but the base branches were **not deleted** on merge, so GitHub never retargeted the upper PRs to `master`. As a result each PR merged into its (already-merged-but-not-on-`master`) base branch instead of `master`:

| PR | merged into | should have been |
|----|-------------|------------------|
| #2774 | `master` ✅ | master |
| #2775 | `forward_match_kwarg` | master |
| #2776 | `endpoint_http_methods_kwarg` | master |
| #2777 | `endpoint_path_kwarg` | master |
| #2778 | `endpoint_app_kwarg` | master |
| #2779 | `endpoint_api_kwarg` | master |

Net effect: **`master` currently has only #2774.** The other five changes pooled in the stack branches but never reached `master`.

### What this does

Brings the five missing commits to `master`, in their original order:

- #2775 — Pass `http_methods` to `Grape::Endpoint` as a keyword instead of via options
- #2776 — Pass `path` to `Grape::Endpoint` as a keyword instead of via options
- #2777 — Add `Grape::Endpoint#mounted_app` reader and `app:` keyword
- #2778 — Rename `Grape::Endpoint`'s `for:` keyword to `api:` and expose `#api`
- #2779 — Promote route metadata to `Grape::Router::Route` keyword arguments (+ drop the vestigial `Options#format`)

`route_attributes_kwargs` shares #2774 with `master` as its merge-base, so the diff is exactly these five commits. The merge is conflict-free and the resulting tree is byte-identical to the top of the original stack.

**Please merge with a merge commit (not squash)** to preserve the five commits individually.

### Note

Do not merge the `revert-2774-forward_match_kwarg` branch — #2774 is the one change that landed correctly; that branch can be deleted. After this merges, the five orphaned stack branches (`forward_match_kwarg`, `endpoint_http_methods_kwarg`, `endpoint_path_kwarg`, `endpoint_app_kwarg`, `endpoint_api_kwarg`) are dead and can be deleted too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)