### PR TITLE
Freeze coercers at construction and synchronize Grape::Util::Cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 * [#2767](https://github.com/ruby-grape/grape/pull/2767): Update rubocop to 1.88.0 and rubocop-rspec to 3.10.2 - [@ericproulx](https://github.com/ericproulx).
 * [#2817](https://github.com/ruby-grape/grape/pull/2817): Remove request-time mutable state from Array and custom-type coercers - [@ericproulx](https://github.com/ericproulx).
+* [#2819](https://github.com/ruby-grape/grape/pull/2819): Freeze coercers at construction, synchronize `Grape::Util::Cache` lookups, and assign `Route#regexp_capture_index` eagerly - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.4 (2026-07-25)

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'logger'
+require 'monitor'
 require 'active_support'
 require 'active_support/isolated_execution_state'
 require 'active_support/core_ext/array/conversions' # to_xml

--- a/lib/grape/router/base_route.rb
+++ b/lib/grape/router/base_route.rb
@@ -22,16 +22,17 @@ module Grape
         @settings = settings
       end
 
-      def regexp_capture_index
-        @regexp_capture_index ||= CaptureIndexCache[@index]
-      end
+      # Assigned eagerly in {#to_regexp} (router compilation) rather than
+      # memoized here: this reader is called from request-time route matching
+      # on instances shared across threads, so it must not write state.
+      attr_reader :regexp_capture_index
 
       def pattern_regexp
         @pattern.to_regexp
       end
 
       def to_regexp(index)
-        @index = index
+        @regexp_capture_index = CaptureIndexCache[index]
         Regexp.new("(?<#{regexp_capture_index}>#{pattern_regexp})")
       end
 

--- a/lib/grape/util/cache.rb
+++ b/lib/grape/util/cache.rb
@@ -2,16 +2,35 @@
 
 module Grape
   module Util
+    # Base class for the lazily-filled lookup caches (coercers, dry-types,
+    # path parts, ...). Subclasses assign a default-block +Hash+ to +@cache+
+    # in their +initialize+.
+    #
+    # Lookups are synchronized: caches are written at API *definition* time
+    # (a +params+ block runs when the class body is evaluated), which is not
+    # covered by the compile-time +Grape::API::Instance::LOCK+ and can happen
+    # concurrently — e.g. parallel eager loading, or two threads autoloading
+    # different API files. A +Monitor+ (reentrant) rather than a +Mutex+,
+    # because a cache miss may re-enter the same cache: building a
+    # multiple-type coercer through +Types::CoercerCache+ builds its member
+    # coercers through +Types.build_coercer+, which lands in the same cache.
     class Cache
       include Singleton
 
       attr_reader :cache
 
+      def initialize
+        @monitor = Monitor.new
+      end
+
+      def [](key)
+        @monitor.synchronize { @cache[key] }
+      end
+
       class << self
         extend Forwardable
 
-        def_delegators :cache, :[]
-        def_delegators :instance, :cache
+        def_delegators :instance, :[], :cache
       end
     end
   end

--- a/lib/grape/util/deep_freeze.rb
+++ b/lib/grape/util/deep_freeze.rb
@@ -10,9 +10,8 @@ module Grape
       #
       # Intentionally left unfrozen:
       #   - Procs / lambdas — may be deferred DB-backed callables
-      #   - Coercers (e.g. ArrayCoercer) — use lazy ivar memoization at request time
       #   - Classes / Modules — shared constants that must remain open
-      #   - ParamsScope — self-freezes at the end of its own initialize
+      #   - Coercers and ParamsScope — self-freeze at construction
       def deep_freeze(obj)
         case obj
         when Hash

--- a/lib/grape/util/freeze_on_new.rb
+++ b/lib/grape/util/freeze_on_new.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Grape
+  module Util
+    # Extend into a class whose instances are shared across requests:
+    # +new+ returns a frozen instance, so any later ivar write — e.g.
+    # request-time memoization — raises FrozenError instead of being a
+    # latent data race.
+    #
+    # Must stay a +new+ wrapper (never an +initialize+ wrapper): the freeze
+    # runs after the entire initialize chain, so subclasses may assign ivars
+    # after +super+. Extending a hierarchy base covers its subclasses —
+    # singleton classes inherit along the class hierarchy.
+    module FreezeOnNew
+      def new(...)
+        super.freeze
+      end
+    end
+  end
+end

--- a/lib/grape/validations/types/custom_type_coercer.rb
+++ b/lib/grape/validations/types/custom_type_coercer.rb
@@ -33,6 +33,8 @@ module Grape
       # contract as +coerced?+, and must be supplied with a coercion
       # +method+.
       class CustomTypeCoercer
+        extend Grape::Util::FreezeOnNew
+
         TYPE_CHECK_METHODS = %i[coerced? parsed?].freeze
         COLLECTION_TYPES = [Array, Set].freeze
         private_constant :TYPE_CHECK_METHODS, :COLLECTION_TYPES

--- a/lib/grape/validations/types/dry_type_coercer.rb
+++ b/lib/grape/validations/types/dry_type_coercer.rb
@@ -8,6 +8,8 @@ module Grape
       # but check its type. More information there
       # https://dry-rb.org/gems/dry-types/main/built-in-types/
       class DryTypeCoercer
+        extend Grape::Util::FreezeOnNew
+
         class << self
           # Returns a collection coercer which corresponds to a given type.
           # Example:

--- a/lib/grape/validations/types/multiple_type_coercer.rb
+++ b/lib/grape/validations/types/multiple_type_coercer.rb
@@ -13,6 +13,8 @@ module Grape
       # an allowed type it should be declared last, since it will always
       # successfully "coerce" the value.
       class MultipleTypeCoercer
+        extend Grape::Util::FreezeOnNew
+
         # Construct a new coercer that will attempt to coerce
         # values to the given list of types in the given order.
         #
@@ -28,7 +30,7 @@ module Grape
             else
               Types.build_coercer type, strict: !@method.nil?
             end
-          end
+          end.freeze
         end
 
         # Coerces the given value.

--- a/lib/grape/validations/types/variant_collection_coercer.rb
+++ b/lib/grape/validations/types/variant_collection_coercer.rb
@@ -6,6 +6,8 @@ module Grape
       # This class wraps {MultipleTypeCoercer}, for use with collections
       # that allow members of more than one type.
       class VariantCollectionCoercer
+        extend Grape::Util::FreezeOnNew
+
         # Construct a new coercer that will attempt to coerce
         # a list of values such that all members are of one of
         # the given types. The container may also optionally be

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -13,6 +13,7 @@ module Grape
       # (e.g. +memoize+, <tt>||=</tt>) will raise +FrozenError+ at request time.
       class Base
         extend Forwardable
+        extend Grape::Util::FreezeOnNew
         include Grape::Util::Translation
 
         attr_reader :attrs
@@ -43,10 +44,6 @@ module Grape
             else
               @default_message_key || (superclass.respond_to?(:default_message_key) ? superclass.default_message_key : nil)
             end
-          end
-
-          def new(...)
-            super.freeze
           end
 
           def inherited(klass)

--- a/lib/grape/validations/validators/contract_scope_validator.rb
+++ b/lib/grape/validations/validators/contract_scope_validator.rb
@@ -4,11 +4,12 @@ module Grape
   module Validations
     module Validators
       class ContractScopeValidator
+        extend Grape::Util::FreezeOnNew
+
         attr_reader :schema
 
         def initialize(schema:)
           @schema = schema
-          freeze
         end
 
         # Validates a given request.

--- a/spec/grape/router/route_spec.rb
+++ b/spec/grape/router/route_spec.rb
@@ -21,6 +21,20 @@ RSpec.describe Grape::Router::Route do
     it { is_expected.to be_a(Grape::Router::BaseRoute) }
   end
 
+  describe '#regexp_capture_index' do
+    subject(:route) { described_class.new(endpoint, :get, pattern, options, forward_match: false) }
+
+    # The reader is called from request-time route matching on instances
+    # shared across threads, so it must be assigned during #to_regexp
+    # (router compilation), never lazily at read time. Freezing the route
+    # proves no ivar is written after compilation.
+    it 'is assigned eagerly by #to_regexp and readable on a frozen route' do
+      route.to_regexp(3)
+      route.freeze
+      expect(route.regexp_capture_index).to eq('_3')
+    end
+  end
+
   describe 'metadata attributes (namespace, prefix, settings)' do
     subject(:route) do
       described_class.new(endpoint, :get, pattern, options, forward_match: false,

--- a/spec/grape/util/cache_spec.rb
+++ b/spec/grape/util/cache_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe Grape::Util::Cache do
+  describe 'synchronized lookup' do
+    it 'computes each key once and returns consistent values across threads' do
+      # The default block runs while the monitor is held, so this plain
+      # counter is race-free by construction.
+      computations = []
+      cache_class = Class.new(described_class) do
+        define_method(:initialize) do
+          super()
+          @cache = Hash.new do |h, key|
+            computations << key
+            h[key] = "computed-#{key}"
+          end
+        end
+      end
+
+      results = Array.new(8) { Thread.new { cache_class.instance['k'] } }.map(&:value)
+
+      expect(results).to all(eq('computed-k'))
+      expect(computations).to eq(['k'])
+    end
+
+    it 'supports reentrant lookups from within a default block' do
+      # Types::CoercerCache re-enters itself: a multiple-type coercer builds
+      # its member coercers through Types.build_coercer, which lands in the
+      # same cache. A non-reentrant lock would deadlock here.
+      expect(Grape::Validations::Types.build_coercer([Integer, Float, String])).to be_frozen
+    end
+  end
+end

--- a/spec/grape/util/freeze_on_new_spec.rb
+++ b/spec/grape/util/freeze_on_new_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe Grape::Util::FreezeOnNew do
+  let(:base) do
+    Class.new do
+      extend Grape::Util::FreezeOnNew
+
+      attr_reader :a
+
+      def initialize
+        @a = 1
+      end
+    end
+  end
+
+  it 'returns frozen instances from new' do
+    expect(base.new).to be_frozen
+  end
+
+  it 'covers subclasses through singleton-class inheritance' do
+    expect(Class.new(base).new).to be_frozen
+  end
+
+  it 'freezes only after the whole initialize chain, so subclasses may assign ivars after super' do
+    subclass = Class.new(base) do
+      attr_reader :b
+
+      def initialize
+        super
+        @b = 2
+      end
+    end
+
+    instance = subclass.new
+    expect(instance).to be_frozen
+    expect(instance.a).to eq(1)
+    expect(instance.b).to eq(2)
+  end
+end

--- a/spec/grape/validations/types_spec.rb
+++ b/spec/grape/validations/types_spec.rb
@@ -97,5 +97,46 @@ describe Grape::Validations::Types do
       b_coercer = described_class.build_coercer(Array[String])
       expect(a_coercer.object_id).to eq(b_coercer.object_id)
     end
+
+    # Coercer instances are shared across requests, so they must be frozen at
+    # construction — a request-time lazy ivar write would be a data race and
+    # now raises FrozenError instead.
+    describe 'returned coercers are frozen' do
+      [
+        Integer,
+        Array[Integer],
+        Array[Array[Integer]],
+        Set[Integer],
+        JSON,
+        [Integer, String]
+      ].each do |type|
+        it "freezes the coercer for #{type.inspect}" do
+          expect(described_class.build_coercer(type)).to be_frozen
+        end
+      end
+
+      it 'freezes a coercer built around a coerce_with method' do
+        expect(described_class.build_coercer(Integer, method: ->(v) { Integer(v) })).to be_frozen
+      end
+
+      it 'freezes a coercer for a custom type' do
+        custom = Class.new do
+          def self.parse(value)
+            value
+          end
+        end
+        expect(described_class.build_coercer(custom)).to be_frozen
+      end
+
+      it 'freezes a directly-built VariantCollectionCoercer' do
+        expect(Grape::Validations::Types::VariantCollectionCoercer.new([Integer, String])).to be_frozen
+      end
+
+      it 'still coerces through a frozen multiple-type coercer' do
+        coercer = described_class.build_coercer([Integer, String])
+        expect(coercer.call('10')).to eq(10)
+        expect(coercer.call('ten')).to eq('ten')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Thread-safety hardening for the coercion layer, following the validation-subsystem audit (#2816/#2817). Three changes, one theme: make shared state provably read-only after construction, and synchronize the one write path that genuinely can run concurrently.

> **Stacked on #2817** (`fix-coercer-request-time-state`) — the coercer freeze depends on its eager `@elem_coercer` build; freezing on top of master's lazy `||=` would raise `FrozenError` at request time. GitHub will retarget this PR to `master` automatically once #2817 merges. Also merges cleanly with #2814's `VariantCollectionCoercer` change (disjoint hunks).

### 1. Coercers freeze at construction — via a named `Grape::Util::FreezeOnNew` module

Validators have had this guarantee for a while (`Base.new` → `super.freeze`); coercers — equally shared across requests and additionally cached process-wide in `Types::CoercerCache` — did not. The blocker is even documented in `DeepFreeze`'s comment: *"Coercers (e.g. ArrayCoercer) — use lazy ivar memoization at request time"*. #2817 removed that memoization, so the exclusion is obsolete.

The idiom now has a name instead of five hand-written copies:

```ruby
module Grape::Util::FreezeOnNew
  def new(...)
    super.freeze
  end
end
```

`extend Grape::Util::FreezeOnNew` is declared on each hierarchy base — `DryTypeCoercer` (covers Primitive/Array/Set via singleton-class inheritance), `CustomTypeCoercer` (covers the collection subclass), `MultipleTypeCoercer` (whose internal `@type_coercers` array is also frozen), and `VariantCollectionCoercer`. `Validators::Base`'s hand-written `new`/`super.freeze` and `ContractScopeValidator`'s end-of-`initialize` `freeze` are converted to the same declaration, so **a grep for `FreezeOnNew` now enumerates every class with the immutability guarantee**.

The module deliberately wraps `new`, never `initialize`: the freeze lands **after the full subclass initialize chain** — `SetCoercer` assigns `@coercer = nil` after `super`, which an initialize-wrapper would break. The freeze is shallow: user-supplied `coerce_with` procs and custom type classes are never frozen.

Payoff: any future request-time `||=` in a coercer becomes a deterministic `FrozenError` in the first spec run instead of a latent JRuby race. The full suite passing with every coercer frozen is itself the proof that no hidden mutation remains.

### 2. `Grape::Util::Cache` lookups are Monitor-synchronized

The compile-time `Instance::LOCK` serializes everything written during `Instance.new` — but the validation caches (`CoercerCache`, `DryTypes::ParamsCache`/`StrictCache`) are written at API **definition** time: a `params` block runs when the class body is evaluated, outside any lock. Two non-exotic scenarios make that concurrent:

- **Parallel eager loading** (Rails 7+ eager loads in parallel in production) — two files defining Grape endpoints load on different threads, both writing `CoercerCache`.
- **Dev-mode lazy autoload under a threaded server** — two concurrent first requests autoload two different API files (Ruby's require lock is per-feature).

On MRI the GVL makes this benign; on JRuby/TruffleRuby (in the edge CI matrix) concurrent unsynchronized `Hash` writes can corrupt or raise. One `Monitor` in the base class covers all eight cache subclasses. **Monitor rather than Mutex** because `CoercerCache` re-enters itself: building a `MultipleTypeCoercer` calls `Types.build_coercer` per member type, which lands back in the same cache — a non-reentrant lock would deadlock (there's a spec pinning exactly this path). Overhead is an uncontended lock on boot-frequency lookups; the caches are never read on the hot request path.

### 3. `Route#regexp_capture_index` assigned eagerly

`base_route.rb` had `@regexp_capture_index ||= CaptureIndexCache[@index]` — a lazy memo on shared `Route` instances **reached from request-time route matching** (`router.rb` optimized/greedy match). It was safe only by side effect: `to_regexp` happened to call it during router compilation, warming it before any request. Same fragile shape as the pre-#2817 `ArrayCoercer`. The index is now assigned directly in `to_regexp` (where `@index` was already being stored — that ivar is gone), the reader is a plain `attr_reader`, and the request path is provably read-only. This also clears the way for freezing `Route` instances entirely later.

## Tests

- `types_spec.rb`: every coercer shape (`Integer`, `Array[Integer]`, nested `Array[Array[Integer]]`, `Set[Integer]`, `JSON`, multiple `[Integer, String]`, `coerce_with` method, custom type, direct `VariantCollectionCoercer`) returns frozen from `build_coercer`, and a frozen multiple-type coercer still coerces.
- New `spec/grape/util/cache_spec.rb`: 8 threads racing a cold key compute it exactly once with consistent results; the reentrant `CoercerCache` path completes (deadlock regression guard).
- `route_spec.rb`: `regexp_capture_index` readable on a **frozen** route after `to_regexp` — proof no ivar is written after compilation.
- New `spec/grape/util/freeze_on_new_spec.rb`: pins the module's two load-bearing properties — subclass coverage via singleton-class inheritance, and freezing only after the whole initialize chain (subclasses may assign ivars after `super`).

Full suite: 2385 examples, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
