### PR TITLE
Recompile the router when a route is declared after compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * [#2827](https://github.com/ruby-grape/grape/pull/2827): Make the `cascade` DSL getter return the configured value (`cascade false` read back as `true`) - [@ericproulx](https://github.com/ericproulx).
 * [#2829](https://github.com/ruby-grape/grape/pull/2829): Fix a cascading route handing over only to the last route registered for the path, making a middle version (3+ mounted versions with a catch-all) answer 406 - [@ericproulx](https://github.com/ericproulx).
 * [#2826](https://github.com/ruby-grape/grape/pull/2826): Fix `api.version` not being set for the root route of a path-versioned API (`GET /v1`) - [@ericproulx](https://github.com/ericproulx).
+* [#2848](https://github.com/ruby-grape/grape/pull/2848): Recompile the router when a route is declared after the API has been compiled, so it is served instead of listed by `routes` and answering 404 - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -206,6 +206,11 @@ module Grape
         )
         endpoints << new_endpoint unless endpoints.include?(new_endpoint)
 
+        # The router is built once, when the API is first compiled, so an
+        # endpoint added after that would be listed by #routes and still 404.
+        # `helpers` and `mount` already invalidate for the same reason.
+        change!
+
         inheritable_setting.route_end
         reset_validations!
       end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -4120,6 +4120,48 @@ describe Grape::API do
     end
   end
 
+  # The router is built once, when the API is first compiled. A route declared
+  # after that was listed by .routes and still answered 404, so the API's own
+  # metadata disagreed with what it served.
+  describe 'a route declared after the API has been compiled' do
+    before do
+      subject.format :json
+      subject.get('/first') { 'first' }
+    end
+
+    it 'is served after a request has already been made' do
+      get '/first'
+      subject.get('/second') { 'second' }
+
+      get '/second'
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq('second'.to_json)
+    end
+
+    it 'is served after recognize_path has compiled the router' do
+      subject.recognize_path('/first')
+      subject.get('/second') { 'second' }
+
+      get '/second'
+      expect(last_response.status).to eq(200)
+    end
+
+    it 'is recognised by recognize_path' do
+      get '/first'
+      subject.get('/second') { 'second' }
+
+      expect(subject.recognize_path('/second')).not_to be_nil
+    end
+
+    it 'leaves the routes declared before it serving' do
+      get '/first'
+      subject.get('/second') { 'second' }
+
+      get '/first'
+      expect(last_response.body).to eq('first'.to_json)
+    end
+  end
+
   describe '.endpoint' do
     before do
       subject.format :json

--- a/spec/grape/dsl/routing_spec.rb
+++ b/spec/grape/dsl/routing_spec.rb
@@ -12,6 +12,10 @@ describe Grape::DSL::Routing do
       class << self
         attr_reader :instance, :base
         attr_accessor :configuration
+
+        # Part of the contract Grape::DSL::Routing expects of its host, the
+        # same way #mount already relies on it.
+        def change!; end
       end
     end
   end


### PR DESCRIPTION
## Summary

The router is built once, when the API is first compiled, and `#compile!` memoizes the instance holding it. A route declared after that point was appended to the endpoint list — `.routes` reported it — but never reached the router, so requests for it answered **404** and `recognize_path` returned nil. The API's own metadata disagreed with what it served.

Whether it bit depended on what had touched the API first:

| sequence | before | after |
| --- | --- | --- |
| `get('/one')` … `get('/two')` | 200 | 200 |
| `api.routes` then `get('/two')` | 200 | 200 |
| a **request**, then `get('/two')` | **404** | 200 |
| `api.recognize_path('/one')`, then `get('/two')` | **404** | 200 |
| a request, then `get('/two')`, then explicit `api.change!` | 200 | 200 |

In every case `.routes` already listed `/two`.

## Approach

Call `#change!` when a route is added. `helpers` and `mount` already do this for exactly the same reason — route declaration was the one mutating DSL call that did not, which is why an explicit `api.change!` was the existing workaround.

The dummy host in `routing_spec.rb` gains `#change!`. `Grape::DSL::Routing` already required it of its host: `#mount` calls it bare too, just from a branch that dummy never reaches.

## Perf

**The normal shape — declare every route, then serve — is unaffected.** `#change!` is a single ivar assignment and compilation is lazy, so the calls made while a class body is evaluated cost nothing:

| | 2000 routes |
| --- | --- |
| before | 1.247s |
| after | 1.242s |

Serving 200 requests against a fully-declared API takes 0.075s, unchanged.

**Interleaving declaration with serving now costs O(n²)**, because each declaration discards the compiled router and the next request rebuilds every endpoint so far:

| declare+request, alternating | total | per route |
| --- | --- | --- |
| n=25 | 0.039s | 1.56 ms |
| n=50 | 0.112s | 2.25 ms |
| n=100 | 0.433s | 4.33 ms |
| n=200 | 1.758s | 8.79 ms |

Worth stating plainly rather than burying: on master the same loop takes 0.014s — but only because it is not doing the work. Every one of those requests answers **404**; that is the bug. The cost is the price of the routes actually being served, and it is paid only by a pattern that previously did not function.

If that pattern matters enough, the follow-up is an incremental router append rather than a full rebuild on invalidation — a substantially larger change to `Grape::Router`, deliberately not attempted here.

## Backward compatibility

No UPGRADING entry. A route that previously 404'd now answers; nothing could have relied on a declared route being unreachable. APIs defined entirely before first use — effectively all of them — are unaffected, since the route table is identical by the time anything compiles.

Longstanding, not a regression: identical in 3.3.4.

## Test plan

- [x] 4 new examples in `api_spec.rb` covering a route added after a request and after `recognize_path`, its visibility to `recognize_path`, and a guard that earlier routes keep serving; verified 3 fail without the `lib/` change.
- [x] Full RSpec suite passes locally (2547 examples, 0 failures).
- [x] RuboCop clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
