### PR TITLE
Expose a swallowed exception on rack.exception in safe_default too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 * [#2840](https://github.com/ruby-grape/grape/pull/2840): Answer 500 instead of letting an exception escape the middleware stack when an error response cannot be rendered (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2840](https://github.com/ruby-grape/grape/pull/2840): Expose the exception that defeated an error rendering on `rack.exception` and write it to `rack.errors`, so error trackers mounted above Grape keep reporting it - [@ericproulx](https://github.com/ericproulx).
 * [#2840](https://github.com/ruby-grape/grape/pull/2840): Add `Grape.config.raise_rendering_errors` to opt out of the failsafe and let an unrenderable error response propagate as before - [@ericproulx](https://github.com/ericproulx).
+* [#2855](https://github.com/ruby-grape/grape/pull/2855): Expose an unhandled exception raised inside a `rescue_from` block on `rack.exception`, so error trackers report it instead of the generic 500 arriving silently - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/README.md
+++ b/README.md
@@ -2836,7 +2836,9 @@ end
 
 The first handler re-raises; the second handler runs against the new exception.
 
-If the re-raised exception has no registered `rescue_from` and is a `Grape::Exceptions::Base` subclass, it is rendered through the default Grape error path (using its own `status` and `message`). Anything else — typos, `NoMethodError`, an unrelated `StandardError` — is treated as an internal error: it is exposed on `env['grape.exception']` for upstream Rack middleware to observe, and rendered to the API consumer as a generic `500 Internal Server Error`. This avoids leaking internal detail in the response body.
+If the re-raised exception has no registered `rescue_from` and is a `Grape::Exceptions::Base` subclass, it is rendered through the default Grape error path (using its own `status` and `message`). Anything else — typos, `NoMethodError`, an unrelated `StandardError` — is treated as an internal error: it is exposed on the rack env for upstream Rack middleware to observe, and rendered to the API consumer as a generic `500 Internal Server Error`. This avoids leaking internal detail in the response body.
+
+Because the exception is answered rather than raised, nothing above Grape catches it, so it is published under `rack.exception` — the key error trackers read for a handled exception — as well as Grape's own `grape.exception`. Grape does no logging of its own here; register a `rescue_from :internal_grape_exceptions` handler to take that over.
 
 You can take control of the internal-error path by opting in with `rescue_from :internal_grape_exceptions`:
 

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -131,17 +131,13 @@ module Grape
         render_failsafe_response
       end
 
-      # Swallowing the exception must not make it invisible. +grape.exception+ is
-      # Grape's own key; +rack.exception+ is what the ecosystem actually reads to
-      # find an exception that never propagated, so a tracker mounted above Grape
-      # keeps reporting these without any application change. The failure also
-      # goes to +rack.errors+ so it reaches the log with no tracker installed —
+      # The exception is published on the rack env (see {#expose_exception}) and
+      # written to +rack.errors+ so it reaches the log with no tracker installed.
       # Rails writes to $stderr from its failsafe branch for the same reason:
       # deferring the logging to the application is not an option when the
       # application's own error rendering is what broke.
       def record_rendering_failure(error)
-        env[Grape::Env::GRAPE_EXCEPTION] = error
-        env[Grape::Env::RACK_EXCEPTION] = error
+        expose_exception(error)
         env[Rack::RACK_ERRORS]&.write("Grape could not render the error response: #{error.class}: #{error.message}\n")
       end
 
@@ -156,6 +152,17 @@ module Grape
         rack_response(FAILSAFE_STATUS, headers, format_message(failsafe_payload(headers)))
       rescue StandardError
         rack_response(FAILSAFE_STATUS, { Rack::CONTENT_TYPE => FAILSAFE_CONTENT_TYPE }, FAILSAFE_MESSAGE)
+      end
+
+      # Publish an exception Grape swallowed, on both keys. +grape.exception+ is
+      # Grape's own and has been set on these paths all along; +rack.exception+ is
+      # what the ecosystem actually reads to find an exception that never
+      # propagated — sentry-ruby collects +env['rack.exception'] ||
+      # env['sinatra.error']+ — so a tracker mounted above Grape keeps reporting
+      # these with no application change.
+      def expose_exception(error)
+        env[Grape::Env::GRAPE_EXCEPTION] = error
+        env[Grape::Env::RACK_EXCEPTION] = error
       end
 
       def failsafe_payload(headers)
@@ -252,7 +259,7 @@ module Grape
       # message. The framework deliberately does no logging of its own
       # here; that's the application's call.
       def safe_default(error, endpoint)
-        env[Grape::Env::GRAPE_EXCEPTION] = error
+        expose_exception(error)
         return run_rescue_handler(internal_grape_exceptions_rescue_handler, error, endpoint, redispatched: true) if internal_grape_exceptions_rescue_handler
 
         framework_default(endpoint)

--- a/spec/grape/middleware/error_spec.rb
+++ b/spec/grape/middleware/error_spec.rb
@@ -292,6 +292,24 @@ describe Grape::Middleware::Error do
         expect(captured).to be_a(NoMethodError)
         expect(captured.message).to include("undefined method 'foo'")
       end
+
+      # grape.exception is Grape's own key, which no error tracker reads. This
+      # path answers 500 rather than letting the exception propagate, so without
+      # rack.exception a tracker above Grape never learns it happened.
+      it "exposes the original exception via env['rack.exception']" do
+        captured = nil
+        original_call = app.method(:call)
+        allow(app).to receive(:call) do |env|
+          result = original_call.call(env)
+          captured = env[Grape::Env::RACK_EXCEPTION]
+          result
+        end
+
+        response
+
+        expect(captured).to be_a(NoMethodError)
+        expect(captured.message).to include("undefined method 'foo'")
+      end
     end
 
     context 'and a redispatched handler also raises' do


### PR DESCRIPTION
Split out of #2840 at review request — that PR is now strictly the rendering failsafe.

**Depends on #2840**, which introduces `Grape::Env::RACK_EXCEPTION` and the shared exposure helper. Based on its branch; the diff here is one call site, a spec, and a README correction. Merge #2840 first and this rebases cleanly.

## The gap

`safe_default` is the unrecognised-error path: an exception raised inside a `rescue_from` block that nothing else handles. Grape answers a generic 500 there rather than letting it propagate, and records the exception on `env['grape.exception']`.

That key is Grape's own and no error tracker reads it. Because the exception never propagates, a tracker mounted above Grape has nothing to catch either. So a bug in a `rescue_from` block — a typo'd method, a nil deref — has always been able to become a silent 500: the request is answered, the log says nothing, the tracker never fires.

This is longstanding, not a regression. It surfaced while fixing #2840, whose failsafe had the identical blind spot.

## The change

Publish the exception on `env['rack.exception']` as well — the convention for an exception that was *handled* rather than raised, which sentry-ruby collects as `env['rack.exception'] || env['sinatra.error']`. Extracted as `expose_exception`, now shared with the rendering failsafe in #2840.

`grape.exception` keeps its current meaning; nothing is removed.

## Documentation

README described this path as exposing the exception on `env['grape.exception']` "for upstream Rack middleware to observe" — the claim this PR makes actually true. Updated to name `rack.exception` and say why the key is needed at all: the exception is answered rather than raised, so nothing above Grape catches it.

No UPGRADING entry: adding an env key is additive, not a contract break.

## What is deliberately not changed

This path stays silent — no `rack.errors` write, unlike the failsafe in #2840. The difference is that here a `rescue_from :internal_grape_exceptions` handler can still own the response, so the logging remains the application's call. In the failsafe there is no such option, because the application's own error rendering is what broke.

## Test plan

- [x] One example asserting `rack.exception` on the unrecognised-error path; verified it fails without the change (`expected nil to be a kind of NoMethodError`).
- [x] Full RSpec suite passes locally (2577 examples, 0 failures).
- [x] RuboCop clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
