### PR TITLE
Restore the nil-base fallback in Grape::API::Instance#to_s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * [#2828](https://github.com/ruby-grape/grape/pull/2828): Compare `Grape::Util::InheritableSetting` by own state instead of serializing both chains through `to_hash`, and give `Grape::Util::InheritableValues` an `==`, so the duplicate-route check in `route` stops costing O(n²) `to_hash` calls on APIs whose namespaces share relative paths - [@ericproulx](https://github.com/ericproulx).
 * [#2831](https://github.com/ruby-grape/grape/pull/2831): Document and test open (beginless/endless) `Range`s as a `values:`/`except_values:` alternative to a dedicated numericality validator - [@dblock](https://github.com/dblock).
 * [#2830](https://github.com/ruby-grape/grape/pull/2830): Remove `Grape::Util::InheritableValues`, resolving inheritable settings by walking `Grape::Util::InheritableSetting#parent` instead of layering a second chain of stores, and keep namespace settings in a plain Hash - [@ericproulx](https://github.com/ericproulx).
+* [#2833](https://github.com/ruby-grape/grape/pull/2833): Fix `Grape::API::Instance.to_s` returning an empty string instead of the class name when the instance has no base (regression from #2581) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/api/instance.rb
+++ b/lib/grape/api/instance.rb
@@ -21,11 +21,11 @@ module Grape
       Boolean = Grape::API::Boolean
 
       class << self
-        extend Forwardable
-
         attr_accessor :configuration
 
-        def_delegators :@base, :to_s
+        def to_s
+          @base&.to_s || super
+        end
 
         attr_reader :base
 

--- a/spec/grape/api/instance_spec.rb
+++ b/spec/grape/api/instance_spec.rb
@@ -31,6 +31,17 @@ describe Grape::API::Instance do
     end
   end
 
+  describe '.to_s' do
+    it 'falls back to the class name when there is no base' do
+      expect(described_class.to_s).to eq('Grape::API::Instance')
+    end
+
+    it 'delegates to the base API once mounted' do
+      stub_const('SomeAPI', Class.new(Grape::API))
+      expect(SomeAPI.base_instance.to_s).to eq('SomeAPI')
+    end
+  end
+
   context 'when an instance is the root' do
     let(:root_api) do
       to_mount = an_instance


### PR DESCRIPTION
## Summary

Fixes #2832.

`Grape::API::Instance.to_s` returns `""` instead of its class name. `#name` is still correct — only `#to_s` is blank, which is what makes it surprising.

## Cause

PR #2581 replaced an explicit, nil-guarded `to_s` override with:

```ruby
def_delegators :@base, :to_s
```

`@base` is only assigned via `base=`, which runs when `Grape::API.mount_instance` builds a mount instance (`lib/grape/api.rb`). The bare `Grape::API::Instance` class is never mounted and never has `base=` called on it, so it stays `@base`-less forever — not a transient state, but permanent for that specific class. The delegator then evaluates `nil.to_s`, yielding `""`.

Anything that enumerates loaded classes and renders them by string representation (Sorbet/Tapioca RBI generation, log/error message interpolation) sees an empty name instead of `Grape::API::Instance`.

## Fix

| Before | After |
|---|---|
| `def_delegators :@base, :to_s` (via `extend Forwardable`) | `def to_s; @base&.to_s || super; end` |

`super` resolves through the singleton-class ancestry to `Module#to_s`, restoring the pre-3.0.0 behavior. The `@base` set case is unaffected — empty string is truthy in Ruby, so the delegation branch behaves exactly as before once an instance is mounted.

`extend Forwardable` is dropped from `Grape::API::Instance`'s singleton class since it existed solely for this one delegator.

## Notes

- Added `describe '.to_s'` coverage in `spec/grape/api/instance_spec.rb`: one example for the unmounted fallback, one mirroring the issue's repro (`SomeAPI.base_instance.to_s == 'SomeAPI'`) for the mounted case.
- Full `bundle exec rubocop` and `bundle exec rspec` (2515 examples) pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)