### PR TITLE
Internalize rescue configuration behind Grape::Util::InheritableSetting accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#2786](https://github.com/ruby-grape/grape/pull/2786): Make route `requirements` and `anchor` explicit keyword arguments and first-class endpoint inputs instead of opaque `route_options` keys - [@ericproulx](https://github.com/ericproulx).
 * [#2788](https://github.com/ruby-grape/grape/pull/2788): Compare the base API instead of `to_s` when refreshing a mounted app - [@ericproulx](https://github.com/ericproulx).
 * [#2796](https://github.com/ruby-grape/grape/pull/2796): Remove `Grape::Util::ReverseStackableValues`, storing rescue handlers in plain per-scope hashes merged over `InheritableSetting#parent` - [@ericproulx](https://github.com/ericproulx).
+* [#2799](https://github.com/ruby-grape/grape/pull/2799): Internalize the remaining rescue configuration (`rescue_options`, meta-selector handlers and flags) behind `Grape::Util::InheritableSetting` accessors - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -82,6 +82,16 @@ A route's declared params were previously carried inside the `route_options` bag
 
 Like `params` above, a route's `requirements` and `anchor` were previously carried inside the `route_options` bag. They are now composed into their own endpoint inputs (`Grape::Endpoint::Options` gains `:requirements` and `:anchor` members, and `Grape::Endpoint.new` gains `requirements:` and `anchor:` keywords) and exposed only through the `route.requirements` and `route.anchor` readers. `route.options[:requirements]` and `route.options[:anchor]` now return `nil` — including for a mount's `anchor: false`. Nothing in Grape or grape-swagger read them that way, so this only affects code that reached into the options Hash for these keys directly.
 
+#### Rescue configuration is recorded through `InheritableSetting` accessors
+
+The remaining rescue state written by `rescue_from` is now recorded and read through dedicated accessors on `Grape::Util::InheritableSetting`, completing the encapsulation started with `rescue_handlers` / `add_rescue_handlers`:
+
+* `rescue_options` / `add_rescue_options(options)` replace `namespace_stackable[:rescue_options]`. The reader absorbs the nearest-scope-wins convention (previously the `&.last` at the read site) and returns a single `Grape::DSL::RescueOptions` or `nil`, not the raw stack.
+* `add_all_rescue_handler(handler)`, `add_grape_exceptions_rescue_handler(handler)` and `add_internal_grape_exceptions_rescue_handler(handler)` replace the direct `namespace_inheritable` writes for the `rescue_from :all` / `:grape_exceptions` / `:internal_grape_exceptions` meta selectors; each records its handler and flips the associated flags.
+* `rescue_all?`, `rescue_grape_exceptions?`, `all_rescue_handler`, `grape_exceptions_rescue_handler` and `internal_grape_exceptions_rescue_handler` replace the corresponding `namespace_inheritable` reads. The two `?` readers return `false` (rather than `nil`) when never set; `Grape::Middleware::Error` only ever used them in boolean context, so behavior is unchanged.
+
+The keys' storage is unchanged for now, so `namespace_stackable[:rescue_options]` and the `namespace_inheritable` keys still return the same values, but they should be considered internal.
+
 ### Upgrading to >= 3.3
 
 #### Minimum required Ruby is now 3.3

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -101,29 +101,18 @@ module Grape
         meta_selector = (args & META_RESCUE_SELECTORS).first
         raise ArgumentError, "rescue_from #{meta_selector.inspect} does not accept additional arguments" if meta_selector && args.size > 1
 
-        namespace_inheritable = nil
-        arg = nil
-
-        if args.one?
-          arg = args.first
-          namespace_inheritable = inheritable_setting.namespace_inheritable
-        end
-
-        case arg
+        case meta_selector
         when :all
-          namespace_inheritable[:rescue_all] = true
-          namespace_inheritable[:all_rescue_handler] = handler
+          inheritable_setting.add_all_rescue_handler(handler)
         when :grape_exceptions
-          namespace_inheritable[:rescue_all] = true
-          namespace_inheritable[:rescue_grape_exceptions] = true
-          namespace_inheritable[:grape_exceptions_rescue_handler] = handler
+          inheritable_setting.add_grape_exceptions_rescue_handler(handler)
         when :internal_grape_exceptions
-          namespace_inheritable[:internal_grape_exceptions_rescue_handler] = handler
+          inheritable_setting.add_internal_grape_exceptions_rescue_handler(handler)
         else
           inheritable_setting.add_rescue_handlers(args.to_h { |klass| [klass, handler] }, subclasses: rescue_subclasses)
         end
 
-        inheritable_setting.namespace_stackable[:rescue_options] = RescueOptions.new(backtrace:, original_exception:)
+        inheritable_setting.add_rescue_options(RescueOptions.new(backtrace:, original_exception:))
       end
 
       # Allows you to specify a default representation entity for a

--- a/lib/grape/dsl/rescue_options.rb
+++ b/lib/grape/dsl/rescue_options.rb
@@ -3,9 +3,10 @@
 module Grape
   module DSL
     # Immutable value object holding the response-shaping booleans accepted
-    # by +Grape::DSL::RequestResponse#rescue_from+. Stored on the
-    # inheritable settings as +namespace_stackable[:rescue_options]+ and
-    # delegated to by +Grape::Middleware::Error+ (which forwards
+    # by +Grape::DSL::RequestResponse#rescue_from+. Recorded on the
+    # inheritable settings via +Grape::Util::InheritableSetting#add_rescue_options+
+    # (the nearest scope's latest registration wins on read, see
+    # +#rescue_options+) and delegated to by +Grape::Middleware::Error+ (which forwards
     # +backtrace+/+original_exception+ to the formatter as
     # +include_backtrace+/+include_original_exception+).
     #

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -373,22 +373,22 @@ module Grape
     end
 
     def error_middleware_options(format, content_types)
-      ns_inh = inheritable_setting.namespace_inheritable
-      ns_stack = inheritable_setting
+      setting = inheritable_setting
+      ns_inh = setting.namespace_inheritable
       {
         format:,
         content_types:,
         default_status: ns_inh[:default_error_status],
-        rescue_all: ns_inh[:rescue_all],
-        rescue_grape_exceptions: ns_inh[:rescue_grape_exceptions],
+        rescue_all: setting.rescue_all?,
+        rescue_grape_exceptions: setting.rescue_grape_exceptions?,
         default_error_formatter: ns_inh[:default_error_formatter],
-        error_formatters: ns_stack.namespace_stackable_with_hash(:error_formatters),
-        rescue_options: ns_stack.namespace_stackable[:rescue_options]&.last,
-        rescue_handlers: ns_stack.rescue_handlers,
-        base_only_rescue_handlers: ns_stack.base_only_rescue_handlers,
-        all_rescue_handler: ns_inh[:all_rescue_handler],
-        grape_exceptions_rescue_handler: ns_inh[:grape_exceptions_rescue_handler],
-        internal_grape_exceptions_rescue_handler: ns_inh[:internal_grape_exceptions_rescue_handler]
+        error_formatters: setting.namespace_stackable_with_hash(:error_formatters),
+        rescue_options: setting.rescue_options,
+        rescue_handlers: setting.rescue_handlers,
+        base_only_rescue_handlers: setting.base_only_rescue_handlers,
+        all_rescue_handler: setting.all_rescue_handler,
+        grape_exceptions_rescue_handler: setting.grape_exceptions_rescue_handler,
+        internal_grape_exceptions_rescue_handler: setting.internal_grape_exceptions_rescue_handler
       }
     end
 

--- a/lib/grape/util/inheritable_setting.rb
+++ b/lib/grape/util/inheritable_setting.rb
@@ -106,6 +106,60 @@ module Grape
         data.each_with_object({}) { |value, result| result.deep_merge!(value) }
       end
 
+      # Response-shaping options recorded by +rescue_from+ (see
+      # DSL::RescueOptions): every +rescue_from+ stacks one entry and the
+      # nearest scope's latest registration wins on read; nil when
+      # +rescue_from+ was never called. Record them with #add_rescue_options;
+      # the backing store is an internal detail.
+      def rescue_options
+        namespace_stackable[:rescue_options].last
+      end
+
+      def add_rescue_options(options)
+        namespace_stackable[:rescue_options] = options
+      end
+
+      # Meta-selector registrations from +rescue_from :all+,
+      # +:grape_exceptions+ and +:internal_grape_exceptions+ (see
+      # DSL::RequestResponse#rescue_from): each records its handler (nil to
+      # use the built-in one) and flips the flags the error middleware reads
+      # through #rescue_all? / #rescue_grape_exceptions?; the backing store
+      # is an internal detail.
+      def add_all_rescue_handler(handler)
+        namespace_inheritable[:rescue_all] = true
+        namespace_inheritable[:all_rescue_handler] = handler
+      end
+
+      def add_grape_exceptions_rescue_handler(handler)
+        namespace_inheritable[:rescue_all] = true
+        namespace_inheritable[:rescue_grape_exceptions] = true
+        namespace_inheritable[:grape_exceptions_rescue_handler] = handler
+      end
+
+      def add_internal_grape_exceptions_rescue_handler(handler)
+        namespace_inheritable[:internal_grape_exceptions_rescue_handler] = handler
+      end
+
+      def rescue_all?
+        namespace_inheritable[:rescue_all] == true
+      end
+
+      def rescue_grape_exceptions?
+        namespace_inheritable[:rescue_grape_exceptions] == true
+      end
+
+      def all_rescue_handler
+        namespace_inheritable[:all_rescue_handler]
+      end
+
+      def grape_exceptions_rescue_handler
+        namespace_inheritable[:grape_exceptions_rescue_handler]
+      end
+
+      def internal_grape_exceptions_rescue_handler
+        namespace_inheritable[:internal_grape_exceptions_rescue_handler]
+      end
+
       # Rescue-handler maps registered by +rescue_from+, keyed by exception
       # class and merged so a nested scope's handler wins. Record them with
       # #add_rescue_handlers; the backing store is an internal detail.

--- a/spec/grape/dsl/request_response_spec.rb
+++ b/spec/grape/dsl/request_response_spec.rb
@@ -95,45 +95,29 @@ describe Grape::DSL::RequestResponse do
     describe ':all' do
       it 'sets rescue all to true' do
         subject.rescue_from :all
-        expect(subject.inheritable_setting.namespace_inheritable.to_hash).to eq(
-          {
-            rescue_all: true,
-            all_rescue_handler: nil
-          }
-        )
+        expect(subject.inheritable_setting.rescue_all?).to be(true)
+        expect(subject.inheritable_setting.all_rescue_handler).to be_nil
       end
 
       it 'sets given proc as rescue handler' do
         rescue_handler_proc = proc {}
         subject.rescue_from :all, rescue_handler_proc
-        expect(subject.inheritable_setting.namespace_inheritable.to_hash).to eq(
-          {
-            rescue_all: true,
-            all_rescue_handler: rescue_handler_proc
-          }
-        )
+        expect(subject.inheritable_setting.rescue_all?).to be(true)
+        expect(subject.inheritable_setting.all_rescue_handler).to eq(rescue_handler_proc)
       end
 
       it 'sets given block as rescue handler' do
         rescue_handler_proc = proc {}
         subject.rescue_from :all, &rescue_handler_proc
-        expect(subject.inheritable_setting.namespace_inheritable.to_hash).to eq(
-          {
-            rescue_all: true,
-            all_rescue_handler: rescue_handler_proc
-          }
-        )
+        expect(subject.inheritable_setting.rescue_all?).to be(true)
+        expect(subject.inheritable_setting.all_rescue_handler).to eq(rescue_handler_proc)
       end
 
       it 'sets a rescue handler declared through :with option' do
         with_block = -> { 'hello' }
         subject.rescue_from :all, with: with_block
-        expect(subject.inheritable_setting.namespace_inheritable.to_hash).to eq(
-          {
-            rescue_all: true,
-            all_rescue_handler: with_block
-          }
-        )
+        expect(subject.inheritable_setting.rescue_all?).to be(true)
+        expect(subject.inheritable_setting.all_rescue_handler).to eq(with_block)
       end
 
       it 'abort if :with option value is not Symbol, String or Proc' do
@@ -152,49 +136,42 @@ describe Grape::DSL::RequestResponse do
     describe ':grape_exceptions' do
       it 'sets rescue all to true' do
         subject.rescue_from :grape_exceptions
-        expect(subject.inheritable_setting.namespace_inheritable.to_hash).to eq(
-          {
-            rescue_all: true,
-            rescue_grape_exceptions: true,
-            grape_exceptions_rescue_handler: nil
-          }
-        )
+        expect(subject.inheritable_setting.rescue_all?).to be(true)
+        expect(subject.inheritable_setting.rescue_grape_exceptions?).to be(true)
+        expect(subject.inheritable_setting.grape_exceptions_rescue_handler).to be_nil
       end
 
       it 'sets given proc as rescue handler' do
         rescue_handler_proc = proc {}
         subject.rescue_from :grape_exceptions, rescue_handler_proc
-        expect(subject.inheritable_setting.namespace_inheritable.to_hash).to eq(
-          {
-            rescue_all: true,
-            rescue_grape_exceptions: true,
-            grape_exceptions_rescue_handler: rescue_handler_proc
-          }
-        )
+        expect(subject.inheritable_setting.rescue_all?).to be(true)
+        expect(subject.inheritable_setting.rescue_grape_exceptions?).to be(true)
+        expect(subject.inheritable_setting.grape_exceptions_rescue_handler).to eq(rescue_handler_proc)
       end
 
       it 'sets given block as rescue handler' do
         rescue_handler_proc = proc {}
         subject.rescue_from :grape_exceptions, &rescue_handler_proc
-        expect(subject.inheritable_setting.namespace_inheritable.to_hash).to eq(
-          {
-            rescue_all: true,
-            rescue_grape_exceptions: true,
-            grape_exceptions_rescue_handler: rescue_handler_proc
-          }
-        )
+        expect(subject.inheritable_setting.rescue_all?).to be(true)
+        expect(subject.inheritable_setting.rescue_grape_exceptions?).to be(true)
+        expect(subject.inheritable_setting.grape_exceptions_rescue_handler).to eq(rescue_handler_proc)
       end
 
       it 'sets a rescue handler declared through :with option' do
         with_block = -> { 'hello' }
         subject.rescue_from :grape_exceptions, with: with_block
-        expect(subject.inheritable_setting.namespace_inheritable.to_hash).to eq(
-          {
-            rescue_all: true,
-            rescue_grape_exceptions: true,
-            grape_exceptions_rescue_handler: with_block
-          }
-        )
+        expect(subject.inheritable_setting.rescue_all?).to be(true)
+        expect(subject.inheritable_setting.rescue_grape_exceptions?).to be(true)
+        expect(subject.inheritable_setting.grape_exceptions_rescue_handler).to eq(with_block)
+      end
+    end
+
+    describe ':internal_grape_exceptions' do
+      it 'sets given proc as rescue handler without rescuing all' do
+        rescue_handler_proc = proc {}
+        subject.rescue_from :internal_grape_exceptions, rescue_handler_proc
+        expect(subject.inheritable_setting.internal_grape_exceptions_rescue_handler).to eq(rescue_handler_proc)
+        expect(subject.inheritable_setting.rescue_all?).to be(false)
       end
     end
 
@@ -216,39 +193,39 @@ describe Grape::DSL::RequestResponse do
     end
 
     describe 'list of exceptions is passed' do
-      let(:default_rescue_options) { [Grape::DSL::RescueOptions.new] }
+      let(:default_rescue_options) { Grape::DSL::RescueOptions.new }
 
       it 'sets hash of exceptions as rescue handlers' do
         subject.rescue_from StandardError
         expect(subject.inheritable_setting.rescue_handlers).to eq(StandardError => nil)
-        expect(subject.inheritable_setting.namespace_stackable[:rescue_options]).to eq(default_rescue_options)
+        expect(subject.inheritable_setting.rescue_options).to eq(default_rescue_options)
       end
 
       it 'rescues only base handlers if rescue_subclasses: false option is passed' do
         subject.rescue_from StandardError, rescue_subclasses: false
         expect(subject.inheritable_setting.base_only_rescue_handlers).to eq(StandardError => nil)
-        expect(subject.inheritable_setting.namespace_stackable[:rescue_options]).to eq(default_rescue_options)
+        expect(subject.inheritable_setting.rescue_options).to eq(default_rescue_options)
       end
 
       it 'sets given proc as rescue handler for each key in hash' do
         rescue_handler_proc = proc {}
         subject.rescue_from StandardError, rescue_handler_proc
         expect(subject.inheritable_setting.rescue_handlers).to eq(StandardError => rescue_handler_proc)
-        expect(subject.inheritable_setting.namespace_stackable[:rescue_options]).to eq(default_rescue_options)
+        expect(subject.inheritable_setting.rescue_options).to eq(default_rescue_options)
       end
 
       it 'sets given block as rescue handler for each key in hash' do
         rescue_handler_proc = proc {}
         subject.rescue_from StandardError, &rescue_handler_proc
         expect(subject.inheritable_setting.rescue_handlers).to eq(StandardError => rescue_handler_proc)
-        expect(subject.inheritable_setting.namespace_stackable[:rescue_options]).to eq(default_rescue_options)
+        expect(subject.inheritable_setting.rescue_options).to eq(default_rescue_options)
       end
 
       it 'sets a rescue handler declared through :with option for each key in hash' do
         with_block = -> { 'hello' }
         subject.rescue_from StandardError, with: with_block
         expect(subject.inheritable_setting.rescue_handlers).to eq(StandardError => with_block)
-        expect(subject.inheritable_setting.namespace_stackable[:rescue_options]).to eq(default_rescue_options)
+        expect(subject.inheritable_setting.rescue_options).to eq(default_rescue_options)
       end
     end
   end


### PR DESCRIPTION
Continues the `InheritableSetting` cleanup from #2795/#2796/#2797/#2798: the remaining rescue state written by `rescue_from` — the stacked `RescueOptions` and the meta-selector handlers/flags — is now recorded and read through intention-revealing accessors on `Grape::Util::InheritableSetting`, completing the rescue-configuration encapsulation started with `rescue_handlers` / `add_rescue_handlers`.

### New accessors on `InheritableSetting`

| Accessor | Replaces |
|---|---|
| `rescue_options` / `add_rescue_options(options)` | `namespace_stackable[:rescue_options]` |
| `add_all_rescue_handler(handler)` | `namespace_inheritable[:rescue_all] = true` + `[:all_rescue_handler] = handler` |
| `add_grape_exceptions_rescue_handler(handler)` | the three `namespace_inheritable` writes for `:grape_exceptions` |
| `add_internal_grape_exceptions_rescue_handler(handler)` | `namespace_inheritable[:internal_grape_exceptions_rescue_handler] = handler` |
| `rescue_all?`, `rescue_grape_exceptions?`, `all_rescue_handler`, `grape_exceptions_rescue_handler`, `internal_grape_exceptions_rescue_handler` | the corresponding `namespace_inheritable` reads |

Notes:

* The `rescue_options` reader absorbs the nearest-scope-wins convention: it returns the latest registered `Grape::DSL::RescueOptions` (or `nil`), hiding the raw stack and the `&.last` previously done at the read site in `Endpoint#error_middleware_options`. Since `StackableValues#[]` returns a frozen empty array for never-written keys, plain `.last` is already nil-safe.
* Each meta-selector writer records its handler *and* flips the associated flags, so the `rescue_all`/`rescue_grape_exceptions` coupling lives in one place instead of being spelled out in the DSL.
* `rescue_from` simplifies: after the mixed-arguments guard, a present meta selector implies it was the only argument, so the method now cases on `meta_selector` directly and the `namespace_inheritable` / `arg` prelude is gone.
* `rescue_all?` / `rescue_grape_exceptions?` return `false` rather than `nil` when never set. `Grape::Middleware::Error` only ever uses them in boolean context, so behavior is unchanged.
* The keys' storage is unchanged, so `to_hash` output and any external readers see the same values; the raw keys should now be considered internal.
* `DSL::RequestResponse` specs now assert through the accessors, and `rescue_from :internal_grape_exceptions` gains its first direct spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
