### PR TITLE
Add Layer-1 thread-safety invariant specs

### DIFF
--- a/spec/grape/util/cache_spec.rb
+++ b/spec/grape/util/cache_spec.rb
@@ -29,4 +29,59 @@ RSpec.describe Grape::Util::Cache do
       expect(Grape::Validations::Types.build_coercer([Integer, Float, String])).to be_frozen
     end
   end
+
+  # Layer-1 thread-safety invariant: every Grape::Util::Cache is written only
+  # while an API is defined and compiled — never at request time. Requests
+  # against shared, unsynchronized-read caches are safe *because* they are
+  # read-only; this pins that property. It would have caught the pre-#2817
+  # ArrayCoercer seeding DryTypes::ParamsCache on the first request.
+  describe 'boot-only growth' do
+    let(:app) do
+      Class.new(Grape::API) do
+        format :json
+
+        params do
+          requires :id, type: Integer
+          optional :ids, type: Array[Integer]
+          optional :tags, type: Set[Integer]
+          optional :multi, type: [Integer, String]
+          optional :state, type: String, values: %w[a b], default: 'a'
+        end
+        get('/lookup') { 'ok' }
+
+        params do
+          requires :doc, type: JSON do
+            requires :name, type: String
+          end
+          optional :variant, type: Hash, oneof: [proc { requires :x, type: Integer }]
+        end
+        post('/nested') { 'ok' }
+      end
+    end
+
+    it 'no cache gains keys after the API is compiled' do
+      # Boot fully — definition already happened (params blocks ran when the
+      # class body evaluated); compile! builds routes, patterns and the
+      # router, which warms the remaining caches.
+      app.compile!
+      before = described_class.subclasses.to_h { |cache| [cache, cache.cache.keys.dup] }
+
+      # First-ever requests happen only now, so any first-request cache write
+      # shows up as growth: valid, invalid, wrong-shape, unmatched-path and
+      # unrouted-method traffic.
+      mr = Rack::MockRequest.new(app)
+      mr.get('/lookup?id=1&ids[]=2&tags[]=3&multi[]=4&state=a')
+      mr.get('/lookup?id=nope&multi[]=x')
+      mr.post('/nested', input: '{"doc":{"name":"n"},"variant":{"x":1}}', 'CONTENT_TYPE' => 'application/json')
+      mr.post('/nested', input: '{"doc":["wrong shape"],"variant":{"y":2}}', 'CONTENT_TYPE' => 'application/json')
+      mr.get('/unmatched')
+      mr.request('OPTIONS', '/lookup')
+      mr.request('PATCH', '/lookup?id=1')
+
+      described_class.subclasses.each do |cache|
+        expect(cache.cache.keys).to match_array(before.fetch(cache, [])),
+                                    "#{cache} gained keys at request time"
+      end
+    end
+  end
 end

