### PR TITLE
Remove deprecation test. Fixed in 2.2.0

### DIFF
--- a/spec/integration/grape_swagger/grape_swagger_spec.rb
+++ b/spec/integration/grape_swagger/grape_swagger_spec.rb
@@ -76,12 +76,4 @@ describe 'GrapeSwagger', if: defined?(GrapeSwagger) do
       expect(swagger.dig('definitions', 'postWidgets', 'required')).to eq(['name'])
     end
   end
-
-  describe 'add_swagger_documentation' do
-    it 'relies on the deprecated positional Hash form of `desc`' do
-      expect do
-        Class.new(Grape::API) { add_swagger_documentation }
-      end.to raise_error(ActiveSupport::DeprecationException, /positional options Hash to `desc`/)
-    end
-  end
 end


### PR DESCRIPTION
This PR removes the deprecation test in `GrapeSwagger add_swagger_documentation relies on the deprecated positional Hash form of desc`. It has been fixed in 2.2.0