### PR TITLE
Tag path params as UTF-8 instead of leaving them binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@
 * [#2827](https://github.com/ruby-grape/grape/pull/2827): Make the `cascade` DSL getter return the configured value (`cascade false` read back as `true`) - [@ericproulx](https://github.com/ericproulx).
 * [#2829](https://github.com/ruby-grape/grape/pull/2829): Fix a cascading route handing over only to the last route registered for the path, making a middle version (3+ mounted versions with a catch-all) answer 406 - [@ericproulx](https://github.com/ericproulx).
 * [#2826](https://github.com/ruby-grape/grape/pull/2826): Fix `api.version` not being set for the root route of a path-versioned API (`GET /v1`) - [@ericproulx](https://github.com/ericproulx).
+* [#2834](https://github.com/ruby-grape/grape/pull/2834): Restore the #2824 fix for cascaded routes leaking `route_info` and path captures, silently reverted by #2829 - [@ericproulx](https://github.com/ericproulx).
+* [#2839](https://github.com/ruby-grape/grape/pull/2839): Tag path params as UTF-8 instead of leaving them ASCII-8BIT, so they compare equal to the non-ASCII literals an API declares (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 * [#2856](https://github.com/ruby-grape/grape/pull/2856): Update simplecov - [@ericproulx](https://github.com/ericproulx).
 * [#2841](https://github.com/ruby-grape/grape/pull/2841): Stop `use`, `helpers`, `rescue_from` and other registrations declared below a route from reaching it when an earlier registration had seeded the same key (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2846](https://github.com/ruby-grape/grape/pull/2846): Keep a `:version` path capture in `params` when the API declares no version, instead of always dropping it as Grape's own - [@ericproulx](https://github.com/ericproulx).
+* [#2839](https://github.com/ruby-grape/grape/pull/2839): Tag path params as UTF-8 instead of leaving them ASCII-8BIT, so they compare equal to the non-ASCII literals an API declares (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -38,6 +38,65 @@ end
 
 Nothing changes for the ordinary arrangement — registrations declared before a route, or inherited from an enclosing namespace or a mounting API, still apply exactly as before, including values an enclosing scope gains after the nested scope was created.
 
+#### Path params are tagged UTF-8 instead of ASCII-8BIT
+
+Params captured from the request path — `route_param`, `:id`-style segments, splats — now come back tagged `UTF-8`. They used to carry the `ASCII-8BIT` encoding of Rack's `PATH_INFO`, because Mustermann decodes the path against that raw string and nothing re-tagged the result. Query and body params were already `UTF-8`, since Rack tags those itself.
+
+**Why UTF-8.** Nothing obliges a client to send it — HTTP treats the request target as octets, and Rack's SPEC has CGI keys carry non-ASCII as `ASCII-8BIT`. UTF-8 is a convention rather than a guarantee. But it is the convention Rack itself already applies to everything *except* the path: `Rack::QueryParser#unescape` decodes the query string and form bodies with `URI.decode_www_form_component(string, Encoding::UTF_8)`, which tags the result without validating it.
+
+One request carrying the same invalid octets in three places, before this change:
+
+| source | encoding | `valid_encoding?` |
+| --- | --- | --- |
+| query — `?q=%C3%28` | `UTF-8` | `false` |
+| form body — `form=%C3%28` | `UTF-8` | `false` |
+| path — `/%C3%28` | **`ASCII-8BIT`** | `true` |
+
+The bytes are equally malformed in all three; only the label differed. The path reads `true` merely because `ASCII-8BIT` considers every byte sequence valid. So this change is not Grape adopting an outside convention — it is Grape agreeing with the library handing it the request. The path param was the odd one out only because Mustermann decodes against `PATH_INFO` directly and never had Rack's `unescape` applied to it.
+
+Grape does exactly what Rack does: re-tag, do not validate. The bytes are untouched, so octets that are *not* UTF-8 stay detectably invalid rather than being scrubbed into something the client never sent. (Rails takes the same approach for path captures — `ActionDispatch::Journey::Router` force-encodes each one to UTF-8 after unescaping.)
+
+**What this fixes.** An API's own declarations used to disagree with themselves depending on where a value arrived from — a binary string never equals the UTF-8 literal it was written as:
+
+```ruby
+params { requires :id, type: String, values: ['café'] }
+```
+
+| request | before | 4.0 |
+| --- | --- | --- |
+| `GET /?id=café` (query) | `200` | unchanged |
+| `GET /café` (path) | `400 "id does not have a valid value"` | `200` |
+
+The same held for `same_as`, `except_values`, and any comparison an endpoint made against a non-ASCII literal. Serialization was affected too: a non-ASCII path param rendered into a JSON response emitted an encoding warning from the `json` gem, and is slated to raise there in json 3.0.
+
+**What can break.** Only the encoding tag changes; the bytes are untouched, and an invalid byte sequence stays invalid rather than being scrubbed. Comparisons against pure-ASCII strings are unaffected. Code that relied on a path param being binary — concatenating one with genuinely binary data, for instance — can now raise `Encoding::CompatibilityError`, and should call `.b` on the param to opt back into binary:
+
+```ruby
+params[:id].b + binary_blob
+```
+
+An application that worked around the old behavior with its own `force_encoding(Encoding::UTF_8)` needs no change; that call is now a no-op.
+
+**Restoring the old behavior wholesale.** If enough code depends on binary path params that patching each site is impractical, a `before` filter at the top of your root API re-tags them all back. `env['grape.routing_args']` holds exactly the params that came from the path, so query and body params are left alone, and `before` runs ahead of validation, so declarations see the binary strings too:
+
+```ruby
+class API < Grape::API
+  before do
+    env['grape.routing_args']&.each_key do |key|
+      next if key == :route_info
+
+      value = params[key]
+      params[key] = value.b if value.is_a?(String)
+      params[key] = value.map(&:b) if value.is_a?(Array)
+    end
+  end
+
+  # ... mounts and routes
+end
+```
+
+Declared in the root API, this covers mounted APIs too. Treat it as a migration aid rather than a permanent setting: it restores the inconsistency this change fixes, so `values: ['café']` will keep rejecting `GET /café` while accepting `?id=café`.
+
 #### `Array`/`Set` of an unsupported type is rejected when the API is defined
 
 Declaring a collection whose element type Grape cannot coerce — `type: Array[Foo]` or `type: Set[Foo]` where `Foo` is neither a primitive, a structure, nor a valid custom type — now raises as soon as the `params` block is evaluated, i.e. while the API class is being loaded:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,45 @@ Upgrading Grape
 
 ### Upgrading to >= 4.0.0
 
+#### Path params are tagged UTF-8 instead of ASCII-8BIT
+
+Params captured from the request path — `route_param`, `:id`-style segments, splats — now come back tagged `UTF-8`. They used to carry the `ASCII-8BIT` encoding of Rack's `PATH_INFO`, because Mustermann decodes the path against that raw string and nothing re-tagged the result. Query and body params were already `UTF-8`, since Rack tags those itself.
+
+**Why UTF-8.** Nothing obliges a client to send it — HTTP treats the request target as octets, and Rack's SPEC has CGI keys carry non-ASCII as `ASCII-8BIT`. UTF-8 is a convention rather than a guarantee. But it is the convention Rack itself already applies to everything *except* the path: `Rack::QueryParser#unescape` decodes the query string and form bodies with `URI.decode_www_form_component(string, Encoding::UTF_8)`, which tags the result without validating it.
+
+One request carrying the same invalid octets in three places, before this change:
+
+| source | encoding | `valid_encoding?` |
+| --- | --- | --- |
+| query — `?q=%C3%28` | `UTF-8` | `false` |
+| form body — `form=%C3%28` | `UTF-8` | `false` |
+| path — `/%C3%28` | **`ASCII-8BIT`** | `true` |
+
+The bytes are equally malformed in all three; only the label differed. The path reads `true` merely because `ASCII-8BIT` considers every byte sequence valid. So this change is not Grape adopting an outside convention — it is Grape agreeing with the library handing it the request. The path param was the odd one out only because Mustermann decodes against `PATH_INFO` directly and never had Rack's `unescape` applied to it.
+
+Grape does exactly what Rack does: re-tag, do not validate. The bytes are untouched, so octets that are *not* UTF-8 stay detectably invalid rather than being scrubbed into something the client never sent. (Rails takes the same approach for path captures — `ActionDispatch::Journey::Router` force-encodes each one to UTF-8 after unescaping.)
+
+**What this fixes.** An API's own declarations used to disagree with themselves depending on where a value arrived from — a binary string never equals the UTF-8 literal it was written as:
+
+```ruby
+params { requires :id, type: String, values: ['café'] }
+```
+
+| request | before | 4.0 |
+| --- | --- | --- |
+| `GET /?id=café` (query) | `200` | unchanged |
+| `GET /café` (path) | `400 "id does not have a valid value"` | `200` |
+
+The same held for `same_as`, `except_values`, and any comparison an endpoint made against a non-ASCII literal. Serialization was affected too: a non-ASCII path param rendered into a JSON response emitted an encoding warning from the `json` gem, and is slated to raise there in json 3.0.
+
+**What can break.** Only the encoding tag changes; the bytes are untouched, and an invalid byte sequence stays invalid rather than being scrubbed. Comparisons against pure-ASCII strings are unaffected. Code that relied on a path param being binary — concatenating one with genuinely binary data, for instance — can now raise `Encoding::CompatibilityError`, and should call `.b` on the param to opt back into binary:
+
+```ruby
+params[:id].b + binary_blob
+```
+
+An application that worked around the old behavior with its own `force_encoding(Encoding::UTF_8)` needs no change; that call is now a no-op.
+
 #### `Array`/`Set` of an unsupported type is rejected when the API is defined
 
 Declaring a collection whose element type Grape cannot coerce — `type: Array[Foo]` or `type: Set[Foo]` where `Foo` is neither a primitive, a structure, nor a valid custom type — now raises as soon as the `params` block is evaluated, i.e. while the API class is being loaded:

--- a/lib/grape/router/route.rb
+++ b/lib/grape/router/route.rb
@@ -49,7 +49,9 @@ module Grape
         parsed = pattern.params(input)
         return unless parsed
 
-        parsed.compact.symbolize_keys
+        params = {}
+        parsed.each { |name, value| params[name.to_sym] = tag_utf8!(value) unless value.nil? }
+        params
       end
 
       protected
@@ -59,6 +61,38 @@ module Grape
       end
 
       private
+
+      # Mustermann decodes path captures out of +PATH_INFO+, which Rack hands us
+      # tagged ASCII-8BIT, so path params came back binary while Rack tags query
+      # and body params UTF-8. That split makes an API's own declarations
+      # disagree with themselves: `values: ['café']` matched `?id=café` but not
+      # `/café`, since a binary string never equals the UTF-8 literal it was
+      # written as.
+      #
+      # Re-tag as UTF-8. Nothing obliges a client to send UTF-8: the request
+      # target is octets to HTTP, and Rack's SPEC has CGI keys carry non-ASCII
+      # as ASCII-8BIT. But UTF-8 is what browsers percent-encode with, what an
+      # IRI maps to, and what Rails settles on — ActionDispatch::Journey::Router
+      # force_encodes every path capture to UTF-8 after unescaping it.
+      #
+      # Only the encoding changes; the bytes are untouched. Octets that are not
+      # UTF-8 therefore stay invalid and are caught downstream rather than being
+      # silently scrubbed into something the client never sent.
+      #
+      # The re-tag is in place, hence the bang. Mustermann's +Pattern#params+
+      # builds a fresh Hash of fresh, unfrozen strings on every call and skips
+      # its own Match cache, so the mutation cannot escape this request — which
+      # is also what lets the Array branch re-tag its elements with +each+.
+      def tag_utf8!(value)
+        case value
+        when String
+          value.force_encoding(Encoding::UTF_8)
+        when Array
+          value.each { |v| tag_utf8!(v) }
+        else
+          value
+        end
+      end
 
       def upcase_method(method)
         method_s = method.to_s

--- a/lib/grape/router/route.rb
+++ b/lib/grape/router/route.rb
@@ -49,7 +49,7 @@ module Grape
         parsed = pattern.params(input)
         return unless parsed
 
-        parsed.compact.symbolize_keys
+        parsed.compact.symbolize_keys.transform_values! { |value| tag_utf8(value) }
       end
 
       protected
@@ -59,6 +59,33 @@ module Grape
       end
 
       private
+
+      # Mustermann decodes path captures out of +PATH_INFO+, which Rack hands us
+      # tagged ASCII-8BIT, so path params came back binary while Rack tags query
+      # and body params UTF-8. That split makes an API's own declarations
+      # disagree with themselves: `values: ['café']` matched `?id=café` but not
+      # `/café`, since a binary string never equals the UTF-8 literal it was
+      # written as.
+      #
+      # Re-tag as UTF-8. Nothing obliges a client to send UTF-8: the request
+      # target is octets to HTTP, and Rack's SPEC has CGI keys carry non-ASCII
+      # as ASCII-8BIT. But UTF-8 is what browsers percent-encode with, what an
+      # IRI maps to, and what Rails settles on — ActionDispatch::Journey::Router
+      # force_encodes every path capture to UTF-8 after unescaping it.
+      #
+      # Only the encoding changes; the bytes are untouched. Octets that are not
+      # UTF-8 therefore stay invalid and are caught downstream rather than being
+      # silently scrubbed into something the client never sent.
+      def tag_utf8(value)
+        # String first: every capture but a multi-splat is one.
+        if value.is_a?(String)
+          value.encoding == Encoding::UTF_8 ? value : (+value).force_encoding(Encoding::UTF_8)
+        elsif value.is_a?(Array)
+          value.map { |element| tag_utf8(element) }
+        else
+          value
+        end
+      end
 
       def upcase_method(method)
         method_s = method.to_s

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -309,6 +309,68 @@ describe Grape::API do
         expect(last_response.body).to eq('{"foo":1234}')
       end
     end
+
+    context 'with a non-ascii segment' do
+      it 'tags the param as UTF-8 rather than leaving it binary' do
+        subject.route_param :id do
+          get { params[:id].encoding.name }
+        end
+
+        get '/caf%C3%A9'
+        expect(last_response.body).to eq('UTF-8')
+      end
+
+      it 'tags every captured segment' do
+        subject.namespace :a do
+          route_param :one do
+            route_param :two do
+              get { [params[:one].encoding.name, params[:two].encoding.name].join(',') }
+            end
+          end
+        end
+
+        get '/a/caf%C3%A9/th%C3%A9'
+        expect(last_response.body).to eq('UTF-8,UTF-8')
+      end
+
+      it 'tags a splat capture' do
+        subject.get('/files/*path') { params[:path].encoding.name }
+
+        get '/files/a/b/caf%C3%A9'
+        expect(last_response.body).to eq('UTF-8')
+      end
+
+      # An unnamed splat captures into an Array rather than a String.
+      it 'tags every element of an unnamed splat capture' do
+        subject.get('/files/*') { params[:splat].map { |s| s.encoding.name }.join(',') }
+
+        get '/files/caf%C3%A9'
+        expect(last_response.body).to eq('UTF-8')
+      end
+
+      # A path param used to arrive binary while the same value arrived UTF-8
+      # through the query string, so an API's own declaration disagreed with
+      # itself depending on where the value came from.
+      it 'compares equal to the utf-8 literal the API declares' do
+        subject.params { requires :id, type: String, values: ['café'] }
+        subject.route_param :id do
+          get { 'matched' }
+        end
+
+        get '/caf%C3%A9'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('matched')
+      end
+
+      it 'leaves the bytes untouched' do
+        subject.route_param :id do
+          get { params[:id] }
+        end
+
+        get '/caf%C3%A9'
+        expect(last_response.body.b).to eq('caf%C3%A9'.b.gsub('%C3%A9', "\xC3\xA9".b))
+      end
+    end
   end
 
   describe '.route' do

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -381,6 +381,68 @@ describe Grape::API do
         expect(last_response.body).to eq('{"foo":1234}')
       end
     end
+
+    context 'with a non-ascii segment' do
+      it 'tags the param as UTF-8 rather than leaving it binary' do
+        subject.route_param :id do
+          get { params[:id].encoding.name }
+        end
+
+        get '/caf%C3%A9'
+        expect(last_response.body).to eq('UTF-8')
+      end
+
+      it 'tags every captured segment' do
+        subject.namespace :a do
+          route_param :one do
+            route_param :two do
+              get { [params[:one].encoding.name, params[:two].encoding.name].join(',') }
+            end
+          end
+        end
+
+        get '/a/caf%C3%A9/th%C3%A9'
+        expect(last_response.body).to eq('UTF-8,UTF-8')
+      end
+
+      it 'tags a splat capture' do
+        subject.get('/files/*path') { params[:path].encoding.name }
+
+        get '/files/a/b/caf%C3%A9'
+        expect(last_response.body).to eq('UTF-8')
+      end
+
+      # An unnamed splat captures into an Array rather than a String.
+      it 'tags every element of an unnamed splat capture' do
+        subject.get('/files/*') { params[:splat].map { |s| s.encoding.name }.join(',') }
+
+        get '/files/caf%C3%A9'
+        expect(last_response.body).to eq('UTF-8')
+      end
+
+      # A path param used to arrive binary while the same value arrived UTF-8
+      # through the query string, so an API's own declaration disagreed with
+      # itself depending on where the value came from.
+      it 'compares equal to the utf-8 literal the API declares' do
+        subject.params { requires :id, type: String, values: ['café'] }
+        subject.route_param :id do
+          get { 'matched' }
+        end
+
+        get '/caf%C3%A9'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('matched')
+      end
+
+      it 'leaves the bytes untouched' do
+        subject.route_param :id do
+          get { params[:id] }
+        end
+
+        get '/caf%C3%A9'
+        expect(last_response.body.b).to eq('caf%C3%A9'.b.gsub('%C3%A9', "\xC3\xA9".b))
+      end
+    end
   end
 
   describe '.route' do


### PR DESCRIPTION
## Summary

Mustermann decodes path captures out of `PATH_INFO`, which Rack hands over tagged `ASCII-8BIT`, and nothing re-tagged the result. Query and body params arrive `UTF-8` because Rack tags those itself — so the same value reached the endpoint with a different encoding depending on where it came from.

That made an API's own declarations disagree with themselves, since a binary string never equals the UTF-8 literal it was written as:

```ruby
params { requires :id, type: String, values: ['café'] }
```

| request | before | after |
| --- | --- | --- |
| `GET /?id=café` (query) | 200 | 200 |
| `GET /café` (path) | **400** `"id does not have a valid value"` | 200 |

The same held for `same_as`, `except_values`, and any comparison an endpoint made against a non-ASCII literal. It also leaked into serialization: a non-ASCII path param rendered into a JSON response drew `warning: JSON.generate: UTF-8 string passed as BINARY`, which the `json` gem says will become an error in json 3.0.

## Approach

Re-tag in `Route#params_for`, the single funnel for path-extracted values.

**Why UTF-8, given the path is octets.** Nothing obliges a client to send UTF-8: HTTP treats the request target as octets, and Rack's SPEC has CGI keys carry non-ASCII as `ASCII-8BIT` — which is exactly why `PATH_INFO` arrives binary in the first place. UTF-8 is the convention rather than a guarantee: it is what browsers percent-encode with, what an IRI maps to, and what Rails settles on — `ActionDispatch::Journey::Router` force-encodes every path capture to UTF-8 after unescaping (`action_dispatch/journey/router.rb:79`, actionpack 8.1.3.1):

```ruby
val = val.include?("%") ? CGI.unescapeURIComponent(val) : val
val.force_encoding(::Encoding::UTF_8)
path_parameters[name.to_sym] = val
```

Only the encoding changes — the bytes are untouched, so octets that are *not* UTF-8 stay detectably invalid and are still caught downstream rather than being silently scrubbed into something the client never sent. Unnamed splats capture into an `Array` (`{"splat" => ["a", "b"]}`), so those are walked too.

## Backward compatibility

UPGRADING entry added. Comparisons against pure-ASCII strings are unaffected, which is the overwhelming majority of code. Code that relied on a path param being binary — concatenating one with genuinely binary data — can now raise `Encoding::CompatibilityError` and should call `.b` on the param. An app that already worked around this with its own `force_encoding` needs no change; that call becomes a no-op.

For an app with too many such sites to patch individually, UPGRADING also documents a wholesale opt-out — a `before` filter at the top of the root API:

```ruby
class API < Grape::API
  before do
    env['grape.routing_args']&.each_key do |key|
      next if key == :route_info

      value = params[key]
      params[key] = value.b if value.is_a?(String)
      params[key] = value.map(&:b) if value.is_a?(Array)
    end
  end

  # ... mounts and routes
end
```

`env['grape.routing_args']` is populated from `params_for` alone, so this touches only path params and leaves query and body params alone; `:route_info` is skipped because it is the `Route` object sharing that hash. `before` runs ahead of validation (`endpoint.rb:167` vs `:178`), so declarations see the binary strings too — verified by `values: ['café']` going back to `400` on `GET /café` with the filter installed. Declared in the root API it covers mounted APIs as well, and the `Array` line matters for splats, where `params[:splat]` is an `Array<String>`.

It is framed there as a migration aid rather than a setting, since it reinstates exactly the inconsistency this PR fixes.

## Perf

The re-tag is unconditional and in place — Mustermann's `Pattern#params` builds a fresh `Hash` of fresh, unfrozen strings on every call and skips its own `Match` cache, so nothing here is shared or frozen and `force_encoding` mutates directly. The tagging itself is therefore allocation-free.

Since every capture has to be visited anyway, `params_for` now does the whole job in one pass, building the result `Hash` directly instead of allocating the two intermediates that `compact` and `symbolize_keys` produced. Net, this branch allocates *less* than master while doing strictly more work.

Measured against `22d79756`, same benchmark both sides.

**`Route#params_for` in isolation** — two captures, binary input:

| | master | this branch |
| --- | --- | --- |
| allocations | 9.0 obj/call | **8.0 obj/call** |
| ASCII path | 607k i/s | 566k i/s (−6.8%) |
| non-ASCII path | 206k i/s | 202k i/s (−2.2%) |

**Full request** — four route shapes:

| route | master | this branch | objects/request |
| --- | --- | --- | --- |
| two captures | 79–81k i/s | 79–81k i/s | 35 → **34** |
| no capture | 92.7k i/s | 93.7k i/s | 31 → **30** |
| splat | 80.0k i/s | 79.8k i/s | 33 → **32** |
| non-ASCII | 58.1k i/s | 57.7k i/s | 71 → **70** |

Allocations drop by exactly one object per request on every shape — an integer count with no variance, so it is the trustworthy signal here. The isolated 6.8% is the `force_encoding` per capture, but `params_for` is ~1.65 µs of a ~12.4 µs request, so it works out to ~0.9% of the request, below the noise floor. I ran the request-level comparison interleaved three times to confirm: every difference stayed inside the ±4–6% error bars.

One note for anyone reproducing this. The obvious one-pass form, `each_with_object({})`, is *slower* than the chain it replaces — `Hash#each_with_object` packs every entry into a pair `Array` before yielding, so it costs 4 objects/call against the chain's 2, and `filter_map { … }.to_h` is worse still at 6. Building into an explicit `Hash` with a two-arity `each` block skips the pair allocation and is the only form that actually wins.

## Test plan

- [x] Six new examples in `api_spec.rb` covering single/multiple/splat/unnamed-splat captures, the `values:` equality case, and a byte-preservation invariant; verified the behavioural ones fail without the `lib/` change.
- [x] Full RSpec suite passes locally (2591 examples, 0 failures).
- [x] RuboCop clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


