### PR TITLE
Compare the base API, not to_s, when refreshing a mounted app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#2792](https://github.com/ruby-grape/grape/pull/2792): Move `Grape::Path` to `Grape::Router::Pattern::Path` and add a `Grape::Router::Pattern.build` factory (`Grape::Path` kept as a deprecated constant) - [@ericproulx](https://github.com/ericproulx).
 * [#2785](https://github.com/ruby-grape/grape/pull/2785): Make route `params` a first-class endpoint input and split `Grape::Router::Route#params` into `#params` (declared definitions) and `#params_for(input)` (extracted values) - [@ericproulx](https://github.com/ericproulx).
 * [#2786](https://github.com/ruby-grape/grape/pull/2786): Make route `requirements` and `anchor` explicit keyword arguments and first-class endpoint inputs instead of opaque `route_options` keys - [@ericproulx](https://github.com/ericproulx).
+* [#2788](https://github.com/ruby-grape/grape/pull/2788): Compare the base API instead of `to_s` when refreshing a mounted app - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/api/instance.rb
+++ b/lib/grape/api/instance.rb
@@ -27,6 +27,8 @@ module Grape
 
         def_delegators :@base, :to_s
 
+        attr_reader :base
+
         def base=(grape_api)
           @base = grape_api
           grape_api.instances << self

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -152,7 +152,7 @@ module Grape
           refresh_already_mounted = opts.any? ? opts.first[:refresh_already_mounted] : false
           if refresh_already_mounted && !endpoints.empty?
             endpoints.delete_if do |endpoint|
-              endpoint.mounted_app.to_s == app.to_s
+              same_mounted_app?(endpoint.mounted_app, app)
             end
           end
 
@@ -292,6 +292,18 @@ module Grape
       def refresh_mounted_api(mounts, *opts)
         opts << { refresh_already_mounted: true }
         mount(mounts, *opts)
+      end
+
+      # Two mounts refer to the same app when they share the same base Grape
+      # API. +mount+ turns every mounted Grape API into a throwaway
+      # +mount_instance+ (a fresh +Class.new+ per mount), so object identity
+      # never holds across mounts; comparing the base is the real signal.
+      # Plain Rack apps have no base and are mounted as-is, so they fall back
+      # to object identity.
+      def same_mounted_app?(mounted, app)
+        return mounted.base.equal?(app.base) if mounted.respond_to?(:base) && app.respond_to?(:base)
+
+        mounted.equal?(app)
       end
 
       # Execute first the provided block, then each of the

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3665,6 +3665,18 @@ describe Grape::API do
         expect { subject.mount app => '/thing' }
           .to change { subject.endpoints.count }.by(1)
       end
+
+      it 'does not confuse two distinct apps that share a name' do
+        other = Class.new(described_class) { get('/y') { 'y' } }
+        # Force a #to_s collision to prove the refresh keys off the base API
+        # identity rather than the string representation.
+        allow(app).to receive(:to_s).and_return('SameName')
+        allow(other).to receive(:to_s).and_return('SameName')
+
+        subject.mount app => '/thing'
+        expect { subject.mount({ other => '/thing' }, refresh_already_mounted: true) }
+          .to change { subject.endpoints.count }.by(1)
+      end
     end
 
     context 'mounting an API' do


### PR DESCRIPTION
### Problem

`refresh_already_mounted` deduplicates endpoints for the "same" mounted app with a string compare:

```ruby
endpoints.delete_if { |endpoint| endpoint.mounted_app.to_s == app.to_s }
```

This only works by accident. `mount` turns every mounted Grape API into a throwaway `mount_instance`, and `mount_instance` builds a **fresh `Class.new(@base_parent)` on every call** (`lib/grape/api.rb`), so two mounts of the same API are *distinct objects* — `app == mounted_app` is always `false`. What makes the `.to_s` compare land is that `Grape::API::Instance` delegates `to_s` to its `@base` (the original API):

```ruby
def_delegators :@base, :to_s   # lib/grape/api/instance.rb
```

So `mounted_app.to_s == app.to_s` is really asking *"do these two throwaway instances share the same base API?"* — through a **string proxy**. That's brittle: it's an identity check dressed up as a string compare, and two distinct APIs that happen to share a name (same `to_s`) falsely dedup.

### Fix

Compare the base API by identity — the real signal the string proxy stands in for. `@base` was writer-only (`base=`), so this exposes a reader and compares it:

```ruby
def same_mounted_app?(mounted, app)
  return mounted.base.equal?(app.base) if mounted.respond_to?(:base) && app.respond_to?(:base)

  mounted.equal?(app)
end
```

Plain Rack apps have no base and are mounted as-is (same object across mounts), so they fall back to object identity.

### Tests

- Existing `refresh_already_mounted` specs still pass (same API → same base → deduped; no flag → duplicated).
- Added a spec that forces a `#to_s` collision between two distinct APIs and asserts the refresh keys off base identity, not the string — it **fails on the old `to_s` compare** (removes the wrong endpoint) and passes with this change.
- Full suite: 2352 examples, 0 failures; RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)