### PR TITLE
Preserve positional options for named params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * [#2829](https://github.com/ruby-grape/grape/pull/2829): Fix a cascading route handing over only to the last route registered for the path, making a middle version (3+ mounted versions with a catch-all) answer 406 - [@ericproulx](https://github.com/ericproulx).
 * [#2826](https://github.com/ruby-grape/grape/pull/2826): Fix `api.version` not being set for the root route of a path-versioned API (`GET /v1`) - [@ericproulx](https://github.com/ericproulx).
 * [#2842](https://github.com/ruby-grape/grape/pull/2842): Warn at definition time when a `rescue_from` class is already covered by one registered earlier in the same scope, since the later handler never runs - [@ericproulx](https://github.com/ericproulx).
+* [#2852](https://github.com/ruby-grape/grape/pull/2852): Preserve positional options hashes passed to named params - [@cyphercodes](https://github.com/cyphercodes).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -54,6 +54,8 @@ module Grape
       #       end
       #     end
       def use(*names, **options)
+        options = names.pop if options.empty? && names.size > 1 && names.last.is_a?(Hash)
+
         named_params = @api.inheritable_setting.named_params || {}
         names.each do |name|
           params_block = named_params.fetch(name) do

--- a/spec/grape/dsl/parameters_spec.rb
+++ b/spec/grape/dsl/parameters_spec.rb
@@ -63,6 +63,13 @@ describe Grape::DSL::Parameters do
       subject.use :params_group, **options
     end
 
+    it 'extracts a positional options hash from named params' do
+      subject.api = Class.new { include Grape::DSL::Settings }.new
+      subject.api.inheritable_setting.add_named_params(named_params)
+      expect(subject).to receive(:instance_exec).with(options).and_yield
+      subject.use :params_group, options
+    end
+
     it 'raises error when non-existent named param is called' do
       subject.api = Class.new { include Grape::DSL::Settings }.new
       expect { subject.use :params_group }.to raise_error('Params :params_group not found!')


### PR DESCRIPTION
## Summary

`Grape::DSL::Parameters#use` still accepts keyword options, but Ruby 3 no longer turns a trailing positional Hash into keywords. After #2618, calls like `use :pagination, { max_per_page: 100 }` treated the Hash as another named params key instead of as options.

This restores the old `extract_options!` behavior for the multi-argument case by extracting a trailing positional Hash when no keyword options were supplied, while preserving single-argument named param lookup.

Fixes #2851.

## Test plan

- [x] Added a regression example for `use :params_group, options`; verified it fails before the fix.
- [x] `bundle exec rspec spec/grape/dsl/parameters_spec.rb` (Ruby 3.4 Docker): 24 examples, 0 failures.
- [x] `bundle exec rubocop lib/grape/dsl/parameters.rb spec/grape/dsl/parameters_spec.rb`: 2 files inspected, no offenses detected.
- [x] `bundle exec rake` (Ruby 3.4 Docker): RuboCop 338 files inspected, no offenses detected; RSpec 2551 examples, 0 failures.
- [ ] CI green.

🤖 AI-assisted with Hermes Agent; changes were reviewed and verified locally.
