### PR TITLE
Harden mounted-app auth surface and error HTML escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 #### Fixes
 
 * [#2767](https://github.com/ruby-grape/grape/pull/2767): Update rubocop to 1.88.0 and rubocop-rspec to 3.10.2 - [@ericproulx](https://github.com/ericproulx).
+* [#2789](https://github.com/ruby-grape/grape/pull/2789): Escape error messages served with a parameterized `text/html` content-type (e.g. `text/html; charset=utf-8`) and warn when a bare Rack app is mounted under authentication - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.2 (2026-07-05)

--- a/lib/grape/content_types.rb
+++ b/lib/grape/content_types.rb
@@ -22,7 +22,19 @@ module Grape
     def mime_types_for(from_settings)
       return MIME_TYPES if from_settings == Grape::ContentTypes::DEFAULTS
 
-      from_settings.invert.transform_keys! { |k| k.include?(';') ? k.split(';', 2).first : k }
+      from_settings.invert.transform_keys! { |k| media_type(k) }
+    end
+
+    # The media type of a content-type header: the part before any `;`
+    # parameters, with surrounding whitespace removed
+    # (e.g. `'text/html'` for `'text/html; charset=utf-8'`). Returns nil for a
+    # nil content type. Skips the split (and its allocation) when there are no
+    # parameters, which is the common case.
+    def media_type(content_type)
+      return if content_type.nil?
+
+      base = content_type.include?(';') ? content_type.split(';', 2).first : content_type
+      base.strip
     end
   end
 end

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -270,6 +270,7 @@ module Grape
 
     def compile!
       @app = config.app || build_stack
+      warn_unauthenticated_mounted_app
       @helpers = build_helpers
       stackable = inheritable_setting.namespace_stackable
       @befores            = stackable[:befores]
@@ -389,6 +390,19 @@ module Grape
       return if helpers.empty?
 
       Module.new { helpers.each { |mod_to_include| include mod_to_include } }
+    end
+
+    # A bare Rack app mounted with +mount+ is called directly (see +compile!+):
+    # it does not go through +build_stack+, so the API's authentication
+    # middleware never runs and the mount is reachable unauthenticated. Mounted
+    # Grape APIs are unaffected because they rebuild their own stack from the
+    # inherited settings. Warn so this bypass isn't silent.
+    def warn_unauthenticated_mounted_app
+      return unless bare_rack_app?
+      return unless inheritable_setting.namespace_inheritable[:auth]
+
+      warn "Grape: #{config.app} is mounted under an API that declares authentication, but authentication " \
+           'middleware does not wrap mounted Rack applications. Requests to this mount are not authenticated by Grape.'
     end
 
     def build_response_cookies

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -58,8 +58,19 @@ module Grape
       private
 
       def rack_response(status, headers, message)
-        message = Rack::Utils.escape_html(message) if headers[Rack::CONTENT_TYPE] == 'text/html'
+        message = Rack::Utils.escape_html(message) if html_content_type?(headers[Rack::CONTENT_TYPE])
         Rack::Response.new(Array.wrap(message), Rack::Utils.status_code(status), Grape::Util::Header.new.merge(headers))
+      end
+
+      # Escaping must key off the media type only, case-insensitively. Comparing
+      # the raw header against 'text/html' would let a parameterized value such
+      # as 'text/html; charset=utf-8' (or a differently-cased 'Text/HTML', which
+      # browsers still treat as HTML) skip escaping and reflect an unescaped
+      # message into an HTML response. Such a header can be set from several
+      # places (a registered content type, or a custom Content-Type passed to
+      # error!/rescue_from), but they all render here.
+      def html_content_type?(content_type)
+        Grape::ContentTypes.media_type(content_type).to_s.casecmp?('text/html')
       end
 
       def format_message(error)

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3579,6 +3579,27 @@ describe Grape::API do
       end
     end
 
+    context 'with a bare rack app mounted under authentication' do
+      it 'warns that the mount is not covered by the auth middleware' do
+        subject.http_basic { |_u, _p| false }
+        subject.mount mounted_app => '/mounty'
+        expect { get '/mounty' }.to output(/not authenticated by Grape/).to_stderr
+        expect(last_response.body).to eq('MOUNTED')
+      end
+
+      it 'does not warn for a bare rack app mounted without authentication' do
+        subject.mount mounted_app => '/mounty'
+        expect { get '/mounty' }.not_to output.to_stderr
+      end
+
+      it 'does not warn for a mounted Grape API under authentication' do
+        inner = Class.new(described_class) { get('/inner') { 'inner' } }
+        subject.http_basic { |_u, _p| false }
+        subject.mount inner => '/sub'
+        expect { get '/sub/inner' }.not_to output.to_stderr
+      end
+    end
+
     describe 'the mounted endpoint' do
       it 'exposes the mounted app through #mounted_app' do
         subject.mount mounted_app => '/mounty'
@@ -4430,6 +4451,40 @@ describe Grape::API do
       get '/something?format=<script>blah</script>'
       expect(last_response.status).to eq(406)
       expect(last_response.body).to eq(Rack::Utils.escape_html("The requested format '<script>blah</script>' is not supported."))
+    end
+  end
+
+  context 'when an HTML error content-type carries a charset parameter' do
+    it 'still escapes the reflected message' do
+      subject.content_type :html, 'text/html; charset=utf-8'
+      subject.format :html
+      subject.formatter :html, ->(object, _env) { object.to_s }
+      subject.rescue_from(:all) { |e| error!(e.message, 400) }
+      subject.get('/echo') { raise params[:q] }
+      get '/echo', q: '<script>alert(1)</script>'
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq(Rack::Utils.escape_html('<script>alert(1)</script>'))
+    end
+
+    it 'escapes when the charset content-type is set by error! rather than registered' do
+      subject.format :json
+      subject.rescue_from(:all) { |e| error!(e.message, 400, 'Content-Type' => 'text/html; charset=utf-8') }
+      subject.get('/echo') { raise params[:q] }
+      get '/echo', q: '<script>alert(1)</script>'
+      expect(last_response.status).to eq(400)
+      expect(last_response.headers['content-type']).to eq('text/html; charset=utf-8')
+      expect(last_response.body).not_to include('<script>')
+      expect(last_response.body).to include('&lt;script&gt;')
+    end
+
+    it 'escapes regardless of the media type casing' do
+      subject.format :json
+      subject.rescue_from(:all) { |e| error!(e.message, 400, 'Content-Type' => 'Text/HTML; charset=utf-8') }
+      subject.get('/echo') { raise params[:q] }
+      get '/echo', q: '<script>alert(1)</script>'
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).not_to include('<script>')
+      expect(last_response.body).to include('&lt;script&gt;')
     end
   end
 

--- a/spec/grape/content_types_spec.rb
+++ b/spec/grape/content_types_spec.rb
@@ -75,4 +75,32 @@ describe Grape::ContentTypes do
       it { is_expected.to eq('application/xml' => :xml) }
     end
   end
+
+  describe '.media_type' do
+    subject { described_class.media_type(content_type) }
+
+    context 'with a bare media type' do
+      let(:content_type) { 'text/html' }
+
+      it { is_expected.to eq('text/html') }
+    end
+
+    context 'with parameters' do
+      let(:content_type) { 'text/html; charset=utf-8' }
+
+      it { is_expected.to eq('text/html') }
+    end
+
+    context 'with surrounding whitespace before the parameter separator' do
+      let(:content_type) { 'text/html ; charset=utf-8' }
+
+      it { is_expected.to eq('text/html') }
+    end
+
+    context 'when nil' do
+      let(:content_type) { nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
> **Stacked on #2793** (this PR now targets `refactor/mountable-marker`). Its `warn_unauthenticated_mounted_app` check uses the `bare_rack_app?` helper / `Grape::Mountable` marker introduced there. Rebase onto `master` once #2793 lands.

Two security-relevant fixes surfaced by a review of `Grape::API`.

### 1. Error HTML escaping bypassable via a `charset` parameter

`Grape::Middleware::Error#rack_response` escaped the error message only when the response content-type was exactly `text/html`:

```ruby
message = Rack::Utils.escape_html(message) if headers[Rack::CONTENT_TYPE] == 'text/html'
```

A parameterized value such as `text/html; charset=utf-8` fails the `==` check and skips escaping, so a reflected message can be returned unescaped into an HTML response. The check now keys off the media type only, and compares it case-insensitively (a browser treats `Text/HTML` as HTML too).

That header can be set from several places, all of which render through `rack_response`:

- a registered content type — `content_type :html, 'text/html; charset=utf-8'`
- a custom `Content-Type` passed to `error!` / `rescue_from` — e.g. `error!(msg, 400, 'Content-Type' => 'text/html; charset=utf-8')` (this also lets a JSON-formatted body be served as `text/html`, so the browser renders the reflected `<script>`)
- a raised `Grape::Exceptions::Base` carrying such headers

The media-type extraction is factored into `Grape::ContentTypes.media_type`, which `mime_types_for` already needed for the same `;`-stripping, so both now share one helper (and it skips the split allocation when there are no parameters).

### 2. Authentication does not wrap mounted bare Rack apps

A bare Rack app mounted with `mount` is called directly and never goes through the endpoint middleware stack (`@app = config.app || build_stack`), so an API's authentication middleware does not wrap it and the mount is reachable unauthenticated:

```ruby
class ProtectedAPI < Grape::API
  http_basic { |u, p| u == 'admin' && p == 'secret' }
  mount LegacyRackApp => '/legacy'   # reachable with no credentials
end
```

Mounted **Grape APIs** are unaffected because they rebuild their own stack from the inherited settings. Rather than change the call path (auto-wrapping mounted Rack apps would break apps that mount bare Rack apps expecting passthrough), this warns at compile time when a bare Rack app is mounted under configured authentication, so the bypass isn't silent.

### Tests

* Regression specs for the charset-escaping bypass — a registered `text/html; charset=…` content type, a `Content-Type` set by `error!`/`rescue_from`, and a mixed-case `Text/HTML` media type.
* `Grape::ContentTypes.media_type` unit specs.
* Specs asserting the auth warning fires under authentication, and does not fire without authentication or for a mounted Grape API.
* Full suite: 2361 examples, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)