### PR TITLE
Render a redirect message as the plain text it claims to be

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 * [#2841](https://github.com/ruby-grape/grape/pull/2841): Stop `use`, `helpers`, `rescue_from` and other registrations declared below a route from reaching it when an earlier registration had seeded the same key (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2846](https://github.com/ruby-grape/grape/pull/2846): Keep a `:version` path capture in `params` when the API declares no version, instead of always dropping it as Grape's own - [@ericproulx](https://github.com/ericproulx).
 * [#2839](https://github.com/ruby-grape/grape/pull/2839): Tag path params as UTF-8 instead of leaving them ASCII-8BIT, so they compare equal to the non-ASCII literals an API declares (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
+* [#2845](https://github.com/ruby-grape/grape/pull/2845): Render `redirect`'s default message as the plain text its content type announces, instead of letting the API's formatter re-encode it (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * [#2827](https://github.com/ruby-grape/grape/pull/2827): Make the `cascade` DSL getter return the configured value (`cascade false` read back as `true`) - [@ericproulx](https://github.com/ericproulx).
 * [#2829](https://github.com/ruby-grape/grape/pull/2829): Fix a cascading route handing over only to the last route registered for the path, making a middle version (3+ mounted versions with a catch-all) answer 406 - [@ericproulx](https://github.com/ericproulx).
 * [#2826](https://github.com/ruby-grape/grape/pull/2826): Fix `api.version` not being set for the root route of a path-versioned API (`GET /v1`) - [@ericproulx](https://github.com/ericproulx).
+* [#2845](https://github.com/ruby-grape/grape/pull/2845): Render a `redirect` message as the plain text its content type announces, instead of letting the API's formatter re-encode it - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -38,6 +38,41 @@ end
 
 Nothing changes for the ordinary arrangement — registrations declared before a route, or inherited from an enclosing namespace or a mounting API, still apply exactly as before, including values an enclosing scope gains after the nested scope was created.
 
+#### `redirect` renders its default message as plain text
+
+The `redirect` API set the content type to `text/plain`, but delegated body rendering to the formatter. With an API defaulting to JSON, a `redirect` would render the body as JSON with a `text/plain` content-type header.
+
+```ruby
+class API < Grape::API
+  format :json
+  get('/r') { redirect '/there' }
+end
+```
+
+```
+Content-Type: text/plain
+
+"This resource has been moved temporarily to /there."
+```
+
+Grape now renders the message it generates with the txt formatter, so the body is the plain sentence the content type claims:
+
+```
+Content-Type: text/plain
+
+This resource has been moved temporarily to /there.
+```
+
+**What can break.** Code that parses a redirect body — `JSON.parse(response.body)` on a redirect succeeded before and now raises — or a test asserting on the encoded form. On a JSON API the `Location` header, the status and the `Content-Type` are unchanged, so a client that follows the redirect is unaffected.
+
+On an API whose formatter cannot serialize a String, such as `format :xml`, `redirect` did not work at all: the formatter raised, and the response was a `500` carrying an error document and no `Location` header. Those APIs now get the `302` and the `Location` they always should have.
+
+This applies only to the message Grape generates. A body you pass yourself is still rendered by the API's formatter, unchanged:
+
+```ruby
+redirect '/there', body: { message: 'moved' }   # still {"message":"moved"} on a JSON API
+```
+
 #### Path params are tagged UTF-8 instead of ASCII-8BIT
 
 Params captured from the request path — `route_param`, `:id`-style segments, splats — now come back tagged `UTF-8`. They used to carry the `ASCII-8BIT` encoding of Rack's `PATH_INFO`, because Mustermann decodes the path against that raw string and nothing re-tagged the result. Query and body params were already `UTF-8`, since Rack tags those itself.

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -52,7 +52,12 @@ module Grape
           body_message ||= "This resource has been moved temporarily to #{url}."
         end
         header 'Location', url
+        # The message is plain text, so say so and render it as such. Setting
+        # only the header left the body to the API's own formatter, which on a
+        # JSON API returned the sentence wrapped in quotes under a text/plain
+        # content type.
         content_type 'text/plain'
+        api_format :txt
         body body_message
       end
 

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -53,6 +53,12 @@ module Grape
         end
         header 'Location', url
         content_type 'text/plain'
+        # Render the message Grape generated as the plain text it is. Setting
+        # only the header left it to the API's own formatter, which on a JSON
+        # API returned the sentence wrapped in quotes under a text/plain content
+        # type. A caller-supplied body keeps the API's format: it may be
+        # structured, and the txt formatter would render a Hash through `to_s`.
+        api_format :txt unless body
         body body_message
       end
 

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -667,6 +667,66 @@ describe Grape::Endpoint do
       get '/hey'
       expect(last_response.body).to eq 'test body'
     end
+
+    # The generated message is announced as text/plain, so it has to be rendered
+    # as such whatever the API's own format is. Left to the JSON formatter it
+    # came back as a quoted JSON string under a text/plain content type.
+    context 'when the API declares a format of its own' do
+      before do
+        subject.format :json
+        subject.get('/hey') { redirect '/ha' }
+      end
+
+      it 'renders the message as plain text' do
+        get '/hey'
+
+        expect(last_response.headers[Rack::CONTENT_TYPE]).to eq('text/plain')
+        expect(last_response.body).to eq 'This resource has been moved temporarily to /ha.'
+      end
+
+      # Only the message Grape generates is known to be text. A body the caller
+      # passed keeps the API's format, so a structured one stays parseable
+      # rather than being rendered through the txt formatter's `to_s`.
+      it 'leaves a structured body to the API format' do
+        subject.get('/there') { redirect '/ha', body: { message: 'go away' } }
+
+        get '/there'
+        expect(last_response.body).to eq({ message: 'go away' }.to_json)
+      end
+
+      it 'leaves a string body to the API format' do
+        subject.get('/there') { redirect '/ha', body: 'go away' }
+
+        get '/there'
+        expect(last_response.body).to eq '"go away"'
+      end
+
+      it 'leaves the format of other routes alone' do
+        subject.get('/plain') { { a: 1 } }
+
+        get '/plain'
+        expect(last_response.headers[Rack::CONTENT_TYPE]).to eq('application/json')
+        expect(last_response.body).to eq({ a: 1 }.to_json)
+      end
+    end
+
+    # The XML formatter cannot serialize a String, so it raised and the redirect
+    # came back as a 500 carrying an error document and no Location header.
+    context 'when the API format cannot serialize a string' do
+      before do
+        subject.format :xml
+        subject.get('/hey') { redirect '/ha' }
+      end
+
+      it 'still redirects' do
+        get '/hey'
+
+        expect(last_response.status).to eq 302
+        expect(last_response.headers['Location']).to eq '/ha'
+        expect(last_response.headers[Rack::CONTENT_TYPE]).to eq('text/plain')
+        expect(last_response.body).to eq 'This resource has been moved temporarily to /ha.'
+      end
+    end
   end
 
   describe 'NameError' do

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -667,6 +667,38 @@ describe Grape::Endpoint do
       get '/hey'
       expect(last_response.body).to eq 'test body'
     end
+
+    # The message is announced as text/plain, so it has to be rendered as such
+    # whatever the API's own format is. Left to the JSON formatter it came back
+    # as a quoted JSON string under a text/plain content type.
+    context 'when the API declares a format of its own' do
+      before do
+        subject.format :json
+        subject.get('/hey') { redirect '/ha' }
+      end
+
+      it 'renders the message as plain text' do
+        get '/hey'
+
+        expect(last_response.headers[Rack::CONTENT_TYPE]).to eq('text/plain')
+        expect(last_response.body).to eq 'This resource has been moved temporarily to /ha.'
+      end
+
+      it 'renders an overridden body as plain text too' do
+        subject.get('/there') { redirect '/ha', body: 'go away' }
+
+        get '/there'
+        expect(last_response.body).to eq 'go away'
+      end
+
+      it 'leaves the format of other routes alone' do
+        subject.get('/plain') { { a: 1 } }
+
+        get '/plain'
+        expect(last_response.headers[Rack::CONTENT_TYPE]).to eq('application/json')
+        expect(last_response.body).to eq({ a: 1 }.to_json)
+      end
+    end
   end
 
   describe 'NameError' do


### PR DESCRIPTION
## Summary

`#redirect` announces its message as `text/plain` — and has since it was introduced in 2015, in a commit literally titled *"Redirect as plain text with optional message override"* — but it only ever set the header. The body was still handed to the API's own formatter:

```ruby
class API < Grape::API
  format :json
  get('/r') { redirect '/there' }
end
```

```
HTTP/1.1 302 Found
Location: /there
Content-Type: text/plain

"This resource has been moved temporarily to /there."
```

Quotes included. That is neither valid plain text nor what a client reading the content type would expect, and the header and body contradict each other.

| API format | before | after |
| --- | --- | --- |
| `format :json` | `302`, `text/plain` + `"…moved temporarily to /there."` (quoted) | `302`, `text/plain` + `…moved temporarily to /there.` |
| `format :txt` | correct already | unchanged |
| `format :xml` | **`500`, `application/xml`, no `Location` header** | `302`, `Location: /there`, `text/plain` + the message |

The `:xml` row is worse than it first looked: the XML formatter cannot serialize a String, so it raised and the error path took over. `redirect` on an XML API has never redirected at all — it answered `500` with `<error><message>cannot convert String to xml</message></error>` and no `Location`. There is a spec pinning the `302` now.

The existing `#redirect` specs missed it because they run on the default `:txt` format, where the formatter is a no-op.

## Approach

Set `api.format` alongside the header for the generated message — the same lever an endpoint already has via `#api_format` (spec'd in `api_spec.rb` as *'can be overwritten with an explicit api_format'*) — so the message is rendered by the txt formatter whatever the API declares. `:txt` is always resolvable: `Grape::Formatter.formatter_for` falls back to the built-in registry, which is not narrowed by the API's `format`.

It is per-request rack env, so other routes on the same API are unaffected — there is a spec pinning that.

## Backward compatibility

**UPGRADING entry added** — @dblock is right that this is a breaking change, and the original description of it here was wrong.

The body of a redirect changes on any API whose format is not `:txt`. Concretely, `JSON.parse(response.body)` on a redirect succeeded before and now raises. On a JSON API the `Location` header, the status and the `Content-Type` are unchanged, so a client that follows the redirect is unaffected — but code that reads the body is.

On a format that could not serialize the message at all, such as `:xml`, the status, `Content-Type` and `Location` all change — from a `500` with no `Location` to the `302` that was always intended.

Longstanding rather than a regression: present since v0.14.0 (`d1bba79d`, 2015) and identical in 3.3.4.

## Scoped to the generated message

The first version of this PR set `api_format :txt` unconditionally, which also caught a body the caller passed. That was worse than the bug on a JSON API:

```ruby
redirect '/there', body: { message: 'moved' }
# before:  {"message":"moved"}
# with the unconditional version:  {message: "moved"}   # Hash#to_s — neither JSON nor useful text
```

So the format is now only forced for the message Grape generates, which is the one body known to be plain text:

```ruby
api_format :txt unless body
```

A caller-supplied body keeps the API's format and is untouched by this PR. The trade-off is that `redirect url, body: 'go away'` on a JSON API still returns `"go away"` quoted under `text/plain` — the same contradiction, for a body Grape cannot assume anything about. Narrowing it further (say, rendering any `String` body as text) is a judgement call I left out; happy to widen it if you'd prefer.

## Test plan

- [x] 5 new examples in `endpoint_spec.rb` under `#redirect`: plain-text body on a JSON API, a structured and a string caller-supplied body both keeping the API's format, a guard that other routes keep it too, and a `302` + `Location` on an XML API. Verified the XML one fails without the `lib/` change (`expected: 302`).
- [x] Full RSpec suite passes locally (2596 examples, 0 failures).
- [x] RuboCop clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

