### PR TITLE
Internalize build_params_with and auth behind Grape::Util::InheritableSetting accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#2786](https://github.com/ruby-grape/grape/pull/2786): Make route `requirements` and `anchor` explicit keyword arguments and first-class endpoint inputs instead of opaque `route_options` keys - [@ericproulx](https://github.com/ericproulx).
 * [#2788](https://github.com/ruby-grape/grape/pull/2788): Compare the base API instead of `to_s` when refreshing a mounted app - [@ericproulx](https://github.com/ericproulx).
 * [#2796](https://github.com/ruby-grape/grape/pull/2796): Remove `Grape::Util::ReverseStackableValues`, storing rescue handlers in plain per-scope hashes merged over `InheritableSetting#parent` - [@ericproulx](https://github.com/ericproulx).
+* [#2808](https://github.com/ruby-grape/grape/pull/2808): Internalize `build_params_with` and `auth` behind `Grape::Util::InheritableSetting` accessors - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -82,6 +82,10 @@ A route's declared params were previously carried inside the `route_options` bag
 
 Like `params` above, a route's `requirements` and `anchor` were previously carried inside the `route_options` bag. They are now composed into their own endpoint inputs (`Grape::Endpoint::Options` gains `:requirements` and `:anchor` members, and `Grape::Endpoint.new` gains `requirements:` and `anchor:` keywords) and exposed only through the `route.requirements` and `route.anchor` readers. `route.options[:requirements]` and `route.options[:anchor]` now return `nil` — including for a mount's `anchor: false`. Nothing in Grape or grape-swagger read them that way, so this only affects code that reached into the options Hash for these keys directly.
 
+#### `build_params_with` and `auth` are recorded through `InheritableSetting` accessors
+
+The params-builder strategy written by `build_with` (both the API-level and the params-block DSL) and the authentication configuration written by the `auth` DSL are now recorded and read through dedicated accessors on `Grape::Util::InheritableSetting` (`build_params_with` / `build_params_with=`, `auth` / `auth=`) instead of raw `namespace_inheritable` keys, completing the per-key `namespace_inheritable` cleanup. The keys' storage is unchanged for now, so `namespace_inheritable[:build_params_with]` and `namespace_inheritable[:auth]` still return the same values, but they should be considered internal.
+
 ### Upgrading to >= 3.3
 
 #### Minimum required Ruby is now 3.3

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -29,7 +29,7 @@ module Grape
       #       end
       #     end
       def build_with(build_with)
-        @api.inheritable_setting.namespace_inheritable[:build_params_with] = build_with
+        @api.inheritable_setting.build_params_with = build_with
       end
 
       # Include reusable params rules among current.

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -102,7 +102,7 @@ module Grape
       end
 
       def build_with(build_with)
-        inheritable_setting.namespace_inheritable[:build_params_with] = build_with
+        inheritable_setting.build_params_with = build_with
       end
 
       # Do not route HEAD requests to GET requests automatically.

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -284,7 +284,7 @@ module Grape
       @after_validations  = stackable[:after_validations]
       @afters             = stackable[:afters]
       @finallies          = stackable[:finallies]
-      @build_params_with  = inheritable_setting.namespace_inheritable[:build_params_with]
+      @build_params_with  = inheritable_setting.build_params_with
     end
 
     def to_routes
@@ -406,7 +406,7 @@ module Grape
     # inherited settings. Warn so this bypass isn't silent.
     def warn_unauthenticated_mounted_app
       return unless bare_rack_app?
-      return unless inheritable_setting.namespace_inheritable[:auth]
+      return unless inheritable_setting.auth
 
       warn "Grape: #{config.app} is mounted under an API that declares authentication, but authentication " \
            'middleware does not wrap mounted Rack applications. Requests to this mount are not authenticated by Grape.'

--- a/lib/grape/middleware/auth/dsl.rb
+++ b/lib/grape/middleware/auth/dsl.rb
@@ -5,12 +5,11 @@ module Grape
     module Auth
       module DSL
         def auth(type = nil, *legacy_options, **options, &block)
-          namespace_inheritable = inheritable_setting.namespace_inheritable
-          return namespace_inheritable[:auth] unless type
+          return inheritable_setting.auth unless type
 
           options = merge_legacy_auth_options(:auth, legacy_options, options)
-          namespace_inheritable[:auth] = { type: type.to_sym, proc: block }.merge!(options)
-          use Grape::Middleware::Auth::Base, namespace_inheritable[:auth]
+          inheritable_setting.auth = { type: type.to_sym, proc: block }.merge!(options)
+          use Grape::Middleware::Auth::Base, inheritable_setting.auth
         end
 
         # Add HTTP Basic authorization to the API.

--- a/lib/grape/util/inheritable_setting.rb
+++ b/lib/grape/util/inheritable_setting.rb
@@ -106,6 +106,32 @@ module Grape
         data.each_with_object({}) { |value, result| result.deep_merge!(value) }
       end
 
+      # The params-builder strategy set by +build_with+ (both the
+      # API-level DSL::Routing#build_with and the params-block
+      # DSL::Parameters#build_with write it), consumed when the endpoint
+      # builds its Grape::Request. Nearest-wins scalar; nil when never set;
+      # the backing store is an internal detail.
+      def build_params_with
+        namespace_inheritable[:build_params_with]
+      end
+
+      def build_params_with=(strategy)
+        namespace_inheritable[:build_params_with] = strategy
+      end
+
+      # The authentication configuration Hash recorded by the +auth+ DSL
+      # (see Middleware::Auth::DSL): {type:, proc:, **options}. Nearest-wins
+      # scalar; nil when no authenticator is declared — Endpoint uses that
+      # to warn about unauthenticated bare Rack mounts; the backing store is
+      # an internal detail.
+      def auth
+        namespace_inheritable[:auth]
+      end
+
+      def auth=(auth_options)
+        namespace_inheritable[:auth] = auth_options
+      end
+
       # Rescue-handler maps registered by +rescue_from+, keyed by exception
       # class and merged so a nested scope's handler wins. Record them with
       # #add_rescue_handlers; the backing store is an internal detail.


### PR DESCRIPTION
Fourth and final per-key batch of the `namespace_inheritable` cleanup (after #2805/#2806/#2807): the params-builder strategy written by `build_with` and the authentication configuration written by the `auth` DSL are now recorded and read through intention-revealing accessors on `Grape::Util::InheritableSetting`.

### New accessors on `InheritableSetting`

| Accessor | Replaces |
|---|---|
| `build_params_with` / `build_params_with=` | `namespace_inheritable[:build_params_with]` |
| `auth` / `auth=` | `namespace_inheritable[:auth]` |

Notes:

* `build_params_with` has two DSL writers — the API-level `DSL::Routing#build_with` and the params-block `DSL::Parameters#build_with` — both now funnel through the one accessor, which documents that fact.
* Converted call sites: those two writers, `Middleware::Auth::DSL#auth` (get-or-set plus the immediate read feeding `use Grape::Middleware::Auth::Base`), and `Endpoint` (`compile!`'s `@build_params_with` snapshot and `warn_unauthenticated_mounted_app`'s auth presence check).
* With this PR plus #2805–#2807, no code outside `InheritableSetting` indexes into `namespace_inheritable` per key anymore — the remaining raw uses are the two bulk `to_hash` consumers (`Endpoint#prepare_default_path_settings`, `Instance#to_route_configs`), which get dedicated accessors in the upcoming visibility-narrowing PR.
* Storage under the raw keys is unchanged; they should now be considered internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
