### PR TITLE
Move HEAD route creation into Grape::Router::Route#to_head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#2778](https://github.com/ruby-grape/grape/pull/2778): Rename `Grape::Endpoint`'s `for:` keyword to `api:` and expose `#api` - [@ericproulx](https://github.com/ericproulx).
 * [#2779](https://github.com/ruby-grape/grape/pull/2779): Promote route metadata (`version`, `namespace`, `prefix`, `requirements`, `anchor`, `settings`) to `Grape::Router::Route` keyword arguments, and drop the unused `Grape::Endpoint::Options` `format` member - [@ericproulx](https://github.com/ericproulx).
 * [#2782](https://github.com/ruby-grape/grape/pull/2782): Remove the dead `format` keyword from `Grape::Router::Pattern` - [@ericproulx](https://github.com/ericproulx).
+* [#2784](https://github.com/ruby-grape/grape/pull/2784): Move HEAD route creation into `Grape::Router::Route#to_head` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -120,10 +120,7 @@ module Grape
         router.append(route.apply(self))
         next if inheritable_setting.namespace_inheritable[:do_not_route_head] || route.request_method != Rack::GET
 
-        route.dup.then do |head_route|
-          head_route.convert_to_head_request!
-          router.append(head_route.apply(self))
-        end
+        router.append(route.to_head.apply(self))
       end
     end
 

--- a/lib/grape/router/route.rb
+++ b/lib/grape/router/route.rb
@@ -19,8 +19,10 @@ module Grape
         @match_function = forward_match ? FORWARD_MATCH_METHOD : NON_FORWARD_MATCH_METHOD
       end
 
-      def convert_to_head_request!
-        @request_method = Rack::HEAD
+      def to_head
+        head = dup
+        head.convert_to_head_request!
+        head
       end
 
       def apply(app)
@@ -41,6 +43,12 @@ module Grape
         return unless parsed
 
         parsed.compact.symbolize_keys
+      end
+
+      protected
+
+      def convert_to_head_request!
+        @request_method = Rack::HEAD
       end
 
       private


### PR DESCRIPTION
`Endpoint#mount_in` built the HEAD variant of a GET route inline:

```ruby
route.dup.then do |head_route|
  head_route.convert_to_head_request!
  router.append(head_route.apply(self))
end
```

Duplicating a route and turning it into a HEAD request is the route's own concern, not the endpoint's.

### Change

- Add `Grape::Router::Route#to_head`, which returns a fresh HEAD copy of the route.
- Demote `convert_to_head_request!` to `protected` — `to_head` is now its only caller, and it calls it on the dup with an explicit receiver (which `protected` permits).
- `mount_in`'s loop body becomes `router.append(route.to_head.apply(self))`.

`mount_in` keeps the decision of *whether* to add a HEAD route (the `do_not_route_head` setting and the `request_method != Rack::GET` check) — that's the endpoint/router's call. `to_head` just builds the variant. The seam is: the endpoint decides, the route constructs.

Behavior is unchanged — `HEAD` on a GET route still 200s, `do_not_route_head!` still 405s on `HEAD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)