### PR TITLE
Fix type: Array + values: [...] coercing to the guessed element type instead of Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 #### Fixes
 
 * [#2767](https://github.com/ruby-grape/grape/pull/2767): Update rubocop to 1.88.0 and rubocop-rspec to 3.10.2 - [@ericproulx](https://github.com/ericproulx).
+* [#2812](https://github.com/ruby-grape/grape/pull/2813): Fix `type: Array` combined with `values: [...]` list coercing to the guessed element type instead of `Array` - [@schinery](https://github.com/schinery).
 * Your contribution here.
 
 ### 3.3.3 (2026-07-17)

--- a/lib/grape/validations/validations_spec.rb
+++ b/lib/grape/validations/validations_spec.rb
@@ -51,6 +51,7 @@ module Grape
         @allow_blank = resolve_value(raw[:allow_blank])
         @fail_fast = raw[:fail_fast] || false
 
+        @guessed_coerce_type = guess_coerce_type(@coerce_type, @values, @except_values)
         @shared_opts = { allow_blank: @allow_blank, fail_fast: @fail_fast }.freeze
         @validator_entries = build_validator_entries(raw)
 
@@ -73,10 +74,14 @@ module Grape
       # construction so an incoherent spec (e.g. a +default+ outside +values+,
       # or +values+ whose elements don't match +type+) can never exist —
       # callers no longer have to remember to invoke these separately.
+      #
+      # NB. +@guessed_coerce_type+ is used only for this check, never for
+      # +coerce_options+ — a bare +type: Array+ combined with scalar
+      # +values:+ must still coerce to +Array+ at runtime (only the elements
+      # are scalar), so the real +@coerce_type+ is never overwritten by it.
       def validate!
-        guessed_coerce_type = guess_coerce_type(@coerce_type, @values, @except_values)
         check_incompatible_option_values(@default, @values, @except_values)
-        validate_value_coercion(guessed_coerce_type, @values, @except_values)
+        validate_value_coercion(@guessed_coerce_type, @values, @except_values)
       end
 
       def check_incompatible_option_values(default, values, except_values)

--- a/lib/grape/validations/validations_spec.rb
+++ b/lib/grape/validations/validations_spec.rb
@@ -51,7 +51,6 @@ module Grape
         @allow_blank = resolve_value(raw[:allow_blank])
         @fail_fast = raw[:fail_fast] || false
 
-        @coerce_type = guess_coerce_type(@coerce_type, @values, @except_values)
         @shared_opts = { allow_blank: @allow_blank, fail_fast: @fail_fast }.freeze
         @validator_entries = build_validator_entries(raw)
 
@@ -75,8 +74,9 @@ module Grape
       # or +values+ whose elements don't match +type+) can never exist —
       # callers no longer have to remember to invoke these separately.
       def validate!
+        guessed_coerce_type = guess_coerce_type(@coerce_type, @values, @except_values)
         check_incompatible_option_values(@default, @values, @except_values)
-        validate_value_coercion(@coerce_type, @values, @except_values)
+        validate_value_coercion(guessed_coerce_type, @values, @except_values)
       end
 
       def check_incompatible_option_values(default, values, except_values)

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -158,6 +158,39 @@ describe Grape::Validations::ParamsScope do
         subject.params { requires :numbers, type: Array, values: 0.0..10 }
       end.to raise_error Grape::Exceptions::IncompatibleOptionValues
     end
+
+    it 'accepts an array containing only allowed values, given as a literal array' do
+      subject.params do
+        optional :periods, type: Array, values: %w[day month]
+      end
+      subject.get('/optional') { 'optional works' }
+
+      get '/optional', periods: %w[day month]
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq('optional works')
+    end
+
+    it 'raises a single values error, not a duplicate coercion error, for a disallowed value' do
+      subject.params do
+        optional :periods, type: Array, values: %w[day month]
+      end
+      subject.get('/optional') { 'optional works' }
+
+      get '/optional', periods: ['year']
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq('periods does not have a valid value')
+    end
+
+    it 'still enforces the declared Array type at runtime, given a literal values array' do
+      subject.params do
+        optional :periods, type: Array, values: %w[day month]
+      end
+      subject.get('/optional') { 'optional works' }
+
+      get '/optional', periods: 'day'
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq('periods is invalid')
+    end
   end
 
   context 'coercing values validation with proc' do

--- a/spec/grape/validations/validations_spec_spec.rb
+++ b/spec/grape/validations/validations_spec_spec.rb
@@ -52,6 +52,12 @@ describe Grape::Validations::ValidationsSpec do
       expect(spec.coerce_type).to eq([Integer, String])
       expect(spec.coerce_type.to_s).to eq('[Integer, String]')
     end
+
+    it 'never lets the values-guessed type leak into coerce_type for a bare Array type' do
+      spec = described_class.from(type: Array, values: %w[a b c])
+      expect(spec.coerce_type).to eq(Array)
+      expect(spec.coerce_options.type).to eq(Array)
+    end
   end
 
   describe 'shared opts' do


### PR DESCRIPTION
`guess_coerce_type`'s result was overwriting `@coerce_type` in place, so `type: Array` + `values: [...]` param coerced at runtime using the guessed element type instead of `Array` — rejecting valid array input and duplicating the `values` error on invalid input. 

The guessed type is now only used locally for the existing declaration-time `validate_value_coercion` check, never for `coerce_options`.

Fixes #2812.
