### PR TITLE
Keep a :version path capture when the API declares no version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * [#2827](https://github.com/ruby-grape/grape/pull/2827): Make the `cascade` DSL getter return the configured value (`cascade false` read back as `true`) - [@ericproulx](https://github.com/ericproulx).
 * [#2829](https://github.com/ruby-grape/grape/pull/2829): Fix a cascading route handing over only to the last route registered for the path, making a middle version (3+ mounted versions with a catch-all) answer 406 - [@ericproulx](https://github.com/ericproulx).
 * [#2826](https://github.com/ruby-grape/grape/pull/2826): Fix `api.version` not being set for the root route of a path-versioned API (`GET /v1`) - [@ericproulx](https://github.com/ericproulx).
+* [#2846](https://github.com/ruby-grape/grape/pull/2846): Keep a `:version` path capture in `params` when the API declares no version, instead of always dropping it as Grape's own - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 * [#2853](https://github.com/ruby-grape/grape/pull/2853): Restore, behind a deprecation warning, the trailing positional options Hash of `requires`, `optional` and `use`, which #2618 turned into a parameter name - [@ericproulx](https://github.com/ericproulx).
 * [#2856](https://github.com/ruby-grape/grape/pull/2856): Update simplecov - [@ericproulx](https://github.com/ericproulx).
 * [#2841](https://github.com/ruby-grape/grape/pull/2841): Stop `use`, `helpers`, `rescue_from` and other registrations declared below a route from reaching it when an earlier registration had seeded the same key (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
+* [#2846](https://github.com/ruby-grape/grape/pull/2846): Keep a `:version` path capture in `params` when the API declares no version, instead of always dropping it as Grape's own - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/lib/grape/request.rb
+++ b/lib/grape/request.rb
@@ -168,13 +168,37 @@ module Grape
 
     def make_params
       params = @params_builder.call(rack_params)
-      routing_args = env[Grape::Env::GRAPE_ROUTING_ARGS]
-      filtered = routing_args&.except(:version, :route_info)
+      filtered = routing_args_as_params(env[Grape::Env::GRAPE_ROUTING_ARGS])
       return params if filtered.blank?
 
       params.deep_merge!(filtered)
     rescue *Grape::RACK_ERRORS
       raise Grape::Exceptions::RequestError
+    end
+
+    # The routing args carry two things that are not request params:
+    # +:route_info+, which is always Grape's own, and +:version+, which is only
+    # Grape's own when the API declared a version — that is captured as a path
+    # segment and exposed through +env['api.version']+ instead.
+    #
+    # An API that declares no version can legitimately name a param +:version+
+    # (`route_param :version`, `get '/:version'`), and that capture belongs to
+    # the application. Dropping it unconditionally left `params[:version]` nil
+    # on a route that had matched, losing the segment silently.
+    def routing_args_as_params(routing_args)
+      return if routing_args.nil?
+      return routing_args.except(:version, :route_info) if grape_owns_version?(routing_args)
+
+      routing_args.except(:route_info)
+    end
+
+    # A route reports a +version+ only when the API declared one, which is the
+    # case where the captured segment is Grape's rather than the application's.
+    def grape_owns_version?(routing_args)
+      return false unless routing_args.key?(:version)
+
+      route = routing_args[:route_info]
+      route.respond_to?(:version) && !route.version.nil?
     end
 
     # Uses a plain `each_header` block instead of `each_header.with_object`:

--- a/spec/grape/request_spec.rb
+++ b/spec/grape/request_spec.rb
@@ -50,13 +50,29 @@ describe Grape::Request do
       let(:routing_args) do
         {
           version: '123',
-          route_info: '456',
+          route_info: instance_double(Grape::Router::Route, version: route_version),
           c: 'ccc'
         }
       end
 
-      it 'cuts version and route_info' do
-        expect(request.params).to eq(ActiveSupport::HashWithIndifferentAccess.new(a: '123', b: 'xyz', c: 'ccc'))
+      context 'when the route carries a version of its own' do
+        let(:route_version) { 'v1' }
+
+        it 'cuts version and route_info' do
+          expect(request.params).to eq(ActiveSupport::HashWithIndifferentAccess.new(a: '123', b: 'xyz', c: 'ccc'))
+        end
+      end
+
+      # Without a declared version the captured segment is the application's:
+      # `route_param :version` on an unversioned API has to reach the endpoint.
+      context 'when the route carries no version' do
+        let(:route_version) { nil }
+
+        it 'cuts only route_info' do
+          expect(request.params).to eq(
+            ActiveSupport::HashWithIndifferentAccess.new(a: '123', b: 'xyz', c: 'ccc', version: '123')
+          )
+        end
       end
     end
 

--- a/spec/integration/hashie/hashie_spec.rb
+++ b/spec/integration/hashie/hashie_spec.rb
@@ -152,7 +152,7 @@ describe 'Hashie', if: defined?(Hashie) do
         let(:routing_args) do
           {
             version: '123',
-            route_info: '456',
+            route_info: instance_double(Grape::Router::Route, version: 'v1'),
             c: 'ccc'
           }
         end


### PR DESCRIPTION
## Summary

`Grape::Request#make_params` dropped `:version` from the routing args unconditionally, alongside `:route_info`:

```ruby
filtered = routing_args&.except(:version, :route_info)
```

That is right when Grape put it there — a path-versioned API captures the version as a segment and exposes it through `env['api.version']` rather than `params`. But it is not always Grape's. An API that declares no version can name a param `:version`:

```ruby
class API < Grape::API
  format :json
  route_param :version do
    get { { v: params[:version] } }   # => {"v": null}
  end
end
```

`GET /abc` matched, Mustermann captured `version => "abc"`, and the value was filtered out before the endpoint saw it — `params[:version]` nil and the key absent from `params` altogether. Same for a bare `get '/:version'`. A segment silently lost on a route that had matched.

| API | `params[:version]` before | after |
| --- | --- | --- |
| no version declared, `route_param :version` | **nil** | `"abc"` |
| no version declared, `get '/:version'` | **nil** | `"abc"` |
| `version 'v1', using: :path` | absent (correct) | absent |
| `version 'v1', using: :header` | absent (correct) | absent |
| `version 'v1', using: :param` | absent (correct) | absent |

## Approach

A route reports a `#version` only when the API declared one — `Grape::Router::BaseRoute` already delegates it to the pattern — so that distinguishes the two cases without any new API. Drop the capture when the route carries a version, keep it otherwise.

All three versioning strategies are unaffected: their routes report a version, so `:version` stays out of `params` and `env['api.version']` remains the way to read it. A path-versioned API with a nested `route_param :id` still gets only `id`.

## Backward compatibility

No UPGRADING entry. The change only adds a param that was being discarded, on APIs that declare no version — where nothing could have depended on it being absent, since the route matched but the value was unreachable.

`request_spec.rb`'s "cuts version and route_info" asserted the old unconditional rule against a synthetic `route_info`; it now covers both branches with a route double that does and does not report a version.

Longstanding, not a regression: identical in 3.3.4.

## Test plan

- [x] `request_spec.rb` split into version-carrying and version-less routes; verified the version-less case fails without the `lib/` change.
- [x] Full RSpec suite passes locally (2544 examples, 0 failures).
- [x] RuboCop clean.
- [x] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)