### PR TITLE
Stop routes from answering every option name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 * [#2845](https://github.com/ruby-grape/grape/pull/2845): Render `redirect`'s default message as the plain text its content type announces, instead of letting the API's formatter re-encode it (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2840](https://github.com/ruby-grape/grape/pull/2840): Answer 500 instead of letting an exception escape the middleware stack when an error response cannot be rendered, exposing it on `rack.exception` and writing it to `rack.errors` so error trackers keep reporting it, with `Grape.config.raise_rendering_errors` to opt back out (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2855](https://github.com/ruby-grape/grape/pull/2855): Expose an unhandled exception raised inside a `rescue_from` block on `rack.exception`, so error trackers report it instead of the generic 500 arriving silently - [@ericproulx](https://github.com/ericproulx).
+* [#2857](https://github.com/ruby-grape/grape/pull/2857): Stop a route from answering every option name through its options Hash, and normalize `desc`'s `success:`/`failure:` onto `entity:`/`http_codes:` (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2843](https://github.com/ruby-grape/grape/pull/2843): Let `rescue_from :grape_exceptions` take precedence over a catch-all registered as a class, so Grape errors keep their own status (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,41 @@ Upgrading Grape
 
 ### Upgrading to >= 4.0.0
 
+#### A route no longer answers every option name
+
+`Grape::Router::BaseRoute` forwarded any unknown method to its options, an `ActiveSupport::OrderedOptions` that answers *anything* with `nil`. Every route therefore responded to every name:
+
+```ruby
+route.respond_to?(:anything_at_all) # => true
+route.anything_at_all               # => nil
+```
+
+That is gone. A route exposes readers for the options Grape documents — `description` plus the `desc` keys (`summary`, `detail`, `entity`, `http_codes`, `tags`, `hidden`, `deprecated`, …) — and raises `NoMethodError` for anything else. It also means a genuinely absent method now says so instead of quietly returning `nil`.
+
+Custom options are still carried and still readable, through the options Hash:
+
+```ruby
+get('/x', my_option: 1) { }
+
+route.my_option        # NoMethodError
+route.options[:my_option] # => 1
+```
+
+#### `desc` stores `success:` and `failure:` under `entity:` and `http_codes:`
+
+In a `desc` block, `success` and `failure` have always been aliases writing to `:entity` and `:http_codes`. A Hash of options never went through that path, so the aliases survived as keys of their own and were readable only through the forwarding described above:
+
+```ruby
+desc 'a', success: Entity        # stored :success
+desc 'b' do success Entity end   # stored :entity
+```
+
+Both now store `:entity`, and `failure:` likewise stores `:http_codes`, so the two forms are equivalent. Read them with `route.entity` and `route.http_codes`. When a description carries both an alias and its documented key, the documented key wins.
+
+`route.options[:success]` and `route.options[:failure]` are consequently `nil`; the values are under `route.options[:entity]` and `route.options[:http_codes]`.
+
+**grape-swagger** reads `route.success`, `route.failure`, `route.default_response` and `route.desc`, so it needs a release built against this: the first two become `route.entity` / `route.http_codes`, and the last two — which are grape-swagger's own conventions rather than Grape options — become `route.options[:default_response]` / `route.options[:desc]`.
+
 #### `use`, `helpers`, `rescue_from` and other registrations no longer reach routes defined above them
 
 A route captures the middleware, helpers, callbacks and rescue handlers registered above it. That was already true most of the time, but not always: `Grape::Util::InheritableSetting#point_in_time_copy` copied a scope's stackable store and its rescue-handler maps shallowly, so the nested Arrays and Hashes stayed shared with the scope. A registration added *after* an endpoint was defined therefore still reached that endpoint — but only when the key already held at least one registration when the endpoint was defined, since otherwise the scope allocated a fresh store only for itself.

--- a/lib/grape/dsl/desc.rb
+++ b/lib/grape/dsl/desc.rb
@@ -61,7 +61,7 @@ module Grape
             endpoint_config = defined?(configuration) ? configuration : nil
             Grape::Util::ApiDescription.new(description, endpoint_config, &config_block).settings
           else
-            options.merge(description:)
+            Grape::Util::ApiDescription.normalize_aliases(options).merge(description:)
           end
         # Only the route scope is consumed downstream (by +route+ and the
         # route's readers, e.g. +http_codes+); the namespace scope was

--- a/lib/grape/router/base_route.rb
+++ b/lib/grape/router/base_route.rb
@@ -5,8 +5,6 @@ module Grape
     class BaseRoute
       extend Forwardable
 
-      delegate_missing_to :@options
-
       attr_reader :options, :pattern, :prefix, :settings, :namespace
 
       # +version+, +anchor+ and +requirements+ shape the matcher, so they are

--- a/lib/grape/router/greedy_route.rb
+++ b/lib/grape/router/greedy_route.rb
@@ -18,7 +18,16 @@ module Grape
         @allow_header = allow_header
       end
 
-      def params(_input = nil)
+      # A greedy route matches by prefix and captures nothing, so it has neither
+      # declared params to document nor values to extract. Both are defined
+      # explicitly: {Grape::Router#process_route} calls +params_for+ on whatever
+      # route it matched, and BaseRoute no longer forwards unknown names to
+      # +@options+ (where an OrderedOptions lookup would answer nil by accident).
+      def params
+        nil
+      end
+
+      def params_for(_input)
         nil
       end
     end

--- a/lib/grape/util/api_description.rb
+++ b/lib/grape/util/api_description.rb
@@ -35,8 +35,25 @@ module Grape
         end
       end
 
-      alias success entity
-      alias failure http_codes
+      # The block form's aliases: writing +success+ stores under +:entity+ and
+      # +failure+ under +:http_codes+, so a description always carries the
+      # documented key whichever spelling was used.
+      ALIASES = { success: :entity, failure: :http_codes }.freeze
+
+      ALIASES.each { |from, to| alias_method from, to }
+
+      # A Hash of options never reaches this class, so its +success+/+failure+
+      # keys would survive unaliased. Rename them to keep both forms
+      # equivalent; an explicit documented key wins over its alias.
+      def self.normalize_aliases(options)
+        return options unless options.keys.intersect?(ALIASES.keys)
+
+        options.except(*ALIASES.keys).merge(
+          ALIASES.filter_map do |from, to|
+            [to, options[from]] if options.key?(from) && !options.key?(to)
+          end.to_h
+        )
+      end
 
       def configuration
         @configuration ||= eval_endpoint_config(@endpoint_configuration)

--- a/spec/grape/dsl/desc_spec.rb
+++ b/spec/grape/dsl/desc_spec.rb
@@ -107,5 +107,30 @@ describe Grape::DSL::Desc do
         expect(subject.namespace_setting(:description)).to be_nil
       end
     end
+
+    # `success` and `failure` are the block form's aliases for `entity` and
+    # `http_codes`. A Hash never reaches Grape::Util::ApiDescription, so the
+    # aliases are normalized on the way in and both forms store alike.
+    describe 'the success and failure aliases' do
+      it 'stores a Hash success under entity and failure under http_codes' do
+        subject.desc 'The description', success: Object, failure: [[401, 'Unauthorized']]
+
+        expect(subject.route_setting(:description)).to eq(
+          description: 'The description', entity: Object, http_codes: [[401, 'Unauthorized']]
+        )
+      end
+
+      it 'lets an explicit entity or http_codes win over its alias' do
+        subject.desc 'The description', entity: Integer, success: Object
+
+        expect(subject.route_setting(:description)).to eq(description: 'The description', entity: Integer)
+      end
+
+      it 'leaves a description carrying neither alias untouched' do
+        subject.desc 'The description', summary: 'summary'
+
+        expect(subject.route_setting(:description)).to eq(description: 'The description', summary: 'summary')
+      end
+    end
   end
 end

--- a/spec/grape/router/route_spec.rb
+++ b/spec/grape/router/route_spec.rb
@@ -21,6 +21,24 @@ RSpec.describe Grape::Router::Route do
     it { is_expected.to be_a(Grape::Router::BaseRoute) }
   end
 
+  # A route used to forward every unknown name to its options, an
+  # ActiveSupport::OrderedOptions that answers anything with nil. A name Grape
+  # does not define now raises instead; custom options are read from #options.
+  describe 'an option Grape does not define a reader for' do
+    subject(:route) { described_class.new(endpoint, :get, pattern, options, forward_match: false) }
+
+    let(:options) { { custom_option: 'value' } }
+
+    it 'is not exposed as a reader' do
+      expect { route.custom_option }.to raise_error(NoMethodError)
+      expect(route).not_to respond_to(:custom_option)
+    end
+
+    it 'is readable from #options' do
+      expect(route.options[:custom_option]).to eq('value')
+    end
+  end
+
   describe '#regexp_capture_index' do
     subject(:route) { described_class.new(endpoint, :get, pattern, options, forward_match: false) }
 


### PR DESCRIPTION
`Grape::Router::BaseRoute` forwarded any unknown method to `@options`, an `ActiveSupport::OrderedOptions` that answers *anything* with `nil`. Every route responded to every name:

```ruby
route.respond_to?(:anything_at_all) # => true
route.anything_at_all               # => nil
```

So a typo, a renamed method and a genuinely unset option were indistinguishable — all three read as `nil`.

## Grape had already been bitten by it

`Grape::Router#process_route` calls `params_for` on whatever route it matched. `GreedyRoute` matches by prefix and captures nothing, and had no such method — the call landed on the forwarding and came back `nil` from an `OrderedOptions` lookup, by accident rather than by intent. Both `params` and `params_for` are now defined explicitly there, which is what the answer always should have been.

## What remains

The readers Grape documents, via the existing `def_delegators` — `description` plus the `desc` keys (`summary`, `detail`, `entity`, `http_codes`, `tags`, `hidden`, `deprecated`, …). Anything else raises `NoMethodError`.

Custom options are untouched and still readable, just not as methods:

```ruby
get('/x', my_option: 1) { }

route.my_option           # NoMethodError
route.options[:my_option] # => 1
```

## One gap had to be closed first

In a `desc` **block**, `success` and `failure` are aliases writing to `:entity` and `:http_codes`. A **Hash** of options never reaches `Grape::Util::ApiDescription`, so those keys survived unaliased — and were then readable *only* through the forwarding:

| declaration | stored keys | `route.entity` | `route.success` |
| --- | --- | --- | --- |
| `desc 'a', success: X` | `[:success, :description]` | `nil` | `X` |
| `desc 'b' do success X end` | `[:entity, :description]` | `X` | `nil` |

Dropping the forwarding without fixing that would have made the Hash spelling unreadable by any reader at all. `desc` now normalizes it, so both forms store `:entity` / `:http_codes` and `route.entity` / `route.http_codes` answer whichever way it was written. An explicit documented key wins over its alias. The block form's aliases are generated from the same map, so the two cannot drift.

## Impact on grape-swagger

grape-swagger reads `route.success`, `route.failure`, `route.default_response` and `route.desc`. Those four are the *only* names in its ~30-method route surface without a real reader behind them — everything else is an `attr_reader`, a `@pattern` delegate, or in `DSL_METHODS`.

They are also recent: 2.1.4 and earlier read `route.options[:success]` and friends; [grape-swagger#984](https://github.com/ruby-grape/grape-swagger/pull/984) converted 19 `route.options` reads down to 1 in 2.2.0. The matching update is small — `route.entity` / `route.http_codes` for the first two, and `route.options[:default_response]` / `route.options[:desc]` for the other two, which are grape-swagger's own conventions rather than Grape options. Called out in UPGRADING.

## Test plan

- [x] 3 examples in `desc_spec.rb`: the Hash form storing under `entity`/`http_codes`, an explicit documented key beating its alias, and a description carrying neither left untouched.
- [x] 2 examples in `route_spec.rb` pinning that an undefined option name raises and is not `respond_to?`, while `route.options[:key]` still reads it.
- [x] Full RSpec suite passes locally (2613 examples, 0 failures).
- [x] RuboCop clean.
- [x] Verified against the grape-swagger working copy on `$LOAD_PATH`: master fails with `undefined method 'success'`, and generates the same document once those four reads are updated.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
