### PR TITLE
Document the removal of the vestigial Endpoint Options format member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * [#2776](https://github.com/ruby-grape/grape/pull/2776): Pass `path` to `Grape::Endpoint` as a keyword instead of via options - [@ericproulx](https://github.com/ericproulx).
 * [#2777](https://github.com/ruby-grape/grape/pull/2777): Add `Grape::Endpoint#mounted_app` reader and `app:` keyword - [@ericproulx](https://github.com/ericproulx).
 * [#2778](https://github.com/ruby-grape/grape/pull/2778): Rename `Grape::Endpoint`'s `for:` keyword to `api:` and expose `#api` - [@ericproulx](https://github.com/ericproulx).
-* [#2779](https://github.com/ruby-grape/grape/pull/2779): Promote route metadata (`version`, `namespace`, `prefix`, `requirements`, `anchor`, `settings`) to `Grape::Router::Route` keyword arguments - [@ericproulx](https://github.com/ericproulx).
+* [#2779](https://github.com/ruby-grape/grape/pull/2779): Promote route metadata (`version`, `namespace`, `prefix`, `requirements`, `anchor`, `settings`) to `Grape::Router::Route` keyword arguments, and drop the unused `Grape::Endpoint::Options` `format` member - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -54,6 +54,12 @@ route.settings      # => { ... }
 
 What changed is the raw bag. `route.options` now holds only what was declared for the route, so it no longer carries the *computed* values for these keys — `route.options[:version]`, `[:namespace]`, `[:prefix]` and `[:settings]` return `nil`. Nothing in Grape or grape-swagger read them that way (grape-swagger uses the `route.prefix` and `route.settings` readers). For `requirements` and `anchor`, which can be supplied as route options (e.g. a mount's `anchor: false`), any explicitly declared value still appears in `route.options`; the effective value always comes from the reader.
 
+#### `Grape::Endpoint` no longer accepts a `format:` keyword
+
+The `:format` member was removed from the endpoint's internal `Options`. Nothing ever passed `format:` to `Grape::Endpoint.new` — `config.format` was always `nil` — so this has no runtime effect (the `(.:format)`/`(.json)` route suffix comes from `Grape::Path`, not from this value). But `Grape::Endpoint.new(..., format: …)` now raises `unknown keyword: :format` instead of silently ignoring it.
+
+`Grape::Router::Pattern#initialize` still accepts `format:` — it remains a valid capture constraint — but it is now optional (`format: nil`).
+
 ### Upgrading to >= 3.3
 
 #### Minimum required Ruby is now 3.3


### PR DESCRIPTION
Follow-up to #2779. That PR promoted route metadata to `Grape::Router::Route` keyword arguments and, in the same change, dropped the always-`nil` `:format` member from the endpoint's internal `Options`. The metadata promotion was documented, but the `format` removal was only recorded in the commit/PR body — not in the CHANGELOG or UPGRADING.

This adds that documentation:

- **CHANGELOG** — extends the #2779 line to mention dropping the unused `Grape::Endpoint::Options` `format` member.
- **UPGRADING** — a short note: `Grape::Endpoint.new(..., format: …)` now raises `unknown keyword: :format` instead of silently ignoring it (nothing ever passed it; `config.format` was always `nil`, and the route's `(.:format)`/`(.json)` suffix comes from `Grape::Path`). `Grape::Router::Pattern#initialize` keeps `format:` as a now-optional keyword.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)