### PR TITLE
Make the cascade DSL getter return the configured value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * [#2819](https://github.com/ruby-grape/grape/pull/2819): Freeze coercers at construction, synchronize `Grape::Util::Cache` lookups, and assign `Route#regexp_capture_index` eagerly - [@ericproulx](https://github.com/ericproulx).
 * [#2824](https://github.com/ruby-grape/grape/pull/2824): Fix cascaded routes (`X-Cascade: pass`) leaking `route_info` and path captures into the next matched route's `route` and `params` - [@ericproulx](https://github.com/ericproulx).
 * [#2825](https://github.com/ruby-grape/grape/pull/2825): Stop `present` entity autodetection from picking up a top-level `::Entity` constant - [@ericproulx](https://github.com/ericproulx).
+* [#2827](https://github.com/ruby-grape/grape/pull/2827): Make the `cascade` DSL getter return the configured value (`cascade false` read back as `true`) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.4 (2026-07-25)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,10 @@ Upgrading Grape
 
 ### Upgrading to >= 4.0.0
 
+#### The `cascade` getter returns the configured value
+
+Calling `cascade` with no argument used to report whether cascading had been *configured at all* (`cascade false` still read back as `true`, contradicting the actual runtime behavior, which was correctly disabled). It now returns the configured value itself — `true`/`false` as set, or `true` when never set. Code that used the getter to detect "was `cascade` called" rather than "does this API cascade" must track that separately.
+
 #### `forward_match` is no longer exposed on routes
 
 `forward_match` is an internal, construction-time detail that decides how a route matches incoming paths (a prefix match for mounted Rack apps, the compiled pattern otherwise). It is now passed to `Grape::Router::Route` as a keyword argument and derived from the mounted app instead of being carried in the route's options.

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -16,7 +16,7 @@ module Grape
       end
 
       def cascade(value = nil)
-        return inheritable_setting.cascade_defined? ? !inheritable_setting.cascade.nil? : true if value.nil?
+        return inheritable_setting.cascade_defined? ? inheritable_setting.cascade : true if value.nil?
 
         inheritable_setting.cascade = value
       end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -4890,12 +4890,33 @@ describe Grape::API do
   describe '.cascade' do
     subject { api.cascade }
 
-    let(:api) do
-      Class.new(Grape::API) do
-        cascade true
-      end
+    context 'when not set' do
+      let(:api) { Class.new(described_class) }
+
+      it { is_expected.to be(true) }
     end
 
-    it { is_expected.to be(true) }
+    context 'when set to true' do
+      let(:api) do
+        Class.new(Grape::API) do
+          cascade true
+        end
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    # Regression: the getter returned whether cascade had been set at all
+    # (!value.nil?), so `cascade false` still read back as true — contradicting
+    # the runtime cascading behavior, which was correctly disabled.
+    context 'when set to false' do
+      let(:api) do
+        Class.new(Grape::API) do
+          cascade false
+        end
+      end
+
+      it { is_expected.to be(false) }
+    end
   end
 end


### PR DESCRIPTION
## Problem

The `cascade` DSL getter doesn't return what was configured:

```ruby
def cascade(value = nil)
  return inheritable_setting.cascade_defined? ? !inheritable_setting.cascade.nil? : true if value.nil?

  inheritable_setting.cascade = value
end
```

`!cascade.nil?` answers "*was cascade set to a non-nil value*", not "*does this API cascade*". So:

```ruby
class API < Grape::API
  cascade false
end

API.cascade  # => true (!)
```

…while the runtime honors the setting correctly — `Grape::API::Instance#cascade?` returns `false` and the `X-Cascade` header is stripped. The getter simply contradicts the actual behavior it's supposed to report. The `!value.nil?` shape goes back at least to v2.4.0 (`!namespace_inheritable(:cascade).nil?`), so this is long-standing, not a recent regression.

## Fix

Return the stored value when one was configured, `true` (the documented default) otherwise:

```ruby
return inheritable_setting.cascade_defined? ? inheritable_setting.cascade : true if value.nil?
```

The getter now always agrees with `Instance#cascade?` for every configured value, including the degenerate `cascade nil` case (both report falsy — previously the getter said `false` while meaning "set to nil").

## Compatibility

Strictly speaking this changes a public getter's return value: anyone using `API.cascade` to detect "*was `cascade` called at all*" (rather than its meaning) would see `false` instead of `true` after `cascade false`. Since the next release is 4.0.0, this lands with an UPGRADING note; the existing `.cascade` spec is extended to cover unset / `true` / `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)