### PR TITLE
Restore the per-attempt routing args in Grape::Router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * [#2825](https://github.com/ruby-grape/grape/pull/2825): Stop `present` entity autodetection from picking up a top-level `::Entity` constant - [@ericproulx](https://github.com/ericproulx).
 * [#2827](https://github.com/ruby-grape/grape/pull/2827): Make the `cascade` DSL getter return the configured value (`cascade false` read back as `true`) - [@ericproulx](https://github.com/ericproulx).
 * [#2829](https://github.com/ruby-grape/grape/pull/2829): Fix a cascading route handing over only to the last route registered for the path, making a middle version (3+ mounted versions with a catch-all) answer 406 - [@ericproulx](https://github.com/ericproulx).
+* [#2834](https://github.com/ruby-grape/grape/pull/2834): Restore the #2824 fix for cascaded routes leaking `route_info` and path captures, silently reverted by #2829 - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.4 (2026-07-25)

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -149,10 +149,14 @@ module Grape
       body.close if body.respond_to?(:close)
     end
 
+    # Routing args are rebuilt for every attempt: when a route cascades
+    # (X-Cascade pass), the next candidate must not observe the previous
+    # attempt's +route_info+ or path captures.
     def process_route(route, input, env, include_allow_header: false)
       route_params = route.params_for(input)
-      env[Grape::Env::GRAPE_ROUTING_ARGS] ||= { route_info: route }
-      env[Grape::Env::GRAPE_ROUTING_ARGS].merge!(route_params) if route_params.present?
+      routing_args = { route_info: route }
+      routing_args.merge!(route_params) if route_params.present?
+      env[Grape::Env::GRAPE_ROUTING_ARGS] = routing_args
       env[Grape::Env::GRAPE_ALLOWED_METHODS] = route.allow_header if include_allow_header
       route.call(env)
     end

--- a/spec/grape/router_spec.rb
+++ b/spec/grape/router_spec.rb
@@ -108,4 +108,39 @@ describe Grape::Router do
       expect(headers['X-Cascade']).to eq('pass')
     end
   end
+
+  # Regression: routing args were seeded once (`||=`) and merged in place, so
+  # when a route cascaded (X-Cascade pass) the next candidate still saw the
+  # previous attempt's :route_info and path captures.
+  describe 'routing args across cascading routes' do
+    let(:app) do
+      v2 = Class.new(Grape::API) do
+        version 'v2', using: :header, vendor: 'grape', cascade: true
+        get ':id' do
+          { from: 'v2' }
+        end
+      end
+      v1 = Class.new(Grape::API) do
+        format :json
+        version 'v1', using: :header, vendor: 'grape'
+        get ':name' do
+          { origin: route.origin, params: params.to_h }
+        end
+      end
+      Class.new(Grape::API) do
+        format :json
+        mount v2
+        mount v1
+      end
+    end
+
+    it 'does not leak route_info or path captures from a cascaded attempt' do
+      get '/123', {}, 'HTTP_ACCEPT' => 'application/vnd.grape-v1+json'
+
+      expect(last_response.status).to eq(200)
+      body = JSON.parse(last_response.body)
+      expect(body['origin']).to eq('/:name')
+      expect(body['params']).to eq('name' => '123')
+    end
+  end
 end


### PR DESCRIPTION
## Summary

#2824's fix is no longer in `master`. This restores it, with its regression spec.

`lib/grape/router.rb#process_route` is back to seeding `env['grape.routing_args']` once with `||=` and merging each attempt's captures in place:

```ruby
env[Grape::Env::GRAPE_ROUTING_ARGS] ||= { route_info: route }
env[Grape::Env::GRAPE_ROUTING_ARGS].merge!(route_params) if route_params.present?
```

## How it was lost

#2824 landed as a merge commit (`0a08e97d`). #2829 was **squash**-merged (`59188e2a`) from a branch cut before #2824, so its squashed diff replayed the stale `router.rb` over the fix and removed the regression spec from `router_spec.rb` in the same stroke. Git reported no conflict — a squash replays the branch diff onto the tip.

`658e0d7f` is still an ancestor of `HEAD` and #2824's CHANGELOG entry survived, so nothing about the history or the changelog suggests the fix is missing. With the spec gone too, the suite stayed green.

## Impact (verified on current master)

Restoring the spec against master fails:

```
origin  = "/:id"                          expected "/:name"
params  = {"id"=>"123", "name"=>"123"}    expected {"name"=>"123"}
```

When a route cascades (`X-Cascade: pass`) and a later candidate answers:

- the `route` helper returns the **cascaded** route, not the serving one;
- the cascaded attempt's path captures **leak into `params`** — the endpoint sees `id`, which it never declared. This is the more consequential half, since it reaches user code and `declared`.

## Notes

- Fix and spec restored verbatim from `658e0d7f`. The router is the only writer of that env key, so assigning unconditionally is safe.
- Verified the spec fails without the change and passes with it.
- Full `bundle exec rubocop` and `bundle exec rspec` (2516 examples) pass.
- I checked the other recent fixes the same way (#2794, #2813, #2810, #2788, #2774) — their regression specs are all still present and green, so this is the only lost fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)