### PR TITLE
Stop entity autodetection from picking up a top-level ::Entity constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * [#2817](https://github.com/ruby-grape/grape/pull/2817): Remove request-time mutable state from Array and custom-type coercers - [@ericproulx](https://github.com/ericproulx).
 * [#2819](https://github.com/ruby-grape/grape/pull/2819): Freeze coercers at construction, synchronize `Grape::Util::Cache` lookups, and assign `Route#regexp_capture_index` eagerly - [@ericproulx](https://github.com/ericproulx).
 * [#2824](https://github.com/ruby-grape/grape/pull/2824): Fix cascaded routes (`X-Cascade: pass`) leaking `route_info` and path captures into the next matched route's `route` and `params` - [@ericproulx](https://github.com/ericproulx).
+* [#2825](https://github.com/ruby-grape/grape/pull/2825): Stop `present` entity autodetection from picking up a top-level `::Entity` constant - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.4 (2026-07-25)

--- a/lib/grape/dsl/entity.rb
+++ b/lib/grape/dsl/entity.rb
@@ -45,7 +45,8 @@ module Grape
       # Attempt to locate the Entity class for a given object, if not given
       # explicitly. This is done by looking for the presence of Klass::Entity,
       # where Klass is the class of the `object` parameter, or one of its
-      # ancestors.
+      # ancestors. Object is excluded from the search: top-level constants
+      # live on it, so a global ::Entity class is not a representer.
       # @param object [Object] the object to locate the Entity class for
       # @return [Class] the located Entity class, or nil if none is found
       def entity_class_for_obj(object)
@@ -57,9 +58,10 @@ module Grape
           return representations[potential] if potential && representations[potential]
         end
 
-        return unless klass.const_defined?(:Entity)
+        owner = klass.ancestors.detect { |ancestor| ancestor != Object && ancestor.const_defined?(:Entity, false) }
+        return unless owner
 
-        entity = klass.const_get(:Entity)
+        entity = owner.const_get(:Entity, false)
         entity if entity.respond_to?(:represent)
       end
 

--- a/spec/integration/grape_entity/entity_spec.rb
+++ b/spec/integration/grape_entity/entity_spec.rb
@@ -133,6 +133,19 @@ describe 'Grape::Entity', if: defined?(Grape::Entity) do
       expect(last_response.body).to eq('Auto-detect!')
     end
 
+    it 'autodetection does not use a top-level ::Entity constant' do
+      some_model = Class.new
+      entity = Class.new(Grape::Entity)
+      stub_const('Entity', entity)
+
+      subject.get '/example' do
+        present some_model.new
+      end
+
+      expect(entity).not_to receive(:represent)
+      get '/example'
+    end
+
     it 'autodetection does not use Entity if it is not a presenter' do
       some_model = Class.new
       entity = Class.new


### PR DESCRIPTION
## Problem

`Grape::DSL::Entity#entity_class_for_obj` auto-detects a presenter with:

```ruby
return unless klass.const_defined?(:Entity)
entity = klass.const_get(:Entity)
```

`const_defined?` with the default `inherit: true` walks the full ancestor chain — including `Object`, which is where Ruby stores top-level constants. So if an application defines any top-level class named `Entity` (a natural name in apps using grape-entity or similar), it is silently treated as `Klass::Entity` for **every** `present`-ed object that doesn't have its own nested `Entity`:

```ruby
class Entity < Grape::Entity  # app-level base class
  expose :id
end

get '/thing' do
  present({ name: 'plain hash' })   # rendered through ::Entity, not returned as-is
end
```

The same path is reachable for empty collections: `object_class([])` resolves to `NilClass` (`[].first.class`), whose ancestor chain also reaches `Object`.

This is the same failure family as #2773, where a top-level `::Options` constant broke middleware building via an over-eager constant lookup.

## Fix

Walk the ancestors explicitly and ask each one for its **own** `Entity` constant (`const_defined?(:Entity, false)`), skipping `Object`:

```ruby
owner = klass.ancestors.detect { |ancestor| ancestor != Object && ancestor.const_defined?(:Entity, false) }
return unless owner

entity = owner.const_get(:Entity, false)
entity if entity.respond_to?(:represent)
```

Documented behavior is preserved: `Klass::Entity` on the object's class or any genuine ancestor (including module ancestors) is still found, nearest-ancestor first — which is exactly what the previous inherited lookup resolved. Only the accidental fallback to the global namespace is gone.

The regression spec stubs a top-level `::Entity` (a `Grape::Entity` subclass, so it passes the `respond_to?(:represent)` check) and asserts it is not used for an object with no nested entity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)