### PR TITLE
Define GreedyRoute#params_for instead of leaning on delegate_missing_to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 * [#2840](https://github.com/ruby-grape/grape/pull/2840): Answer 500 instead of letting an exception escape the middleware stack when an error response cannot be rendered, exposing it on `rack.exception` and writing it to `rack.errors` so error trackers keep reporting it, with `Grape.config.raise_rendering_errors` to opt back out (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2855](https://github.com/ruby-grape/grape/pull/2855): Expose an unhandled exception raised inside a `rescue_from` block on `rack.exception`, so error trackers report it instead of the generic 500 arriving silently - [@ericproulx](https://github.com/ericproulx).
 * [#2843](https://github.com/ruby-grape/grape/pull/2843): Let `rescue_from :grape_exceptions` take precedence over a catch-all registered as a class, so Grape errors keep their own status (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
+* [#2858](https://github.com/ruby-grape/grape/pull/2858): Define `Grape::Router::GreedyRoute#params_for` instead of letting the call fall through to the route's options Hash - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/lib/grape/router/greedy_route.rb
+++ b/lib/grape/router/greedy_route.rb
@@ -18,7 +18,11 @@ module Grape
         @allow_header = allow_header
       end
 
-      def params(_input = nil)
+      def params
+        nil
+      end
+
+      def params_for(_input)
         nil
       end
     end

--- a/spec/grape/router/greedy_route_spec.rb
+++ b/spec/grape/router/greedy_route_spec.rb
@@ -35,4 +35,13 @@ RSpec.describe Grape::Router::GreedyRoute do
 
     it { is_expected.to be_nil }
   end
+
+  # A greedy route answers auto-OPTIONS and 405, and Router#process_route asks
+  # every route it dispatches for the params of the matched path. A greedy
+  # route captures nothing, so there are none.
+  describe '#params_for' do
+    subject { instance.params_for('/anything') }
+
+    it { is_expected.to be_nil }
+  end
 end


### PR DESCRIPTION
`Grape::Router::Route` splits its two param readers: `#params` returns the route's declared definitions, `#params_for(input)` extracts the values out of a matched path. `GreedyRoute` still carried the older combined `#params(_input = nil)`.

A greedy route is what answers auto-OPTIONS and 405, and it reaches `Router#process_route` like any other route, which asks it for `route.params_for(input)`:

```ruby
def process_route(route, input, env, include_allow_header: false)
  route_params = route.params_for(input)
```

That call only returned `nil` because `BaseRoute` delegates missing methods to its options bag, where `ActiveSupport::OrderedOptions#method_missing` answers any unknown reader with `nil`.

This defines the method instead. Behavior is unchanged — a greedy route captures nothing, so both readers are `nil` — but the no-op is now stated rather than borrowed from the options Hash, and it no longer breaks if that bag stops absorbing unknown methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
