### PR TITLE
Internalize callback filters behind Grape::Util::InheritableSetting accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#2786](https://github.com/ruby-grape/grape/pull/2786): Make route `requirements` and `anchor` explicit keyword arguments and first-class endpoint inputs instead of opaque `route_options` keys - [@ericproulx](https://github.com/ericproulx).
 * [#2788](https://github.com/ruby-grape/grape/pull/2788): Compare the base API instead of `to_s` when refreshing a mounted app - [@ericproulx](https://github.com/ericproulx).
 * [#2796](https://github.com/ruby-grape/grape/pull/2796): Remove `Grape::Util::ReverseStackableValues`, storing rescue handlers in plain per-scope hashes merged over `InheritableSetting#parent` - [@ericproulx](https://github.com/ericproulx).
+* [#2798](https://github.com/ruby-grape/grape/pull/2798): Internalize callback filters behind `Grape::Util::InheritableSetting` accessors (`callbacks` / `add_callback`) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -82,6 +82,10 @@ A route's declared params were previously carried inside the `route_options` bag
 
 Like `params` above, a route's `requirements` and `anchor` were previously carried inside the `route_options` bag. They are now composed into their own endpoint inputs (`Grape::Endpoint::Options` gains `:requirements` and `:anchor` members, and `Grape::Endpoint.new` gains `requirements:` and `anchor:` keywords) and exposed only through the `route.requirements` and `route.anchor` readers. `route.options[:requirements]` and `route.options[:anchor]` now return `nil` — including for a mount's `anchor: false`. Nothing in Grape or grape-swagger read them that way, so this only affects code that reached into the options Hash for these keys directly.
 
+#### Callback filters are recorded through `InheritableSetting` accessors
+
+The filter blocks registered by `before`, `before_validation`, `after_validation`, `after` and `finally` are now recorded and read through dedicated accessors on `Grape::Util::InheritableSetting` — `add_callback(name, block)` to record, and `callbacks` returning a Hash keyed by the DSL method names (`callbacks[:before]`, `callbacks[:finally]`, …) — instead of raw `namespace_stackable` keys, following the same move made for rescue handlers. The keys' storage is unchanged for now, so `namespace_stackable[:befores]` and friends still return the same values, but the pluralized keys should be considered internal.
+
 ### Upgrading to >= 3.3
 
 #### Minimum required Ruby is now 3.3

--- a/lib/grape/dsl/callbacks.rb
+++ b/lib/grape/dsl/callbacks.rb
@@ -9,15 +9,9 @@ module Grape
       # after: execute the given block after the endpoint code has run except in unsuccessful
       # finally: execute the given block after the endpoint code even if unsuccessful
 
-      {
-        before: :befores,
-        before_validation: :before_validations,
-        after_validation: :after_validations,
-        after: :afters,
-        finally: :finallies
-      }.each do |method_name, plural_key|
-        define_method method_name do |&block|
-          inheritable_setting.namespace_stackable[plural_key] = block
+      %i[before before_validation after_validation after finally].each do |callback_name|
+        define_method callback_name do |&block|
+          inheritable_setting.add_callback(callback_name, block)
         end
       end
     end

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -278,12 +278,12 @@ module Grape
       @app = config.app || build_stack
       warn_unauthenticated_mounted_app
       @helpers = build_helpers
-      stackable = inheritable_setting.namespace_stackable
-      @befores            = stackable[:befores]
-      @before_validations = stackable[:before_validations]
-      @after_validations  = stackable[:after_validations]
-      @afters             = stackable[:afters]
-      @finallies          = stackable[:finallies]
+      callbacks = inheritable_setting.callbacks
+      @befores            = callbacks.fetch(:before)
+      @before_validations = callbacks.fetch(:before_validation)
+      @after_validations  = callbacks.fetch(:after_validation)
+      @afters             = callbacks.fetch(:after)
+      @finallies          = callbacks.fetch(:finally)
       @build_params_with  = inheritable_setting.namespace_inheritable[:build_params_with]
     end
 

--- a/lib/grape/util/inheritable_setting.rb
+++ b/lib/grape/util/inheritable_setting.rb
@@ -5,6 +5,16 @@ module Grape
     # A branchable, inheritable settings object which can store both stackable
     # and inheritable values (see InheritableValues and StackableValues).
     class InheritableSetting
+      # Maps the callbacks DSL method names to their pluralized
+      # namespace-stackable storage keys (see #callbacks / #add_callback).
+      CALLBACK_STORE_KEYS = {
+        before: :befores,
+        before_validation: :before_validations,
+        after_validation: :after_validations,
+        after: :afters,
+        finally: :finallies
+      }.freeze
+
       attr_reader :route, :namespace, :namespace_inheritable, :namespace_stackable, :parent
 
       # Lazy-allocated; +api_class+ and +point_in_time_copies+ are rarely
@@ -104,6 +114,19 @@ module Grape
         return if data.blank?
 
         data.each_with_object({}) { |value, result| result.deep_merge!(value) }
+      end
+
+      # Filter blocks registered by the callbacks DSL (see DSL::Callbacks),
+      # as a callback-name => blocks Array Hash keyed by the DSL method names
+      # (+:before+, +:before_validation+, +:after_validation+, +:after+,
+      # +:finally+), outermost scope first. Record them with #add_callback;
+      # the backing store is an internal detail.
+      def callbacks
+        CALLBACK_STORE_KEYS.transform_values { |store_key| namespace_stackable[store_key] }
+      end
+
+      def add_callback(callback_name, block)
+        namespace_stackable[CALLBACK_STORE_KEYS.fetch(callback_name)] = block
       end
 
       # Rescue-handler maps registered by +rescue_from+, keyed by exception

--- a/spec/grape/dsl/callbacks_spec.rb
+++ b/spec/grape/dsl/callbacks_spec.rb
@@ -15,28 +15,35 @@ describe Grape::DSL::Callbacks do
   describe '.before' do
     it 'adds a block to "before"' do
       subject.before(&proc)
-      expect(subject.inheritable_setting.namespace_stackable[:befores]).to eq([proc])
+      expect(subject.inheritable_setting.callbacks[:before]).to eq([proc])
     end
   end
 
   describe '.before_validation' do
     it 'adds a block to "before_validation"' do
       subject.before_validation(&proc)
-      expect(subject.inheritable_setting.namespace_stackable[:before_validations]).to eq([proc])
+      expect(subject.inheritable_setting.callbacks[:before_validation]).to eq([proc])
     end
   end
 
   describe '.after_validation' do
     it 'adds a block to "after_validation"' do
       subject.after_validation(&proc)
-      expect(subject.inheritable_setting.namespace_stackable[:after_validations]).to eq([proc])
+      expect(subject.inheritable_setting.callbacks[:after_validation]).to eq([proc])
     end
   end
 
   describe '.after' do
     it 'adds a block to "after"' do
       subject.after(&proc)
-      expect(subject.inheritable_setting.namespace_stackable[:afters]).to eq([proc])
+      expect(subject.inheritable_setting.callbacks[:after]).to eq([proc])
+    end
+  end
+
+  describe '.finally' do
+    it 'adds a block to "finally"' do
+      subject.finally(&proc)
+      expect(subject.inheritable_setting.callbacks[:finally]).to eq([proc])
     end
   end
 end


### PR DESCRIPTION
Continues the `InheritableSetting` cleanup from #2795/#2796: the filter blocks registered by the callbacks DSL (`before`, `before_validation`, `after_validation`, `after`, `finally`) are now recorded and read through intention-revealing accessors on `Grape::Util::InheritableSetting`, so no caller indexes into `namespace_stackable` for these keys anymore.

### New accessors on `InheritableSetting`

Following the `rescue_handlers` / `add_rescue_handlers` precedent:

| Accessor | Replaces |
|---|---|
| `callbacks` | `namespace_stackable[:befores]`, `[:before_validations]`, `[:after_validations]`, `[:afters]`, `[:finallies]` |
| `add_callback(name, block)` | `namespace_stackable[<pluralized key>] = block` |

Notes:

* `callbacks` returns a Hash keyed by the DSL method names (`callbacks[:before]`, `callbacks[:finally]`, …), matching how users write the DSL and the `type` labels already used by `run_filters` / instrumentation payloads. The singular→pluralized mapping now lives in one place: `InheritableSetting::CALLBACK_STORE_KEYS`.
* `add_callback` uses `fetch`, so a typo'd callback name raises `KeyError` at definition time; `Endpoint#compile!` reads with `callbacks.fetch(...)`, so key drift fails loudly at boot instead of leaving a `nil` ivar that would only crash at request time inside `run_filters`.
* `DSL::Callbacks` no longer knows anything about storage — it collapses to five method names delegating to `add_callback`.
* Storage under the pluralized `namespace_stackable` keys is unchanged, so `to_hash` output and external readers (e.g. grape-swagger) see no difference; the pluralized keys should now be considered internal.
* The DSL spec now asserts through the public `callbacks` accessor and gains coverage for the previously untested `.finally`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
