### PR TITLE
Fix line-anchored regexes matching per line instead of whole string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 #### Fixes
 
 * [#2767](https://github.com/ruby-grape/grape/pull/2767): Update rubocop to 1.88.0 and rubocop-rspec to 3.10.2 - [@ericproulx](https://github.com/ericproulx).
+* [#2815](https://github.com/ruby-grape/grape/pull/2815): Fix line-anchored regexes: `type: JSON` payloads containing a blank line were silently coerced to `nil` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.4 (2026-07-25)

--- a/lib/grape/router/pattern/path.rb
+++ b/lib/grape/router/pattern/path.rb
@@ -61,7 +61,7 @@ module Grape
         end
 
         def valid_part?(part)
-          part&.match?(/^\S/) && not_slash?(part)
+          part&.match?(/\A\S/) && not_slash?(part)
         end
 
         class PartsCache < Grape::Util::Cache

--- a/lib/grape/validations/types/json.rb
+++ b/lib/grape/validations/types/json.rb
@@ -17,9 +17,7 @@ module Grape
           # @return [Hash,Array<Hash>,nil]
           def parse(input)
             return input if parsed?(input)
-
-            # Allow nulls and blank strings
-            return if input.nil? || input.match?(/^\s*$/)
+            return if input.blank?
 
             JSON.parse(input, symbolize_names: true)
           end

--- a/spec/grape/router/pattern/path_spec.rb
+++ b/spec/grape/router/pattern/path_spec.rb
@@ -88,6 +88,11 @@ RSpec.describe Grape::Router::Pattern::Path do
         path = described_class.new(nil, nil, path_settings(version: :v1, version_options: Grape::DSL::VersionOptions.new))
         expect(path.suffix).to eql('(/.:format)')
       end
+
+      it "includes a '/' when the path starts with whitespace" do
+        path = described_class.new("\n/path", nil, path_settings(version: :v1, version_options: Grape::DSL::VersionOptions.new))
+        expect(path.suffix).to eql('(/.:format)')
+      end
     end
   end
 end

--- a/spec/grape/validations/types/json_spec.rb
+++ b/spec/grape/validations/types/json_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe Grape::Validations::Types::Json do
+  describe '.parse' do
+    it 'returns nil for nil' do
+      expect(described_class.parse(nil)).to be_nil
+    end
+
+    it 'returns nil for a blank string' do
+      expect(described_class.parse('   ')).to be_nil
+    end
+
+    it 'parses a JSON object' do
+      expect(described_class.parse('{"a":1}')).to eq(a: 1)
+    end
+
+    it 'parses JSON containing a blank line' do
+      expect(described_class.parse("{\"a\": 1,\n\n\"b\": 2}")).to eq(a: 1, b: 2)
+    end
+
+    it 'parses JSON followed by a trailing blank line' do
+      expect(described_class.parse("[{\"a\":1}]\n\n")).to eq([{ a: 1 }])
+    end
+  end
+
+  describe Grape::Validations::Types::JsonArray do
+    describe '.parse' do
+      it 'returns nil for a blank string' do
+        expect(described_class.parse('   ')).to be_nil
+      end
+
+      it 'wraps an object containing a blank line in an array' do
+        expect(described_class.parse("{\"a\": 1,\n\n\"b\": 2}")).to eq([{ a: 1, b: 2 }])
+      end
+    end
+  end
+end

--- a/spec/grape/validations/validators/coerce_validator_spec.rb
+++ b/spec/grape/validations/validators/coerce_validator_spec.rb
@@ -971,6 +971,25 @@ describe Grape::Validations::Validators::CoerceValidator do
         expect(last_response.body).to eq('splines[x] does not have a valid value')
       end
 
+      it 'parses a payload containing a blank line' do
+        subject.params do
+          requires :splines, type: JSON do
+            requires :x, type: Integer
+          end
+        end
+        subject.get '/' do
+          params[:splines][:x]
+        end
+
+        get '/', splines: <<~JSON
+          {"x": 1,
+
+          "ints": [1, 2]}
+        JSON
+        expect(last_response).to be_successful
+        expect(last_response.body).to eq('1')
+      end
+
       it 'accepts Array[JSON] shorthand' do
         subject.params do
           requires :splines, type: Array[JSON] do


### PR DESCRIPTION
## Summary

Two whole-string checks used `^`/`$`, which in Ruby anchor to **lines**, not string boundaries. Both misfired on multi-line input.

### `Grape::Validations::Types::Json#parse` — user-visible bug

The "allow nulls and blank strings" guard was:

```ruby
return if input.nil? || input.match?(/^\s*$/)
```

`/^\s*$/` matches any string *containing* a blank (or whitespace-only) line, so perfectly valid JSON payloads were treated as blank and silently coerced to `nil`:

```ruby
"[1,2]\n\n".match?(/^\s*$/)                 # => true (trailing blank line)
"{\"a\": 1,\n\n \"b\": 2}".match?(/^\s*$/)  # => true (pretty-printed with an empty line)
```

For a `type: JSON` param this means the payload vanishes — the param behaves as if it were never sent. Fixed by replacing the regex with `input.blank?` (ActiveSupport is already a dependency and `blank?` is used elsewhere in the validators), which anchors correctly, covers the `nil` check, and drops the regex entirely.

### `Grape::Router::Pattern::Path#valid_part?` — latent

```ruby
part&.match?(/^\S/)   # meant: starts with a non-whitespace character
```

A part like `"\n/path"` passed because `^\S` matches at the start of its second line. Path parts virtually never contain newlines, so this is latent rather than user-visible, but it is the identical anchoring mistake — fixed with `\A\S`.

For reference, `Grape::Util::MediaType::VENDOR_VERSION_HEADER_REGEX` is the in-repo precedent doing this correctly with `\A...\z`.

## Tests

- New `spec/grape/validations/types/json_spec.rb` unit-covering `Json.parse`/`JsonArray.parse`: nil/blank inputs still return `nil`; payloads with an interior blank line or a trailing blank line now parse.
- Integration case in `coerce_validator_spec.rb` (`first-class JSON` context): a `type: JSON` param whose payload contains a blank line reaches the endpoint parsed.
- Suffix case in `router/pattern/path_spec.rb`: a part starting with whitespace no longer counts as a valid part.

Full suite: 2376 examples, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
