### PR TITLE
Don't mutate router maps at request time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 #### Fixes
 
 * [#2767](https://github.com/ruby-grape/grape/pull/2767): Update rubocop to 1.88.0 and rubocop-rspec to 3.10.2 - [@ericproulx](https://github.com/ericproulx).
+* [#2790](https://github.com/ruby-grape/grape/pull/2790): Stop mutating `Grape::Router`'s internal maps at request time for HTTP methods with no routes (data race on JRuby/TruffleRuby and unbounded growth) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.2 (2026-07-05)

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -13,8 +13,11 @@ module Grape
     def initialize
       @neutral_map = []
       @neutral_regexes = []
-      @map = Hash.new { |hash, key| hash[key] = [] }
-      @optimized_map = Hash.new { |hash, key| hash[key] = // }
+      # Plain hashes with no auto-vivifying default: a lookup for an HTTP method
+      # that has no routes must not insert a key. `compile!` freezes both maps,
+      # so request-time reads never mutate shared state (see #match? / #rotation).
+      @map = {}
+      @optimized_map = {}
     end
 
     def compile!
@@ -29,11 +32,13 @@ module Grape
         optimized_map = routes.map.with_index { |route, index| route.to_regexp(index) }
         @optimized_map[method] = Regexp.union(optimized_map)
       end
+      @map.freeze
+      @optimized_map.freeze
       @compiled = true
     end
 
     def append(route)
-      @map[route.request_method] << route
+      (@map[route.request_method] ||= []) << route
     end
 
     def associate_routes(greedy_route)
@@ -73,7 +78,7 @@ module Grape
 
     def rotation(input, method, env, exact_route)
       response = nil
-      @map[method].each do |route|
+      @map[method]&.each do |route|
         next if exact_route == route
         next unless route.match?(input)
 
@@ -139,7 +144,7 @@ module Grape
     end
 
     def match?(input, method)
-      @optimized_map[method].match(input) { |m| @map[method].detect { |route| m[route.regexp_capture_index] } }
+      @optimized_map[method]&.match(input) { |m| @map[method].detect { |route| m[route.regexp_capture_index] } }
     end
 
     def greedy_match?(input)

--- a/spec/grape/router_spec.rb
+++ b/spec/grape/router_spec.rb
@@ -8,4 +8,44 @@ describe Grape::Router do
       )
     end
   end
+
+  describe 'request-time map isolation' do
+    subject(:router) { described_class.new }
+
+    let(:endpoint) { instance_double(Grape::Endpoint) }
+    let(:pattern) do
+      Grape::Router::Pattern.new(origin: '/hello', suffix: '', anchor: true, params: {}, version: nil, requirements: {})
+    end
+    let(:route) { Grape::Router::Route.new(endpoint, :get, pattern, {}, forward_match: false) }
+
+    before do
+      router.append(route)
+      router.compile!
+    end
+
+    it 'freezes the internal maps after compilation' do
+      expect(router.instance_variable_get(:@map)).to be_frozen
+      expect(router.instance_variable_get(:@optimized_map)).to be_frozen
+    end
+
+    # Regression: the maps used to be auto-vivifying hashes, so a request whose
+    # HTTP method had no routes inserted a key at request time — a data race
+    # under concurrency and unbounded growth from arbitrary methods.
+    it 'does not mutate the maps when routing a method that has no routes' do
+      map = router.instance_variable_get(:@map)
+      optimized_map = router.instance_variable_get(:@optimized_map)
+      keys_before = [map.keys.sort, optimized_map.keys.sort]
+
+      %w[POST PUT PROPFIND CUSTOM].each do |http_method|
+        router.call(Rack::MockRequest.env_for('/hello', method: http_method))
+      end
+
+      expect([map.keys.sort, optimized_map.keys.sort]).to eq(keys_before)
+    end
+
+    it 'routes a method with no routes to the default 404 response without error' do
+      status, = router.call(Rack::MockRequest.env_for('/hello', method: 'POST'))
+      expect(status).to eq(404)
+    end
+  end
 end


### PR DESCRIPTION
### Problem

`Grape::Router` builds its lookup tables as auto-vivifying hashes:

```ruby
@map           = Hash.new { |hash, key| hash[key] = [] }
@optimized_map = Hash.new { |hash, key| hash[key] = // }
```

`compile!` only populates keys for HTTP methods that have routes, but at request time `#match?` and `#rotation` index the maps by the *request's* method. Any method with no routes triggers the default block and **inserts a key into the shared hashes at request time**. `@router.freeze` doesn't help — `freeze` is shallow, so the inner hashes stay mutable.

Demonstration on a GET-only API (starts with `["GET", "HEAD"]`):

```
POST /hello      -> 405, maps now ["GET","HEAD","POST","*"]
PROPFIND /hello  -> maps now [..., "PROPFIND"]
200 concurrent requests, each a distinct custom method -> maps grow to 203 keys
```

Impact:
- **JRuby / TruffleRuby (no GVL):** concurrent `Hash#[]=` on a plain hash is a data race → lost updates / corrupted state.
- **All runtimes:** unbounded growth — every distinct method string becomes a permanent key, so a client able to send arbitrary methods grows the maps without limit (memory-exhaustion vector).
- **MRI:** currently safe only because the GVL serializes each insert; still shared mutable state on the hot path.

### Fix

- Use plain hashes (no auto-vivifying default).
- Create the routes array explicitly on `append` (`(@map[method] ||= []) << route`).
- `freeze` both maps at the end of `compile!` so any future request-time write raises loudly instead of silently mutating.
- Read missing keys without inserting: `#match?` via safe navigation, `#rotation` via `&.each`.

Requests with an unrouted method still resolve to 404/405 exactly as before.

### Tests

New `spec/grape/router_spec.rb` regressions assert the maps are frozen after compilation, that routing methods with no routes does not mutate them, and that such requests still return the default 404 without error. Full suite: 2354 examples, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)