### PR TITLE
Remove request-time mutable state from Array and custom-type coercers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [#2814](https://github.com/ruby-grape/grape/pull/2814): Fix `type: [A, B]` combined with `values:`/`except_values:` raising `IncompatibleOptionValues` at definition time - [@ericproulx](https://github.com/ericproulx).
 * [#2815](https://github.com/ruby-grape/grape/pull/2815): Fix line-anchored regexes: `type: JSON` payloads containing a blank line were silently coerced to `nil` - [@ericproulx](https://github.com/ericproulx).
 * [#2817](https://github.com/ruby-grape/grape/pull/2817): Remove request-time mutable state from Array and custom-type coercers - [@ericproulx](https://github.com/ericproulx).
+* [#2819](https://github.com/ruby-grape/grape/pull/2819): Freeze coercers at construction, synchronize `Grape::Util::Cache` lookups, and assign `Route#regexp_capture_index` eagerly - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.4 (2026-07-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [#2816](https://github.com/ruby-grape/grape/pull/2816): Guard `length`, `same_as` and `oneof` validators against non-hash params (500 → 400) - [@ericproulx](https://github.com/ericproulx).
 * [#2814](https://github.com/ruby-grape/grape/pull/2814): Fix `type: [A, B]` combined with `values:`/`except_values:` raising `IncompatibleOptionValues` at definition time - [@ericproulx](https://github.com/ericproulx).
 * [#2815](https://github.com/ruby-grape/grape/pull/2815): Fix line-anchored regexes: `type: JSON` payloads containing a blank line were silently coerced to `nil` - [@ericproulx](https://github.com/ericproulx).
+* [#2817](https://github.com/ruby-grape/grape/pull/2817): Remove request-time mutable state from Array and custom-type coercers - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.4 (2026-07-25)

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'logger'
+require 'monitor'
 require 'active_support'
 require 'active_support/isolated_execution_state'
 require 'active_support/core_ext/array/conversions' # to_xml

--- a/lib/grape/router/base_route.rb
+++ b/lib/grape/router/base_route.rb
@@ -22,16 +22,17 @@ module Grape
         @settings = settings
       end
 
-      def regexp_capture_index
-        @regexp_capture_index ||= CaptureIndexCache[@index]
-      end
+      # Assigned eagerly in {#to_regexp} (router compilation) rather than
+      # memoized here: this reader is called from request-time route matching
+      # on instances shared across threads, so it must not write state.
+      attr_reader :regexp_capture_index
 
       def pattern_regexp
         @pattern.to_regexp
       end
 
       def to_regexp(index)
-        @index = index
+        @regexp_capture_index = CaptureIndexCache[index]
         Regexp.new("(?<#{regexp_capture_index}>#{pattern_regexp})")
       end
 

--- a/lib/grape/util/cache.rb
+++ b/lib/grape/util/cache.rb
@@ -2,16 +2,35 @@
 
 module Grape
   module Util
+    # Base class for the lazily-filled lookup caches (coercers, dry-types,
+    # path parts, ...). Subclasses assign a default-block +Hash+ to +@cache+
+    # in their +initialize+.
+    #
+    # Lookups are synchronized: caches are written at API *definition* time
+    # (a +params+ block runs when the class body is evaluated), which is not
+    # covered by the compile-time +Grape::API::Instance::LOCK+ and can happen
+    # concurrently — e.g. parallel eager loading, or two threads autoloading
+    # different API files. A +Monitor+ (reentrant) rather than a +Mutex+,
+    # because a cache miss may re-enter the same cache: building a
+    # multiple-type coercer through +Types::CoercerCache+ builds its member
+    # coercers through +Types.build_coercer+, which lands in the same cache.
     class Cache
       include Singleton
 
       attr_reader :cache
 
+      def initialize
+        @monitor = Monitor.new
+      end
+
+      def [](key)
+        @monitor.synchronize { @cache[key] }
+      end
+
       class << self
         extend Forwardable
 
-        def_delegators :cache, :[]
-        def_delegators :instance, :cache
+        def_delegators :instance, :[], :cache
       end
     end
   end

--- a/lib/grape/util/deep_freeze.rb
+++ b/lib/grape/util/deep_freeze.rb
@@ -10,9 +10,8 @@ module Grape
       #
       # Intentionally left unfrozen:
       #   - Procs / lambdas — may be deferred DB-backed callables
-      #   - Coercers (e.g. ArrayCoercer) — use lazy ivar memoization at request time
       #   - Classes / Modules — shared constants that must remain open
-      #   - ParamsScope — self-freezes at the end of its own initialize
+      #   - Coercers and ParamsScope — self-freeze at construction
       def deep_freeze(obj)
         case obj
         when Hash

--- a/lib/grape/util/freeze_on_new.rb
+++ b/lib/grape/util/freeze_on_new.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Grape
+  module Util
+    # Extend into a class whose instances are shared across requests:
+    # +new+ returns a frozen instance, so any later ivar write — e.g.
+    # request-time memoization — raises FrozenError instead of being a
+    # latent data race.
+    #
+    # Must stay a +new+ wrapper (never an +initialize+ wrapper): the freeze
+    # runs after the entire initialize chain, so subclasses may assign ivars
+    # after +super+. Extending a hierarchy base covers its subclasses —
+    # singleton classes inherit along the class hierarchy.
+    module FreezeOnNew
+      def new(...)
+        super.freeze
+      end
+    end
+  end
+end

--- a/lib/grape/validations/types/array_coercer.rb
+++ b/lib/grape/validations/types/array_coercer.rb
@@ -15,7 +15,9 @@ module Grape
         def initialize(type, strict: false)
           super
           @coercer = strict ? DryTypes::Strict::Array : DryTypes::Params::Array
-          @subtype = type.first
+          # Built eagerly: instances are shared across requests (and cached in
+          # Types::CoercerCache), so no lazy state may be created at call time.
+          @elem_coercer = DryTypeCoercer.coercer_instance_for(type.first, strict:)
         end
 
         def call(_val)
@@ -27,7 +29,7 @@ module Grape
 
         protected
 
-        attr_reader :subtype
+        attr_reader :elem_coercer
 
         def coerce_elements(collection)
           return if collection.nil?
@@ -49,10 +51,6 @@ module Grape
         # Virtus doesn't allow nil in arrays.
         def reject?(val)
           val.nil?
-        end
-
-        def elem_coercer
-          @elem_coercer ||= DryTypeCoercer.coercer_instance_for(subtype, strict:)
         end
       end
     end

--- a/lib/grape/validations/types/custom_type_coercer.rb
+++ b/lib/grape/validations/types/custom_type_coercer.rb
@@ -88,8 +88,12 @@ module Grape
           ->(val) { method.call(val).deep_symbolize_keys }
         end
 
+        # +dup+ before +map!+: the collection is whatever the user's coercion
+        # method returned — possibly frozen, possibly the input itself — so we
+        # must not mutate it in place. +dup+ also preserves the class, keeping a
+        # +Set+ a +Set+ (unlike +map+, which would return an +Array+).
         def collection_symbolizer(method)
-          ->(val) { method.call(val).map! { |item| symbolize_if_hash(item) } }
+          ->(val) { method.call(val).dup.map! { |item| symbolize_if_hash(item) } }
         end
 
         def symbolize_if_hash(item)

--- a/lib/grape/validations/types/custom_type_coercer.rb
+++ b/lib/grape/validations/types/custom_type_coercer.rb
@@ -33,6 +33,8 @@ module Grape
       # contract as +coerced?+, and must be supplied with a coercion
       # +method+.
       class CustomTypeCoercer
+        extend Grape::Util::FreezeOnNew
+
         TYPE_CHECK_METHODS = %i[coerced? parsed?].freeze
         COLLECTION_TYPES = [Array, Set].freeze
         private_constant :TYPE_CHECK_METHODS, :COLLECTION_TYPES

--- a/lib/grape/validations/types/dry_type_coercer.rb
+++ b/lib/grape/validations/types/dry_type_coercer.rb
@@ -8,6 +8,8 @@ module Grape
       # but check its type. More information there
       # https://dry-rb.org/gems/dry-types/main/built-in-types/
       class DryTypeCoercer
+        extend Grape::Util::FreezeOnNew
+
         class << self
           # Returns a collection coercer which corresponds to a given type.
           # Example:

--- a/lib/grape/validations/types/multiple_type_coercer.rb
+++ b/lib/grape/validations/types/multiple_type_coercer.rb
@@ -13,6 +13,8 @@ module Grape
       # an allowed type it should be declared last, since it will always
       # successfully "coerce" the value.
       class MultipleTypeCoercer
+        extend Grape::Util::FreezeOnNew
+
         # Construct a new coercer that will attempt to coerce
         # values to the given list of types in the given order.
         #
@@ -28,7 +30,7 @@ module Grape
             else
               Types.build_coercer type, strict: !@method.nil?
             end
-          end
+          end.freeze
         end
 
         # Coerces the given value.

--- a/lib/grape/validations/types/variant_collection_coercer.rb
+++ b/lib/grape/validations/types/variant_collection_coercer.rb
@@ -6,6 +6,8 @@ module Grape
       # This class wraps {MultipleTypeCoercer}, for use with collections
       # that allow members of more than one type.
       class VariantCollectionCoercer
+        extend Grape::Util::FreezeOnNew
+
         # @return [Array<Class>,Set<Class>] the member types as declared in the DSL
         attr_reader :types
 

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -13,6 +13,7 @@ module Grape
       # (e.g. +memoize+, <tt>||=</tt>) will raise +FrozenError+ at request time.
       class Base
         extend Forwardable
+        extend Grape::Util::FreezeOnNew
         include Grape::Util::Translation
 
         attr_reader :attrs
@@ -43,10 +44,6 @@ module Grape
             else
               @default_message_key || (superclass.respond_to?(:default_message_key) ? superclass.default_message_key : nil)
             end
-          end
-
-          def new(...)
-            super.freeze
           end
 
           def inherited(klass)

--- a/lib/grape/validations/validators/contract_scope_validator.rb
+++ b/lib/grape/validations/validators/contract_scope_validator.rb
@@ -4,11 +4,12 @@ module Grape
   module Validations
     module Validators
       class ContractScopeValidator
+        extend Grape::Util::FreezeOnNew
+
         attr_reader :schema
 
         def initialize(schema:)
           @schema = schema
-          freeze
         end
 
         # Validates a given request.

--- a/spec/grape/router/route_spec.rb
+++ b/spec/grape/router/route_spec.rb
@@ -21,6 +21,20 @@ RSpec.describe Grape::Router::Route do
     it { is_expected.to be_a(Grape::Router::BaseRoute) }
   end
 
+  describe '#regexp_capture_index' do
+    subject(:route) { described_class.new(endpoint, :get, pattern, options, forward_match: false) }
+
+    # The reader is called from request-time route matching on instances
+    # shared across threads, so it must be assigned during #to_regexp
+    # (router compilation), never lazily at read time. Freezing the route
+    # proves no ivar is written after compilation.
+    it 'is assigned eagerly by #to_regexp and readable on a frozen route' do
+      route.to_regexp(3)
+      route.freeze
+      expect(route.regexp_capture_index).to eq('_3')
+    end
+  end
+
   describe 'metadata attributes (namespace, prefix, settings)' do
     subject(:route) do
       described_class.new(endpoint, :get, pattern, options, forward_match: false,

--- a/spec/grape/util/cache_spec.rb
+++ b/spec/grape/util/cache_spec.rb
@@ -29,4 +29,59 @@ RSpec.describe Grape::Util::Cache do
       expect(Grape::Validations::Types.build_coercer([Integer, Float, String])).to be_frozen
     end
   end
+
+  # Layer-1 thread-safety invariant: every Grape::Util::Cache is written only
+  # while an API is defined and compiled — never at request time. Requests
+  # against shared, unsynchronized-read caches are safe *because* they are
+  # read-only; this pins that property. It would have caught the pre-#2817
+  # ArrayCoercer seeding DryTypes::ParamsCache on the first request.
+  describe 'boot-only growth' do
+    let(:app) do
+      Class.new(Grape::API) do
+        format :json
+
+        params do
+          requires :id, type: Integer
+          optional :ids, type: Array[Integer]
+          optional :tags, type: Set[Integer]
+          optional :multi, type: [Integer, String]
+          optional :state, type: String, values: %w[a b], default: 'a'
+        end
+        get('/lookup') { 'ok' }
+
+        params do
+          requires :doc, type: JSON do
+            requires :name, type: String
+          end
+          optional :variant, type: Hash, oneof: [proc { requires :x, type: Integer }]
+        end
+        post('/nested') { 'ok' }
+      end
+    end
+
+    it 'no cache gains keys after the API is compiled' do
+      # Boot fully — definition already happened (params blocks ran when the
+      # class body evaluated); compile! builds routes, patterns and the
+      # router, which warms the remaining caches.
+      app.compile!
+      before = described_class.subclasses.to_h { |cache| [cache, cache.cache.keys.dup] }
+
+      # First-ever requests happen only now, so any first-request cache write
+      # shows up as growth: valid, invalid, wrong-shape, unmatched-path and
+      # unrouted-method traffic.
+      mr = Rack::MockRequest.new(app)
+      mr.get('/lookup?id=1&ids[]=2&tags[]=3&multi[]=4&state=a')
+      mr.get('/lookup?id=nope&multi[]=x')
+      mr.post('/nested', input: '{"doc":{"name":"n"},"variant":{"x":1}}', 'CONTENT_TYPE' => 'application/json')
+      mr.post('/nested', input: '{"doc":["wrong shape"],"variant":{"y":2}}', 'CONTENT_TYPE' => 'application/json')
+      mr.get('/unmatched')
+      mr.request('OPTIONS', '/lookup')
+      mr.request('PATCH', '/lookup?id=1')
+
+      described_class.subclasses.each do |cache|
+        expect(cache.cache.keys).to match_array(before.fetch(cache, [])),
+                                    "#{cache} gained keys at request time"
+      end
+    end
+  end
 end

--- a/spec/grape/util/cache_spec.rb
+++ b/spec/grape/util/cache_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe Grape::Util::Cache do
+  describe 'synchronized lookup' do
+    it 'computes each key once and returns consistent values across threads' do
+      # The default block runs while the monitor is held, so this plain
+      # counter is race-free by construction.
+      computations = []
+      cache_class = Class.new(described_class) do
+        define_method(:initialize) do
+          super()
+          @cache = Hash.new do |h, key|
+            computations << key
+            h[key] = "computed-#{key}"
+          end
+        end
+      end
+
+      results = Array.new(8) { Thread.new { cache_class.instance['k'] } }.map(&:value)
+
+      expect(results).to all(eq('computed-k'))
+      expect(computations).to eq(['k'])
+    end
+
+    it 'supports reentrant lookups from within a default block' do
+      # Types::CoercerCache re-enters itself: a multiple-type coercer builds
+      # its member coercers through Types.build_coercer, which lands in the
+      # same cache. A non-reentrant lock would deadlock here.
+      expect(Grape::Validations::Types.build_coercer([Integer, Float, String])).to be_frozen
+    end
+  end
+end

--- a/spec/grape/util/freeze_on_new_spec.rb
+++ b/spec/grape/util/freeze_on_new_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe Grape::Util::FreezeOnNew do
+  let(:base) do
+    Class.new do
+      extend Grape::Util::FreezeOnNew
+
+      attr_reader :a
+
+      def initialize
+        @a = 1
+      end
+    end
+  end
+
+  it 'returns frozen instances from new' do
+    expect(base.new).to be_frozen
+  end
+
+  it 'covers subclasses through singleton-class inheritance' do
+    expect(Class.new(base).new).to be_frozen
+  end
+
+  it 'freezes only after the whole initialize chain, so subclasses may assign ivars after super' do
+    subclass = Class.new(base) do
+      attr_reader :b
+
+      def initialize
+        super
+        @b = 2
+      end
+    end
+
+    instance = subclass.new
+    expect(instance).to be_frozen
+    expect(instance.a).to eq(1)
+    expect(instance.b).to eq(2)
+  end
+end

--- a/spec/grape/validations/frozen_validation_graph_spec.rb
+++ b/spec/grape/validations/frozen_validation_graph_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+# Layer-1 thread-safety invariant: the validation object graph shared across
+# requests is immutable. Validators, their iterators, params scopes and
+# coercers all freeze at construction (see Grape::Util::FreezeOnNew), so a
+# request-time ivar write raises FrozenError deterministically instead of
+# being a latent data race.
+#
+# This spec enforces the contract structurally: it walks every object
+# reachable from the compiled routes' validator lists and asserts that each
+# instance of a contract class is frozen — catching classes that never
+# adopted the freeze contract, not just regressions in those that did.
+RSpec.describe Grape::Validations do
+  describe 'frozen shared validation graph' do
+    let(:custom_type) do
+      Class.new do
+        def self.parse(value)
+          value.to_s
+        end
+      end
+    end
+
+    # One API touching every validator and coercer shape, so the walk sweeps
+    # the whole taxonomy: primitive/array/set/nested/multiple/variant/custom
+    # coercers, every stock validator, oneof variants, lateral (given) and
+    # nested scopes.
+    let(:app) do
+      ct = custom_type
+      Class.new(Grape::API) do
+        format :json
+
+        params do
+          requires :id, type: Integer
+          optional :ids, type: Array[Integer]
+          optional :matrix, type: Array[Array[Integer]]
+          optional :tags, type: Set[Integer]
+          optional :multi, type: [Integer, String]
+          optional :kinds, types: [Integer, String]
+          optional :custom, type: ct
+          optional :customs, type: Array[ct]
+          optional :stripped, type: String, coerce_with: lambda(&:strip)
+          optional :state, type: String, values: %w[a b], default: 'a'
+          optional :lazy, type: Integer, values: -> { [1, 2] }
+          optional :not_these, type: Integer, except_values: [99]
+          optional :code, type: String, regexp: /\A[a-z]+\z/, length: { min: 1, max: 10 }
+          optional :pw, type: String
+          optional :pw2, type: String, same_as: :pw, allow_blank: false
+          mutually_exclusive :custom, :stripped
+          at_least_one_of :id, :ids
+        end
+        post('/all') { 'ok' }
+
+        params do
+          requires :doc, type: JSON do
+            requires :name, type: String
+          end
+          requires :root, type: Hash do
+            requires :inner, type: Array do
+              requires :leaf, type: String
+            end
+          end
+          optional :variant, type: Hash, oneof: [
+            proc { requires :x, type: Integer },
+            proc { requires :y, type: String }
+          ]
+          optional :mode, type: String
+          given :mode do
+            requires :detail, type: String
+          end
+        end
+        post('/nested') { 'ok' }
+      end
+    end
+
+    # Classes whose instances are shared across requests and must be frozen.
+    def frozen_contract_classes
+      [
+        Grape::Validations::Validators::Base,
+        Grape::Validations::Validators::ContractScopeValidator,
+        Grape::Validations::AttributesIterator,
+        Grape::Validations::ParamsScope,
+        Grape::Validations::Types::DryTypeCoercer,
+        Grape::Validations::Types::CustomTypeCoercer,
+        Grape::Validations::Types::MultipleTypeCoercer,
+        Grape::Validations::Types::VariantCollectionCoercer
+      ]
+    end
+
+    # Walks ivars and collection members. Skips value types, callables
+    # (user-supplied procs are deliberately unfrozen), open classes/modules,
+    # and dry-types internals (external library, outside grape's contract).
+    def walk(obj, path, seen, violations, census)
+      case obj
+      when Module, Proc, Method, UnboundMethod, Symbol, Numeric, Range, Regexp, true, false, nil
+        return
+      end
+      return if obj.class.name&.start_with?('Dry::')
+      return if seen.key?(obj)
+
+      seen[obj] = true
+      if frozen_contract_classes.any? { |klass| obj.is_a?(klass) }
+        census[obj.class] += 1
+        violations << "#{path} (#{obj.class})" unless obj.frozen?
+      end
+      walk_members(obj, path, seen, violations, census)
+    end
+
+    def walk_members(obj, path, seen, violations, census)
+      case obj
+      when Hash
+        obj.each do |k, v|
+          walk(k, "#{path}.key(#{k.inspect[0, 30]})", seen, violations, census)
+          walk(v, "#{path}[#{k.inspect[0, 30]}]", seen, violations, census)
+        end
+      when Array, Set
+        obj.each_with_index { |e, i| walk(e, "#{path}[#{i}]", seen, violations, census) }
+      else
+        obj.instance_variables.each do |ivar|
+          walk(obj.instance_variable_get(ivar), "#{path}.#{ivar}", seen, violations, census)
+        end
+      end
+    end
+
+    def walk_route_validations(api)
+      violations = []
+      census = Hash.new(0)
+      seen = {}.compare_by_identity
+      api.endpoints.each_with_index do |endpoint, i|
+        Array(endpoint.inheritable_setting.route[:validations]).each_with_index do |validator, j|
+          walk(validator, "endpoint[#{i}].validator[#{j}]", seen, violations, census)
+        end
+      end
+      [violations, census]
+    end
+
+    it 'freezes every validator, iterator, scope and coercer reachable from the routes' do
+      violations, census = walk_route_validations(app)
+
+      expect(violations).to be_empty, "unfrozen shared objects:\n  #{violations.join("\n  ")}"
+
+      # The walk must actually have swept the taxonomy — an empty walk would
+      # pass vacuously. Presence of these classes proves coverage, including
+      # oneof variant validators reached through nested walking.
+      expect(census.keys).to include(
+        Grape::Validations::Validators::PresenceValidator,
+        Grape::Validations::Validators::CoerceValidator,
+        Grape::Validations::Validators::ValuesValidator,
+        Grape::Validations::Validators::OneofValidator,
+        Grape::Validations::Validators::MutuallyExclusiveValidator,
+        Grape::Validations::SingleAttributeIterator,
+        Grape::Validations::MultipleAttributesIterator,
+        Grape::Validations::ParamsScope,
+        Grape::Validations::Types::PrimitiveCoercer,
+        Grape::Validations::Types::ArrayCoercer,
+        Grape::Validations::Types::SetCoercer,
+        Grape::Validations::Types::CustomTypeCoercer,
+        Grape::Validations::Types::CustomTypeCollectionCoercer,
+        Grape::Validations::Types::MultipleTypeCoercer,
+        Grape::Validations::Types::VariantCollectionCoercer
+      )
+    end
+
+    it 'reports an unfrozen contract instance (walker self-test)' do
+      scope = app.endpoints.first.inheritable_setting.route[:validations].first.__send__(:scope)
+      unfrozen = Grape::Validations::SingleAttributeIterator.new([:a], scope)
+
+      violations = []
+      walk(unfrozen, 'probe', {}.compare_by_identity, violations, Hash.new(0))
+
+      expect(violations).to contain_exactly("probe (#{unfrozen.class})")
+    end
+  end
+end

--- a/spec/grape/validations/types/array_coercer_spec.rb
+++ b/spec/grape/validations/types/array_coercer_spec.rb
@@ -29,5 +29,17 @@ describe Grape::Validations::Types::ArrayCoercer do
         expect(subject.call([['10'], ['20']])).to eq([Set[10], Set[20]])
       end
     end
+
+    context 'when the instance is frozen' do
+      let(:type) { Array[Integer] }
+
+      # Instances are shared across requests (and cached in CoercerCache), so
+      # the element coercer must be built eagerly rather than memoized at call
+      # time. Freezing the instance proves no lazy ivar is written by #call.
+      it 'coerces without creating lazy state' do
+        subject.freeze
+        expect(subject.call(%w[10 20])).to eq([10, 20])
+      end
+    end
   end
 end

--- a/spec/grape/validations/types/custom_type_coercer_spec.rb
+++ b/spec/grape/validations/types/custom_type_coercer_spec.rb
@@ -23,6 +23,17 @@ describe Grape::Validations::Types::CustomTypeCoercer do
           expect(coercer.call('[{"foo":"bar"}]')).to eq(Set[{ foo: 'bar' }])
         end
       end
+
+      context 'when the coercion method returns a frozen array' do
+        let(:type) { Array }
+        let(:coerce_method) { ->(val) { JSON.parse(val).freeze } }
+
+        # The returned array belongs to the user's coercion method and may be
+        # frozen or be the input itself, so symbolization must not mutate it.
+        it 'symbolizes without mutating the returned array' do
+          expect(coercer.call('[{"foo":"bar"}]')).to eq([{ foo: 'bar' }])
+        end
+      end
     end
   end
 end

--- a/spec/grape/validations/types_spec.rb
+++ b/spec/grape/validations/types_spec.rb
@@ -97,5 +97,46 @@ describe Grape::Validations::Types do
       b_coercer = described_class.build_coercer(Array[String])
       expect(a_coercer.object_id).to eq(b_coercer.object_id)
     end
+
+    # Coercer instances are shared across requests, so they must be frozen at
+    # construction — a request-time lazy ivar write would be a data race and
+    # now raises FrozenError instead.
+    describe 'returned coercers are frozen' do
+      [
+        Integer,
+        Array[Integer],
+        Array[Array[Integer]],
+        Set[Integer],
+        JSON,
+        [Integer, String]
+      ].each do |type|
+        it "freezes the coercer for #{type.inspect}" do
+          expect(described_class.build_coercer(type)).to be_frozen
+        end
+      end
+
+      it 'freezes a coercer built around a coerce_with method' do
+        expect(described_class.build_coercer(Integer, method: ->(v) { Integer(v) })).to be_frozen
+      end
+
+      it 'freezes a coercer for a custom type' do
+        custom = Class.new do
+          def self.parse(value)
+            value
+          end
+        end
+        expect(described_class.build_coercer(custom)).to be_frozen
+      end
+
+      it 'freezes a directly-built VariantCollectionCoercer' do
+        expect(Grape::Validations::Types::VariantCollectionCoercer.new([Integer, String])).to be_frozen
+      end
+
+      it 'still coerces through a frozen multiple-type coercer' do
+        coercer = described_class.build_coercer([Integer, String])
+        expect(coercer.call('10')).to eq(10)
+        expect(coercer.call('ten')).to eq('ten')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Two coercers in the types layer created or mutated state at request time on instances that are **shared across requests** — coercers are built once at definition time and cached in `Types::CoercerCache`. Found during the same validation-subsystem audit as #2816. Neither is a hard crash on MRI, but both violate the layer's "no request-time mutable state" contract and one produces a user-visible wrong result.

### 1. `ArrayCoercer` — lazy element coercer built at call time

```ruby
def elem_coercer
  @elem_coercer ||= DryTypeCoercer.coercer_instance_for(subtype, strict:)
end
```

`coerce_elements` calls this per element, so the **first request** to reach a shared coercer instance writes a new ivar, and that first call can also seed `DryTypes::ParamsCache` — a `Grape::Util::Cache` backed by an unsynchronized default-block `Hash`. Same shared-mutable-default-hash shape flagged elsewhere in the codebase. `SetCoercer` subclasses `ArrayCoercer` and inherits the lazy path.

**Fix:** build the element coercer eagerly in `initialize` (renaming the now-redundant `@subtype` ivar to `@elem_coercer`). `SetCoercer` gets the eager build for free via `super`.

### 2. `CustomTypeCoercer` — `map!` on the user's returned collection

```ruby
def collection_symbolizer(method)
  ->(val) { method.call(val).map! { |item| symbolize_if_hash(item) } }
end
```

`method` is the user's `coerce_with` (or a custom type's `parse`). Calling `map!` on its return value mutates an object Grape doesn't own. If that value is **frozen**, `map!` raises `FrozenError`, which `CoerceValidator` catches under its blanket `rescue StandardError` and reports as a spurious `"<param> is invalid"` 400 — even though coercion succeeded.

**Fix:** `dup` before `map!`. `dup` returns an unfrozen shallow copy, so the user's object is never mutated, and — unlike switching to `map` — it **preserves the class**, keeping a `Set` a `Set` (`Set#map` returns an `Array`). The symbolized hashes are fresh (`deep_symbolize_keys`), so nothing shared is touched.

> Note: the first draft of this fix used `map` instead of `dup.map!` and was caught by the existing `CustomTypeCoercer` Set spec — `Set#map` silently downgrades the result to an `Array`. The regression spec added here locks that in.

## Tests

- `array_coercer_spec.rb`: a **frozen coercer instance** still coerces — a deterministic proof that `#call` creates no lazy ivar (a frozen instance with a lazy `||=` would raise `FrozenError`).
- `custom_type_coercer_spec.rb`: a coercion method returning a **frozen array** is symbolized without raising; the existing Set spec continues to assert the `Set` return type is preserved.

No behavioral change for the ordinary (unfrozen, non-shared-contention) paths. Full suite: 2369 examples, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)