### PR TITLE
Add fuzz test for adversarial nesting depth

### DIFF
--- a/spec/grape/validations/adversarial_nesting_depth_spec.rb
+++ b/spec/grape/validations/adversarial_nesting_depth_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+# Fuzz test for adversarial nesting depth.
+#
+# Several validation-runtime paths recurse on the *shape* of the incoming
+# params rather than on anything Grape controls: AttributesIterator#do_each
+# recurses into nested arrays, and coercion/oneof walk nested hashes and
+# arrays. A deeply nested payload is therefore a resource-exhaustion surface.
+#
+# In practice the upstream parsers cap depth long before Grape's own recursion
+# ceiling is reached (Rack::Utils.param_depth_limit for query/form bodies,
+# JSON's max_nesting for JSON bodies), so an over-the-wire request degrades to
+# a controlled 4xx. This spec fuzzes random shapes and depths through every
+# recursive path and asserts the invariant that matters: a request is never
+# answered with a 5xx / uncaught exception, no matter how it is nested.
+#
+# +AttributesIterator+ is the primary recursion site under test; the other
+# paths (Hash/JSON coercion, oneof) are exercised through the same requests.
+describe Grape::Validations::AttributesIterator do
+  describe 'adversarial nesting depth', :aggregate_failures do
+    subject(:app) do
+      Class.new(Grape::API) do
+        format :json
+        # No rescue_from: Grape's own error middleware turns parse/validation
+        # failures into 4xx. Anything Grape does *not* recognise (a genuine
+        # crash such as SystemStackError) propagates instead — surfacing as a
+        # 5xx status or a raised exception that fails the example. Both are
+        # what we hunt.
+
+        params do
+          requires :list, type: Array do
+            requires :name, type: String
+          end
+        end
+        post('/array_scope') { 'ok' }
+
+        params do
+          requires :root, type: Hash do
+            requires :name, type: String
+          end
+        end
+        post('/hash_scope') { 'ok' }
+
+        params do
+          requires :doc, type: JSON do
+            requires :name, type: String
+          end
+        end
+        post('/json_type') { 'ok' }
+
+        params do
+          requires :value, type: Hash, oneof: [proc { requires :x, type: Integer }]
+        end
+        post('/oneof') { 'ok' }
+
+        params do
+          requires :ids, type: Set[Integer]
+        end
+        post('/set_coercion') { 'ok' }
+      end
+    end
+
+    # Deterministic per RSpec seed: a failing run reproduces with --seed <n>.
+    let(:rng) { Random.new(RSpec.configuration.seed) }
+    let(:endpoints) { %w[/array_scope /hash_scope /json_type /oneof /set_coercion] }
+    let(:shapes) { %i[array hash mixed] }
+    let(:leaves) { ['"x"', '1', 'true', '{"name":"x"}', 'null'] }
+
+    # A raw JSON fragment nested +depth+ levels deep in the given shape.
+    def nested_fragment(depth, shape, leaf)
+      case shape
+      when :array then ('[' * depth) + leaf + (']' * depth)
+      when :hash  then ('{"k":' * depth) + leaf + ('}' * depth)
+      else # :mixed — alternate array and hash wrappers
+        frag = leaf
+        depth.times { |i| frag = i.even? ? "[#{frag}]" : %({"k":#{frag}}) }
+        frag
+      end
+    end
+
+    # Build a raw request body targeting +endpoint+ with a payload nested
+    # +depth+ levels deep. The top-level key each endpoint requires is wrapped
+    # around the adversarial fragment.
+    def adversarial_body(endpoint, depth, shape, leaf)
+      fragment = nested_fragment(depth, shape, leaf)
+      case endpoint
+      when '/array_scope'  then %({"list":#{fragment}})
+      when '/hash_scope'   then %({"root":#{fragment}})
+      when '/oneof'        then %({"value":#{fragment}})
+      when '/set_coercion' then %({"ids":#{fragment}})
+      when '/json_type'    then %({"doc":#{fragment.to_json}}) # coerced via JSON.parse
+      end
+    end
+
+    it 'never answers a deeply nested request with a 5xx' do
+      300.times do
+        endpoint = endpoints.sample(random: rng)
+        shape = shapes.sample(random: rng)
+        leaf = leaves.sample(random: rng)
+        # Span both sides of the parser limits: depths <100 actually reach and
+        # exercise Grape's recursion; depths >100 are rejected upstream.
+        depth = rng.rand(1..400)
+        body = adversarial_body(endpoint, depth, shape, leaf)
+
+        post endpoint, body, 'CONTENT_TYPE' => 'application/json'
+
+        expect(last_response.status).to(
+          be < 500,
+          "5xx on #{endpoint} shape=#{shape} depth=#{depth} leaf=#{leaf}: " \
+          "#{last_response.status} #{last_response.body[0, 200]}"
+        )
+      end
+    end
+
+    # Anchored extremes: well past every parser limit and past Grape's own
+    # recursion ceiling, on every endpoint and shape, run regardless of RNG.
+    anchored_endpoints = %w[/array_scope /hash_scope /json_type /oneof /set_coercion]
+    anchored_shapes = %i[array hash mixed]
+
+    [100, 500, 2000].each do |depth|
+      context "at depth #{depth}" do
+        anchored_endpoints.each do |endpoint|
+          anchored_shapes.each do |shape|
+            it "degrades gracefully on #{endpoint} (#{shape})" do
+              body = adversarial_body(endpoint, depth, shape, '{"name":"x"}')
+
+              post endpoint, body, 'CONTENT_TYPE' => 'application/json'
+
+              expect(last_response.status).to be < 500
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a fuzz test that hammers Grape's recursive validation paths with randomly-shaped, deeply-nested payloads and asserts the invariant that matters for a resource-exhaustion surface: **a request is never answered with a 5xx or an uncaught exception, no matter how it is nested.**

This closes the one gap I explicitly flagged as un-covered in the recent validator audit (follow-up to #2814–#2817): the runtime recursion on input *shape*.

## Why nesting depth is a surface

Several validation paths recurse on the structure of the incoming params, not on anything Grape controls:

- `AttributesIterator#do_each` recurses into nested arrays.
- Coercion (`deep_symbolize_keys`) and `oneof` (`deep_dup`) walk nested hashes/arrays.

I measured Grape's intrinsic ceiling by driving `AttributesIterator#do_each` directly with a nested Ruby array: it raises `SystemStackError` at roughly **2000–3000** levels. `SystemStackError` is not a `StandardError`, so nothing in `run_validators` would catch it.

## Why it isn't reachable over HTTP (what the test documents)

The upstream parsers cap depth far below that ceiling, so a real request degrades to a controlled 4xx long before Grape's recursion is stressed:

| Vector | Cap | Result at over-cap depth |
|---|---|---|
| Query / form params | `Rack::Utils.param_depth_limit` (32) | rejected → clean 4xx |
| JSON body | `JSON.parse` `max_nesting` (100) | rejected → clean 4xx |

I verified end-to-end over raw request bytes that every recursive endpoint (`type: Array`/`Hash` scopes, `type: JSON`, `oneof`, `Set` coercion) returns a 4xx at depths of 100, 500, and 2000 — never a 5xx. So the intrinsic ceiling is latent / defense-in-depth, not a live DoS. The fuzz test **pins that guarantee in place**: if a future change lifted a parser cap or introduced unbounded recursion at a reachable depth, it would fail.

## What the test does

- Defines one API with five endpoints, one per recursive path.
- Fuzzes **300** requests: random endpoint × random shape (nested arrays / hashes / alternating) × random leaf × random depth in `1..400` (spanning both sides of the parser caps — depths under ~100 genuinely reach and exercise Grape's recursion).
- Adds **45 anchored** cases (depths 100/500/2000 × 5 endpoints × 3 shapes) so the extremes always run regardless of RNG.
- Asserts every response status is `< 500`.
- The generator is seeded from `RSpec.configuration.seed`, so a failure reproduces deterministically with `--seed <n>` and the message prints the offending `endpoint / shape / depth / leaf`.

I confirmed the test has teeth by temporarily injecting a crash into `do_each` at a shallow, reachable depth — the fuzz loop and anchored cases both caught it.

## Notes

- Pure test addition, no production changes.
- Runs in well under a second (every deep payload is rejected cheaply by the parsers).
- Verified stable across seeds 1, 7, 99, 4242, 88888 and the default randomized run. Full suite: 2413 examples, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)