### PR TITLE
Update simplecov

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Configuration only. `SimpleCov.start` lives in spec/spec_helper.rb.
 if ENV['GITHUB_USER'] # only when running CI
   require 'simplecov-lcov'
   SimpleCov::Formatter::LcovFormatter.config do |c|
@@ -10,7 +11,5 @@ if ENV['GITHUB_USER'] # only when running CI
   SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
 end
 
-SimpleCov.start do
-  enable_coverage :branch
-  add_filter '/spec/'
-end
+SimpleCov.enable_coverage :branch
+SimpleCov.skip '/spec/'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 * [#2838](https://github.com/ruby-grape/grape/pull/2838): Reject request params nested in more arrays than the block declares, instead of silently unwrapping them and passing validation, and report `type: Array[JSON]` errors against the element that failed - [@ericproulx](https://github.com/ericproulx).
 * [#2842](https://github.com/ruby-grape/grape/pull/2842): Warn at definition time when a `rescue_from` class is already covered by one registered earlier in the same scope, since the later handler never runs - [@ericproulx](https://github.com/ericproulx).
 * [#2853](https://github.com/ruby-grape/grape/pull/2853): Restore, behind a deprecation warning, the trailing positional options Hash of `requires`, `optional` and `use`, which #2618 turned into a parameter name - [@ericproulx](https://github.com/ericproulx).
+* [#2856](https://github.com/ruby-grape/grape/pull/2856): Update simplecov - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :test do
   gem 'rack-contrib', require: false
   gem 'rack-test', '~> 2.1'
   gem 'rspec', '~> 3.13'
-  gem 'simplecov', '~> 0.21', require: false
+  gem 'simplecov', '~> 1.1', require: false
   gem 'simplecov-lcov', '~> 0.8', require: false
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'simplecov'
+SimpleCov.start
+
 require 'rubygems'
 require 'bundler'
 Bundler.require :default, :test


### PR DESCRIPTION
Updates the `simplecov` development dependency from `~> 0.21` (resolving to 0.22.0) to `~> 1.1` (resolving to 1.1.1), and adjusts our configuration for the two APIs 1.x deprecates.

## The bump

```diff
-  gem 'simplecov', '~> 0.21', require: false
+  gem 'simplecov', '~> 1.1', require: false
```

`~> 0.21` is a pessimistic constraint on a `0.x` series, so it can never resolve past `0.22.0` — the last release of that line. Everything from 1.0.0 onward was out of reach until the restriction moved.

simplecov 1.1.1 requires Ruby `>= 3.2`; our gemspec already requires `>= 3.3`, so every supported version is covered.

`simplecov-lcov` stays at `~> 0.8` (0.9.0, its latest). It declares `simplecov ~> 0.18` only as a **development** dependency, so it imposes no runtime constraint and does not conflict with the 1.x bump — the LCOV formatter still resolves and runs.

## Deprecations the bump surfaced

Running the suite against 1.1.1 printed two warnings, both from `.simplecov`.

### 1. `SimpleCov.start` inside `.simplecov`

> `[DEPRECATION] Calling `SimpleCov.start` from `.simplecov` is deprecated and will be removed in a future release. `.simplecov` should contain configuration only; move the `SimpleCov.start` call into your `spec_helper.rb` / `test_helper.rb`.` — [simplecov#581](https://github.com/simplecov-ruby/simplecov/issues/581)

Tracking still begins today for backward compatibility, but a future release will require the explicit call from a test helper. Split accordingly: `.simplecov` keeps the configuration, `spec/spec_helper.rb` starts the run.

```ruby
# spec/spec_helper.rb
require 'simplecov'
SimpleCov.start

require 'rubygems'
require 'bundler'
Bundler.require :default, :test
```

The ordering is what matters here, and it is preserved. `.simplecov` is auto-loaded by `simplecov/defaults.rb` at `require 'simplecov'` time, so the file's configuration is applied *before* the new `SimpleCov.start` on the next line — and that call still runs ahead of `Bundler.require :default, :test`, which is what loads Grape. Coverage therefore still begins before any of `lib/` is required, which is the one hard requirement simplecov places on the call site.

`SimpleCov.start` is additive rather than a reset — `initial_setup` only loads a profile or a block, neither of which we pass — so nothing it does discards what `.simplecov` configured.

### 2. `SimpleCov.add_filter` → `SimpleCov.skip`

> `[DEPRECATION] `SimpleCov.add_filter` is deprecated. Replace with `SimpleCov.skip` (same arguments, same behavior).`

In 1.x `add_filter` is a thin wrapper that warns and forwards to `skip`; the matcher grammar is unchanged.

Both `enable_coverage` and `skip` are `SimpleCov::Configuration` methods, so they read fine at the top level of a config-only file without the `start` block that used to wrap them:

```ruby
SimpleCov.enable_coverage :branch
SimpleCov.skip '/spec/'
```

Those two lines plus the CI-only LCOV formatter block are the whole of `.simplecov`, and `SimpleCov.start` in `spec_helper.rb` is the only other simplecov call anywhere in the repo — so this is the complete deprecation surface. None of the other APIs 1.x deprecates (`track_files`, `use_merging`, `enable_for_subprocesses`, `nocov_token`/`skip_token`, `minimum_coverage_by_file`/`by_group`, `print_error_status`, `enable_coverage_for_eval`) are used here.

## Coverage is measured identically

Verified against a `master` worktree running the old pin, to confirm the bump and the config restructure do not move what is measured or reported:

| | line | branch |
| --- | --- | --- |
| `master`, simplecov 0.22.0 | 97.12% (3780 / 3892) | 91.54% (1191 / 1301) |
| this branch, simplecov 1.1.1 | 97.12% (3780 / 3892) | 91.54% (1191 / 1301) |

Identical to the file count, which is the check that `enable_coverage :branch` and the `/spec/` skip both still apply after moving out of the `start` block.

## Test plan

- [x] Full RSpec suite passes (2575 examples, 0 failures).
- [x] No simplecov deprecation warnings remain in the suite output.
- [x] Line and branch coverage byte-identical to the 0.22.0 baseline (table above).
- [x] The CI-only path exercised with `GITHUB_USER=1`; `simplecov-lcov` 0.9.0 still writes `coverage/lcov.info`.
- [x] RuboCop clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
