### PR TITLE
Read a route's version, anchor and requirements from its pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#2778](https://github.com/ruby-grape/grape/pull/2778): Rename `Grape::Endpoint`'s `for:` keyword to `api:` and expose `#api` - [@ericproulx](https://github.com/ericproulx).
 * [#2779](https://github.com/ruby-grape/grape/pull/2779): Promote route metadata (`version`, `namespace`, `prefix`, `requirements`, `anchor`, `settings`) to `Grape::Router::Route` keyword arguments, and drop the unused `Grape::Endpoint::Options` `format` member - [@ericproulx](https://github.com/ericproulx).
 * [#2782](https://github.com/ruby-grape/grape/pull/2782): Remove the dead `format` keyword from `Grape::Router::Pattern` - [@ericproulx](https://github.com/ericproulx).
+* [#2783](https://github.com/ruby-grape/grape/pull/2783): Read a route's `version`, `anchor` and `requirements` from its pattern instead of storing them again on the route - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -304,7 +304,7 @@ module Grape
             version:,
             requirements:
           )
-          Grape::Router::Route.new(self, method, pattern, route_options, forward_match:, version:, namespace:, prefix:, requirements:, anchor:, settings:)
+          Grape::Router::Route.new(self, method, pattern, route_options, forward_match:, namespace:, prefix:, settings:)
         end
       end
     end

--- a/lib/grape/router/base_route.rb
+++ b/lib/grape/router/base_route.rb
@@ -7,19 +7,18 @@ module Grape
 
       delegate_missing_to :@options
 
-      attr_reader :options, :pattern, :version, :prefix, :requirements, :anchor, :settings, :namespace
+      attr_reader :options, :pattern, :prefix, :settings, :namespace
 
-      def_delegators :@pattern, :path, :origin
+      # +version+, +anchor+ and +requirements+ shape the matcher, so they are
+      # read from the pattern rather than stored again on the route.
+      def_delegators :@pattern, :path, :origin, :version, :anchor, :requirements
       def_delegators :@options, :description, *Grape::Util::ApiDescription::DSL_METHODS
 
-      def initialize(pattern, options = {}, version: nil, namespace: nil, prefix: nil, requirements: nil, anchor: nil, settings: nil)
+      def initialize(pattern, options = {}, namespace: nil, prefix: nil, settings: nil)
         @pattern = pattern
         @options = options.is_a?(ActiveSupport::OrderedOptions) ? options : ActiveSupport::OrderedOptions.new.update(options)
-        @version = version
         @namespace = namespace
         @prefix = prefix
-        @requirements = requirements
-        @anchor = anchor
         @settings = settings
       end
 

--- a/lib/grape/router/pattern.rb
+++ b/lib/grape/router/pattern.rb
@@ -7,7 +7,7 @@ module Grape
 
       DEFAULT_CAPTURES = %w[format version].freeze
 
-      attr_reader :origin, :path, :pattern, :to_regexp
+      attr_reader :origin, :path, :pattern, :to_regexp, :anchor, :version, :requirements
 
       def_delegators :pattern, :params
       def_delegators :to_regexp, :===
@@ -15,6 +15,9 @@ module Grape
 
       def initialize(origin:, suffix:, anchor:, params:, version:, requirements:)
         @origin = origin
+        @anchor = anchor
+        @version = version
+        @requirements = requirements
         @path = PatternCache[[build_path_from_pattern(@origin, anchor), suffix]]
         @pattern = MustermannPattern.new(@path, uri_decode: true, params:, capture: extract_capture(version, requirements))
         @to_regexp = @pattern.to_regexp
@@ -29,12 +32,9 @@ module Grape
       private
 
       def extract_capture(version, requirements)
-        capture = {}
-        capture[:version] = map_str(version) if version.present?
+        return requirements if version.blank?
 
-        return capture if requirements.blank?
-
-        requirements.merge(capture)
+        requirements.merge(version: map_str(version))
       end
 
       def build_path_from_pattern(pattern, anchor)

--- a/spec/grape/router/pattern_spec.rb
+++ b/spec/grape/router/pattern_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe Grape::Router::Pattern do
+  describe 'match-parameter readers' do
+    subject(:pattern) do
+      described_class.new(origin: '/x', suffix: '', anchor: false, params: {}, version: 'v1', requirements: { id: /\d+/ })
+    end
+
+    it 'exposes anchor, version and requirements' do
+      expect(pattern.anchor).to be(false)
+      expect(pattern.version).to eq('v1')
+      expect(pattern.requirements).to eq(id: /\d+/)
+    end
+  end
+end

--- a/spec/grape/router/route_spec.rb
+++ b/spec/grape/router/route_spec.rb
@@ -21,24 +21,20 @@ RSpec.describe Grape::Router::Route do
     it { is_expected.to be_a(Grape::Router::BaseRoute) }
   end
 
-  describe 'route attributes' do
+  describe 'metadata attributes (namespace, prefix, settings)' do
     subject(:route) do
       described_class.new(endpoint, :get, pattern, options, forward_match: false,
-                                                            version: 'v1', namespace: '/things', prefix: '/api',
-                                                            requirements: { id: /\d+/ }, anchor: false, settings: { a: 1 })
+                                                            namespace: '/things', prefix: '/api', settings: { a: 1 })
     end
 
     it 'exposes them as readers' do
-      expect(route.version).to eq('v1')
       expect(route.namespace).to eq('/things')
       expect(route.prefix).to eq('/api')
-      expect(route.requirements).to eq(id: /\d+/)
-      expect(route.anchor).to be(false)
       expect(route.settings).to eq(a: 1)
     end
 
     it 'does not leak them into the options Hash' do
-      %i[version namespace prefix requirements anchor settings].each do |key|
+      %i[namespace prefix settings].each do |key|
         expect(route.options).not_to have_key(key)
       end
     end
@@ -47,13 +43,24 @@ RSpec.describe Grape::Router::Route do
       subject(:route) { described_class.new(endpoint, :get, pattern, options, forward_match: false) }
 
       it 'defaults to nil' do
-        expect(route.version).to be_nil
         expect(route.namespace).to be_nil
         expect(route.prefix).to be_nil
-        expect(route.requirements).to be_nil
-        expect(route.anchor).to be_nil
         expect(route.settings).to be_nil
       end
+    end
+  end
+
+  describe 'match parameters delegated to the pattern (version, anchor, requirements)' do
+    subject(:route) { described_class.new(endpoint, :get, pattern, options, forward_match: false) }
+
+    let(:pattern) do
+      Grape::Router::Pattern.new(origin: '/mounty', suffix: '', anchor: false, params: {}, version: 'v1', requirements: { id: /\d+/ })
+    end
+
+    it 'reads them from the pattern' do
+      expect(route.version).to eq('v1')
+      expect(route.anchor).to be(false)
+      expect(route.requirements).to eq(id: /\d+/)
     end
   end
 


### PR DESCRIPTION
Rebased onto master now that #2782 is merged.

`version`, `anchor` and `requirements` are the attributes that shape the matcher — they're passed to `Grape::Router::Pattern` to build the mustermann pattern. But they were *also* passed to `Grape::Router::Route` and stored as ivars, solely to back the `route.version`/`route.anchor`/`route.requirements` readers. That's a redundant second copy.

### Change

- `Grape::Router::Pattern` now stores and exposes `anchor`, `version`, `requirements` (`attr_reader`). Its `initialize` signature is unchanged.
- `Grape::Router::BaseRoute` delegates those three readers to `@pattern`, alongside the existing `def_delegators :@pattern, :path, :origin`. They're dropped from its `attr_reader`, `initialize` keywords and ivars.
- `Endpoint#to_routes` no longer passes them to `Route.new`.
- Metadata that does **not** shape matching — `namespace`, `prefix`, `settings` — stays as `Route` keyword arguments.

The line is principled: **the pattern owns the match parameters; the route owns the metadata.**

Also collapses `extract_capture` to a guard plus a single merge. With the `format` keyword gone (#2782) it just adds an optional `version` constraint to `requirements`, so the intermediate accumulator hash was noise — this is the simplification that didn't make it into #2782 before it merged.

### Notes

- grape-swagger already passes `anchor`/`version`/`requirements` to `Pattern.new` and passes **none** of them to `Route.new`, so its routes' readers become correct instead of `nil`.
- `GreedyRoute` borrows another route's pattern, so its `version`/`anchor`/`requirements` now reflect that pattern rather than `nil`. Nothing reads them (the OPTIONS/405 suite is green), so it's invisible — noted for completeness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)