### PR TITLE
Answer Route#success and #failure whichever way desc spelled them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 * [#2855](https://github.com/ruby-grape/grape/pull/2855): Expose an unhandled exception raised inside a `rescue_from` block on `rack.exception`, so error trackers report it instead of the generic 500 arriving silently - [@ericproulx](https://github.com/ericproulx).
 * [#2843](https://github.com/ruby-grape/grape/pull/2843): Let `rescue_from :grape_exceptions` take precedence over a catch-all registered as a class, so Grape errors keep their own status (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2858](https://github.com/ruby-grape/grape/pull/2858): Define `Grape::Router::GreedyRoute#params_for` instead of letting the call fall through to the route's options Hash - [@ericproulx](https://github.com/ericproulx).
+* [#2859](https://github.com/ruby-grape/grape/pull/2859): Answer `Grape::Router::Route#success` and `#failure` from the description whichever way it was written - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/lib/grape/router/base_route.rb
+++ b/lib/grape/router/base_route.rb
@@ -22,6 +22,19 @@ module Grape
         @settings = settings
       end
 
+      # +success+ and +failure+ are the +desc+ DSL's names for +entity+ and
+      # +http_codes+: the block form writes the canonical key, a keyword option
+      # keeps the name it was written with, so both spellings are read here.
+      # Without this they resolve through +delegate_missing_to+, which answers
+      # nil for whichever of the two keys the description did not use.
+      def success
+        @options[:entity] || @options[:success]
+      end
+
+      def failure
+        @options[:http_codes] || @options[:failure]
+      end
+
       # Assigned eagerly in {#to_regexp} (router compilation) rather than
       # memoized here: this reader is called from request-time route matching
       # on instances shared across threads, so it must not write state.

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3387,6 +3387,29 @@ describe Grape::API do
       end
     end
 
+    describe 'a described api structure' do
+      before do
+        subject.desc 'block form' do
+          success Object
+          failure [[401, 'Unauthorized']]
+        end
+        subject.get('/block') { 'pong' }
+
+        subject.desc 'keyword form', success: Object, failure: [[401, 'Unauthorized']]
+        subject.get('/keyword') { 'pong' }
+      end
+
+      # The block DSL records `success`/`failure` under `entity`/`http_codes`,
+      # while keyword options keep the name they were written with. A route
+      # answers both readers either way.
+      it 'exposes success and failure however the description spelled them' do
+        subject.routes.each do |route|
+          expect(route.success).to eq(Object)
+          expect(route.failure).to eq([[401, 'Unauthorized']])
+        end
+      end
+    end
+
     describe 'api structure with two versions and a namespace' do
       before do
         subject.version 'v1', using: :path

--- a/spec/grape/router/route_spec.rb
+++ b/spec/grape/router/route_spec.rb
@@ -78,6 +78,37 @@ RSpec.describe Grape::Router::Route do
     end
   end
 
+  describe '#success and #failure' do
+    subject(:route) { described_class.new(endpoint, :get, pattern, options, forward_match: false) }
+
+    context 'when the description used the block DSL names' do
+      let(:options) { { entity: Object, http_codes: [[401, 'Unauthorized']] } }
+
+      it 'reads the canonical keys' do
+        expect(route.success).to eq(Object)
+        expect(route.failure).to eq([[401, 'Unauthorized']])
+      end
+    end
+
+    context 'when the description was written as keyword options' do
+      let(:options) { { success: Object, failure: [[401, 'Unauthorized']] } }
+
+      it 'reads the keys as spelled' do
+        expect(route.success).to eq(Object)
+        expect(route.failure).to eq([[401, 'Unauthorized']])
+      end
+    end
+
+    context 'when the description carries neither' do
+      let(:options) { {} }
+
+      it 'returns nil' do
+        expect(route.success).to be_nil
+        expect(route.failure).to be_nil
+      end
+    end
+  end
+
   describe 'params' do
     let(:pattern) do
       Grape::Router::Pattern.new(origin: '/users/:id', suffix: '', anchor: true,


### PR DESCRIPTION
## Summary

`success` and `failure` are grape's documented names for `entity` and `http_codes` — README lists them ("`success`: (former entity)…"), and `Grape::Util::ApiDescription` carries `alias success entity` / `alias failure http_codes`. A route, though, could only answer whichever spelling the description happened to use:

```ruby
desc 'block form' do
  success Object
  failure [[404, 'nope']]
end
get('/a') { }

desc 'keyword form', success: Object, failure: [[404, 'nope']]
get('/b') { }
```

```
/a: success=nil    failure=nil            entity=Object  http_codes=[[404, "nope"]]
/b: success=Object failure=[[404,"nope"]] entity=nil     http_codes=nil
```

The block DSL writes `:entity` / `:http_codes`; a keyword option keeps the key it was written with. Neither call raised, because `BaseRoute` delegates missing methods to its options bag and `ActiveSupport::OrderedOptions` answers any unknown reader with `nil` — so the miss was silent.

This defines both readers on `BaseRoute`, each resolving the value from either key.

## Impact

grape-swagger already works around the split with `route.entity || route.success` and `route.http_codes || route.failure`, so its main paths were unaffected — but `produces_object` calls `file_response?(route.success)`, which saw nothing when the description was written as a block, so `success 'file'` never defaulted to `application/octet-stream`.

Context from the other side: [ruby-grape/grape-swagger#987](https://github.com/ruby-grape/grape-swagger/issues/987) audits every `route.<name>` read in grape-swagger and finds four that resolve to no method Grape defines — `success`, `failure`, `default_response` and `desc` — answered only because `BaseRoute` forwards unknown names to its options bag. This PR turns the first two into real readers.

## Out of scope

`entity` and `http_codes` still read only their own key. The error formatter's presenter lookup uses `route_info.http_codes`, so a presenter declared as `desc 'x', failure: [[408, 'Gone', ErrorPresenter]]` is still ignored. Same for `route.default`, which resolves to `Hash#default` rather than the `:default` option. Both are follow-ups.

## Test plan

- [x] `spec/grape/router/route_spec.rb` — both spellings, and neither.
- [x] `spec/grape/api_spec.rb` — end-to-end through `desc`, block form and keyword form.
- [x] Full RSpec suite (2612), plus the grape_entity and grape_swagger gemfiles.
- [x] RuboCop clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
