### PR TITLE
Fix cascaded routes leaking routing args into the next matched route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [#2815](https://github.com/ruby-grape/grape/pull/2815): Fix line-anchored regexes: `type: JSON` payloads containing a blank line were silently coerced to `nil` - [@ericproulx](https://github.com/ericproulx).
 * [#2817](https://github.com/ruby-grape/grape/pull/2817): Remove request-time mutable state from Array and custom-type coercers - [@ericproulx](https://github.com/ericproulx).
 * [#2819](https://github.com/ruby-grape/grape/pull/2819): Freeze coercers at construction, synchronize `Grape::Util::Cache` lookups, and assign `Route#regexp_capture_index` eagerly - [@ericproulx](https://github.com/ericproulx).
+* [#2824](https://github.com/ruby-grape/grape/pull/2824): Fix cascaded routes (`X-Cascade: pass`) leaking `route_info` and path captures into the next matched route's `route` and `params` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.4 (2026-07-25)

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -126,10 +126,14 @@ module Grape
       !cascade
     end
 
+    # Routing args are rebuilt for every attempt: when a route cascades
+    # (X-Cascade pass), the next candidate must not observe the previous
+    # attempt's +route_info+ or path captures.
     def process_route(route, input, env, include_allow_header: false)
       route_params = route.params_for(input)
-      env[Grape::Env::GRAPE_ROUTING_ARGS] ||= { route_info: route }
-      env[Grape::Env::GRAPE_ROUTING_ARGS].merge!(route_params) if route_params.present?
+      routing_args = { route_info: route }
+      routing_args.merge!(route_params) if route_params.present?
+      env[Grape::Env::GRAPE_ROUTING_ARGS] = routing_args
       env[Grape::Env::GRAPE_ALLOWED_METHODS] = route.allow_header if include_allow_header
       route.call(env)
     end

--- a/spec/grape/router_spec.rb
+++ b/spec/grape/router_spec.rb
@@ -48,4 +48,39 @@ describe Grape::Router do
       expect(status).to eq(404)
     end
   end
+
+  # Regression: routing args were seeded once (`||=`) and merged in place, so
+  # when a route cascaded (X-Cascade pass) the next candidate still saw the
+  # previous attempt's :route_info and path captures.
+  describe 'routing args across cascading routes' do
+    let(:app) do
+      v2 = Class.new(Grape::API) do
+        version 'v2', using: :header, vendor: 'grape', cascade: true
+        get ':id' do
+          { from: 'v2' }
+        end
+      end
+      v1 = Class.new(Grape::API) do
+        format :json
+        version 'v1', using: :header, vendor: 'grape'
+        get ':name' do
+          { origin: route.origin, params: params.to_h }
+        end
+      end
+      Class.new(Grape::API) do
+        format :json
+        mount v2
+        mount v1
+      end
+    end
+
+    it 'does not leak route_info or path captures from a cascaded attempt' do
+      get '/123', {}, 'HTTP_ACCEPT' => 'application/vnd.grape-v1+json'
+
+      expect(last_response.status).to eq(200)
+      body = JSON.parse(last_response.body)
+      expect(body['origin']).to eq('/:name')
+      expect(body['params']).to eq('name' => '123')
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`Grape::Router#process_route` seeds the routing args once and then merges every subsequent attempt's captures into the same Hash:

```ruby
env[Grape::Env::GRAPE_ROUTING_ARGS] ||= { route_info: route }
env[Grape::Env::GRAPE_ROUTING_ARGS].merge!(route_params) if route_params.present?
```

When a matched route responds with `X-Cascade: pass` (the canonical case: header/accept-version versioning with `cascade: true`), `#rotation` (and the `'*'`-method fallback in `#transaction`) tries the next candidate route — but `process_route` runs again on an env whose routing args were already populated by the failed attempt. Because of the `||=`, two things go wrong for the route that ultimately serves the request:

* **`:route_info` still points at the first (cascaded) route.** The `route` helper inside the endpoint returns the wrong route, and `ErrorFormatter::Base#present` resolves `http_codes` entity presenters from the wrong route's metadata.
* **The failed attempt's path captures merge into `params`.** Any capture name the winning route doesn't declare survives the merge and shows up in the endpoint's `params`.

### Reproduction

```ruby
v2 = Class.new(Grape::API) do
  version 'v2', using: :header, vendor: 'grape', cascade: true
  get ':id' { { from: 'v2' } }
end
v1 = Class.new(Grape::API) do
  format :json
  version 'v1', using: :header, vendor: 'grape'
  get ':name' { { origin: route.origin, params: params.to_h } }
end
app = Class.new(Grape::API) { mount v2; mount v1 }
```

`GET /123` with `Accept: application/vnd.grape-v1+json` — the v2 route matches first, its versioner cascades, and the v1 endpoint then responds with:

```json
{"origin":"/:id","params":{"id":"123","name":"123"}}
```

`route.origin` belongs to the v2 route it never ran, and `params[:id]` is a capture the v1 route never declared. Expected (and after this fix):

```json
{"origin":"/:name","params":{"name":"123"}}
```

## Fix

Build a fresh `{ route_info: route }.merge(route_params)` on every `process_route` call. The router is the only writer of `env['grape.routing_args']` (readers: `Grape::Request#make_params`, the `route` helper, and `ErrorFormatter::Base`), so resetting per attempt is safe — including for the greedy OPTIONS/405 helper routes, whose `params_for` yields no captures and which previously ran with an unset or unrelated args Hash anyway.

This behavior predates the recent router refactors — the `||=`/seed-once shape goes back through #2754, #2689 and #2636 to the original `make_routing_args(default_args || { route_info: route })`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)