### PR TITLE
Internalize content negotiation state behind Grape::Util::InheritableSetting accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#2786](https://github.com/ruby-grape/grape/pull/2786): Make route `requirements` and `anchor` explicit keyword arguments and first-class endpoint inputs instead of opaque `route_options` keys - [@ericproulx](https://github.com/ericproulx).
 * [#2788](https://github.com/ruby-grape/grape/pull/2788): Compare the base API instead of `to_s` when refreshing a mounted app - [@ericproulx](https://github.com/ericproulx).
 * [#2796](https://github.com/ruby-grape/grape/pull/2796): Remove `Grape::Util::ReverseStackableValues`, storing rescue handlers in plain per-scope hashes merged over `InheritableSetting#parent` - [@ericproulx](https://github.com/ericproulx).
+* [#2800](https://github.com/ruby-grape/grape/pull/2800): Internalize content negotiation state (content types, formatters, parsers, error formatters) behind `Grape::Util::InheritableSetting` accessors - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -82,6 +82,10 @@ A route's declared params were previously carried inside the `route_options` bag
 
 Like `params` above, a route's `requirements` and `anchor` were previously carried inside the `route_options` bag. They are now composed into their own endpoint inputs (`Grape::Endpoint::Options` gains `:requirements` and `:anchor` members, and `Grape::Endpoint.new` gains `requirements:` and `anchor:` keywords) and exposed only through the `route.requirements` and `route.anchor` readers. `route.options[:requirements]` and `route.options[:anchor]` now return `nil` — including for a mount's `anchor: false`. Nothing in Grape or grape-swagger read them that way, so this only affects code that reached into the options Hash for these keys directly.
 
+#### Content negotiation state is recorded through `InheritableSetting` accessors
+
+The state written by the `content_type`, `format`, `formatter`, `parser` and `error_formatter` DSL methods is now recorded and read through dedicated accessors on `Grape::Util::InheritableSetting` (`content_types` / `add_content_type`, `formatters` / `add_formatter`, `parsers` / `add_parser`, `error_formatters` / `add_error_formatter`) instead of raw `namespace_stackable` keys, following the same move made for rescue handlers. Each writer records one single-entry Hash per registration and each reader absorbs the `namespace_stackable_with_hash` deep-merge convention, returning the merged name => value Hash (nearest scope wins) or `nil` when nothing is registered. The keys' storage is unchanged for now, so `namespace_stackable[:content_types]` and friends still return the same values, but they should be considered internal.
+
 ### Upgrading to >= 3.3
 
 #### Minimum required Ruby is now 3.3

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -23,17 +23,17 @@ module Grape
         content_type = content_types[symbolic_new_format]
         raise Grape::Exceptions::MissingMimeType.new(new_format) unless content_type
 
-        inheritable_setting.namespace_stackable[:content_types] = { symbolic_new_format => content_type }
+        inheritable_setting.add_content_type(symbolic_new_format, content_type)
       end
 
       # Specify a custom formatter for a content-type.
       def formatter(content_type, new_formatter)
-        inheritable_setting.namespace_stackable[:formatters] = { content_type.to_sym => new_formatter }
+        inheritable_setting.add_formatter(content_type.to_sym, new_formatter)
       end
 
       # Specify a custom parser for a content-type.
       def parser(content_type, new_parser)
-        inheritable_setting.namespace_stackable[:parsers] = { content_type.to_sym => new_parser }
+        inheritable_setting.add_parser(content_type.to_sym, new_parser)
       end
 
       # Specify a default error formatter.
@@ -46,19 +46,18 @@ module Grape
 
       def error_formatter(format, options = nil, with: nil)
         formatter = with || options
-        inheritable_setting.namespace_stackable[:error_formatters] = { format.to_sym => formatter }
+        inheritable_setting.add_error_formatter(format.to_sym, formatter)
       end
 
       # Specify additional content-types, e.g.:
       #   content_type :xls, 'application/vnd.ms-excel'
       def content_type(key, val)
-        inheritable_setting.namespace_stackable[:content_types] = { key.to_sym => val }
+        inheritable_setting.add_content_type(key.to_sym, val)
       end
 
       # All available content types.
       def content_types
-        c_types = inheritable_setting.namespace_stackable_with_hash(:content_types)
-        Grape::ContentTypes.content_types_for c_types
+        Grape::ContentTypes.content_types_for(inheritable_setting.content_types)
       end
 
       # Specify the default status code for errors.

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -342,7 +342,7 @@ module Grape
     def build_stack
       stack = Grape::Middleware::Stack.new
 
-      content_types = inheritable_setting.namespace_stackable_with_hash(:content_types)
+      content_types = inheritable_setting.content_types
       format = inheritable_setting.namespace_inheritable[:format]
 
       stack.use Rack::Head
@@ -364,8 +364,8 @@ module Grape
                 format:,
                 default_format: inheritable_setting.namespace_inheritable[:default_format] || :txt,
                 content_types:,
-                formatters: inheritable_setting.namespace_stackable_with_hash(:formatters),
-                parsers: inheritable_setting.namespace_stackable_with_hash(:parsers)
+                formatters: inheritable_setting.formatters,
+                parsers: inheritable_setting.parsers
 
       builder = stack.build
       builder.run ->(env) { env[Grape::Env::API_ENDPOINT].run }
@@ -382,7 +382,7 @@ module Grape
         rescue_all: ns_inh[:rescue_all],
         rescue_grape_exceptions: ns_inh[:rescue_grape_exceptions],
         default_error_formatter: ns_inh[:default_error_formatter],
-        error_formatters: ns_stack.namespace_stackable_with_hash(:error_formatters),
+        error_formatters: ns_stack.error_formatters,
         rescue_options: ns_stack.namespace_stackable[:rescue_options]&.last,
         rescue_handlers: ns_stack.rescue_handlers,
         base_only_rescue_handlers: ns_stack.base_only_rescue_handlers,

--- a/lib/grape/util/inheritable_setting.rb
+++ b/lib/grape/util/inheritable_setting.rb
@@ -106,6 +106,45 @@ module Grape
         data.each_with_object({}) { |value, result| result.deep_merge!(value) }
       end
 
+      # Content negotiation registries recorded by the request/response DSL
+      # (see DSL::RequestResponse): the content-type registry (+content_type+
+      # and +format+), and the formatter, parser and error-formatter handler
+      # maps. Each registration stacks one single-entry Hash, deep-merged on
+      # read so a nested scope's registration wins; readers return nil when
+      # nothing is registered. Record entries with the corresponding +add_*+
+      # writer; the backing store is an internal detail.
+      def content_types
+        namespace_stackable_with_hash(:content_types)
+      end
+
+      def add_content_type(format, content_type)
+        namespace_stackable[:content_types] = { format => content_type }
+      end
+
+      def formatters
+        namespace_stackable_with_hash(:formatters)
+      end
+
+      def add_formatter(content_type, formatter)
+        namespace_stackable[:formatters] = { content_type => formatter }
+      end
+
+      def parsers
+        namespace_stackable_with_hash(:parsers)
+      end
+
+      def add_parser(content_type, parser)
+        namespace_stackable[:parsers] = { content_type => parser }
+      end
+
+      def error_formatters
+        namespace_stackable_with_hash(:error_formatters)
+      end
+
+      def add_error_formatter(format, formatter)
+        namespace_stackable[:error_formatters] = { format => formatter }
+      end
+
       # Rescue-handler maps registered by +rescue_from+, keyed by exception
       # class and merged so a nested scope's handler wins. Record them with
       # #add_rescue_handlers; the backing store is an internal detail.

--- a/spec/grape/dsl/request_response_spec.rb
+++ b/spec/grape/dsl/request_response_spec.rb
@@ -36,14 +36,14 @@ describe Grape::DSL::RequestResponse do
   describe '.formatter' do
     it 'sets the formatter for a content type' do
       subject.formatter c_type, :formatter
-      expect(subject.inheritable_setting.namespace_stackable[:formatters]).to eq([{ c_type.to_sym => :formatter }])
+      expect(subject.inheritable_setting.formatters).to eq(c_type.to_sym => :formatter)
     end
   end
 
   describe '.parser' do
     it 'sets a parser for a content type' do
       subject.parser c_type, :parser
-      expect(subject.inheritable_setting.namespace_stackable[:parsers]).to eq([{ c_type.to_sym => :parser }])
+      expect(subject.inheritable_setting.parsers).to eq(c_type.to_sym => :parser)
     end
   end
 
@@ -58,19 +58,19 @@ describe Grape::DSL::RequestResponse do
     it 'sets a error_formatter' do
       format = 'txt'
       subject.error_formatter format, :error_formatter
-      expect(subject.inheritable_setting.namespace_stackable[:error_formatters]).to eq([{ format.to_sym => :error_formatter }])
+      expect(subject.inheritable_setting.error_formatters).to eq(format.to_sym => :error_formatter)
     end
 
     it 'understands syntactic sugar' do
       subject.error_formatter format, with: :error_formatter
-      expect(subject.inheritable_setting.namespace_stackable[:error_formatters]).to eq([{ format.to_sym => :error_formatter }])
+      expect(subject.inheritable_setting.error_formatters).to eq(format.to_sym => :error_formatter)
     end
   end
 
   describe '.content_type' do
     it 'sets a content type for a format' do
       subject.content_type format, c_type
-      expect(subject.inheritable_setting.namespace_stackable[:content_types]).to eq([{ format.to_sym => c_type }])
+      expect(subject.inheritable_setting.content_types).to eq(format.to_sym => c_type)
     end
   end
 


### PR DESCRIPTION
Continues the `InheritableSetting` cleanup from #2795–#2799: the content negotiation state written by the `content_type` / `format` / `formatter` / `parser` / `error_formatter` DSL methods is now recorded and read through intention-revealing accessors on `Grape::Util::InheritableSetting`, so no caller indexes into `namespace_stackable` (or calls `namespace_stackable_with_hash`) for these keys anymore.

### New accessors on `InheritableSetting`

| Accessor | Replaces |
|---|---|
| `content_types` / `add_content_type(format, content_type)` | `namespace_stackable_with_hash(:content_types)` / `namespace_stackable[:content_types] = { format => type }` |
| `formatters` / `add_formatter(content_type, formatter)` | same pattern for `:formatters` |
| `parsers` / `add_parser(content_type, parser)` | same pattern for `:parsers` |
| `error_formatters` / `add_error_formatter(format, formatter)` | same pattern for `:error_formatters` |

Notes:

* Each writer absorbs the single-entry-Hash-per-registration storage shape; each reader absorbs the `namespace_stackable_with_hash` deep-merge convention (merged name ⇒ value Hash, nearest scope wins, `nil` when nothing is registered). Symbol normalization (`.to_sym`) stays in the DSL, since it's input handling.
* Converted call sites: `DSL::RequestResponse` (all five DSL methods plus the `content_types` reader) and `Endpoint` (`build_stack`, `error_middleware_options`).
* `DSL::RequestResponse#content_types` (the "with defaults" view used by `format`) now reads `Grape::ContentTypes.content_types_for(inheritable_setting.content_types)` — behavior unchanged, since the reader returns `nil` exactly where `namespace_stackable_with_hash` did.
* Storage under the raw keys is unchanged, so `to_hash` output and any external readers see the same values; the raw keys should now be considered internal.
* Specs assert through the accessors, which also means they now check the merged read (`{json: ...}`) rather than the raw stack shape (`[{json: ...}]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
