### PR TITLE
Define #hash alongside the eql?/== pairs that lacked one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [#2831](https://github.com/ruby-grape/grape/pull/2831): Document and test open (beginless/endless) `Range`s as a `values:`/`except_values:` alternative to a dedicated numericality validator - [@dblock](https://github.com/dblock).
 * [#2830](https://github.com/ruby-grape/grape/pull/2830): Remove `Grape::Util::InheritableValues`, resolving inheritable settings by walking `Grape::Util::InheritableSetting#parent` instead of layering a second chain of stores, and keep namespace settings in a plain Hash - [@ericproulx](https://github.com/ericproulx).
 * [#2833](https://github.com/ruby-grape/grape/pull/2833): Fix `Grape::API::Instance.to_s` returning an empty string instead of the class name when the instance has no base (regression from #2581) - [@ericproulx](https://github.com/ericproulx).
+* [#2836](https://github.com/ruby-grape/grape/pull/2836): Define `#hash` alongside the `eql?`/`==` pairs on `Grape::Endpoint`, `Grape::Util::InheritableSetting`, `Grape::Middleware::Stack::Middleware`, `Grape::ServeStream::StreamResponse` and `Grape::ServeStream::FileBody`, so equal objects hash alike in a `Hash`, `Set` or `uniq` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -141,6 +141,14 @@ module Grape
     end
     alias eql? ==
 
+    # Mirrors #==. The class stays out: #== admits a subclass instance
+    # through is_a?, and such a pair must hash alike. The block (#source) is
+    # not part of either, matching the long-standing duplicate-route check in
+    # DSL::Routing#route.
+    def hash
+      [config, inheritable_setting].hash
+    end
+
     # The purpose of this override is solely for stripping internals when an error occurs while calling
     # an endpoint through an api. See https://github.com/ruby-grape/grape/issues/2398
     # Otherwise, it calls super.

--- a/lib/grape/middleware/stack.rb
+++ b/lib/grape/middleware/stack.rb
@@ -30,6 +30,15 @@ module Grape
         end
         alias eql? ==
 
+        # Keyed on the wrapped class, so two Middleware wrapping the same
+        # class hash alike — and so does the class itself, which #== also
+        # accepts. The superclass fallback above can't be honoured here (a
+        # class and its superclass hash differently); it only ever serves
+        # #index / #include?, which compare with #== rather than by hash.
+        def hash
+          klass.hash
+        end
+
         def inspect
           klass.to_s
         end

--- a/lib/grape/serve_stream/file_body.rb
+++ b/lib/grape/serve_stream/file_body.rb
@@ -32,6 +32,12 @@ module Grape
         path == other.path
       end
       alias eql? ==
+
+      # Mirrors #==, which keys on the path alone and does not check the
+      # class, so the class must stay out of the hash too.
+      def hash
+        path.hash
+      end
     end
   end
 end

--- a/lib/grape/serve_stream/stream_response.rb
+++ b/lib/grape/serve_stream/stream_response.rb
@@ -19,6 +19,12 @@ module Grape
         stream == other.stream
       end
       alias eql? ==
+
+      # Mirrors #==, which keys on the stream alone and does not check the
+      # class, so the class must stay out of the hash too.
+      def hash
+        stream.hash
+      end
     end
   end
 end

--- a/lib/grape/util/inheritable_setting.rb
+++ b/lib/grape/util/inheritable_setting.rb
@@ -237,6 +237,16 @@ module Grape
       end
       alias eql? ==
 
+      # Keyed on the fully resolved state, because #== accepts two instances
+      # whose own stores differ as long as their chains resolve alike (the
+      # #to_hash path above) — hashing own state would tell those apart. The
+      # same-parent fast path implies equal resolved state, so it agrees. This
+      # is the cold path: nothing in Grape uses a setting as a Hash key or in
+      # a Set, and #== keeps avoiding #to_hash wherever it can.
+      def hash
+        to_hash.hash
+      end
+
       # Validator instances registered by +params+ and +contract+ blocks,
       # outermost scope first. Record them with #add_validation; the backing
       # store is an internal detail.

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -1025,6 +1025,30 @@ describe Grape::Endpoint do
     end
   end
 
+  describe '#hash' do
+    let(:options) do
+      {
+        http_methods: 'GET',
+        path: '/x',
+        route_options: {},
+        api: Class.new
+      }
+    end
+    let(:settings) { Grape::Util::InheritableSetting.new }
+
+    it 'matches for two endpoints built from the same settings and config' do
+      one = described_class.new(settings, **options) { 'x' }
+      another = described_class.new(settings, **options) { 'x' }
+      expect(one.hash).to eq another.hash
+    end
+
+    it 'dedups equal endpoints in a Set' do
+      endpoints = [described_class.new(settings, **options) { 'x' },
+                   described_class.new(settings, **options) { 'x' }]
+      expect(Set.new(endpoints).size).to eq 1
+    end
+  end
+
   describe '#inspect' do
     subject { described_class.new(settings, **options).inspect }
 

--- a/spec/grape/middleware/stack/middleware_spec.rb
+++ b/spec/grape/middleware/stack/middleware_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+describe Grape::Middleware::Stack::Middleware do
+  let(:middleware_class) { Class.new }
+
+  describe '#hash' do
+    it 'matches for two entries wrapping the same class' do
+      one = described_class.new(middleware_class, [], nil)
+      another = described_class.new(middleware_class, [], nil)
+      expect(one.hash).to eq another.hash
+    end
+
+    # #== also accepts the wrapped class itself, so it has to hash alike.
+    it 'matches the wrapped class' do
+      expect(described_class.new(middleware_class, [], nil).hash).to eq middleware_class.hash
+    end
+  end
+end

--- a/spec/grape/serve_stream/file_body_spec.rb
+++ b/spec/grape/serve_stream/file_body_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+describe Grape::ServeStream::FileBody do
+  describe '#hash' do
+    it 'matches for two bodies with an equal path' do
+      expect(described_class.new('/tmp/a').hash).to eq described_class.new(+'/tmp/a').hash
+    end
+
+    it 'dedups equal bodies in a Set' do
+      expect(Set.new([described_class.new('/tmp/a'), described_class.new(+'/tmp/a')]).size).to eq 1
+    end
+  end
+end

--- a/spec/grape/serve_stream/stream_response_spec.rb
+++ b/spec/grape/serve_stream/stream_response_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+describe Grape::ServeStream::StreamResponse do
+  let(:stream) { StringIO.new('a stream') }
+
+  describe '#hash' do
+    it 'matches for two responses wrapping the same stream' do
+      one = described_class.new(stream)
+      another = described_class.new(stream)
+      expect(one.hash).to eq another.hash
+    end
+
+    it 'dedups equal responses in a Set' do
+      expect(Set.new([described_class.new(stream), described_class.new(stream)]).size).to eq 1
+    end
+  end
+end

--- a/spec/grape/util/inheritable_setting_spec.rb
+++ b/spec/grape/util/inheritable_setting_spec.rb
@@ -25,6 +25,28 @@ describe Grape::Util::InheritableSetting do
     end
   end
 
+  describe '#hash' do
+    it 'matches for two copies forked from the same scope' do
+      sibling = subject.point_in_time_copy
+      expect(subject.point_in_time_copy.hash).to eq sibling.hash
+    end
+
+    # #== accepts two instances whose own stores differ as long as their
+    # chains resolve alike, so #hash has to key on the resolved state.
+    it 'matches when different chains resolve to the same values' do
+      parent = described_class.new
+      parent.add_helper(:shared)
+      inherits = described_class.new.tap { |setting| setting.inherit_from(parent) }
+
+      standalone = described_class.new
+      standalone.add_helper(:shared)
+
+      expect(inherits).to eq standalone
+      expect(inherits.hash).to eq standalone.hash
+      expect(Set.new([inherits, standalone]).size).to eq 1
+    end
+  end
+
   describe '#==' do
     # Endpoint settings are forked as siblings sharing one parent, so this is
     # the shape the duplicate-route check in DSL::Routing#route compares.


### PR DESCRIPTION
## Summary

Five classes alias `eql?` to `==` without defining `hash`:

| Class | `==` keys on |
|---|---|
| `Grape::Endpoint` | `config`, `inheritable_setting` |
| `Grape::Util::InheritableSetting` | own state, or resolved state across chains |
| `Grape::Middleware::Stack::Middleware` | the wrapped class |
| `Grape::ServeStream::StreamResponse` | `stream` |
| `Grape::ServeStream::FileBody` | `path` |

Ruby requires equal objects to hash alike. Without `hash`, each falls back to identity, so equal objects land in different buckets and never dedup in a `Hash`, a `Set` or under `uniq`. `Grape::Namespace` and `Grape::Util::MediaType` already pair the two — this brings the rest in line.

## Deriving each hash

Each `hash` mirrors exactly what its `==` compares, and nothing more:

- **`StreamResponse` / `FileBody`** key on `stream` / `path` alone. Their `==` does not check the class, so the class stays *out* of the hash — including it would break pairs that `==` accepts.
- **`Middleware`** keys on the wrapped class, which also makes it agree with the class itself, something its `==` accepts. The `name.nil? && klass.superclass == other` fallback can't be honoured (a class and its superclass hash differently); it only ever serves `#index` / `#include?`, which compare with `==` rather than by hash.
- **`Endpoint`** keys on `config` and `inheritable_setting`, omitting the class: its `==` admits a subclass instance through `is_a?`, and such a pair must hash alike. The block (`#source`) is in neither, matching the long-standing duplicate-route check in `DSL::Routing#route`.
- **`InheritableSetting`** keys on the **resolved** state (`#to_hash`). This is the subtle one: its `==` accepts two instances whose own stores differ as long as their chains resolve alike, so hashing own state would tell those apart. The same-parent fast path implies equal resolved state, so it agrees too.

  This is the cold path — nothing in Grape uses a setting as a `Hash` key or in a `Set`, and `==` keeps avoiding `to_hash` wherever it can (#2828 is untouched).

## Notes

- 10 specs added (2 per class), including one pinning the case that rules out the cheaper option: two `InheritableSetting`s with **different own stores** that resolve to the same values are `==` and must hash alike.
- Verified in both directions: all 10 fail without the change (identity hashes, `Set` size 2 instead of 1) and pass with it.
- `Middleware`'s specs live in a new `spec/grape/middleware/stack/middleware_spec.rb` rather than nested in `stack_spec.rb`, whose `before { subject.use ... }` hook and `described_class` don't apply to the inner class.
- Full `bundle exec rubocop` and `bundle exec rspec` (2526 examples) pass.
- No caller in Grape relies on hash lookups for these, so this closes a latent hole rather than fixing an observed failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)