--- a/spec/grape/validations/frozen_validation_graph_spec.rb
+++ b/spec/grape/validations/frozen_validation_graph_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+# Layer-1 thread-safety invariant: the validation object graph shared across
+# requests is immutable. Validators, their iterators, params scopes and
+# coercers all freeze at construction (see Grape::Util::FreezeOnNew), so a
+# request-time ivar write raises FrozenError deterministically instead of
+# being a latent data race.
+#
+# This spec enforces the contract structurally: it walks every object
+# reachable from the compiled routes' validator lists and asserts that each
+# instance of a contract class is frozen — catching classes that never
+# adopted the freeze contract, not just regressions in those that did.
+RSpec.describe Grape::Validations do
+  describe 'frozen shared validation graph' do
+    let(:custom_type) do
+      Class.new do
+        def self.parse(value)
+          value.to_s
+        end
+      end
+    end
+
+    # One API touching every validator and coercer shape, so the walk sweeps
+    # the whole taxonomy: primitive/array/set/nested/multiple/variant/custom
+    # coercers, every stock validator, oneof variants, lateral (given) and
+    # nested scopes.
+    let(:app) do
+      ct = custom_type
+      Class.new(Grape::API) do
+        format :json
+
+        params do
+          requires :id, type: Integer
+          optional :ids, type: Array[Integer]
+          optional :matrix, type: Array[Array[Integer]]
+          optional :tags, type: Set[Integer]
+          optional :multi, type: [Integer, String]
+          optional :kinds, types: [Integer, String]
+          optional :custom, type: ct
+          optional :customs, type: Array[ct]
+          optional :stripped, type: String, coerce_with: lambda(&:strip)
+          optional :state, type: String, values: %w[a b], default: 'a'
+          optional :lazy, type: Integer, values: -> { [1, 2] }
+          optional :not_these, type: Integer, except_values: [99]
+          optional :code, type: String, regexp: /\A[a-z]+\z/, length: { min: 1, max: 10 }
+          optional :pw, type: String
+          optional :pw2, type: String, same_as: :pw, allow_blank: false
+          mutually_exclusive :custom, :stripped
+          at_least_one_of :id, :ids
+        end
+        post('/all') { 'ok' }
+
+        params do
+          requires :doc, type: JSON do
+            requires :name, type: String
+          end
+          requires :root, type: Hash do
+            requires :inner, type: Array do
+              requires :leaf, type: String
+            end
+          end
+          optional :variant, type: Hash, oneof: [
+            proc { requires :x, type: Integer },
+            proc { requires :y, type: String }
+          ]
+          optional :mode, type: String
+          given :mode do
+            requires :detail, type: String
+          end
+        end
+        post('/nested') { 'ok' }
+      end
+    end
+
+    # Classes whose instances are shared across requests and must be frozen.
+    def frozen_contract_classes
+      [
+        Grape::Validations::Validators::Base,
+        Grape::Validations::Validators::ContractScopeValidator,
+        Grape::Validations::AttributesIterator,
+        Grape::Validations::ParamsScope,
+        Grape::Validations::Types::DryTypeCoercer,
+        Grape::Validations::Types::CustomTypeCoercer,
+        Grape::Validations::Types::MultipleTypeCoercer,
+        Grape::Validations::Types::VariantCollectionCoercer
+      ]
+    end
+
+    # Walks ivars and collection members. Skips value types, callables
+    # (user-supplied procs are deliberately unfrozen), open classes/modules,
+    # and dry-types internals (external library, outside grape's contract).
+    def walk(obj, path, seen, violations, census)
+      case obj
+      when Module, Proc, Method, UnboundMethod, Symbol, Numeric, Range, Regexp, true, false, nil
+        return
+      end
+      return if obj.class.name&.start_with?('Dry::')
+      return if seen.key?(obj)
+
+      seen[obj] = true
+      if frozen_contract_classes.any? { |klass| obj.is_a?(klass) }
+        census[obj.class] += 1
+        violations << "#{path} (#{obj.class})" unless obj.frozen?
+      end
+      walk_members(obj, path, seen, violations, census)
+    end
+
+    def walk_members(obj, path, seen, violations, census)
+      case obj
+      when Hash
+        obj.each do |k, v|
+          walk(k, "#{path}.key(#{k.inspect[0, 30]})", seen, violations, census)
+          walk(v, "#{path}[#{k.inspect[0, 30]}]", seen, violations, census)
+        end
+      when Array, Set
+        obj.each_with_index { |e, i| walk(e, "#{path}[#{i}]", seen, violations, census) }
+      else
+        obj.instance_variables.each do |ivar|
+          walk(obj.instance_variable_get(ivar), "#{path}.#{ivar}", seen, violations, census)
+        end
+      end
+    end
+
+    def walk_route_validations(api)
+      violations = []
+      census = Hash.new(0)
+      seen = {}.compare_by_identity
+      api.endpoints.each_with_index do |endpoint, i|
+        Array(endpoint.inheritable_setting.route[:validations]).each_with_index do |validator, j|
+          walk(validator, "endpoint[#{i}].validator[#{j}]", seen, violations, census)
+        end
+      end
+      [violations, census]
+    end
+
+    it 'freezes every validator, iterator, scope and coercer reachable from the routes' do
+      violations, census = walk_route_validations(app)
+
+      expect(violations).to be_empty, "unfrozen shared objects:\n  #{violations.join("\n  ")}"
+
+      # The walk must actually have swept the taxonomy — an empty walk would
+      # pass vacuously. Presence of these classes proves coverage, including
+      # oneof variant validators reached through nested walking.
+      expect(census.keys).to include(
+        Grape::Validations::Validators::PresenceValidator,
+        Grape::Validations::Validators::CoerceValidator,
+        Grape::Validations::Validators::ValuesValidator,
+        Grape::Validations::Validators::OneofValidator,
+        Grape::Validations::Validators::MutuallyExclusiveValidator,
+        Grape::Validations::SingleAttributeIterator,
+        Grape::Validations::MultipleAttributesIterator,
+        Grape::Validations::ParamsScope,
+        Grape::Validations::Types::PrimitiveCoercer,
+        Grape::Validations::Types::ArrayCoercer,
+        Grape::Validations::Types::SetCoercer,
+        Grape::Validations::Types::CustomTypeCoercer,
+        Grape::Validations::Types::CustomTypeCollectionCoercer,
+        Grape::Validations::Types::MultipleTypeCoercer,
+        Grape::Validations::Types::VariantCollectionCoercer
+      )
+    end
+
+    it 'reports an unfrozen contract instance (walker self-test)' do
+      scope = app.endpoints.first.inheritable_setting.route[:validations].first.__send__(:scope)
+      unfrozen = Grape::Validations::SingleAttributeIterator.new([:a], scope)
+
+      violations = []
+      walk(unfrozen, 'probe', {}.compare_by_identity, violations, Hash.new(0))
+
+      expect(violations).to contain_exactly("probe (#{unfrozen.class})")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Test-only PR adding the two deterministic invariant tests from the thread-safety plan ("Layer 1") — the follow-up to #2819. Instead of trying to *observe* races with threads (which the GVL hides on MRI), these make the invariants that prevent races **fail loudly and deterministically** when violated. Zero timing sensitivity, zero flakiness.

