### PR TITLE
Encapsulate namespace_reverse_stackable behind rescue-handler methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#2782](https://github.com/ruby-grape/grape/pull/2782): Remove the dead `format` keyword from `Grape::Router::Pattern` - [@ericproulx](https://github.com/ericproulx).
 * [#2783](https://github.com/ruby-grape/grape/pull/2783): Read a route's `version`, `anchor` and `requirements` from its pattern instead of storing them again on the route - [@ericproulx](https://github.com/ericproulx).
 * [#2784](https://github.com/ruby-grape/grape/pull/2784): Move HEAD route creation into `Grape::Router::Route#to_head` - [@ericproulx](https://github.com/ericproulx).
+* [#2795](https://github.com/ruby-grape/grape/pull/2795): Make `Grape::Util::InheritableSetting#namespace_reverse_stackable` internal, exposing `rescue_handlers` / `base_only_rescue_handlers` / `add_rescue_handlers` instead - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -120,8 +120,7 @@ module Grape
         when :internal_grape_exceptions
           namespace_inheritable[:internal_grape_exceptions_rescue_handler] = handler
         else
-          handler_type = rescue_subclasses ? :rescue_handlers : :base_only_rescue_handlers
-          inheritable_setting.namespace_reverse_stackable[handler_type] = args.to_h { |klass| [klass, handler] }
+          inheritable_setting.add_rescue_handlers(args.to_h { |klass| [klass, handler] }, subclasses: rescue_subclasses)
         end
 
         inheritable_setting.namespace_stackable[:rescue_options] = RescueOptions.new(backtrace:, original_exception:)

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -369,8 +369,8 @@ module Grape
         default_error_formatter: ns_inh[:default_error_formatter],
         error_formatters: ns_stack.namespace_stackable_with_hash(:error_formatters),
         rescue_options: ns_stack.namespace_stackable[:rescue_options]&.last,
-        rescue_handlers:,
-        base_only_rescue_handlers:,
+        rescue_handlers: ns_stack.rescue_handlers,
+        base_only_rescue_handlers: ns_stack.base_only_rescue_handlers,
         all_rescue_handler: ns_inh[:all_rescue_handler],
         grape_exceptions_rescue_handler: ns_inh[:grape_exceptions_rescue_handler],
         internal_grape_exceptions_rescue_handler: ns_inh[:internal_grape_exceptions_rescue_handler]
@@ -395,27 +395,6 @@ module Grape
 
     def lint?
       inheritable_setting.namespace_inheritable[:lint] || Grape.config.lint
-    end
-
-    def rescue_handlers
-      merged_reverse_stackable(:rescue_handlers)
-    end
-
-    def base_only_rescue_handlers
-      merged_reverse_stackable(:base_only_rescue_handlers)
-    end
-
-    # Merge a reverse-stackable handler map (as written by +rescue_from+) into a
-    # single Hash. The reverse store lists child-scope handlers before inherited
-    # ones, and the first-wins merge keeps the child's handler for a given
-    # class, so a nested +rescue_from+ overrides an outer one.
-    def merged_reverse_stackable(key)
-      handlers = inheritable_setting.namespace_reverse_stackable[key]
-      return if handlers.blank?
-
-      handlers.each_with_object({}) do |handler, result|
-        result.merge!(handler) { |_k, s1, _s2| s1 }
-      end
     end
   end
 end

--- a/lib/grape/util/inheritable_setting.rb
+++ b/lib/grape/util/inheritable_setting.rb
@@ -5,7 +5,7 @@ module Grape
     # A branchable, inheritable settings object which can store both stackable
     # and inheritable values (see InheritableValues and StackableValues).
     class InheritableSetting
-      attr_reader :route, :namespace, :namespace_inheritable, :namespace_stackable, :namespace_reverse_stackable, :parent
+      attr_reader :route, :namespace, :namespace_inheritable, :namespace_stackable, :parent
 
       # Lazy-allocated; +api_class+ and +point_in_time_copies+ are rarely
       # written on most settings layers, so don't pay for a Hash/Array each.
@@ -107,7 +107,27 @@ module Grape
         data.each_with_object({}) { |value, result| result.deep_merge!(value) }
       end
 
+      # Rescue-handler maps registered by +rescue_from+, keyed by exception
+      # class and merged so a nested scope's handler wins. Record them with
+      # #add_rescue_handlers; the backing store is an internal detail.
+      def rescue_handlers
+        merged_rescue_handlers(:rescue_handlers)
+      end
+
+      def base_only_rescue_handlers
+        merged_rescue_handlers(:base_only_rescue_handlers)
+      end
+
+      def add_rescue_handlers(mapping, subclasses:)
+        namespace_reverse_stackable[subclasses ? :rescue_handlers : :base_only_rescue_handlers] = mapping
+      end
+
       protected
+
+      # Reverse-stackable so a child scope's rescue handlers precede inherited
+      # ones. Reached only through #rescue_handlers / #base_only_rescue_handlers
+      # / #add_rescue_handlers, and #inherit_from / #copy_state_from.
+      attr_reader :namespace_reverse_stackable
 
       # Used by +point_in_time_copy+ to populate a freshly-built instance
       # with cloned state from another instance of the same class.
@@ -118,6 +138,15 @@ module Grape
         @namespace_reverse_stackable = source.namespace_reverse_stackable.clone
         @route = source.route.clone
         @api_class = source.api_class
+      end
+
+      private
+
+      def merged_rescue_handlers(key)
+        handlers = namespace_reverse_stackable[key]
+        return if handlers.blank?
+
+        handlers.each_with_object({}) { |handler, result| result.merge!(handler) { |_k, s1, _s2| s1 } }
       end
     end
   end

--- a/spec/grape/dsl/request_response_spec.rb
+++ b/spec/grape/dsl/request_response_spec.rb
@@ -220,34 +220,34 @@ describe Grape::DSL::RequestResponse do
 
       it 'sets hash of exceptions as rescue handlers' do
         subject.rescue_from StandardError
-        expect(subject.inheritable_setting.namespace_reverse_stackable[:rescue_handlers]).to eq([{ StandardError => nil }])
+        expect(subject.inheritable_setting.rescue_handlers).to eq(StandardError => nil)
         expect(subject.inheritable_setting.namespace_stackable[:rescue_options]).to eq(default_rescue_options)
       end
 
       it 'rescues only base handlers if rescue_subclasses: false option is passed' do
         subject.rescue_from StandardError, rescue_subclasses: false
-        expect(subject.inheritable_setting.namespace_reverse_stackable[:base_only_rescue_handlers]).to eq([{ StandardError => nil }])
+        expect(subject.inheritable_setting.base_only_rescue_handlers).to eq(StandardError => nil)
         expect(subject.inheritable_setting.namespace_stackable[:rescue_options]).to eq(default_rescue_options)
       end
 
       it 'sets given proc as rescue handler for each key in hash' do
         rescue_handler_proc = proc {}
         subject.rescue_from StandardError, rescue_handler_proc
-        expect(subject.inheritable_setting.namespace_reverse_stackable[:rescue_handlers]).to eq([{ StandardError => rescue_handler_proc }])
+        expect(subject.inheritable_setting.rescue_handlers).to eq(StandardError => rescue_handler_proc)
         expect(subject.inheritable_setting.namespace_stackable[:rescue_options]).to eq(default_rescue_options)
       end
 
       it 'sets given block as rescue handler for each key in hash' do
         rescue_handler_proc = proc {}
         subject.rescue_from StandardError, &rescue_handler_proc
-        expect(subject.inheritable_setting.namespace_reverse_stackable[:rescue_handlers]).to eq([{ StandardError => rescue_handler_proc }])
+        expect(subject.inheritable_setting.rescue_handlers).to eq(StandardError => rescue_handler_proc)
         expect(subject.inheritable_setting.namespace_stackable[:rescue_options]).to eq(default_rescue_options)
       end
 
       it 'sets a rescue handler declared through :with option for each key in hash' do
         with_block = -> { 'hello' }
         subject.rescue_from StandardError, with: with_block
-        expect(subject.inheritable_setting.namespace_reverse_stackable[:rescue_handlers]).to eq([{ StandardError => with_block }])
+        expect(subject.inheritable_setting.rescue_handlers).to eq(StandardError => with_block)
         expect(subject.inheritable_setting.namespace_stackable[:rescue_options]).to eq(default_rescue_options)
       end
     end

--- a/spec/grape/util/inheritable_setting_spec.rb
+++ b/spec/grape/util/inheritable_setting_spec.rb
@@ -12,7 +12,6 @@ describe Grape::Util::InheritableSetting do
       settings.namespace[:namespace_thing] = :namespace_foo_bar
       settings.namespace_inheritable[:namespace_inheritable_thing] = :namespace_inheritable_foo_bar
       settings.namespace_stackable[:namespace_stackable_thing] = :namespace_stackable_foo_bar
-      settings.namespace_reverse_stackable[:namespace_reverse_stackable_thing] = :namespace_reverse_stackable_foo_bar
       settings.route[:route_thing] = :route_foo_bar
     end
   end
@@ -22,7 +21,6 @@ describe Grape::Util::InheritableSetting do
       settings.namespace[:namespace_thing] = :namespace_foo_bar_other
       settings.namespace_inheritable[:namespace_inheritable_thing] = :namespace_inheritable_foo_bar_other
       settings.namespace_stackable[:namespace_stackable_thing] = :namespace_stackable_foo_bar_other
-      settings.namespace_reverse_stackable[:namespace_reverse_stackable_thing] = :namespace_reverse_stackable_foo_bar_other
       settings.route[:route_thing] = :route_foo_bar_other
     end
   end
@@ -116,13 +114,24 @@ describe Grape::Util::InheritableSetting do
     end
   end
 
-  describe '#namespace_reverse_stackable' do
-    it 'works with reverse stackable values' do
-      expect(subject.namespace_reverse_stackable[:namespace_reverse_stackable_thing]).to eq [:namespace_reverse_stackable_foo_bar]
+  describe '#rescue_handlers / #add_rescue_handlers' do
+    it 'records subclass-matching handlers under rescue_handlers' do
+      subject.add_rescue_handlers({ StandardError => :handler }, subclasses: true)
+      expect(subject.rescue_handlers).to eq(StandardError => :handler)
+      expect(subject.base_only_rescue_handlers).to be_nil
+    end
 
-      subject.inherit_from other_parent
+    it 'records exact-match handlers under base_only_rescue_handlers' do
+      subject.add_rescue_handlers({ StandardError => :handler }, subclasses: false)
+      expect(subject.base_only_rescue_handlers).to eq(StandardError => :handler)
+      expect(subject.rescue_handlers).to be_nil
+    end
 
-      expect(subject.namespace_reverse_stackable[:namespace_reverse_stackable_thing]).to eq [:namespace_reverse_stackable_foo_bar_other]
+    it 'lets a nested scope override an inherited handler for the same class' do
+      parent = described_class.new.tap { |s| s.add_rescue_handlers({ StandardError => :parent }, subclasses: true) }
+      subject.inherit_from parent
+      subject.add_rescue_handlers({ StandardError => :child }, subclasses: true)
+      expect(subject.rescue_handlers).to eq(StandardError => :child)
     end
   end
 
@@ -192,14 +201,6 @@ describe Grape::Util::InheritableSetting do
       expect(cloned_obj.namespace_stackable[:namespace_stackable_thing]).to eq [:namespace_stackable_foo_bar]
     end
 
-    it 'decouples namespace reverse stackable values' do
-      expect(cloned_obj.namespace_reverse_stackable[:namespace_reverse_stackable_thing]).to eq [:namespace_reverse_stackable_foo_bar]
-
-      subject.namespace_reverse_stackable[:namespace_reverse_stackable_thing] = :other_thing
-      expect(subject.namespace_reverse_stackable[:namespace_reverse_stackable_thing]).to eq %i[other_thing namespace_reverse_stackable_foo_bar]
-      expect(cloned_obj.namespace_reverse_stackable[:namespace_reverse_stackable_thing]).to eq [:namespace_reverse_stackable_foo_bar]
-    end
-
     it 'decouples route values' do
       expect(cloned_obj.route[:route_thing]).to eq :route_foo_bar
 
@@ -218,7 +219,7 @@ describe Grape::Util::InheritableSetting do
       subject.namespace[:namespace_thing] = :namespace_foo_bar
       subject.namespace_inheritable[:namespace_inheritable_thing] = :namespace_inheritable_foo_bar
       subject.namespace_stackable[:namespace_stackable_thing] = [:namespace_stackable_foo_bar]
-      subject.namespace_reverse_stackable[:namespace_reverse_stackable_thing] = [:namespace_reverse_stackable_foo_bar]
+      subject.add_rescue_handlers({ StandardError => :handler }, subclasses: true)
       subject.route[:route_thing] = :route_foo_bar
       expect(subject.to_hash).to match(
         global: { global_thing: :global_foo_bar },
@@ -227,8 +228,7 @@ describe Grape::Util::InheritableSetting do
           namespace_inheritable_thing: :namespace_inheritable_foo_bar
         },
         namespace_stackable: { namespace_stackable_thing: [:namespace_stackable_foo_bar, [:namespace_stackable_foo_bar]] },
-        namespace_reverse_stackable:
-          { namespace_reverse_stackable_thing: [[:namespace_reverse_stackable_foo_bar], :namespace_reverse_stackable_foo_bar] },
+        namespace_reverse_stackable: { rescue_handlers: [{ StandardError => :handler }] },
         route: { route_thing: :route_foo_bar }
       )
     end


### PR DESCRIPTION
> **Stacked on #2794** (targets `fix/base-only-rescue-handlers`). Rebase onto `master` once #2794 lands.

Follow-up to #2794. That bug happened because `namespace_reverse_stackable` — a store whose *only* purpose is rescue-handler maps — was a public `attr_reader` that two different files reached into with raw keys, so the base-only write and read could drift onto different stores.

### Change

Make `namespace_reverse_stackable` **`protected`** (still used internally by `inherit_from` / `copy_state_from` / `to_hash`), and expose intent-revealing methods on `InheritableSetting`:

```ruby
def rescue_handlers            # merged, child-scope handlers win
def base_only_rescue_handlers  # merged, child-scope handlers win
def add_rescue_handlers(mapping, subclasses:)
```

- **Write** (`dsl/request_response.rb`): the `handler_type` branch collapses into `add_rescue_handlers(mapping, subclasses: rescue_subclasses)`.
- **Read** (`endpoint.rb`): `error_middleware_options` calls `ns_stack.rescue_handlers` / `.base_only_rescue_handlers`; the child-precedence merge moves out of `Endpoint` onto `InheritableSetting`, and the three `Endpoint` privates from #2794 go away.

Now one place knows the key, the store, and the merge — the write/read can't drift apart again.

### Tests

The reverse-ordering behaviour is already covered by `ReverseStackableValues`' own spec (14 examples), so the `InheritableSetting` specs that poked `subject.namespace_reverse_stackable[...]` are replaced with tests for `rescue_handlers` / `base_only_rescue_handlers` / `add_rescue_handlers` (including nested-scope override). `request_response_spec` assertions switch from the raw store to the named readers.

Full suite: 2353 examples, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)