### PR TITLE
Stop populating the write-only namespace description in desc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#2782](https://github.com/ruby-grape/grape/pull/2782): Remove the dead `format` keyword from `Grape::Router::Pattern` - [@ericproulx](https://github.com/ericproulx).
 * [#2783](https://github.com/ruby-grape/grape/pull/2783): Read a route's `version`, `anchor` and `requirements` from its pattern instead of storing them again on the route - [@ericproulx](https://github.com/ericproulx).
 * [#2784](https://github.com/ruby-grape/grape/pull/2784): Move HEAD route creation into `Grape::Router::Route#to_head` - [@ericproulx](https://github.com/ericproulx).
+* [#2787](https://github.com/ruby-grape/grape/pull/2787): Stop populating the write-only `namespace_setting(:description)` in `desc` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -60,6 +60,10 @@ The `:format` member was removed from the endpoint's internal `Options`. Nothing
 
 `Grape::Router::Pattern#initialize` no longer accepts `format:` either. It was never given a non-`nil` value — a route's `:format` capture comes from the path suffix built by `Grape::Path`, not from the pattern — so the keyword was dead. `Grape::Router::Pattern.new(..., format: …)` now raises `unknown keyword: :format`.
 
+#### `desc` no longer populates `namespace_setting(:description)`
+
+`desc` used to store its settings under both the route scope (`route_setting(:description)`) and the namespace scope (`namespace_setting(:description)`). The namespace copy was write-only — the namespace scope isn't wired for inheritance and nothing in Grape or grape-swagger ever read it — so `desc` now writes only the route scope. `namespace_setting(:description)` returns `nil`; read a route's description through `route_setting(:description)` or the `route.description` reader.
+
 ### Upgrading to >= 3.3
 
 #### Minimum required Ruby is now 3.3

--- a/lib/grape/dsl/desc.rb
+++ b/lib/grape/dsl/desc.rb
@@ -63,7 +63,9 @@ module Grape
           else
             options.merge(description:)
           end
-        inheritable_setting.namespace[:description] = settings
+        # Only the route scope is consumed downstream (by +route+ and the
+        # route's readers, e.g. +http_codes+); the namespace scope was
+        # write-only, so it is no longer populated.
         inheritable_setting.route[:description] = settings
       end
     end

--- a/spec/grape/dsl/desc_spec.rb
+++ b/spec/grape/dsl/desc_spec.rb
@@ -15,8 +15,8 @@ describe Grape::DSL::Desc do
       desc_text = 'The description'
       options = { message: 'none' }
       subject.desc desc_text, **options
-      expect(subject.namespace_setting(:description)).to eq(options.merge(description: desc_text))
       expect(subject.route_setting(:description)).to eq(options.merge(description: desc_text))
+      expect(subject.namespace_setting(:description)).to be_nil
     end
 
     context 'when a positional options Hash is passed' do
@@ -31,8 +31,8 @@ describe Grape::DSL::Desc do
         Grape.deprecator.silence do
           subject.desc desc_text, options
         end
-        expect(subject.namespace_setting(:description)).to eq(options.merge(description: desc_text))
         expect(subject.route_setting(:description)).to eq(options.merge(description: desc_text))
+        expect(subject.namespace_setting(:description)).to be_nil
       end
     end
 
@@ -103,8 +103,8 @@ describe Grape::DSL::Desc do
           security %w[array of security schemes]
         end
 
-        expect(subject.namespace_setting(:description)).to eq(expected_options)
         expect(subject.route_setting(:description)).to eq(expected_options)
+        expect(subject.namespace_setting(:description)).to be_nil
       end
     end
   end


### PR DESCRIPTION
`desc` wrote its settings into two places — the route scope (`route_setting(:description)`) and the namespace scope (`namespace_setting(:description)`) — but the namespace copy was pure dead state:

- Grape's runtime reads only `route[:description]` (in `route()`, and only for the `:params` key).
- The namespace scope isn't wired for inheritance — `InheritableSetting#inherit_from` sets `inherited_values` for `namespace_inheritable`/`namespace_stackable`/`namespace_reverse_stackable` and merges `route`, but never touches `@namespace`. So namespace-scope values are only cloned by `point_in_time_copy` and never consulted.
- grape-swagger doesn't read it either (checked against the local checkout).

Confirmed by experiment: dropping the write breaks only the `desc_spec.rb` assertions that checked the write itself — the rest of the suite is unaffected.

### Change

`desc` now writes only the route scope. `namespace_setting(:description)` returns `nil`; a route's description remains available via `route_setting(:description)` and the `route.description` reader. UPGRADING note added.

Full suite green (2351 examples, 0 failures); RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)