### PR TITLE
Internalize middleware and helper registrations behind Grape::Util::InheritableSetting accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#2786](https://github.com/ruby-grape/grape/pull/2786): Make route `requirements` and `anchor` explicit keyword arguments and first-class endpoint inputs instead of opaque `route_options` keys - [@ericproulx](https://github.com/ericproulx).
 * [#2788](https://github.com/ruby-grape/grape/pull/2788): Compare the base API instead of `to_s` when refreshing a mounted app - [@ericproulx](https://github.com/ericproulx).
 * [#2796](https://github.com/ruby-grape/grape/pull/2796): Remove `Grape::Util::ReverseStackableValues`, storing rescue handlers in plain per-scope hashes merged over `InheritableSetting#parent` - [@ericproulx](https://github.com/ericproulx).
+* [#2802](https://github.com/ruby-grape/grape/pull/2802): Internalize middleware and helper registrations behind `Grape::Util::InheritableSetting` accessors (`middleware` / `add_middleware`, `helpers` / `add_helper`) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -82,6 +82,12 @@ A route's declared params were previously carried inside the `route_options` bag
 
 Like `params` above, a route's `requirements` and `anchor` were previously carried inside the `route_options` bag. They are now composed into their own endpoint inputs (`Grape::Endpoint::Options` gains `:requirements` and `:anchor` members, and `Grape::Endpoint.new` gains `requirements:` and `anchor:` keywords) and exposed only through the `route.requirements` and `route.anchor` readers. `route.options[:requirements]` and `route.options[:anchor]` now return `nil` — including for a mount's `anchor: false`. Nothing in Grape or grape-swagger read them that way, so this only affects code that reached into the options Hash for these keys directly.
 
+#### Middleware and helper registrations are recorded through `InheritableSetting` accessors
+
+The state written by the middleware DSL (`use`, `insert`, `insert_before`, `insert_after`) and by `helpers` is now recorded and read through dedicated accessors on `Grape::Util::InheritableSetting` (`middleware` / `add_middleware`, `helpers` / `add_helper`) instead of raw `namespace_stackable` keys, following the same move made for rescue handlers. The keys' storage is unchanged for now, so `namespace_stackable[:middleware]` and `namespace_stackable[:helpers]` still return the same values, but they should be considered internal.
+
+One micro-change: the `middleware` DSL reader dropped its `|| []` fallback — `Grape::Util::StackableValues#[]` never returns `nil`, so the fallback was dead code. When no middleware is registered the reader now returns the shared frozen empty array instead of a fresh mutable one; no caller in Grape or grape-swagger mutates the returned array.
+
 ### Upgrading to >= 3.3
 
 #### Minimum required Ruby is now 3.3

--- a/lib/grape/dsl/helpers.rb
+++ b/lib/grape/dsl/helpers.rb
@@ -52,12 +52,12 @@ module Grape
       def make_inclusion(mod, &)
         define_boolean_in_mod(mod)
         inject_api_helpers_to_mod(mod, &)
-        inheritable_setting.namespace_stackable[:helpers] = mod
+        inheritable_setting.add_helper(mod)
       end
 
       def include_all_in_scope
         mod = Module.new
-        namespace_stackable(:helpers).each { |mod_to_include| mod.include mod_to_include }
+        inheritable_setting.helpers.each { |mod_to_include| mod.include mod_to_include }
         change!
         mod
       end

--- a/lib/grape/dsl/middleware.rb
+++ b/lib/grape/dsl/middleware.rb
@@ -13,7 +13,7 @@ module Grape
         arr = [:use, middleware_class, *args]
         arr << block if block
 
-        inheritable_setting.namespace_stackable[:middleware] = arr
+        inheritable_setting.add_middleware(arr)
       end
 
       %i[insert insert_before insert_after].each do |method_name|
@@ -21,7 +21,7 @@ module Grape
           arr = [method_name, *args]
           arr << block if block
 
-          inheritable_setting.namespace_stackable[:middleware] = arr
+          inheritable_setting.add_middleware(arr)
         end
       end
 
@@ -29,7 +29,7 @@ module Grape
       # and arguments that are currently applied to the
       # application.
       def middleware
-        inheritable_setting.namespace_stackable[:middleware] || []
+        inheritable_setting.middleware
       end
     end
   end

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -349,7 +349,7 @@ module Grape
       stack.use Rack::Lint if lint?
       stack.use Grape::Middleware::Error, **error_middleware_options(format, content_types)
 
-      stack.concat inheritable_setting.namespace_stackable[:middleware]
+      stack.concat inheritable_setting.middleware
 
       if inheritable_setting.namespace_inheritable[:version].present?
         version_options = inheritable_setting.namespace_inheritable[:version_options]
@@ -393,7 +393,7 @@ module Grape
     end
 
     def build_helpers
-      helpers = inheritable_setting.namespace_stackable[:helpers]
+      helpers = inheritable_setting.helpers
       return if helpers.empty?
 
       Module.new { helpers.each { |mod_to_include| include mod_to_include } }

--- a/lib/grape/util/inheritable_setting.rb
+++ b/lib/grape/util/inheritable_setting.rb
@@ -106,6 +106,30 @@ module Grape
         data.each_with_object({}) { |value, result| result.deep_merge!(value) }
       end
 
+      # Middleware specs recorded by the middleware DSL (+use+, +insert+,
+      # +insert_before+, +insert_after+; see DSL::Middleware), one
+      # [operation, *arguments] Array per registration, outermost scope
+      # first. Record them with #add_middleware; the backing store is an
+      # internal detail.
+      def middleware
+        namespace_stackable[:middleware]
+      end
+
+      def add_middleware(operation_with_arguments)
+        namespace_stackable[:middleware] = operation_with_arguments
+      end
+
+      # Helper modules registered by +helpers+ blocks and modules (see
+      # DSL::Helpers), outermost scope first. Record them with #add_helper;
+      # the backing store is an internal detail.
+      def helpers
+        namespace_stackable[:helpers]
+      end
+
+      def add_helper(mod)
+        namespace_stackable[:helpers] = mod
+      end
+
       # Rescue-handler maps registered by +rescue_from+, keyed by exception
       # class and merged so a nested scope's handler wins. Record them with
       # #add_rescue_handlers; the backing store is an internal detail.

--- a/spec/grape/dsl/helpers_spec.rb
+++ b/spec/grape/dsl/helpers_spec.rb
@@ -9,7 +9,7 @@ describe Grape::DSL::Helpers do
       extend Grape::DSL::Settings
 
       def self.mods
-        inheritable_setting.namespace_stackable[:helpers]
+        inheritable_setting.helpers
       end
 
       def self.first_mod

--- a/spec/grape/dsl/middleware_spec.rb
+++ b/spec/grape/dsl/middleware_spec.rb
@@ -17,28 +17,28 @@ describe Grape::DSL::Middleware do
   describe '.use' do
     it 'adds a middleware with the right operation' do
       subject.use foo_middleware, :arg1, &proc
-      expect(subject.inheritable_setting.namespace_stackable[:middleware]).to eq([[:use, foo_middleware, :arg1, proc]])
+      expect(subject.inheritable_setting.middleware).to eq([[:use, foo_middleware, :arg1, proc]])
     end
   end
 
   describe '.insert' do
     it 'adds a middleware with the right operation' do
       subject.insert 0, :arg1, &proc
-      expect(subject.inheritable_setting.namespace_stackable[:middleware]).to eq([[:insert, 0, :arg1, proc]])
+      expect(subject.inheritable_setting.middleware).to eq([[:insert, 0, :arg1, proc]])
     end
   end
 
   describe '.insert_before' do
     it 'adds a middleware with the right operation' do
       subject.insert_before foo_middleware, :arg1, &proc
-      expect(subject.inheritable_setting.namespace_stackable[:middleware]).to eq([[:insert_before, foo_middleware, :arg1, proc]])
+      expect(subject.inheritable_setting.middleware).to eq([[:insert_before, foo_middleware, :arg1, proc]])
     end
   end
 
   describe '.insert_after' do
     it 'adds a middleware with the right operation' do
       subject.insert_after foo_middleware, :arg1, &proc
-      expect(subject.inheritable_setting.namespace_stackable[:middleware]).to eq([[:insert_after, foo_middleware, :arg1, proc]])
+      expect(subject.inheritable_setting.middleware).to eq([[:insert_after, foo_middleware, :arg1, proc]])
     end
   end
 


### PR DESCRIPTION
Continues the `InheritableSetting` cleanup from #2795–#2801: the registrations written by the middleware DSL (`use`, `insert`, `insert_before`, `insert_after`) and by `helpers` are now recorded and read through intention-revealing accessors on `Grape::Util::InheritableSetting`, so no caller indexes into `namespace_stackable` for these keys anymore.

### New accessors on `InheritableSetting`

| Accessor | Replaces |
|---|---|
| `middleware` / `add_middleware(operation_with_arguments)` | `namespace_stackable[:middleware]` |
| `helpers` / `add_helper(mod)` | `namespace_stackable[:helpers]` / `namespace_stackable(:helpers)` |

Notes:

* Converted call sites: `DSL::Middleware` (all four registration methods plus the `middleware` reader), `DSL::Helpers` (`make_inclusion`, `include_all_in_scope`) and `Endpoint` (`build_stack`, `build_helpers`).
* **Dead fallback removal:** the `middleware` DSL reader was `namespace_stackable[:middleware] || []`. `StackableValues#[]` never returns `nil` — it returns the frozen `EMPTY` array for never-written keys — so the `|| []` could never take effect. Dropping it means the empty case now returns the shared frozen array instead of a fresh mutable one; every caller (`Endpoint#build_stack`'s `stack.concat`, spec comparisons) only reads the result.
* Storage under the raw keys is unchanged, so `to_hash` output and any external readers see the same values; the raw keys should now be considered internal.
* `DSL::Middleware` and `DSL::Helpers` specs now assert through the accessors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
