### PR TITLE
Nest Grape::Path inside Grape::Router::Pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#2782](https://github.com/ruby-grape/grape/pull/2782): Remove the dead `format` keyword from `Grape::Router::Pattern` - [@ericproulx](https://github.com/ericproulx).
 * [#2783](https://github.com/ruby-grape/grape/pull/2783): Read a route's `version`, `anchor` and `requirements` from its pattern instead of storing them again on the route - [@ericproulx](https://github.com/ericproulx).
 * [#2784](https://github.com/ruby-grape/grape/pull/2784): Move HEAD route creation into `Grape::Router::Route#to_head` - [@ericproulx](https://github.com/ericproulx).
+* [#2792](https://github.com/ruby-grape/grape/pull/2792): Move `Grape::Path` to `Grape::Router::Pattern::Path` and add a `Grape::Router::Pattern.build` factory (`Grape::Path` kept as a deprecated constant) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -292,10 +292,10 @@ module Grape
 
       config.http_methods.flat_map do |method|
         config.path.map do |path|
-          prepared_path = Path.new(path, namespace, path_settings)
-          pattern = Grape::Router::Pattern.new(
-            origin: prepared_path.origin,
-            suffix: prepared_path.suffix,
+          pattern = Grape::Router::Pattern.build(
+            path:,
+            namespace:,
+            settings: path_settings,
             anchor:,
             params: route_options[:params],
             version:,

--- a/lib/grape/path.rb
+++ b/lib/grape/path.rb
@@ -1,73 +1,12 @@
 # frozen_string_literal: true
 
 module Grape
-  # Represents a path to an endpoint.
-  class Path
-    DEFAULT_FORMAT_SEGMENT = '(/.:format)'
-    NO_VERSIONING_WITH_VALID_PATH_FORMAT_SEGMENT = '(.:format)'
-    VERSION_SEGMENT = ':version'
-
-    attr_reader :origin, :suffix
-
-    def initialize(raw_path, raw_namespace, settings)
-      @origin = PartsCache[build_parts(raw_path, raw_namespace, settings)]
-      @suffix = build_suffix(raw_path, raw_namespace, settings)
-    end
-
-    def to_s
-      "#{origin}#{suffix}"
-    end
-
-    private
-
-    def build_suffix(raw_path, raw_namespace, settings)
-      return "(.#{settings[:format]})" if uses_specific_format?(settings)
-      return NO_VERSIONING_WITH_VALID_PATH_FORMAT_SEGMENT if !uses_path_versioning?(settings) || valid_part?(raw_namespace) || valid_part?(raw_path)
-
-      DEFAULT_FORMAT_SEGMENT
-    end
-
-    def build_parts(raw_path, raw_namespace, settings)
-      parts = []
-      add_part(parts, settings[:mount_path])
-      add_part(parts, settings[:root_prefix])
-      parts << VERSION_SEGMENT if uses_path_versioning?(settings)
-      add_part(parts, raw_namespace)
-      add_part(parts, raw_path)
-      parts
-    end
-
-    def add_part(parts, value)
-      parts << value if value && not_slash?(value)
-    end
-
-    def not_slash?(value)
-      value != '/'
-    end
-
-    def uses_specific_format?(settings)
-      return false unless settings.key?(:format) && settings.key?(:content_types)
-
-      settings[:format] && Array(settings[:content_types]).size == 1
-    end
-
-    def uses_path_versioning?(settings)
-      return false unless settings.key?(:version) && settings[:version_options]
-
-      settings[:version] && settings[:version_options].using == :path
-    end
-
-    def valid_part?(part)
-      part&.match?(/^\S/) && not_slash?(part)
-    end
-
-    class PartsCache < Grape::Util::Cache
-      def initialize
-        super
-        @cache = Hash.new do |h, parts|
-          h[parts] = Grape::Util::PathNormalizer.call(parts.join('/'))
-        end
-      end
-    end
-  end
+  # @deprecated +Grape::Path+ moved to {Grape::Router::Pattern::Path}, since it
+  #   is a router-internal detail that only exists to build a
+  #   {Grape::Router::Pattern}. Reference the new constant instead.
+  Path = ActiveSupport::Deprecation::DeprecatedConstantProxy.new(
+    'Grape::Path',
+    'Grape::Router::Pattern::Path',
+    Grape.deprecator
+  )
 end

--- a/lib/grape/router/pattern.rb
+++ b/lib/grape/router/pattern.rb
@@ -13,6 +13,14 @@ module Grape
       def_delegators :to_regexp, :===
       alias match? ===
 
+      # Build a Pattern from a raw path, namespace and the API's inheritable
+      # settings. {Path} owns the settings-aware assembly of +origin+/+suffix+;
+      # the Pattern itself stays value-based (see {#initialize}).
+      def self.build(path:, namespace:, settings:, anchor:, params:, version:, requirements:)
+        built_path = Path.new(path, namespace, settings)
+        new(origin: built_path.origin, suffix: built_path.suffix, anchor:, params:, version:, requirements:)
+      end
+
       def initialize(origin:, suffix:, anchor:, params:, version:, requirements:)
         @origin = origin
         @anchor = anchor

--- a/lib/grape/router/pattern/path.rb
+++ b/lib/grape/router/pattern/path.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Grape
+  class Router
+    class Pattern
+      # Assembles the path template a {Pattern} compiles into a matcher. It turns
+      # a raw path plus the API's inheritable settings (mount path, root prefix,
+      # path-versioning and format) into an +origin+ (the route prefix) and a
+      # +suffix+ (the format segment). {Pattern.build} is the entry point that
+      # wires this into pattern construction.
+      class Path
+        DEFAULT_FORMAT_SEGMENT = '(/.:format)'
+        NO_VERSIONING_WITH_VALID_PATH_FORMAT_SEGMENT = '(.:format)'
+        VERSION_SEGMENT = ':version'
+
+        attr_reader :origin, :suffix
+
+        def initialize(raw_path, raw_namespace, settings)
+          @origin = PartsCache[build_parts(raw_path, raw_namespace, settings)]
+          @suffix = build_suffix(raw_path, raw_namespace, settings)
+        end
+
+        def to_s
+          "#{origin}#{suffix}"
+        end
+
+        private
+
+        def build_suffix(raw_path, raw_namespace, settings)
+          return "(.#{settings[:format]})" if uses_specific_format?(settings)
+          return NO_VERSIONING_WITH_VALID_PATH_FORMAT_SEGMENT if !uses_path_versioning?(settings) || valid_part?(raw_namespace) || valid_part?(raw_path)
+
+          DEFAULT_FORMAT_SEGMENT
+        end
+
+        def build_parts(raw_path, raw_namespace, settings)
+          parts = []
+          add_part(parts, settings[:mount_path])
+          add_part(parts, settings[:root_prefix])
+          parts << VERSION_SEGMENT if uses_path_versioning?(settings)
+          add_part(parts, raw_namespace)
+          add_part(parts, raw_path)
+          parts
+        end
+
+        def add_part(parts, value)
+          parts << value if value && not_slash?(value)
+        end
+
+        def not_slash?(value)
+          value != '/'
+        end
+
+        def uses_specific_format?(settings)
+          return false unless settings.key?(:format) && settings.key?(:content_types)
+
+          settings[:format] && Array(settings[:content_types]).size == 1
+        end
+
+        def uses_path_versioning?(settings)
+          return false unless settings.key?(:version) && settings[:version_options]
+
+          settings[:version] && settings[:version_options].using == :path
+        end
+
+        def valid_part?(part)
+          part&.match?(/^\S/) && not_slash?(part)
+        end
+
+        class PartsCache < Grape::Util::Cache
+          def initialize
+            super
+            @cache = Hash.new do |h, parts|
+              h[parts] = Grape::Util::PathNormalizer.call(parts.join('/'))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/grape/path_spec.rb
+++ b/spec/grape/path_spec.rb
@@ -1,90 +1,9 @@
 # frozen_string_literal: true
 
-describe Grape::Path do
-  describe '#origin' do
-    context 'mount_path' do
-      it 'is not included when it is nil' do
-        path = described_class.new(nil, nil, mount_path: '/foo/bar')
-        expect(path.origin).to eql '/foo/bar'
-      end
-
-      it 'is included when it is not nil' do
-        path = described_class.new(nil, nil, {})
-        expect(path.origin).to eql('/')
-      end
-    end
-
-    context 'root_prefix' do
-      it 'is not included when it is nil' do
-        path = described_class.new(nil, nil, {})
-        expect(path.origin).to eql('/')
-      end
-
-      it 'is included after the mount path' do
-        path = described_class.new(
-          nil,
-          nil,
-          mount_path: '/foo',
-          root_prefix: '/hello'
-        )
-
-        expect(path.origin).to eql('/foo/hello')
-      end
-    end
-
-    it 'uses the namespace after the mount path and root prefix' do
-      path = described_class.new(
-        nil,
-        'namespace',
-        mount_path: '/foo',
-        root_prefix: '/hello'
-      )
-
-      expect(path.origin).to eql('/foo/hello/namespace')
-    end
-
-    it 'uses the raw path after the namespace' do
-      path = described_class.new(
-        'raw_path',
-        'namespace',
-        mount_path: '/foo',
-        root_prefix: '/hello'
-      )
-
-      expect(path.origin).to eql('/foo/hello/namespace/raw_path')
-    end
-  end
-
-  describe '#suffix' do
-    context 'when using a specific format' do
-      it 'accepts specified format' do
-        path = described_class.new(nil, nil, format: 'json', content_types: 'application/json')
-        expect(path.suffix).to eql('(.json)')
-      end
-    end
-
-    context 'when path versioning is used' do
-      it "includes a '/'" do
-        path = described_class.new(nil, nil, version: :v1, version_options: Grape::DSL::VersionOptions.new)
-        expect(path.suffix).to eql('(/.:format)')
-      end
-    end
-
-    context 'when path versioning is not used' do
-      it "does not include a '/' when the path has a namespace" do
-        path = described_class.new(nil, 'namespace', {})
-        expect(path.suffix).to eql('(.:format)')
-      end
-
-      it "does not include a '/' when the path has a path" do
-        path = described_class.new('/path', nil, version: :v1, version_options: Grape::DSL::VersionOptions.new)
-        expect(path.suffix).to eql('(.:format)')
-      end
-
-      it "includes a '/' otherwise" do
-        path = described_class.new(nil, nil, version: :v1, version_options: Grape::DSL::VersionOptions.new)
-        expect(path.suffix).to eql('(/.:format)')
-      end
-    end
+RSpec.describe 'Grape::Path' do
+  it 'is deprecated and points at Grape::Router::Pattern::Path' do
+    expect { Grape::Path.new(nil, nil, {}) }.to raise_error(
+      ActiveSupport::DeprecationException, /Grape::Path is deprecated.*Grape::Router::Pattern::Path/m
+    )
   end
 end

--- a/spec/grape/router/pattern/path_spec.rb
+++ b/spec/grape/router/pattern/path_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+RSpec.describe Grape::Router::Pattern::Path do
+  describe '#origin' do
+    context 'mount_path' do
+      it 'is not included when it is nil' do
+        path = described_class.new(nil, nil, mount_path: '/foo/bar')
+        expect(path.origin).to eql '/foo/bar'
+      end
+
+      it 'is included when it is not nil' do
+        path = described_class.new(nil, nil, {})
+        expect(path.origin).to eql('/')
+      end
+    end
+
+    context 'root_prefix' do
+      it 'is not included when it is nil' do
+        path = described_class.new(nil, nil, {})
+        expect(path.origin).to eql('/')
+      end
+
+      it 'is included after the mount path' do
+        path = described_class.new(
+          nil,
+          nil,
+          mount_path: '/foo',
+          root_prefix: '/hello'
+        )
+
+        expect(path.origin).to eql('/foo/hello')
+      end
+    end
+
+    it 'uses the namespace after the mount path and root prefix' do
+      path = described_class.new(
+        nil,
+        'namespace',
+        mount_path: '/foo',
+        root_prefix: '/hello'
+      )
+
+      expect(path.origin).to eql('/foo/hello/namespace')
+    end
+
+    it 'uses the raw path after the namespace' do
+      path = described_class.new(
+        'raw_path',
+        'namespace',
+        mount_path: '/foo',
+        root_prefix: '/hello'
+      )
+
+      expect(path.origin).to eql('/foo/hello/namespace/raw_path')
+    end
+  end
+
+  describe '#suffix' do
+    context 'when using a specific format' do
+      it 'accepts specified format' do
+        path = described_class.new(nil, nil, format: 'json', content_types: 'application/json')
+        expect(path.suffix).to eql('(.json)')
+      end
+    end
+
+    context 'when path versioning is used' do
+      it "includes a '/'" do
+        path = described_class.new(nil, nil, version: :v1, version_options: Grape::DSL::VersionOptions.new)
+        expect(path.suffix).to eql('(/.:format)')
+      end
+    end
+
+    context 'when path versioning is not used' do
+      it "does not include a '/' when the path has a namespace" do
+        path = described_class.new(nil, 'namespace', {})
+        expect(path.suffix).to eql('(.:format)')
+      end
+
+      it "does not include a '/' when the path has a path" do
+        path = described_class.new('/path', nil, version: :v1, version_options: Grape::DSL::VersionOptions.new)
+        expect(path.suffix).to eql('(.:format)')
+      end
+
+      it "includes a '/' otherwise" do
+        path = described_class.new(nil, nil, version: :v1, version_options: Grape::DSL::VersionOptions.new)
+        expect(path.suffix).to eql('(/.:format)')
+      end
+    end
+  end
+end

--- a/spec/grape/router/pattern_spec.rb
+++ b/spec/grape/router/pattern_spec.rb
@@ -12,4 +12,15 @@ RSpec.describe Grape::Router::Pattern do
       expect(pattern.requirements).to eq(id: /\d+/)
     end
   end
+
+  describe '.build' do
+    subject(:pattern) do
+      described_class.build(path: '/foo', namespace: 'ns', settings: { root_prefix: '/api' }, anchor: true, params: {}, version: nil, requirements: {})
+    end
+
+    it 'assembles origin/suffix from the path, namespace and settings via Path' do
+      expect(pattern.origin).to eq('/api/ns/foo')
+      expect(pattern.path).to eq('/api/ns/foo(.:format)')
+    end
+  end
 end


### PR DESCRIPTION
`Grape::Path` only ever existed to compute the `origin`/`suffix` strings that `Grape::Router::Pattern` compiles into a matcher. It had a single caller (`Endpoint#to_routes`) and only its `.origin`/`.suffix` were ever read, yet it sat at the top level of the `Grape` namespace as if it were public API.

### Change

- Move it to **`Grape::Router::Pattern::Path`** — where it belongs, as a router-internal collaborator of `Pattern`.
- Add a **`Pattern.build(path:, namespace:, settings:, anchor:, params:, version:, requirements:)`** factory that constructs the `Path` internally and derives `origin`/`suffix` from it. The endpoint now makes a single call instead of building a `Path` and threading its outputs into `Pattern.new`:

```ruby
# before
prepared_path = Path.new(path, namespace, path_settings)
pattern = Grape::Router::Pattern.new(origin: prepared_path.origin, suffix: prepared_path.suffix, anchor:, params: route_options[:params], version:, requirements:)

# after
pattern = Grape::Router::Pattern.build(path:, namespace:, settings: path_settings, anchor:, params: route_options[:params], version:, requirements:)
```

`Pattern.new` is intentionally left value-based (`origin:`/`suffix:`/…) — the matcher never learns about the settings-hash shape (`version_options.using`, `content_types`, `format`, `mount_path`, `root_prefix`). Only `Path`, and the thin `build` factory, are settings-aware. `Path` keeps its own class and spec.

`Grape::Path` is retained as a deprecated `ActiveSupport::Deprecation::DeprecatedConstantProxy` pointing at the new constant, so external references keep working with a warning.

### Tests

- `spec/grape/path_spec.rb` moved to `spec/grape/router/pattern/path_spec.rb` (unchanged assertions, new constant), plus a small `spec/grape/path_spec.rb` that asserts the old constant is deprecated.
- Added a `Pattern.build` example. Full suite: 2353 examples, 0 failures. RuboCop clean. Verified `require 'grape'` (which eager-loads) works with the proxy under `deprecator.behavior = :raise`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)