### PR TITLE
Internalize represent registrations behind Grape::Util::InheritableSetting accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#2786](https://github.com/ruby-grape/grape/pull/2786): Make route `requirements` and `anchor` explicit keyword arguments and first-class endpoint inputs instead of opaque `route_options` keys - [@ericproulx](https://github.com/ericproulx).
 * [#2788](https://github.com/ruby-grape/grape/pull/2788): Compare the base API instead of `to_s` when refreshing a mounted app - [@ericproulx](https://github.com/ericproulx).
 * [#2796](https://github.com/ruby-grape/grape/pull/2796): Remove `Grape::Util::ReverseStackableValues`, storing rescue handlers in plain per-scope hashes merged over `InheritableSetting#parent` - [@ericproulx](https://github.com/ericproulx).
+* [#2801](https://github.com/ruby-grape/grape/pull/2801): Internalize `represent` registrations behind `Grape::Util::InheritableSetting` accessors (`representations` / `add_representation`), and remove the inert `:representations` seeding in `Grape::Endpoint#initialize` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -82,6 +82,12 @@ A route's declared params were previously carried inside the `route_options` bag
 
 Like `params` above, a route's `requirements` and `anchor` were previously carried inside the `route_options` bag. They are now composed into their own endpoint inputs (`Grape::Endpoint::Options` gains `:requirements` and `:anchor` members, and `Grape::Endpoint.new` gains `requirements:` and `anchor:` keywords) and exposed only through the `route.requirements` and `route.anchor` readers. `route.options[:requirements]` and `route.options[:anchor]` now return `nil` — including for a mount's `anchor: false`. Nothing in Grape or grape-swagger read them that way, so this only affects code that reached into the options Hash for these keys directly.
 
+#### `represent` registrations are recorded through `InheritableSetting` accessors
+
+The model-class => entity-class registrations written by `represent` are now recorded and read through dedicated accessors on `Grape::Util::InheritableSetting` (`representations` / `add_representation(model_class, entity_class)`) instead of raw `namespace_stackable` keys, following the same move made for rescue handlers. The reader absorbs the `namespace_stackable_with_hash` deep-merge convention, returning the merged Hash (nearest scope wins) or `nil` when nothing is registered. The key's storage is unchanged for now, so `namespace_stackable[:representations]` still returns the same values, but it should be considered internal.
+
+Also removed: the `namespace_stackable[:representations] ||= []` line in `Grape::Endpoint#initialize`. It was provably inert — `Grape::Util::StackableValues#[]` always returns an array (a frozen empty one for never-written keys), which is truthy, so the `||=` assignment could never execute. No settings state changes as a result.
+
 ### Upgrading to >= 3.3
 
 #### Minimum required Ruby is now 3.3

--- a/lib/grape/dsl/entity.rb
+++ b/lib/grape/dsl/entity.rb
@@ -51,7 +51,7 @@ module Grape
       def entity_class_for_obj(object)
         klass = object_class(object)
 
-        representations = inheritable_setting.namespace_stackable_with_hash(:representations)
+        representations = inheritable_setting.representations
         if representations
           potential = klass.ancestors.detect { |potential| representations.key?(potential) }
           return representations[potential] if potential && representations[potential]

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -149,7 +149,7 @@ module Grape
       def represent(model_class, with:)
         raise Grape::Exceptions::InvalidWithOptionForRepresent.new unless with.is_a?(Class)
 
-        inheritable_setting.namespace_stackable[:representations] = { model_class => with }
+        inheritable_setting.add_representation(model_class, with)
       end
 
       private

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -75,7 +75,6 @@ module Grape
       inheritable_setting.route[:declared_params] = inheritable_setting.namespace_stackable[:declared_params].flatten
       inheritable_setting.route[:saved_validations] = inheritable_setting.namespace_stackable[:validations].dup
 
-      inheritable_setting.namespace_stackable[:representations] ||= []
       inheritable_setting.namespace_inheritable[:default_error_status] ||= 500
 
       @options = options

--- a/lib/grape/util/inheritable_setting.rb
+++ b/lib/grape/util/inheritable_setting.rb
@@ -106,6 +106,19 @@ module Grape
         data.each_with_object({}) { |value, result| result.deep_merge!(value) }
       end
 
+      # Model-class => entity-class registrations from +represent+ (see
+      # DSL::RequestResponse), one single-entry Hash per registration,
+      # deep-merged on read so a nested scope's registration wins; nil when
+      # none are registered. Record them with #add_representation; the
+      # backing store is an internal detail.
+      def representations
+        namespace_stackable_with_hash(:representations)
+      end
+
+      def add_representation(model_class, entity_class)
+        namespace_stackable[:representations] = { model_class => entity_class }
+      end
+
       # Rescue-handler maps registered by +rescue_from+, keyed by exception
       # class and merged so a nested scope's handler wins. Record them with
       # #add_rescue_handlers; the backing store is an internal detail.

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -140,7 +140,7 @@ describe Grape::API do
       dummy_presenter_klass = Class.new
       represent_object = Class.new
       subject.represent represent_object, with: dummy_presenter_klass
-      expect(subject.inheritable_setting.namespace_stackable[:representations]).to eq([{ represent_object => dummy_presenter_klass }])
+      expect(subject.inheritable_setting.representations).to eq(represent_object => dummy_presenter_klass)
     end
   end
 

--- a/spec/grape/dsl/request_response_spec.rb
+++ b/spec/grape/dsl/request_response_spec.rb
@@ -257,7 +257,7 @@ describe Grape::DSL::RequestResponse do
     it 'sets a presenter for a class' do
       presenter = Class.new
       subject.represent :ThisClass, with: presenter
-      expect(subject.inheritable_setting.namespace_stackable[:representations]).to eq([{ ThisClass: presenter }])
+      expect(subject.inheritable_setting.representations).to eq(ThisClass: presenter)
     end
   end
 end


### PR DESCRIPTION
Continues the `InheritableSetting` cleanup from #2795–#2800: the model-class ⇒ entity-class registrations written by `represent` are now recorded and read through intention-revealing accessors on `Grape::Util::InheritableSetting`, and a provably inert settings write in `Endpoint#initialize` is removed.

### New accessors on `InheritableSetting`

| Accessor | Replaces |
|---|---|
| `representations` / `add_representation(model_class, entity_class)` | `namespace_stackable_with_hash(:representations)` / `namespace_stackable[:representations] = { model => entity }` |

Notes:

* The writer absorbs the single-entry-Hash-per-registration storage shape; the reader absorbs the `namespace_stackable_with_hash` deep-merge convention (merged Hash, nearest scope wins, `nil` when nothing is registered). Converted call sites: `DSL::RequestResponse#represent` and `DSL::Entity#entity_class_for_obj`.
* **Dead code removal:** `Endpoint#initialize` did `inheritable_setting.namespace_stackable[:representations] ||= []`. Since `StackableValues#[]` always returns an array — the frozen `EMPTY` for never-written keys — the read side of `||=` is always truthy and the assignment can never execute. Verified empirically: after running the line on a fresh setting, `namespace_stackable.to_hash` is still `{}`. (Had it ever fired, it would have pushed an empty-array entry onto the stack rather than seeding a default, so removing it is safe in both worlds.)
* Storage under the raw key is unchanged, so `to_hash` output and any external readers see the same values; the raw key should now be considered internal.
* Specs assert through the accessor, now checking the merged read (`{Model => Entity}`) rather than the raw stack shape (`[{Model => Entity}]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
