### PR TITLE
Internalize namespace and mount-path registrations behind Grape::Util::InheritableSetting accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#2786](https://github.com/ruby-grape/grape/pull/2786): Make route `requirements` and `anchor` explicit keyword arguments and first-class endpoint inputs instead of opaque `route_options` keys - [@ericproulx](https://github.com/ericproulx).
 * [#2788](https://github.com/ruby-grape/grape/pull/2788): Compare the base API instead of `to_s` when refreshing a mounted app - [@ericproulx](https://github.com/ericproulx).
 * [#2796](https://github.com/ruby-grape/grape/pull/2796): Remove `Grape::Util::ReverseStackableValues`, storing rescue handlers in plain per-scope hashes merged over `InheritableSetting#parent` - [@ericproulx](https://github.com/ericproulx).
+* [#2803](https://github.com/ruby-grape/grape/pull/2803): Internalize namespace and mount-path registrations behind `Grape::Util::InheritableSetting` accessors (`namespaces` / `add_namespace` / `namespace_path` / `namespace_requirements`, `mount_path` / `add_mount_path`) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -82,6 +82,16 @@ A route's declared params were previously carried inside the `route_options` bag
 
 Like `params` above, a route's `requirements` and `anchor` were previously carried inside the `route_options` bag. They are now composed into their own endpoint inputs (`Grape::Endpoint::Options` gains `:requirements` and `:anchor` members, and `Grape::Endpoint.new` gains `requirements:` and `anchor:` keywords) and exposed only through the `route.requirements` and `route.anchor` readers. `route.options[:requirements]` and `route.options[:anchor]` now return `nil` — including for a mount's `anchor: false`. Nothing in Grape or grape-swagger read them that way, so this only affects code that reached into the options Hash for these keys directly.
 
+#### Namespace and mount-path registrations are recorded through `InheritableSetting` accessors
+
+The `Grape::Namespace` objects registered by the `namespace` DSL (and its `group` / `resource` / `resources` / `segment` aliases) and the mount path recorded by `mount` are now written and read through dedicated accessors on `Grape::Util::InheritableSetting` instead of raw `namespace_stackable` keys, following the same move made for rescue handlers:
+
+* `namespaces` / `add_namespace(namespace)` replace `namespace_stackable[:namespace]` (not to be confused with the pre-existing `namespace` reader, which returns the `InheritableValues` store).
+* `namespace_path` returns the normalized joined path prefix, absorbing the `Grape::Namespace.joined_space_path(...)` call previously spelled out at the read sites, and `namespace_requirements` returns the requirements declared by registered namespaces, absorbing the `filter_map(&:requirements)`.
+* `mount_path` / `add_mount_path(path)` replace `namespace_stackable[:mount_path]`; the reader absorbs the outermost-wins convention (previously the `.first` at the read site in `Endpoint#build_stack`).
+
+The keys' storage is unchanged for now, so `namespace_stackable[:namespace]` and `namespace_stackable[:mount_path]` still return the same values, but they should be considered internal.
+
 ### Upgrading to >= 3.3
 
 #### Minimum required Ruby is now 3.3

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -137,7 +137,7 @@ module Grape
           # instantiated Grape::API::Instance (vs. a bare Rack app).
           if app.is_a?(Grape::Mountable)
             mount_path = Grape::Util::PathNormalizer.call(path)
-            app.top_level_setting.namespace_stackable[:mount_path] = mount_path
+            app.top_level_setting.add_mount_path(mount_path)
 
             app.inherit_settings(inheritable_setting)
 
@@ -229,11 +229,11 @@ module Grape
       #       end
       #     end
       def namespace(space = nil, requirements: nil, **options, &block)
-        return Namespace.joined_space_path(inheritable_setting.namespace_stackable[:namespace]) unless space || block
+        return inheritable_setting.namespace_path unless space || block
 
         within_namespace do
           nest(block) do
-            inheritable_setting.namespace_stackable[:namespace] = Grape::Namespace.new(space, requirements:, **options) if space
+            inheritable_setting.add_namespace(Grape::Namespace.new(space, requirements:, **options)) if space
           end
         end
       end

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -131,7 +131,7 @@ module Grape
     end
 
     def namespace
-      @namespace ||= Namespace.joined_space_path(inheritable_setting.namespace_stackable[:namespace])
+      @namespace ||= inheritable_setting.namespace_path
     end
 
     def call(env)
@@ -328,7 +328,7 @@ module Grape
     end
 
     def prepare_routes_requirements(route_options_requirements)
-      namespace_requirements = inheritable_setting.namespace_stackable[:namespace].filter_map(&:requirements)
+      namespace_requirements = inheritable_setting.namespace_requirements
       namespace_requirements << route_options_requirements if route_options_requirements.present?
       namespace_requirements.reduce({}, :merge)
     end
@@ -357,7 +357,7 @@ module Grape
                   versions: inheritable_setting.namespace_inheritable[:version].flatten,
                   version_options:,
                   prefix: inheritable_setting.namespace_inheritable[:root_prefix],
-                  mount_path: inheritable_setting.namespace_stackable[:mount_path].first
+                  mount_path: inheritable_setting.mount_path
       end
 
       stack.use Grape::Middleware::Formatter,

--- a/lib/grape/namespace.rb
+++ b/lib/grape/namespace.rb
@@ -35,8 +35,9 @@ module Grape
       [self.class, space, requirements, options].hash
     end
 
-    # Join the namespaces from a list of settings to create a path prefix.
-    # @param settings [Array] list of Grape::Util::InheritableSettings.
+    # Join the namespaces from a list of Namespace objects to create a path
+    # prefix.
+    # @param settings [Array] list of Grape::Namespace objects.
     def self.joined_space_path(settings)
       JoinedSpaceCache[joined_space(settings)]
     end

--- a/lib/grape/util/inheritable_setting.rb
+++ b/lib/grape/util/inheritable_setting.rb
@@ -106,6 +106,43 @@ module Grape
         data.each_with_object({}) { |value, result| result.deep_merge!(value) }
       end
 
+      # Grape::Namespace objects registered by the +namespace+ DSL and its
+      # aliases (group, resource, resources, segment; see DSL::Routing),
+      # outermost scope first. Not to be confused with the #namespace values
+      # store. Record them with #add_namespace; the backing store is an
+      # internal detail.
+      def namespaces
+        namespace_stackable[:namespace]
+      end
+
+      def add_namespace(namespace)
+        namespace_stackable[:namespace] = namespace
+      end
+
+      # The normalized path prefix formed by joining every registered
+      # namespace's space (see Grape::Namespace.joined_space_path).
+      def namespace_path
+        Grape::Namespace.joined_space_path(namespaces)
+      end
+
+      # The param requirements declared by registered namespaces, outermost
+      # scope first.
+      def namespace_requirements
+        namespaces.filter_map(&:requirements)
+      end
+
+      # The path a Grape API is mounted under, recorded on the mounted API's
+      # top-level settings by +mount+ (see DSL::Routing). Reading returns the
+      # outermost mount path — nil when the API is not mounted; the backing
+      # store is an internal detail.
+      def mount_path
+        namespace_stackable[:mount_path].first
+      end
+
+      def add_mount_path(mount_path)
+        namespace_stackable[:mount_path] = mount_path
+      end
+
       # Rescue-handler maps registered by +rescue_from+, keyed by exception
       # class and merged so a nested scope's handler wins. Record them with
       # #add_rescue_handlers; the backing store is an internal detail.


### PR DESCRIPTION
Continues the `InheritableSetting` cleanup from #2795–#2802: the `Grape::Namespace` objects registered by the `namespace` DSL (and its `group` / `resource` / `resources` / `segment` aliases) and the mount path recorded by `mount` are now written and read through intention-revealing accessors on `Grape::Util::InheritableSetting`, so no caller indexes into `namespace_stackable` for these keys anymore.

### New accessors on `InheritableSetting`

| Accessor | Replaces |
|---|---|
| `namespaces` / `add_namespace(namespace)` | `namespace_stackable[:namespace]` |
| `namespace_path` | `Grape::Namespace.joined_space_path(namespace_stackable[:namespace])` |
| `namespace_requirements` | `namespace_stackable[:namespace].filter_map(&:requirements)` |
| `mount_path` / `add_mount_path(path)` | `namespace_stackable[:mount_path]` / `.first` |

Notes:

* The two derived readers absorb the read conventions previously spelled out at the call sites: `namespace_path` performs the joined-and-normalized prefix lookup used by both `Endpoint#namespace` and the `namespace` DSL getter, and `namespace_requirements` performs the requirements `filter_map` used by `Endpoint#prepare_routes_requirements` (still returning a fresh Array, which that call site appends to).
* `mount_path` absorbs the outermost-wins `.first` previously done in `Endpoint#build_stack` when configuring the versioner middleware, and documents it: with nested mounts the stack carries one entry per mount level, outermost first. The write side (`add_mount_path`) is recorded on the mounted API's top-level settings by `DSL::Routing#mount`, as before.
* Naming: the raw-stack reader is `namespaces` (plural) because `InheritableSetting#namespace` already exists as the reader for the `InheritableValues` namespace store; the doc comments call out the distinction.
* Also fixes the `@param` doc on `Grape::Namespace.joined_space_path`, which claimed the argument is a list of `InheritableSetting`s — it has always been a list of `Grape::Namespace` objects.
* Storage under the raw keys is unchanged, so `to_hash` output, route pattern settings (`settings[:mount_path]` in `Router::Pattern::Path`, which reads the stacked Array via `to_hash`) and any external readers see the same values; the raw keys should now be considered internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