> **Stacked on #2819** (`freeze-coercers-and-sync-caches`): the frozen-graph assertions require `FreezeOnNew`, and the cache spec file this extends was introduced there. Retargets automatically as the stack merges.

### 1. Frozen-graph canary (`spec/grape/validations/frozen_validation_graph_spec.rb`)

Builds one API touching the full taxonomy — every stock validator, primitive/array/set/nested-array/multiple/variant/custom coercers, `oneof` variants, nested and lateral (`given`) scopes — then **walks every object reachable from the compiled routes' validator lists** and asserts each instance of a contract class (validators, iterators, `ParamsScope`, all coercer hierarchies) is frozen.

Design notes:

- The walker recurses through ivars, hashes, arrays and sets, skipping value types, callables (user-supplied procs are deliberately unfrozen), open classes/modules, and `Dry::` internals (external library, outside grape's contract). Cycle-safe via an identity-keyed seen set.
- It asserts frozenness **by reachability, not by roster** — a future shared class that never adopts `FreezeOnNew` fails this spec, which is stronger than re-testing the classes that already opted in.
- A **census assertion** requires the walk to have visited 15 specific classes (including `oneof` variant validators reached through nesting and `MultipleAttributesIterator`) — so the spec can't pass vacuously by walking nothing. The prototype run visits ~276 objects.
- A **walker self-test** feeds it a deliberately unfrozen iterator and asserts the violation is reported — the canary's own smoke detector.

### 2. Cache growth canary (in `spec/grape/util/cache_spec.rb`)

Snapshots every `Grape::Util::Cache` subclass's key set after definition + `compile!`, then fires **first-ever** requests — valid, invalid, wrong-shape payloads, unmatched path (404), `OPTIONS`, and un-routed `PATCH` (405) — and asserts no cache gained a key.

This pins the property that makes the caches' unsynchronized reads safe: **they are written only at boot**. #2819's Monitor makes concurrent writes safe; this spec ensures request-time writes don't (re)appear silently. It would have caught the pre-#2817 `ArrayCoercer` lazily seeding `DryTypes::ParamsCache` on the first request. Discovered via `Class#subclasses`, so future caches are covered automatically.

## Results

Both canaries pass on first run against the current stack — independent confirmation that #2816–#2819 left no request-time mutation in the validation layer, including on error/404/405 paths.

Full suite: 2388 examples, 0 failures. RuboCop clean. No CHANGELOG entry (test-only, matching #2818's precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)