### PR TITLE
Set api.version when the version is the only path segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * [#2825](https://github.com/ruby-grape/grape/pull/2825): Stop `present` entity autodetection from picking up a top-level `::Entity` constant - [@ericproulx](https://github.com/ericproulx).
 * [#2827](https://github.com/ruby-grape/grape/pull/2827): Make the `cascade` DSL getter return the configured value (`cascade false` read back as `true`) - [@ericproulx](https://github.com/ericproulx).
 * [#2829](https://github.com/ruby-grape/grape/pull/2829): Fix a cascading route handing over only to the last route registered for the path, making a middle version (3+ mounted versions with a catch-all) answer 406 - [@ericproulx](https://github.com/ericproulx).
+* [#2826](https://github.com/ruby-grape/grape/pull/2826): Fix `api.version` not being set for the root route of a path-versioned API (`GET /v1`) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.4 (2026-07-25)

--- a/lib/grape/middleware/versioner/path.rb
+++ b/lib/grape/middleware/versioner/path.rb
@@ -31,13 +31,34 @@ module Grape
           end
 
           slash_position = path_info.index('/', 1) # omit the first one
-          return unless slash_position
+          return version_from_first_segment(path_info, slash_position) if slash_position
 
+          version_from_only_segment(path_info)
+        end
+
+        private
+
+        def version_from_first_segment(path_info, slash_position)
           potential_version = path_info[1..(slash_position - 1)]
           return unless potential_version.match?(pattern)
 
           version_not_found! unless potential_version_match?(potential_version)
           env[Grape::Env::API_VERSION] = potential_version
+        end
+
+        # The path is a single segment (e.g. `GET /v1` — the root route of a
+        # path-versioned API). Nothing follows to disambiguate a version from a
+        # plain path or from a `.format` suffix (`/v1.json`), so the version is
+        # only recorded on an exact match against the declared versions, and an
+        # unmatched segment is left for the router to resolve — never a 404.
+        def version_from_only_segment(path_info)
+          candidate = path_info[1..]
+          candidate = candidate[0...candidate.rindex('.')] while candidate.include?('.') && !declared_version?(candidate)
+          env[Grape::Env::API_VERSION] = candidate if declared_version?(candidate)
+        end
+
+        def declared_version?(candidate)
+          versions.present? && versions.include?(candidate)
         end
       end
     end

--- a/spec/grape/middleware/versioner/path_spec.rb
+++ b/spec/grape/middleware/versioner/path_spec.rb
@@ -59,4 +59,33 @@ describe Grape::Middleware::Versioner::Path do
       expect(subject.call(Rack::PATH_INFO => '/mounted/v1/foo').last).to eq('v1')
     end
   end
+
+  # Regression: the version was only extracted when a second slash followed it,
+  # so the root route of a path-versioned API (`GET /v1`) ran without
+  # env['api.version'] being set.
+  context 'when the version is the only path segment' do
+    let(:options) { { versions: %w[v1] } }
+
+    it 'sets the version' do
+      expect(subject.call(Rack::PATH_INFO => '/v1').last).to eq('v1')
+    end
+
+    it 'sets the version when a format suffix follows' do
+      expect(subject.call(Rack::PATH_INFO => '/v1.json').last).to eq('v1')
+    end
+
+    it 'sets a dotted version when a format suffix follows' do
+      options[:versions] = %w[v1.2]
+      expect(subject.call(Rack::PATH_INFO => '/v1.2.json').last).to eq('v1.2')
+    end
+
+    it 'sets the version behind a prefix' do
+      options[:prefix] = '/api'
+      expect(subject.call(Rack::PATH_INFO => '/api/v1').last).to eq('v1')
+    end
+
+    it 'leaves an unknown segment for the router instead of failing with 404' do
+      expect(subject.call(Rack::PATH_INFO => '/awesome').last).to be_nil
+    end
+  end
 end

--- a/spec/grape/middleware/versioner/path_spec.rb
+++ b/spec/grape/middleware/versioner/path_spec.rb
@@ -74,14 +74,20 @@ describe Grape::Middleware::Versioner::Path do
       expect(subject.call(Rack::PATH_INFO => '/v1.json').last).to eq('v1')
     end
 
-    it 'sets a dotted version when a format suffix follows' do
-      options[:versions] = %w[v1.2]
-      expect(subject.call(Rack::PATH_INFO => '/v1.2.json').last).to eq('v1.2')
+    context 'with a dotted version' do
+      let(:options) { { versions: %w[v1.2] } }
+
+      it 'sets the version when a format suffix follows' do
+        expect(subject.call(Rack::PATH_INFO => '/v1.2.json').last).to eq('v1.2')
+      end
     end
 
-    it 'sets the version behind a prefix' do
-      options[:prefix] = '/api'
-      expect(subject.call(Rack::PATH_INFO => '/api/v1').last).to eq('v1')
+    context 'behind a prefix' do
+      let(:options) { { versions: %w[v1], prefix: '/api' } }
+
+      it 'sets the version' do
+        expect(subject.call(Rack::PATH_INFO => '/api/v1').last).to eq('v1')
+      end
     end
 
     it 'leaves an unknown segment for the router instead of failing with 404' do

--- a/spec/shared/versioning_examples.rb
+++ b/spec/shared/versioning_examples.rb
@@ -11,6 +11,16 @@ shared_examples_for 'versioning' do
     expect(last_response.body).to eql 'Version: v1'
   end
 
+  it 'sets the API version for the root route' do
+    subject.format :txt
+    subject.version 'v1', **macro_options.except(:format)
+    subject.get do
+      "Version: #{request.env[Grape::Env::API_VERSION]}"
+    end
+    versioned_get '/', 'v1', macro_options
+    expect(last_response.body).to eql 'Version: v1'
+  end
+
   it 'adds the prefix before the API version' do
     subject.format :txt
     subject.prefix 'api'


### PR DESCRIPTION
## Problem

`Grape::Middleware::Versioner::Path` extracts the version from the first path segment — but only when a **second** slash follows it:

```ruby
slash_position = path_info.index('/', 1) # omit the first one
return unless slash_position
```

For the root route of a path-versioned API there is no second segment, so the middleware returned early and never set `env['api.version']`:

```ruby
class API < Grape::API
  version 'v1', using: :path
  get '/' do
    { version_seen: version }
  end
end
```

`GET /v1` → `200` with `{"version_seen":null}`. The route matches (the version lives in the compiled route pattern), but everything that reads `env['api.version']` sees nothing: the `version` helper, `Grape::DSL::Entity#entity_representation_for` (entities lose their `version:` embed, breaking conditional exposures), and `ErrorFormatter::Base#present`. The same happens with a format suffix (`GET /v1.json`) and behind a prefix (`GET /api/v1`).

Only the versioner middlewares write `api.version`, so nothing downstream recovers it from the route's version capture either. The logic is identical at least as far back as v2.4.0 — long-standing, not a regression.

## Fix

When the (prefix-stripped) path is a single segment, record the version on an **exact match** against the declared versions, trimming a trailing `.format` suffix right-to-left so dotted versions still work:

* `/v1` → `v1`
* `/v1.json` → `v1` (suffix trimmed)
* `/v1.2.json` with `version 'v1.2'` → `v1.2` (rightmost dot trimmed first)
* `/awesome` → no version, **no 404** — the segment is left for the router to resolve

The single-segment branch deliberately never raises `version_not_found!`: with no following segment there is nothing to disambiguate a version from a plain path, so an unknown segment falls through to the router's 404 exactly as before. Multi-segment behavior (`/v3/foo` → 404 with `X-Cascade: pass` for an undeclared version) is unchanged.

## Tests

* Middleware-level cases for all of the above in `versioner/path_spec.rb`.
* A `sets the API version for the root route` example added to the shared versioning examples, so the root route is now covered end-to-end for **all four** strategies (`:path` — previously failing — plus `:param`, `:header`, `:accept_version_header`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)