### PR TITLE
Remove the dead format keyword from Grape::Router::Pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#2777](https://github.com/ruby-grape/grape/pull/2777): Add `Grape::Endpoint#mounted_app` reader and `app:` keyword - [@ericproulx](https://github.com/ericproulx).
 * [#2778](https://github.com/ruby-grape/grape/pull/2778): Rename `Grape::Endpoint`'s `for:` keyword to `api:` and expose `#api` - [@ericproulx](https://github.com/ericproulx).
 * [#2779](https://github.com/ruby-grape/grape/pull/2779): Promote route metadata (`version`, `namespace`, `prefix`, `requirements`, `anchor`, `settings`) to `Grape::Router::Route` keyword arguments, and drop the unused `Grape::Endpoint::Options` `format` member - [@ericproulx](https://github.com/ericproulx).
+* [#2782](https://github.com/ruby-grape/grape/pull/2782): Remove the dead `format` keyword from `Grape::Router::Pattern` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -58,7 +58,7 @@ What changed is the raw bag. `route.options` now holds only what was declared fo
 
 The `:format` member was removed from the endpoint's internal `Options`. Nothing ever passed `format:` to `Grape::Endpoint.new` — `config.format` was always `nil` — so this has no runtime effect (the `(.:format)`/`(.json)` route suffix comes from `Grape::Path`, not from this value). But `Grape::Endpoint.new(..., format: …)` now raises `unknown keyword: :format` instead of silently ignoring it.
 
-`Grape::Router::Pattern#initialize` still accepts `format:` — it remains a valid capture constraint — but it is now optional (`format: nil`).
+`Grape::Router::Pattern#initialize` no longer accepts `format:` either. It was never given a non-`nil` value — a route's `:format` capture comes from the path suffix built by `Grape::Path`, not from the pattern — so the keyword was dead. `Grape::Router::Pattern.new(..., format: …)` now raises `unknown keyword: :format`.
 
 ### Upgrading to >= 3.3
 

--- a/lib/grape/router/pattern.rb
+++ b/lib/grape/router/pattern.rb
@@ -13,10 +13,10 @@ module Grape
       def_delegators :to_regexp, :===
       alias match? ===
 
-      def initialize(origin:, suffix:, anchor:, params:, version:, requirements:, format: nil)
+      def initialize(origin:, suffix:, anchor:, params:, version:, requirements:)
         @origin = origin
         @path = PatternCache[[build_path_from_pattern(@origin, anchor), suffix]]
-        @pattern = MustermannPattern.new(@path, uri_decode: true, params:, capture: extract_capture(format, version, requirements))
+        @pattern = MustermannPattern.new(@path, uri_decode: true, params:, capture: extract_capture(version, requirements))
         @to_regexp = @pattern.to_regexp
       end
 
@@ -28,9 +28,8 @@ module Grape
 
       private
 
-      def extract_capture(format, version, requirements)
+      def extract_capture(version, requirements)
         capture = {}
-        capture[:format] = map_str(format) if format.present?
         capture[:version] = map_str(version) if version.present?
 
         return capture if requirements.blank?

--- a/spec/grape/router/route_spec.rb
+++ b/spec/grape/router/route_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Grape::Router::Route do
       suffix: '',
       anchor: true,
       params: {},
-      format: nil,
       version: nil,
       requirements: {}
     )


### PR DESCRIPTION
`Grape::Router::Pattern#initialize` took a `format:` keyword and used it in `extract_capture` to constrain the mustermann `:format` capture. It was dead:

- **Nothing passed a non-`nil` value.** The endpoint stopped passing `format:` when the vestigial `Grape::Endpoint::Options` `format` member was removed (#2779), and grape-swagger's test helper passes `format: nil`. So `format.present?` was never true and `capture[:format] = …` never ran.
- **It was redundant.** A route's `:format` capture comes from the path suffix that `Grape::Path` builds — `(.json)` for a specific format, `(.:format)` otherwise — not from the pattern.

This drops the keyword and the dead branch. `DEFAULT_CAPTURES` still lists `format` (that path-derived capture) and `map_str` still serves `version`, so matching is unchanged — `format :json` still yields `/x(.json)`, plain `/x(.:format)`.

### Upgrading

`Grape::Router::Pattern.new(..., format: …)` now raises `unknown keyword: :format`. The UPGRADING note from #2781 (which described `format:` as an optional keyword on `Pattern`) is corrected accordingly.

Note: grape-swagger's test helper passes `format: nil` to `Pattern.new` and will need a one-line drop — but it already can't run against grape 4.0 HEAD (it calls `Route.new` without the required `forward_match:`), so this folds into the 4.0 update it needs regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)