### PR TITLE
Internalize params state behind Grape::Util::InheritableSetting accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#2786](https://github.com/ruby-grape/grape/pull/2786): Make route `requirements` and `anchor` explicit keyword arguments and first-class endpoint inputs instead of opaque `route_options` keys - [@ericproulx](https://github.com/ericproulx).
 * [#2788](https://github.com/ruby-grape/grape/pull/2788): Compare the base API instead of `to_s` when refreshing a mounted app - [@ericproulx](https://github.com/ericproulx).
 * [#2796](https://github.com/ruby-grape/grape/pull/2796): Remove `Grape::Util::ReverseStackableValues`, storing rescue handlers in plain per-scope hashes merged over `InheritableSetting#parent` - [@ericproulx](https://github.com/ericproulx).
+* [#2797](https://github.com/ruby-grape/grape/pull/2797): Internalize params state (validations, declared params, param documentation, named params) behind `Grape::Util::InheritableSetting` accessors, and remove the unused `api_class` / `point_in_time_copies` readers - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -82,6 +82,16 @@ A route's declared params were previously carried inside the `route_options` bag
 
 Like `params` above, a route's `requirements` and `anchor` were previously carried inside the `route_options` bag. They are now composed into their own endpoint inputs (`Grape::Endpoint::Options` gains `:requirements` and `:anchor` members, and `Grape::Endpoint.new` gains `requirements:` and `anchor:` keywords) and exposed only through the `route.requirements` and `route.anchor` readers. `route.options[:requirements]` and `route.options[:anchor]` now return `nil` — including for a mount's `anchor: false`. Nothing in Grape or grape-swagger read them that way, so this only affects code that reached into the options Hash for these keys directly.
 
+#### Params state is recorded through `InheritableSetting` accessors
+
+The state accumulated by `params` / `contract` blocks — validator instances, declared params, param documentation and reusable named params — is now recorded and read through dedicated accessors on `Grape::Util::InheritableSetting` (`validations` / `add_validation`, `declared_params` / `add_declared_params`, `params_documentation` / `add_params_documentation`, `named_params` / `add_named_params`, `reset_validations!`) instead of raw `namespace_stackable` keys, following the same move made for rescue handlers. The keys' storage is unchanged for now, so `namespace_stackable[:validations]` and friends still return the same values, but they should be considered internal.
+
+Related contract changes, none with known external consumers:
+
+* `Grape::Endpoint#inherit_settings` now takes the parent `Grape::Util::InheritableSetting` instead of that setting's raw `namespace_stackable` store.
+* The endpoint's request-time validator snapshot moved from `route_setting(:saved_validations)` to `route_setting(:validations)`, symmetric with `route_setting(:declared_params)`. The vestigial `saved_` prefix dated back to the 2014 settings refactor. Neither key appears in `route.settings`, as before.
+* `Grape::Util::InheritableSetting#api_class` (a Hash nothing in Grape ever wrote to) and `#point_in_time_copies` (only ever used internally) are removed.
+
 ### Upgrading to >= 3.3
 
 #### Minimum required Ruby is now 3.3

--- a/lib/grape/api/instance.rb
+++ b/lib/grape/api/instance.rb
@@ -83,7 +83,7 @@ module Grape
           # Propagate any inherited params down to our endpoints, and reset any
           # compiled routes.
           endpoints.each do |e|
-            e.inherit_settings(top_level_setting.namespace_stackable)
+            e.inherit_settings(top_level_setting)
             e.reset_routes!
           end
 

--- a/lib/grape/dsl/declared.rb
+++ b/lib/grape/dsl/declared.rb
@@ -24,7 +24,7 @@ module Grape
 
         contract_key_map = inheritable_setting.namespace_stackable[:contract_key_map]
         handler = DeclaredParamsHandler.new(include_missing:, evaluate_given:, stringify:, contract_key_map:)
-        declared_params = include_parent_namespaces ? inheritable_setting.route[:declared_params] : (inheritable_setting.namespace_stackable[:declared_params].last || [])
+        declared_params = include_parent_namespaces ? inheritable_setting.route[:declared_params] : (inheritable_setting.declared_params.last || [])
         renamed_params = inheritable_setting.route[:renamed_params] || {}
         route_params = config.params
 

--- a/lib/grape/dsl/helpers.rb
+++ b/lib/grape/dsl/helpers.rb
@@ -115,7 +115,7 @@ module Grape
         def process_named_params
           return if @named_params.blank?
 
-          api.inheritable_setting.namespace_stackable[:named_params] = @named_params
+          api.inheritable_setting.add_named_params(@named_params)
         end
       end
     end

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -54,7 +54,7 @@ module Grape
       #       end
       #     end
       def use(*names, **options)
-        named_params = @api.inheritable_setting.namespace_stackable_with_hash(:named_params) || {}
+        named_params = @api.inheritable_setting.named_params || {}
         names.each do |name|
           params_block = named_params.fetch(name) do
             raise "Params :#{name} not found!"

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -273,7 +273,7 @@ module Grape
       # Compose a route's params: the declared params (+params do … end+) deep-merged
       # with any documented alongside +desc ..., params:+ (+description_params+).
       def prepare_params(description_params)
-        endpoint_params = inheritable_setting.namespace_stackable_with_hash(:params) || {}
+        endpoint_params = inheritable_setting.params_documentation || {}
         return endpoint_params if description_params.blank?
 
         endpoint_params.deep_merge(description_params)

--- a/lib/grape/dsl/validations.rb
+++ b/lib/grape/dsl/validations.rb
@@ -44,7 +44,7 @@ module Grape
       #      # whatever
       #    end
       def reset_validations!
-        inheritable_setting.namespace_stackable.delete(:declared_params, :params, :validations)
+        inheritable_setting.reset_validations!
       end
     end
   end

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -67,16 +67,7 @@ module Grape
     # endpoint does not know if it will be mounted under a different endpoint.
     # @yield a block defining what your API should do when this endpoint is hit
     def initialize(new_settings, http_methods:, path:, api:, app: nil, params: {}, requirements: nil, anchor: true, **options, &block)
-      self.inheritable_setting = new_settings.point_in_time_copy
-
-      # now +namespace_stackable(:declared_params)+ contains all params defined for
-      # this endpoint and its parents, but later it will be cleaned up,
-      # see +reset_validations!+ in lib/grape/dsl/validations.rb
-      inheritable_setting.route[:declared_params] = inheritable_setting.namespace_stackable[:declared_params].flatten
-      inheritable_setting.route[:saved_validations] = inheritable_setting.namespace_stackable[:validations].dup
-
-      inheritable_setting.namespace_stackable[:representations] ||= []
-      inheritable_setting.namespace_inheritable[:default_error_status] ||= 500
+      self.inheritable_setting = new_settings.point_in_time_copy_for_endpoint
 
       @options = options
       @config = Options.new(http_methods:, path:, api:, app:, params:, requirements:, anchor:, **options)
@@ -93,15 +84,16 @@ module Grape
       @endpoints = @config.app.endpoints if @config.app.respond_to?(:endpoints)
     end
 
-    # Update our settings from a given set of stackable parameters. Used when
+    # Update our settings from a given parent settings instance. Used when
     # the endpoint's API is mounted under another one.
-    def inherit_settings(namespace_stackable)
-      parent_validations = namespace_stackable[:validations]
-      inheritable_setting.route[:saved_validations].concat(parent_validations) if parent_validations.any?
-      parent_declared_params = namespace_stackable[:declared_params]
+    # @param settings [Grape::Util::InheritableSetting]
+    def inherit_settings(settings)
+      parent_validations = settings.validations
+      inheritable_setting.route[:validations].concat(parent_validations) if parent_validations.any?
+      parent_declared_params = settings.declared_params
       inheritable_setting.route[:declared_params].concat(parent_declared_params.flatten) if parent_declared_params.any?
 
-      endpoints&.each { |e| e.inherit_settings(namespace_stackable) }
+      endpoints&.each { |e| e.inherit_settings(settings) }
     end
 
     def routes
@@ -209,7 +201,7 @@ module Grape
     end
 
     def run_validators(request:)
-      validators = inheritable_setting.route[:saved_validations]
+      validators = inheritable_setting.route[:validations]
       return if validators.blank?
 
       validation_exceptions = nil
@@ -296,7 +288,7 @@ module Grape
       prefix = inheritable_setting.namespace_inheritable[:root_prefix]
       requirements = prepare_routes_requirements(config.requirements)
       anchor = config.anchor
-      settings = inheritable_setting.route.except(:declared_params, :saved_validations)
+      settings = inheritable_setting.route.except(:declared_params, :validations)
 
       config.http_methods.flat_map do |method|
         config.path.map do |path|

--- a/lib/grape/util/inheritable_setting.rb
+++ b/lib/grape/util/inheritable_setting.rb
@@ -7,16 +7,6 @@ module Grape
     class InheritableSetting
       attr_reader :route, :namespace, :namespace_inheritable, :namespace_stackable, :parent
 
-      # Lazy-allocated; +api_class+ and +point_in_time_copies+ are rarely
-      # written on most settings layers, so don't pay for a Hash/Array each.
-      def api_class
-        @api_class ||= {}
-      end
-
-      def point_in_time_copies
-        @point_in_time_copies ||= []
-      end
-
       # Retrieve global settings.
       def self.global
         @global ||= {}
@@ -39,7 +29,7 @@ module Grape
         @namespace_inheritable = InheritableValues.new
         @namespace_stackable = StackableValues.new
         @parent = nil
-        # @api_class, @point_in_time_copies and @rescue_handler_maps stay nil until first access.
+        @point_in_time_copies = nil
       end
 
       # Return the class-level global properties.
@@ -69,10 +59,23 @@ module Grape
       # which were made.
       def point_in_time_copy
         new_setting = self.class.new
-        point_in_time_copies << new_setting
+        (@point_in_time_copies ||= []) << new_setting
         new_setting.copy_state_from(self)
         new_setting.inherit_from(parent)
         new_setting
+      end
+
+      # Fork a point-in-time copy prepared for a freshly-built endpoint: the
+      # declared params and validations accumulated by the surrounding scopes
+      # are snapshotted into the copy's per-route settings, since the
+      # namespace stacks are wiped between routes (see #reset_validations!),
+      # and request-serving defaults are applied.
+      def point_in_time_copy_for_endpoint
+        copy = point_in_time_copy
+        copy.route[:declared_params] = copy.declared_params.flatten
+        copy.route[:validations] = copy.validations.dup
+        copy.namespace_inheritable[:default_error_status] ||= 500
+        copy
       end
 
       # Resets the instance store of per-route settings.
@@ -104,6 +107,60 @@ module Grape
         return if data.blank?
 
         data.each_with_object({}) { |value, result| result.deep_merge!(value) }
+      end
+
+      # Validator instances registered by +params+ and +contract+ blocks,
+      # outermost scope first. Record them with #add_validation; the backing
+      # store is an internal detail.
+      def validations
+        namespace_stackable[:validations]
+      end
+
+      def add_validation(validator)
+        namespace_stackable[:validations] = validator
+      end
+
+      # Declared-params entries registered by +params+ blocks, one Array per
+      # scope, outermost scope first. Record them with #add_declared_params;
+      # the backing store is an internal detail.
+      def declared_params
+        namespace_stackable[:declared_params]
+      end
+
+      def add_declared_params(params)
+        namespace_stackable[:declared_params] = params
+      end
+
+      # Param documentation recorded by +params+ blocks (see
+      # Validations::ParamsDocumentation) as one attribute-name => details
+      # Hash per scope, deep-merged on read; nil when nothing is documented.
+      # Record entries with #add_params_documentation; the backing store is
+      # an internal detail.
+      def params_documentation
+        namespace_stackable_with_hash(:params)
+      end
+
+      def add_params_documentation(documented_attrs)
+        namespace_stackable[:params] = documented_attrs
+      end
+
+      # Drops this scope's own validations, declared params and params
+      # documentation once an endpoint has consumed them (see
+      # +reset_validations!+ in DSL::Validations). Inherited entries are kept.
+      def reset_validations!
+        namespace_stackable.delete(:declared_params, :params, :validations)
+      end
+
+      # Reusable +params :name do ... end+ blocks defined in helpers, as one
+      # name => block Hash per scope, deep-merged on read; nil when none are
+      # defined. Consumed by +use+. Record entries with #add_named_params;
+      # the backing store is an internal detail.
+      def named_params
+        namespace_stackable_with_hash(:named_params)
+      end
+
+      def add_named_params(named_params)
+        namespace_stackable[:named_params] = named_params
       end
 
       # Rescue-handler maps registered by +rescue_from+, keyed by exception
@@ -150,7 +207,6 @@ module Grape
         @namespace_stackable = source.namespace_stackable.clone
         @rescue_handler_maps = source.rescue_handler_maps&.dup
         @route = source.route.clone
-        @api_class = source.api_class
       end
     end
   end

--- a/lib/grape/validations/contract_scope.rb
+++ b/lib/grape/validations/contract_scope.rb
@@ -21,7 +21,7 @@ module Grape
         end
 
         api.inheritable_setting.namespace_stackable[:contract_key_map] = key_map
-        api.inheritable_setting.namespace_stackable[:validations] = Validators::ContractScopeValidator.new(schema: contract)
+        api.inheritable_setting.add_validation(Validators::ContractScopeValidator.new(schema: contract))
       end
     end
   end

--- a/lib/grape/validations/oneof_collector.rb
+++ b/lib/grape/validations/oneof_collector.rb
@@ -8,7 +8,11 @@ module Grape
     # the real API. Exposes only the slice of the API surface that
     # ParamsScope and its helpers touch during definition.
     class OneofCollector
+      extend Forwardable
+
       attr_reader :inheritable_setting
+
+      def_delegator :@inheritable_setting, :validations
 
       def initialize
         @inheritable_setting = Grape::Util::InheritableSetting.new
@@ -19,20 +23,12 @@ module Grape
         nil
       end
 
-      def validators
-        inheritable_setting.namespace_stackable[:validations]
-      end
-
-      def declared_params
-        inheritable_setting.namespace_stackable[:declared_params]
-      end
-
       # Evaluate +variant_block+ in a fresh +ParamsScope+ backed by a new
       # collector and return the validators that the block registered.
       def self.collect(variant_block)
         collector = new
         ParamsScope.new(api: collector, type: Hash, &variant_block)
-        collector.validators
+        collector.validations
       end
     end
   end

--- a/lib/grape/validations/params_documentation.rb
+++ b/lib/grape/validations/params_documentation.rb
@@ -11,7 +11,7 @@ module Grape
         documented_attrs = attrs.to_h do |name|
           [full_name(name), extract_details(spec)]
         end
-        @api.inheritable_setting.namespace_stackable[:params] = documented_attrs
+        @api.inheritable_setting.add_params_documentation(documented_attrs)
       end
 
       private

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -316,7 +316,7 @@ module Grape
         push_renamed_param(full_path, @element_renamed) if @element_renamed
         return @parent.push_declared_params [{ @element => @declared_params }] if nested?
 
-        @api.inheritable_setting.namespace_stackable[:declared_params] = @declared_params
+        @api.inheritable_setting.add_declared_params(@declared_params)
       ensure
         @declared_params = nil
       end
@@ -400,7 +400,7 @@ module Grape
           self,
           opts
         )
-        @api.inheritable_setting.namespace_stackable[:validations] = validator_instance
+        @api.inheritable_setting.add_validation(validator_instance)
       end
 
       def all_element_blank?(scoped_params)

--- a/spec/grape/dsl/parameters_spec.rb
+++ b/spec/grape/dsl/parameters_spec.rb
@@ -53,17 +53,12 @@ describe Grape::DSL::Parameters do
   end
 
   describe '#use' do
-    before do
-      allow_message_expectations_on_nil
-      allow(subject.api).to receive(:namespace_stackable).with(:named_params)
-    end
-
     let(:options) { { option: 'value' } }
     let(:named_params) { { params_group: proc {} } }
 
     it 'calls processes associated with named params' do
       subject.api = Class.new { include Grape::DSL::Settings }.new
-      subject.api.inheritable_setting.namespace_stackable[:named_params] = named_params
+      subject.api.inheritable_setting.add_named_params(named_params)
       expect(subject).to receive(:instance_exec).with(options).and_yield
       subject.use :params_group, **options
     end

--- a/spec/grape/dsl/routing_spec.rb
+++ b/spec/grape/dsl/routing_spec.rb
@@ -152,7 +152,7 @@ describe Grape::DSL::Routing do
 
     it 'generates correct endpoint options' do
       subject.inheritable_setting.route[:description] = { fiz: 'baz' }
-      subject.inheritable_setting.namespace_stackable[:params] = { nuz: 'naz' }
+      subject.inheritable_setting.add_params_documentation({ nuz: 'naz' })
 
       expect(Grape::Endpoint).to receive(:new) do |_inheritable_setting, endpoint_options|
         expect(endpoint_options[:http_methods]).to eq :get

--- a/spec/grape/util/inheritable_setting_spec.rb
+++ b/spec/grape/util/inheritable_setting_spec.rb
@@ -52,16 +52,6 @@ describe Grape::Util::InheritableSetting do
     end
   end
 
-  describe '#api_class' do
-    it 'is specific to the class' do
-      subject.api_class[:some_thing] = :foo_bar
-      parent.api_class[:some_thing] = :some_thing
-
-      expect(subject.api_class[:some_thing]).to eq :foo_bar
-      expect(parent.api_class[:some_thing]).to eq :some_thing
-    end
-  end
-
   describe '#namespace' do
     it 'sets a value until the end of a namespace' do
       subject.namespace[:some_thing] = :foo_bar
@@ -150,13 +140,6 @@ describe Grape::Util::InheritableSetting do
     end
   end
 
-  describe '#api_class' do
-    it 'is specific to the class' do
-      subject.api_class[:some_thing] = :foo_bar
-      expect(subject.api_class[:some_thing]).to eq :foo_bar
-    end
-  end
-
   describe '#inherit_from' do
     it 'notifies clones' do
       new_settings = subject.point_in_time_copy
@@ -169,8 +152,8 @@ describe Grape::Util::InheritableSetting do
   describe '#point_in_time_copy' do
     let!(:cloned_obj) { subject.point_in_time_copy }
 
-    it 'resets point_in_time_copies' do
-      expect(cloned_obj.point_in_time_copies).to be_empty
+    it 'does not carry over the list of registered clones' do
+      expect(cloned_obj.instance_variable_get(:@point_in_time_copies)).to be_nil
     end
 
     it 'decouples namespace values' do
@@ -209,7 +192,7 @@ describe Grape::Util::InheritableSetting do
     end
 
     it 'adds itself to original as clone' do
-      expect(subject.point_in_time_copies).to include(cloned_obj)
+      expect(subject.instance_variable_get(:@point_in_time_copies)).to include(cloned_obj)
     end
   end
 

--- a/spec/grape/validations/params_documentation_spec.rb
+++ b/spec/grape/validations/params_documentation_spec.rb
@@ -43,7 +43,7 @@ describe Grape::Validations::ParamsDocumentation do
         except_values: [4, 5, 6]
       }
       subject.document_params(attrs, spec_for(validations))
-      stored = api_double.inheritable_setting.namespace_stackable[:params].first
+      stored = api_double.inheritable_setting.params_documentation
       expect(stored.keys).to include('full_name_foo', 'full_name_bar')
       expect(stored['full_name_foo']).to include(
         required: true,
@@ -69,7 +69,7 @@ describe Grape::Validations::ParamsDocumentation do
 
       it 'does not store any documented params' do
         subject.document_params([:foo], spec_for(validations))
-        expect(api_double.inheritable_setting.namespace_stackable[:params]).to be_empty
+        expect(api_double.inheritable_setting.params_documentation).to be_nil
       end
 
       it 'does not mutate the input validations' do
@@ -86,7 +86,7 @@ describe Grape::Validations::ParamsDocumentation do
 
       it 'does not raise an error' do
         expect { subject.document_params([:foo], spec_for(validations)) }.not_to raise_error
-        expect(api_double.inheritable_setting.namespace_stackable[:params].first['full_name_foo']).to eq({ required: false })
+        expect(api_double.inheritable_setting.params_documentation['full_name_foo']).to eq({ required: false })
       end
     end
 
@@ -97,7 +97,7 @@ describe Grape::Validations::ParamsDocumentation do
 
       it 'uses description if desc is not present' do
         subject.document_params([:foo], spec_for(validations))
-        expect(api_double.inheritable_setting.namespace_stackable[:params].first['full_name_foo'][:desc]).to eq('desc2')
+        expect(api_double.inheritable_setting.params_documentation['full_name_foo'][:desc]).to eq('desc2')
       end
     end
 
@@ -108,7 +108,7 @@ describe Grape::Validations::ParamsDocumentation do
 
       it 'uses description if desc is not present' do
         subject.document_params([:foo], spec_for(validations))
-        expect(api_double.inheritable_setting.namespace_stackable[:params].first['full_name_foo']).to eq({ required: false })
+        expect(api_double.inheritable_setting.params_documentation['full_name_foo']).to eq({ required: false })
       end
     end
 
@@ -119,7 +119,7 @@ describe Grape::Validations::ParamsDocumentation do
 
       it 'does not include documentation' do
         subject.document_params([:foo], spec_for(validations))
-        expect(api_double.inheritable_setting.namespace_stackable[:params].first['full_name_foo']).not_to have_key(:documentation)
+        expect(api_double.inheritable_setting.params_documentation['full_name_foo']).not_to have_key(:documentation)
       end
     end
 
@@ -130,7 +130,7 @@ describe Grape::Validations::ParamsDocumentation do
 
       it 'sets type as nil' do
         subject.document_params([:foo], spec_for(validations))
-        expect(api_double.inheritable_setting.namespace_stackable[:params].first['full_name_foo'][:type]).to be_nil
+        expect(api_double.inheritable_setting.params_documentation['full_name_foo'][:type]).to be_nil
       end
     end
   end


### PR DESCRIPTION
Continues the `InheritableSetting` cleanup started in #2795/#2796: the params-derived state (`:validations`, `:declared_params`, `:params`, `:named_params`) is now recorded and read through intention-revealing accessors on `Grape::Util::InheritableSetting`, so no caller indexes into `namespace_stackable` for these keys anymore. Also removes two pieces of dead code found along the way.

### New accessors on `InheritableSetting`

Following the `rescue_handlers` / `add_rescue_handlers` precedent:

| Accessor | Replaces |
|---|---|
| `validations` / `add_validation(validator)` | `namespace_stackable[:validations]` |
| `declared_params` / `add_declared_params(params)` | `namespace_stackable[:declared_params]` |
| `params_documentation` / `add_params_documentation(attrs)` | `namespace_stackable_with_hash(:params)` / `namespace_stackable[:params]` |
| `named_params` / `add_named_params(named_params)` | `namespace_stackable_with_hash(:named_params)` / `namespace_stackable[:named_params]` |
| `reset_validations!` | `namespace_stackable.delete(:declared_params, :params, :validations)` |
| `point_in_time_copy_for_endpoint` | the four settings-mutating lines at the top of `Endpoint#initialize` |

Notes:

* `:params` is deliberately renamed to `params_documentation` at the accessor level — the key stores attribute-name ⇒ details hashes written by `Validations::ParamsDocumentation` for route docs, not params. The reader also absorbs the `namespace_stackable_with_hash` deep-merge convention (returns `nil` when nothing is documented).
* `DSL::Validations#reset_validations!` now delegates to the setting, which owns the three-key own-layer delete.
* `named_params` covers the reusable `params :name do ... end` blocks defined in helpers and consumed by `use`; like `params_documentation` it deep-merges the per-scope hashes on read and returns `nil` when none are defined.
* Converted call sites: `ParamsScope`, `ContractScope`, `OneofCollector`, `ParamsDocumentation`, `DSL::Declared`, `DSL::Routing#prepare_params`, `DSL::Helpers`, `DSL::Parameters#use`, `Endpoint`.

### `Endpoint#inherit_settings` takes an `InheritableSetting`

`Endpoint#inherit_settings` previously received the raw `StackableValues` object (`Instance#inherit_settings` plucked `top_level_setting.namespace_stackable` and handed the bare store across the object boundary). It now receives the parent `InheritableSetting` itself and reads through the accessors, matching the signature of `Instance#inherit_settings`, which already took the settings object.

### `Endpoint#initialize` settings preparation moved onto the setting

The endpoint fork is now a single call, `new_settings.point_in_time_copy_for_endpoint`, which snapshots the accumulated `declared_params` (flattened) and `validations` into the copy's per-route settings and applies the `default_error_status ||= 500` default. These four lines only ever mutated the setting object, so they belong on it.

### `route[:saved_validations]` renamed to `route[:validations]`

The `saved_` prefix was load-bearing in the 2014 settings refactor (f859682), which created both snapshot keys as `saved_*` because an unprefixed `route_setting(:declared_params)` sibling existed in the same route hash and the two were combined at read time. 12786e6 (2020) collapsed that dual-source logic and renamed only `saved_declared_params` → `declared_params`; `saved_validations` kept its prefix by accident. There is nothing left for it to collide with, so the two snapshot keys now share their sources' names. The key remains excluded from `Route#settings`, as before.

### Dead code removed

* **`InheritableSetting#api_class`** — never written by anything in `lib/`; the only production reference was `copy_state_from` copying the (always empty, shared-by-reference) Hash to itself. Removed along with its specs.
* **`InheritableSetting#point_in_time_copies`** — only ever called on `self`; now an internal lazily-allocated ivar with no public reader.
* **`namespace_stackable[:representations] ||= []`** in `Endpoint#initialize` — a verified no-op since the 2014 settings refactor: `StackableValues#[]` never returns `nil` (it returns a frozen `EMPTY` array), so the assignment never ran. Had it ever run, pushing a bare `[]` entry onto the stack would make `namespace_stackable_with_hash(:representations)` raise `TypeError` in the deep-merge, so the line was both dead and a trap.
* **`OneofCollector#declared_params`** — no callers; and its `validators` method is now a `delegate :validations, to: :inheritable_setting` (first use of ActiveSupport `delegate` in lib — the extension was already required for `delegate_missing_to`).

### Breaking changes (all internal surface, no known consumers)

* `InheritableSetting#api_class` and `#point_in_time_copies` are removed.
* `Endpoint#inherit_settings` takes the parent `InheritableSetting` instead of a `StackableValues`.
* `route_setting(:saved_validations)` returns `nil`; the snapshot lives under `route_setting(:validations)`. It was never part of `Route#settings`, so grape-swagger-style introspection is unaffected.

2361 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
