### PR TITLE
Deprecate the positional options Hash in requires, optional and use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * [#2829](https://github.com/ruby-grape/grape/pull/2829): Fix a cascading route handing over only to the last route registered for the path, making a middle version (3+ mounted versions with a catch-all) answer 406 - [@ericproulx](https://github.com/ericproulx).
 * [#2826](https://github.com/ruby-grape/grape/pull/2826): Fix `api.version` not being set for the root route of a path-versioned API (`GET /v1`) - [@ericproulx](https://github.com/ericproulx).
 * [#2842](https://github.com/ruby-grape/grape/pull/2842): Warn at definition time when a `rescue_from` class is already covered by one registered earlier in the same scope, since the later handler never runs - [@ericproulx](https://github.com/ericproulx).
+* [#2853](https://github.com/ruby-grape/grape/pull/2853): Restore, behind a deprecation warning, the trailing positional options Hash of `requires`, `optional` and `use`, which #2618 turned into a parameter name - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -707,7 +707,16 @@ Grape has been modernized to use Ruby 3+'s preferred argument delegation pattern
 - Method signatures are now more explicit and follow Ruby 3+ best practices
 - The `active_support/core_ext/array/extract_options` dependency has been removed
 
-This is a modernization effort that improves code quality while maintaining full backward compatibility.
+Passing the options of `requires`, `optional` and `use` as a trailing positional Hash still works, but is deprecated:
+
+```ruby
+params do
+  requires :id, { type: Integer } # deprecated
+  requires :id, type: Integer     # do this instead
+end
+```
+
+Under `extract_options!` the braces made no difference. They do now: Ruby only turns a trailing Hash into keyword arguments when it is written without braces, so a braced Hash lands in the splat and would otherwise be taken for a parameter name.
 
 See [#2618](https://github.com/ruby-grape/grape/pull/2618) for more information.
 

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -54,6 +54,8 @@ module Grape
       #       end
       #     end
       def use(*names, **options)
+        return redispatch_legacy_options(:use, names, options) if legacy_options?(names)
+
         named_params = @api.inheritable_setting.named_params || {}
         names.each do |name|
           params_block = named_params.fetch(name) do
@@ -74,8 +76,8 @@ module Grape
       #
       # @param attrs list of parameters names, or, if :using is
       #   passed as an option, which keys to include (:all or :none) from
-      #   the :using hash. The last key can be a hash, which specifies
-      #   options for the parameters
+      #   the :using hash. Passing the options as a trailing positional Hash
+      #   is deprecated; pass them as keyword arguments instead.
       # @option attrs :type [Class] the type to coerce this parameter to before
       #   passing it to the endpoint. See {Grape::Validations::Types} for a list of
       #   types that are supported automatically. Custom classes may be used
@@ -123,6 +125,8 @@ module Grape
       #       end
       #     end
       def requires(*attrs, using: nil, except: nil, **opts, &block)
+        return redispatch_legacy_options(:requires, attrs, { using:, except: }.compact.merge(opts), &block) if legacy_options?(attrs)
+
         opts[:presence] = { value: true, message: opts[:message] }
         opts = @group.deep_merge(opts) if @group
 
@@ -137,6 +141,8 @@ module Grape
       # @param (see #requires)
       # @option (see #requires)
       def optional(*attrs, using: nil, except: nil, **opts, &block)
+        return redispatch_legacy_options(:optional, attrs, { using:, except: }.compact.merge(opts), &block) if legacy_options?(attrs)
+
         type = opts[:type]
         opts = @group.deep_merge(opts) if @group
 
@@ -209,6 +215,22 @@ module Grape
       end
 
       private
+
+      # @deprecated A trailing positional options Hash is deprecated; pass keyword
+      #   arguments instead. Before Ruby 3 keyword separation this Hash was pulled
+      #   off the argument list by `extract_options!`; now it lands in the splat and
+      #   would silently be treated as a parameter name.
+      def legacy_options?(args)
+        args.size > 1 && args.last.is_a?(Hash)
+      end
+
+      # Re-invokes +method_name+ with the trailing Hash splatted as keyword
+      # arguments, so Ruby routes its keys to the same place they would have
+      # reached had the caller omitted the braces.
+      def redispatch_legacy_options(method_name, args, opts, &)
+        Grape.deprecator.warn("Passing a positional options Hash to `#{method_name}` is deprecated. Pass keyword arguments instead.")
+        __send__(method_name, *args[0..-2], **args.last.merge(opts), &)
+      end
 
       def first_hash_key_or_param(parameter)
         parameter.is_a?(Hash) ? parameter.keys.first : parameter

--- a/spec/grape/dsl/parameters_spec.rb
+++ b/spec/grape/dsl/parameters_spec.rb
@@ -244,6 +244,60 @@ describe Grape::DSL::Parameters do
     end
   end
 
+  describe 'deprecated positional options Hash' do
+    it 'deprecates a positional Hash for `requires` but still works when silenced' do
+      expect { subject.requires :id, { type: Integer, desc: 'Identity.' } }
+        .to raise_error(ActiveSupport::DeprecationException, /positional options Hash to `requires`/)
+
+      Grape.deprecator.silence { subject.requires :id, { type: Integer, desc: 'Identity.' } }
+      expect(subject.validate_attributes_reader).to eq([[:id], { type: Integer, desc: 'Identity.', presence: { value: true, message: nil } }])
+      expect(subject.push_declared_params_reader).to eq([:id])
+    end
+
+    it 'deprecates a positional Hash for `optional` but still works when silenced' do
+      expect { subject.optional :id, { type: Integer, desc: 'Identity.' } }
+        .to raise_error(ActiveSupport::DeprecationException, /positional options Hash to `optional`/)
+
+      Grape.deprecator.silence { subject.optional :id, { type: Integer, desc: 'Identity.' } }
+      expect(subject.validate_attributes_reader).to eq([[:id], { type: Integer, desc: 'Identity.' }])
+      expect(subject.push_declared_params_reader).to eq([:id])
+    end
+
+    it 'deprecates a positional Hash for `use` but still works when silenced' do
+      subject.api = Class.new { include Grape::DSL::Settings }.new
+      subject.api.inheritable_setting.add_named_params(params_group: proc {})
+
+      expect { subject.use :params_group, { option: 'value' } }
+        .to raise_error(ActiveSupport::DeprecationException, /positional options Hash to `use`/)
+
+      expect(subject).to receive(:instance_exec).with(option: 'value').and_yield
+      Grape.deprecator.silence { subject.use :params_group, { option: 'value' } }
+    end
+
+    it 'keeps the options of the positional Hash applying to every attribute' do
+      Grape.deprecator.silence { subject.requires :a, :b, { type: Integer } }
+
+      expect(subject.validate_attributes_reader).to eq([%i[a b], { type: Integer, presence: { value: true, message: nil } }])
+      expect(subject.push_declared_params_reader).to eq(%i[a b])
+    end
+
+    it 'routes :using out of the positional Hash to the keyword argument' do
+      documentation = { id: { type: Integer } }
+      expect(subject).to receive(:require_required_and_optional_fields).with(:all, using: documentation, except: nil)
+
+      Grape.deprecator.silence { subject.requires :all, { using: documentation } }
+    end
+
+    it 'does not deprecate keyword arguments' do
+      expect { subject.requires :id, type: Integer }.not_to raise_error
+      expect { subject.optional :id, type: Integer }.not_to raise_error
+    end
+
+    it 'does not deprecate a Hash that is the only argument' do
+      expect { subject.requires(type: Integer) }.not_to raise_error
+    end
+  end
+
   describe '#params' do
     it 'inherits params from parent' do
       parent_params = { foo: 'bar' }

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -9,6 +9,22 @@ describe Grape::Validations::ParamsScope do
     subject
   end
 
+  context 'when the options are given as a deprecated positional Hash' do
+    it 'coerces the parameter as if the options had been passed as keyword arguments' do
+      Grape.deprecator.silence do
+        subject.params do
+          requires :id, { type: Integer }
+          optional :page, { type: Integer, default: 1 }
+        end
+      end
+      subject.get('/legacy') { [params[:id].class, params[:page]].join(',') }
+
+      get '/legacy', id: '5'
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq('Integer,1')
+    end
+  end
+
   context 'when using custom types' do
     let(:custom_type) do
       Class.new do


### PR DESCRIPTION
Fixes #2851. Supersedes #2852.

## The bug

[#2618](https://github.com/ruby-grape/grape/pull/2618) replaced `attrs.extract_options!` with an explicit `**opts` parameter in `Grape::DSL::Parameters`. As @OuYangJinTing pointed out in #2851, the two are not equivalent: Ruby only converts a trailing `Hash` into keyword arguments when it is written *without* braces, so a braced Hash stays in the splat — where these methods take it for a parameter name.

`UPGRADING.md` claimed the change maintained "full backward compatibility". It did not:

| call | behaviour on master |
| --- | --- |
| `optional :id, { type: Integer }` | **silent** — no coercion, `params[:id]` is a `String` |
| `requires :id, { type: Integer }` | every request `400`s with `{type: Integer} is missing`, and `:id` loses its coercion |
| `use :pg, { foo: 1 }` | `RuntimeError: Params :{foo: 1} not found!` |

The `optional` case is the dangerous one. Nothing raises, nothing warns — a parameter that used to arrive coerced now arrives as a raw `String`, and the API keeps answering `200`.

## The fix

The old behaviour is restored behind a deprecation warning, following the `merge_legacy_auth_options` precedent already used for `auth`, `http_basic`, `http_digest` and `desc`:

```ruby
params do
  requires :id, { type: Integer } # warns, still works
  requires :id, type: Integer     # do this instead
end
```

```
DEPRECATION WARNING: Passing a positional options Hash to `requires` is deprecated. Pass keyword arguments instead.
```

Two private helpers in `lib/grape/dsl/parameters.rb` do the work:

```ruby
def legacy_options?(args)
  args.size > 1 && args.last.is_a?(Hash)
end

def redispatch_legacy_options(method_name, args, opts, &)
  Grape.deprecator.warn("Passing a positional options Hash to `#{method_name}` is deprecated. Pass keyword arguments instead.")
  __send__(method_name, *args[0..-2], **args.last.merge(opts), &)
end
```

### Why re-dispatch instead of merging into `**opts`

`requires` and `optional` declare `using:` and `except:` as *explicit* keyword parameters. Merging the legacy Hash into `**opts` in place would leave `:using` sitting in `opts` while the `using` local stayed `nil`, so `requires :all, { using: Entity.documentation }` would quietly build a parameter literally named `:all` instead of expanding the documentation Hash — one silent bug swapped for another.

Splatting the Hash back at the call site and re-invoking the method lets Ruby redo the keyword routing, and it keeps working if either method gains another explicit keyword later. Keyword arguments win over the legacy Hash on conflict, matching `legacy_options.first.merge(options)` in `Grape::Middleware::Auth::DSL`.

## Relationship to #2852

@cyphercodes' #2852 fixes the same issue for `use`. This PR is a superset of it and I think it should land instead, for three reasons:

1. **`requires` and `optional` are affected too**, and `optional` fails silently — the worst of the three. #2852 leaves both untouched.
2. **A deprecation rather than a silent restore.** #2852 restores the old behaviour with no warning, which keeps the legacy form working indefinitely with nothing prompting anyone to migrate. Grape already deprecates exactly this pattern in four other DSL methods; this makes the fifth, sixth and seventh consistent with them.
3. **`using:` / `except:` routing**, described above, which a positional extraction inside `use` doesn't need but `requires` and `optional` do.

#2852's guard also requires `options.empty?`, so a mixed call like `use :pg, { a: 1 }, b: 2` silently drops `{ a: 1 }`; here the two are merged with the keywords taking precedence, as `extract_options!` effectively did.

Thanks @cyphercodes for the fix and the regression example — the `use` spec here is yours, extended.

## Scope

Deliberately left alone:

- **`given(*attrs, &)`** must *not* get this check. It has no `**`, so keyword arguments legitimately arrive as a trailing Hash in `attrs` — that is what `first_hash_key_or_param` exists for. The check only applies to methods that actually declare a double splat.
- **A Hash that is the only argument** (`requires({ type: Integer })`) does not warn; the guard is `args.size > 1`. With nothing in front of it there is no parameter being declared either way, so there is no prior behaviour to preserve.
- **`Grape::DSL::Entity#present`** has the same latent problem — `present(obj, { with: X })` silently drops the options because the `args.count == 2 && args.first.is_a?(Symbol)` destructuring fails. It is unrelated to named params and out of scope here; happy to open a follow-up.

## Docs

- The `@param attrs` doc for `requires` still advertised the trailing Hash ("The last key can be a hash, which specifies options for the parameters"). Updated to point at keyword arguments.
- `UPGRADING.md` — the >= 3.0.0 section that introduced this is amended: the "full backward compatibility" claim is now accurate again, with the deprecated form spelled out. No new entry, since nothing breaks.

## Test plan

- [x] `spec/grape/dsl/parameters_spec.rb` — warns and still works for `requires`, `optional` and `use`; options of a positional Hash apply to every attribute; `:using` routes out of the Hash to the keyword parameter; the keyword form does not warn; a lone Hash does not warn.
- [x] `spec/grape/validations/params_scope_spec.rb` — request-level regression proving the coercion that was silently lost is applied again.
- [x] `bundle exec rspec` — 2558 examples, 0 failures.
- [x] `bundle exec rubocop` — no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
