### PR TITLE
Answer 500 when an error response cannot be rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 * [#2846](https://github.com/ruby-grape/grape/pull/2846): Keep a `:version` path capture in `params` when the API declares no version, instead of always dropping it as Grape's own - [@ericproulx](https://github.com/ericproulx).
 * [#2839](https://github.com/ruby-grape/grape/pull/2839): Tag path params as UTF-8 instead of leaving them ASCII-8BIT, so they compare equal to the non-ASCII literals an API declares (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2845](https://github.com/ruby-grape/grape/pull/2845): Render `redirect`'s default message as the plain text its content type announces, instead of letting the API's formatter re-encode it (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
+* [#2840](https://github.com/ruby-grape/grape/pull/2840): Answer 500 instead of letting an exception escape the middleware stack when an error response cannot be rendered, exposing it on `rack.exception` and writing it to `rack.errors` so error trackers keep reporting it, with `Grape.config.raise_rendering_errors` to opt back out (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@
 * [#2827](https://github.com/ruby-grape/grape/pull/2827): Make the `cascade` DSL getter return the configured value (`cascade false` read back as `true`) - [@ericproulx](https://github.com/ericproulx).
 * [#2829](https://github.com/ruby-grape/grape/pull/2829): Fix a cascading route handing over only to the last route registered for the path, making a middle version (3+ mounted versions with a catch-all) answer 406 - [@ericproulx](https://github.com/ericproulx).
 * [#2826](https://github.com/ruby-grape/grape/pull/2826): Fix `api.version` not being set for the root route of a path-versioned API (`GET /v1`) - [@ericproulx](https://github.com/ericproulx).
+* [#2834](https://github.com/ruby-grape/grape/pull/2834): Restore the #2824 fix for cascaded routes leaking `route_info` and path captures, silently reverted by #2829 - [@ericproulx](https://github.com/ericproulx).
+* [#2840](https://github.com/ruby-grape/grape/pull/2840): Answer 500 instead of letting an exception escape the middleware stack when an error response cannot be rendered (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * [#2839](https://github.com/ruby-grape/grape/pull/2839): Tag path params as UTF-8 instead of leaving them ASCII-8BIT, so they compare equal to the non-ASCII literals an API declares (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2845](https://github.com/ruby-grape/grape/pull/2845): Render `redirect`'s default message as the plain text its content type announces, instead of letting the API's formatter re-encode it (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2840](https://github.com/ruby-grape/grape/pull/2840): Answer 500 instead of letting an exception escape the middleware stack when an error response cannot be rendered, exposing it on `rack.exception` and writing it to `rack.errors` so error trackers keep reporting it, with `Grape.config.raise_rendering_errors` to opt back out (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
+* [#2855](https://github.com/ruby-grape/grape/pull/2855): Expose an unhandled exception raised inside a `rescue_from` block on `rack.exception`, so error trackers report it instead of the generic 500 arriving silently - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/README.md
+++ b/README.md
@@ -2848,7 +2848,9 @@ end
 
 The first handler re-raises; the second handler runs against the new exception.
 
-If the re-raised exception has no registered `rescue_from` and is a `Grape::Exceptions::Base` subclass, it is rendered through the default Grape error path (using its own `status` and `message`). Anything else — typos, `NoMethodError`, an unrelated `StandardError` — is treated as an internal error: it is exposed on `env['grape.exception']` for upstream Rack middleware to observe, and rendered to the API consumer as a generic `500 Internal Server Error`. This avoids leaking internal detail in the response body.
+If the re-raised exception has no registered `rescue_from` and is a `Grape::Exceptions::Base` subclass, it is rendered through the default Grape error path (using its own `status` and `message`). Anything else — typos, `NoMethodError`, an unrelated `StandardError` — is treated as an internal error: it is exposed on the rack env for upstream Rack middleware to observe, and rendered to the API consumer as a generic `500 Internal Server Error`. This avoids leaking internal detail in the response body.
+
+Because the exception is answered rather than raised, nothing above Grape catches it, so it is published under `rack.exception` — the key error trackers read for a handled exception — as well as Grape's own `grape.exception`. Grape does no logging of its own here; register a `rescue_from :internal_grape_exceptions` handler to take that over.
 
 You can take control of the internal-error path by opting in with `rescue_from :internal_grape_exceptions`:
 

--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ Use `Grape.configure` to set up global settings at load time.
 Currently the configurable settings are:
 
 * `param_builder`: Sets the [Parameter Builder](#parameters), defaults to `Grape::Extensions::ActiveSupport::HashWithIndifferentAccess::ParamBuilder`.
+* `raise_rendering_errors`: Lets an error response that cannot be rendered propagate out of the middleware stack instead of being answered with a failsafe `500`, defaults to `false`. See [When the error response itself cannot be rendered](#when-the-error-response-itself-cannot-be-rendered).
 
 To change a setting value make sure that at some point during load time the following code runs
 
@@ -3002,6 +3003,38 @@ Here `'inner'` will be result of handling occurred `ArgumentError`.
 Any exception that is not subclass of `StandardError` should be rescued explicitly.
 Usually it is not a case for an application logic as such errors point to problems in Ruby runtime.
 This is following [standard recommendations for exceptions handling](https://ruby-doc.org/core/Exception.html).
+
+#### When the error response itself cannot be rendered
+
+A `rescue_from` handler can build a payload its error formatter cannot serialize. The common case is echoing request-derived text back to the client:
+
+```ruby
+class Missing < StandardError; end
+
+class API < Grape::API
+  format :json
+
+  rescue_from(Missing) { |e| error!({ error: 'not_found', detail: e.message }, 404) }
+
+  route_param(:id) { get { raise Missing, "no such thing: #{params[:id]}" } }
+end
+```
+
+`GET /%C3%28` puts an invalid UTF-8 byte in `params[:id]`, and the JSON formatter raises when it reaches that byte in the message — after the handler has already returned, so `rescue_from :all` does not help.
+
+Rather than let that exception escape the middleware stack, Grape answers `500`: first retrying the API's own format with the framework's `Internal Server Error` message, then falling back to a bare `text/plain` body if even that cannot be rendered.
+
+The exception is published on the rack env under `rack.exception` — the key error trackers read to find an exception that was handled rather than raised — and on Grape's own `grape.exception`. It is also written to `rack.errors`, so it reaches the log with no tracker installed.
+
+To opt out and have the exception propagate out of the middleware stack instead:
+
+```ruby
+Grape.configure do |config|
+  config.raise_rendering_errors = true
+end
+```
+
+With this on the failsafe never runs: the exception is re-raised untouched, so neither env key is set and nothing is written to `rack.errors`.
 
 ## Logging
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -131,6 +131,34 @@ end
 ```
 
 Declared in the root API, this covers mounted APIs too. Treat it as a migration aid rather than a permanent setting: it restores the inconsistency this change fixes, so `values: ['café']` will keep rejecting `GET /café` while accepting `?id=café`.
+#### A failed error rendering answers 500 instead of escaping the middleware stack
+
+When Grape could not render an error response — an error formatter handed a payload it cannot serialize, most often — the exception escaped every middleware above Grape and reached the application server. Rendering runs inside `Grape::Middleware::Error#call!`'s own `rescue` clause, so that clause did not cover it.
+
+Grape now answers `500` instead: first retrying the API's format with the framework's own `Internal Server Error` message, then falling back to a bare `text/plain` body if even that cannot be rendered.
+
+This mirrors what `ActionDispatch::ShowExceptions#render_exception` does in Rails: try the application's own error rendering, and fall back to a bare `500 Internal Server Error` in `text/plain` when that rendering is itself broken.
+
+**What can break.** Code that observed these exceptions by letting them propagate — a test asserting `expect { get '/' }.to raise_error`, most directly — no longer sees them raised. The exception is published on the rack env instead, under both Grape's own key and the conventional one that error trackers read:
+
+```ruby
+env[Grape::Env::RACK_EXCEPTION]  # 'rack.exception' — what trackers collect
+env[Grape::Env::GRAPE_EXCEPTION] # 'grape.exception' — same object, Grape's key
+```
+
+An error tracker mounted as Rack middleware above Grape therefore keeps reporting these with no change on your side: sentry-ruby, for one, collects `env['rack.exception'] || env['sinatra.error']` for exactly this case — an exception that was handled rather than raised. The failure is also written to `rack.errors`, so it lands in the server log even with no tracker installed.
+
+**Opting out.** To keep the pre-4.0 behaviour and have the exception propagate out of the middleware stack:
+
+```ruby
+Grape.configure do |config|
+  config.raise_rendering_errors = true
+end
+```
+
+With this on, the failsafe never runs: the exception is re-raised untouched, so neither env key is set and nothing is written to `rack.errors` — whatever caught it before catches it again.
+
+Exceptions that no `rescue_from` matches still propagate exactly as before; only rendering failures changed.
 
 #### `Array`/`Set` of an unsupported type is rejected when the API is defined
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,20 @@ Upgrading Grape
 
 ### Upgrading to >= 4.0.0
 
+#### A failed error rendering answers 500 instead of escaping the middleware stack
+
+When Grape could not render an error response — an error formatter handed a payload it cannot serialize, most often — the exception escaped every middleware above Grape and reached the application server. Rendering runs inside `Grape::Middleware::Error#call!`'s own `rescue` clause, so that clause did not cover it.
+
+Grape now answers `500` instead: first retrying the API's format with the framework's own `Internal Server Error` message, then falling back to a bare `text/plain` body if even that cannot be rendered.
+
+**What can break.** Code that observed these exceptions by letting them propagate — an error tracker mounted as Rack middleware above Grape, or a test asserting `expect { get '/' }.to raise_error` — no longer sees them. The exception is exposed on the rack env instead, under the same key the existing unrecognised-error path uses:
+
+```ruby
+env[Grape::Env::GRAPE_EXCEPTION] # => the exception that defeated rendering
+```
+
+Exceptions that no `rescue_from` matches still propagate exactly as before; only rendering failures changed.
+
 #### `Array`/`Set` of an unsupported type is rejected when the API is defined
 
 Declaring a collection whose element type Grape cannot coerce — `type: Array[Foo]` or `type: Set[Foo]` where `Foo` is neither a primitive, a structure, nor a valid custom type — now raises as soon as the `params` block is evaluated, i.e. while the API class is being loaded:

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -53,6 +53,9 @@ module Grape
   setting :param_builder, default: :hash_with_indifferent_access
   setting :lint, default: false
   setting :warn_on_helper_overrides, default: false
+  # Let an error response that cannot be rendered propagate out of the
+  # middleware stack instead of being answered with a failsafe 500.
+  setting :raise_rendering_errors, default: false
 
   HTTP_SUPPORTED_METHODS = [
     Rack::GET,

--- a/lib/grape/env.rb
+++ b/lib/grape/env.rb
@@ -14,5 +14,11 @@ module Grape
     GRAPE_ROUTING_ARGS = 'grape.routing_args'
     GRAPE_ALLOWED_METHODS = 'grape.allowed_methods'
     GRAPE_EXCEPTION = 'grape.exception'
+
+    # Not a Grape-owned key: the de-facto convention for an exception that was
+    # handled rather than raised, which is how error trackers find one they
+    # never saw propagate. sentry-ruby, for one, collects
+    # +env['rack.exception'] || env['sinatra.error']+.
+    RACK_EXCEPTION = 'rack.exception'
   end
 end

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -48,6 +48,13 @@ module Grape
       def_delegator :rescue_options, :backtrace, :include_backtrace
       def_delegator :rescue_options, :original_exception, :include_original_exception
 
+      # Emitted by {#failsafe_response} once even the framework's own message
+      # could not be rendered. Deliberately built without a formatter, an i18n
+      # lookup or anything else that could be the thing that is broken.
+      FAILSAFE_STATUS = 500
+      FAILSAFE_MESSAGE = '500 Internal Server Error'
+      FAILSAFE_CONTENT_TYPE = 'text/plain'
+
       def call!(env)
         @env = env
         error_response(catch(:error) { return @app.call(@env) })
@@ -104,7 +111,45 @@ module Grape
           backtrace: raw.backtrace || raw.original_exception&.backtrace || []
         )
         env[Grape::Env::API_ENDPOINT].status(payload.status) # error! may not have been called
-        rack_response(payload.status, payload.headers, format_message(payload))
+        begin
+          rack_response(payload.status, payload.headers, format_message(payload))
+        rescue StandardError => e
+          failsafe_response(e)
+        end
+      end
+
+      # Last resort for an error response that could not be rendered — an error
+      # formatter handed a payload it cannot serialize, typically. Rendering runs
+      # inside #call!'s rescue clause, so it is not covered by that rescue and
+      # anything raised here would escape the entire middleware stack. Grape has
+      # committed to answering with an error by this point, so it answers with
+      # one that does not depend on the payload rather than dropping the request.
+      #
+      # First retry the API's own format with the framework's InternalServerError,
+      # whose message is a static string and so cannot be what defeated the first
+      # attempt. Should even that fail — a wholesale broken formatter, rather than
+      # one payload it choked on — drop the formatter entirely. Both attempts call
+      # {#format_message} directly rather than re-entering {#error_response}, so
+      # this path cannot recurse.
+      #
+      # The exception is exposed on the rack env so upstream middleware (loggers,
+      # error trackers) can still observe what actually went wrong.
+      def failsafe_response(error)
+        env[Grape::Env::GRAPE_EXCEPTION] = error
+        headers = { Rack::CONTENT_TYPE => content_type }
+        rack_response(FAILSAFE_STATUS, headers, format_message(failsafe_payload(headers)))
+      rescue StandardError
+        rack_response(FAILSAFE_STATUS, { Rack::CONTENT_TYPE => FAILSAFE_CONTENT_TYPE }, FAILSAFE_MESSAGE)
+      end
+
+      def failsafe_payload(headers)
+        Grape::Exceptions::ErrorResponse.new(
+          status: FAILSAFE_STATUS,
+          message: Grape::Exceptions::InternalServerError.new.message,
+          headers:,
+          backtrace: [],
+          original_exception: nil
+        )
       end
 
       def default_rescue_handler(exception)

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -131,17 +131,13 @@ module Grape
         render_failsafe_response
       end
 
-      # Swallowing the exception must not make it invisible. +grape.exception+ is
-      # Grape's own key; +rack.exception+ is what the ecosystem actually reads to
-      # find an exception that never propagated, so a tracker mounted above Grape
-      # keeps reporting these without any application change. The failure also
-      # goes to +rack.errors+ so it reaches the log with no tracker installed —
+      # The exception is published on the rack env (see {#expose_exception}) and
+      # written to +rack.errors+ so it reaches the log with no tracker installed.
       # Rails writes to $stderr from its failsafe branch for the same reason:
       # deferring the logging to the application is not an option when the
       # application's own error rendering is what broke.
       def record_rendering_failure(error)
-        env[Grape::Env::GRAPE_EXCEPTION] = error
-        env[Grape::Env::RACK_EXCEPTION] = error
+        expose_exception(error)
         env[Rack::RACK_ERRORS]&.write("Grape could not render the error response: #{error.class}: #{error.message}\n")
       end
 
@@ -156,6 +152,17 @@ module Grape
         rack_response(FAILSAFE_STATUS, headers, format_message(failsafe_payload(headers)))
       rescue StandardError
         rack_response(FAILSAFE_STATUS, { Rack::CONTENT_TYPE => FAILSAFE_CONTENT_TYPE }, FAILSAFE_MESSAGE)
+      end
+
+      # Publish an exception Grape swallowed, on both keys. +grape.exception+ is
+      # Grape's own and has been set on these paths all along; +rack.exception+ is
+      # what the ecosystem actually reads to find an exception that never
+      # propagated — sentry-ruby collects +env['rack.exception'] ||
+      # env['sinatra.error']+ — so a tracker mounted above Grape keeps reporting
+      # these with no application change.
+      def expose_exception(error)
+        env[Grape::Env::GRAPE_EXCEPTION] = error
+        env[Grape::Env::RACK_EXCEPTION] = error
       end
 
       def failsafe_payload(headers)
@@ -252,7 +259,7 @@ module Grape
       # message. The framework deliberately does no logging of its own
       # here; that's the application's call.
       def safe_default(error, endpoint)
-        env[Grape::Env::GRAPE_EXCEPTION] = error
+        expose_exception(error)
         return run_rescue_handler(internal_grape_exceptions_rescue_handler, error, endpoint, redispatched: true) if internal_grape_exceptions_rescue_handler
 
         framework_default(endpoint)

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -48,6 +48,13 @@ module Grape
       def_delegator :rescue_options, :backtrace, :include_backtrace
       def_delegator :rescue_options, :original_exception, :include_original_exception
 
+      # Emitted by {#render_failsafe_response} once even the framework's own message
+      # could not be rendered. Deliberately built without a formatter, an i18n
+      # lookup or anything else that could be the thing that is broken.
+      FAILSAFE_STATUS = 500
+      FAILSAFE_MESSAGE = '500 Internal Server Error'
+      FAILSAFE_CONTENT_TYPE = 'text/plain'
+
       def call!(env)
         @env = env
         error_response(catch(:error) { return @app.call(@env) })
@@ -104,7 +111,61 @@ module Grape
           backtrace: raw.backtrace || raw.original_exception&.backtrace || []
         )
         env[Grape::Env::API_ENDPOINT].status(payload.status) # error! may not have been called
+        render_response(payload)
+      end
+
+      # Rendering runs inside #call!'s own rescue clause, so it is not covered by
+      # that rescue: an error formatter that raises on the payload it was handed
+      # takes the exception out through every middleware above Grape. By this
+      # point Grape has committed to answering with an error, so it answers with
+      # one that does not depend on the payload rather than dropping the request.
+      #
+      # +Grape.config.raise_rendering_errors+ opts back out, for an application
+      # that would rather have the exception propagate as it did before.
+      def render_response(payload)
         rack_response(payload.status, payload.headers, format_message(payload))
+      rescue StandardError => e
+        raise if Grape.config.raise_rendering_errors
+
+        record_rendering_failure(e)
+        render_failsafe_response
+      end
+
+      # Swallowing the exception must not make it invisible. +grape.exception+ is
+      # Grape's own key; +rack.exception+ is what the ecosystem actually reads to
+      # find an exception that never propagated, so a tracker mounted above Grape
+      # keeps reporting these without any application change. The failure also
+      # goes to +rack.errors+ so it reaches the log with no tracker installed —
+      # Rails writes to $stderr from its failsafe branch for the same reason:
+      # deferring the logging to the application is not an option when the
+      # application's own error rendering is what broke.
+      def record_rendering_failure(error)
+        env[Grape::Env::GRAPE_EXCEPTION] = error
+        env[Grape::Env::RACK_EXCEPTION] = error
+        env[Rack::RACK_ERRORS]&.write("Grape could not render the error response: #{error.class}: #{error.message}\n")
+      end
+
+      # First retry the API's own format with the framework's InternalServerError,
+      # whose message is a static string and so cannot be what defeated the first
+      # attempt. Should even that fail — a wholesale broken formatter, rather than
+      # one payload it choked on — drop the formatter entirely. Both attempts call
+      # {#format_message} directly rather than re-entering {#error_response}, so
+      # this path cannot recurse.
+      def render_failsafe_response
+        headers = { Rack::CONTENT_TYPE => content_type }
+        rack_response(FAILSAFE_STATUS, headers, format_message(failsafe_payload(headers)))
+      rescue StandardError
+        rack_response(FAILSAFE_STATUS, { Rack::CONTENT_TYPE => FAILSAFE_CONTENT_TYPE }, FAILSAFE_MESSAGE)
+      end
+
+      def failsafe_payload(headers)
+        Grape::Exceptions::ErrorResponse.new(
+          status: FAILSAFE_STATUS,
+          message: Grape::Exceptions::InternalServerError.new.message,
+          headers:,
+          backtrace: [],
+          original_exception: nil
+        )
       end
 
       def default_rescue_handler(exception)

--- a/spec/grape/middleware/error_spec.rb
+++ b/spec/grape/middleware/error_spec.rb
@@ -99,6 +99,109 @@ describe Grape::Middleware::Error do
     end
   end
 
+  # Rendering happens inside #call!'s rescue clause, so it is not covered by
+  # that rescue: without a failsafe an error formatter that raises takes the
+  # exception straight out through every middleware above.
+  describe 'when the error response cannot be rendered' do
+    subject(:response) do
+      get '/'
+      last_response
+    end
+
+    context 'and the formatter chokes on the payload' do
+      let(:app) do
+        Class.new(Grape::API) do
+          format :json
+
+          rescue_from(:all) { |e| error!({ detail: e.message }, 404) }
+
+          # A message the JSON formatter cannot serialize.
+          get('/') { raise StandardError, +"bad \xC3 byte".b }
+        end
+      end
+
+      it 'answers with the framework message in the API format' do
+        expect(response.status).to eq(500)
+        expect(response.headers[Rack::CONTENT_TYPE]).to include('application/json')
+        expect(JSON.parse(response.body)).to eq('error' => 'Internal Server Error')
+      end
+
+      it 'exposes the rendering failure on the rack env' do
+        get '/'
+        expect(last_request.env[Grape::Env::GRAPE_EXCEPTION]).to be_a(StandardError)
+      end
+
+      # The key error trackers read to find an exception that never propagated;
+      # grape.exception alone leaves a swallowed failure invisible to them.
+      it 'exposes the rendering failure under rack.exception' do
+        get '/'
+        expect(last_request.env[Grape::Env::RACK_EXCEPTION]).to be(last_request.env[Grape::Env::GRAPE_EXCEPTION])
+      end
+
+      it 'writes the rendering failure to rack.errors' do
+        errors = StringIO.new
+        get '/', {}, Rack::RACK_ERRORS => errors
+        expect(errors.string).to include('Grape could not render the error response: JSON::GeneratorError')
+      end
+    end
+
+    context 'and the formatter is broken outright' do
+      let(:app) do
+        Class.new(Grape::API) do
+          format :json
+
+          error_formatter :json, ->(**) { raise 'formatter is broken' }
+          rescue_from(:all) { error!({ detail: 'nope' }, 404) }
+
+          get('/') { raise StandardError, 'boom' }
+        end
+      end
+
+      it 'drops the formatter rather than recursing' do
+        expect(response.status).to eq(500)
+        expect(response.headers[Rack::CONTENT_TYPE]).to include('text/plain')
+        expect(response.body).to eq('500 Internal Server Error')
+      end
+    end
+
+    context 'and nothing rescues the original exception' do
+      let(:app) do
+        Class.new(Grape::API) do
+          format :json
+
+          get('/') { raise ArgumentError, 'kaboom' }
+        end
+      end
+
+      it 'keeps propagating it' do
+        expect { get '/' }.to raise_error(ArgumentError, 'kaboom')
+      end
+    end
+
+    context 'and Grape.config.raise_rendering_errors is set' do
+      let(:app) do
+        Class.new(Grape::API) do
+          format :json
+
+          rescue_from(:all) { |e| error!({ detail: e.message }, 404) }
+
+          get('/') { raise StandardError, +"bad \xC3 byte".b }
+        end
+      end
+
+      around do |example|
+        Grape.config.raise_rendering_errors = true
+        example.run
+      ensure
+        Grape.config.raise_rendering_errors = false
+      end
+
+      it 'lets the rendering failure propagate as it did before the failsafe' do
+        expect { get '/' }.to raise_error(JSON::GeneratorError)
+      end
+    end
+  end
+
   describe 'when a rescue_from block raises' do
     subject(:response) do
       get '/'

--- a/spec/grape/middleware/error_spec.rb
+++ b/spec/grape/middleware/error_spec.rb
@@ -292,6 +292,24 @@ describe Grape::Middleware::Error do
         expect(captured).to be_a(NoMethodError)
         expect(captured.message).to include("undefined method 'foo'")
       end
+
+      # grape.exception is Grape's own key, which no error tracker reads. This
+      # path answers 500 rather than letting the exception propagate, so without
+      # rack.exception a tracker above Grape never learns it happened.
+      it "exposes the original exception via env['rack.exception']" do
+        captured = nil
+        original_call = app.method(:call)
+        allow(app).to receive(:call) do |env|
+          result = original_call.call(env)
+          captured = env[Grape::Env::RACK_EXCEPTION]
+          result
+        end
+
+        response
+
+        expect(captured).to be_a(NoMethodError)
+        expect(captured.message).to include("undefined method 'foo'")
+      end
     end
 
     context 'and a redispatched handler also raises' do

--- a/spec/grape/middleware/error_spec.rb
+++ b/spec/grape/middleware/error_spec.rb
@@ -99,6 +99,73 @@ describe Grape::Middleware::Error do
     end
   end
 
+  # Rendering happens inside #call!'s rescue clause, so it is not covered by
+  # that rescue: without a failsafe an error formatter that raises takes the
+  # exception straight out through every middleware above.
+  describe 'when the error response cannot be rendered' do
+    subject(:response) do
+      get '/'
+      last_response
+    end
+
+    context 'and the formatter chokes on the payload' do
+      let(:app) do
+        Class.new(Grape::API) do
+          format :json
+
+          rescue_from(:all) { |e| error!({ detail: e.message }, 404) }
+
+          # A message the JSON formatter cannot serialize.
+          get('/') { raise StandardError, +"bad \xC3 byte".b }
+        end
+      end
+
+      it 'answers with the framework message in the API format' do
+        expect(response.status).to eq(500)
+        expect(response.headers[Rack::CONTENT_TYPE]).to include('application/json')
+        expect(JSON.parse(response.body)).to eq('error' => 'Internal Server Error')
+      end
+
+      it 'exposes the rendering failure on the rack env' do
+        get '/'
+        expect(last_request.env[Grape::Env::GRAPE_EXCEPTION]).to be_a(StandardError)
+      end
+    end
+
+    context 'and the formatter is broken outright' do
+      let(:app) do
+        Class.new(Grape::API) do
+          format :json
+
+          error_formatter :json, ->(**) { raise 'formatter is broken' }
+          rescue_from(:all) { error!({ detail: 'nope' }, 404) }
+
+          get('/') { raise StandardError, 'boom' }
+        end
+      end
+
+      it 'drops the formatter rather than recursing' do
+        expect(response.status).to eq(500)
+        expect(response.headers[Rack::CONTENT_TYPE]).to include('text/plain')
+        expect(response.body).to eq('500 Internal Server Error')
+      end
+    end
+
+    context 'and nothing rescues the original exception' do
+      let(:app) do
+        Class.new(Grape::API) do
+          format :json
+
+          get('/') { raise ArgumentError, 'kaboom' }
+        end
+      end
+
+      it 'keeps propagating it' do
+        expect { get '/' }.to raise_error(ArgumentError, 'kaboom')
+      end
+    end
+  end
+
   describe 'when a rescue_from block raises' do
     subject(:response) do
       get '/'


### PR DESCRIPTION
## Summary

`Grape::Middleware::Error#call!` renders the error response from inside its own `rescue` clause, so that clause never covered the rendering. An error formatter that raised on the payload it was handed took the exception straight out through every middleware above Grape and into the application server. `rescue_from :all` did not help — the failure happens *after* the handler has already returned its payload.

The trigger is client-controlled, which is what makes this more than a cosmetic issue. A `rescue_from` handler echoing request-derived bytes is enough:

```ruby
class API < Grape::API
  format :json
  rescue_from(Missing) { |e| error!({ error: 'not_found', detail: e.message }, 404) }
  route_param(:id) { get { raise Missing, "no such thing: #{params[:id]}" } }
end
```

`GET /%C3%28` — an invalid UTF-8 byte in the path — makes the JSON formatter raise `JSON::GeneratorError`, and the request dies instead of being answered. Any API whose handler interpolates request-derived text can be made to defeat its own error handling on demand.

| scenario | before | after |
| --- | --- | --- |
| formatter chokes on the payload | `JSON::GeneratorError` escapes the stack | `500` `{"error":"Internal Server Error"}` in the API format |
| formatter broken outright | `RuntimeError` escapes the stack | `500` `text/plain` `500 Internal Server Error` |
| no `rescue_from` matches the exception | propagates | propagates (unchanged) |
| format has no error formatter | falls back to the default error formatter | unchanged |

## Approach

Guard the rendering. On failure, first retry the API's own format with the framework's `InternalServerError` — its message is a static string, so it cannot be what defeated the first attempt — and if that fails too, answer without a formatter at all. Both attempts call `format_message` directly rather than re-entering `error_response`, so the fallback cannot recurse.

This is the shape Rails already has. `ActionDispatch::ShowExceptions#render_exception` tries the application's own error rendering and falls back to a hardcoded `[500, text/plain, "500 Internal Server Error\n..."]` when that rendering is itself broken — same two tiers, same status, same content type, and it calls the second tier "failsafe" too.

Rendering is split so each tier is named rather than nested in a `begin` block inside `error_response`:

```ruby
render_response(payload)   # → record_rendering_failure + render_failsafe_response
```

The guard sits on the rendering rather than around `run_rescue_handler`. I tried the wider placement first; it swallowed things that must keep propagating, including the deprecation raised when a handler returns a Hash (`error_spec.rb:95`). Routing the retry through `framework_default` was also wrong — that goes back through `run_rescue_handler`, whose failure path redispatches into `framework_default` again, turning a clean `RuntimeError` into `SystemStackError`.

## Swallowing an exception must not make it invisible

Answering 500 means an exception that used to propagate no longer does, and Grape is usually mounted inside a host stack that was reporting it. Setting `env['grape.exception']` is not enough on its own: that key is Grape-private and nothing in the ecosystem reads it, so a rendering failure Sentry used to report as a raised exception would have quietly become an unremarkable 500.

So the exception is also published on `env['rack.exception']` — the convention for an exception that was *handled* rather than raised, which sentry-ruby collects as `env['rack.exception'] || env['sinatra.error']` — and the failure is written to `rack.errors`, so it reaches the server log even with no tracker installed. Measured with a tracker middleware mounted above Grape, using the repro above:

| | tracker observes | client gets |
| --- | --- | --- |
| master | `raised: JSON::GeneratorError` | `500 text/html`, the host's error page |
| this PR | `rack.exception: JSON::GeneratorError` | `500 application/json` |

Rails writes to `$stderr` from its failsafe branch for the same reason: deferring the logging to the application is not an option there, because the application's own error rendering is precisely what broke.

## Opting out

`Grape.config.raise_rendering_errors` keeps the old behaviour, alongside the existing `lint` / `warn_on_helper_overrides` settings:

```ruby
Grape.configure do |config|
  config.raise_rendering_errors = true
end
```

With it on the failsafe never runs: the exception is re-raised untouched, so neither env key is set and nothing is written to `rack.errors` — whatever caught it before catches it again.

## Backward compatibility

UPGRADING entry added, including the opt-out. Tests asserting `expect { get '/' }.to raise_error` on a rendering failure no longer see it raised; error trackers above Grape keep reporting it via `rack.exception` with no application change. Exceptions that no `rescue_from` matches still propagate exactly as before.

README documents the behaviour under Exception Handling, with `raise_rendering_errors` listed in Configuration.

## Test plan

- [x] Seven examples in `error_spec.rb` covering both fallback tiers, `grape.exception`, `rack.exception`, `rack.errors`, the opt-out, and the invariant that an unrescued exception still propagates; verified the behavioural ones fail without the `lib/` change.
- [x] End-to-end check with a tracker middleware mounted above Grape (table above), on master and on this branch, plus the documented example verified in both config states.
- [x] Full RSpec suite passes locally (2576 examples, 0 failures).
- [x] RuboCop clean.
- [ ] CI green.

---

Follow-up: #2855 applies the same `rack.exception` exposure to `safe_default`, the pre-existing unrecognised-error path, which had the identical blind spot. Split out of this PR at review request; based on this branch since it needs `Grape::Env::RACK_EXCEPTION`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
