### PR TITLE
Read Route#default from the description, not from Hash#default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 * [#2843](https://github.com/ruby-grape/grape/pull/2843): Let `rescue_from :grape_exceptions` take precedence over a catch-all registered as a class, so Grape errors keep their own status (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2858](https://github.com/ruby-grape/grape/pull/2858): Define `Grape::Router::GreedyRoute#params_for` instead of letting the call fall through to the route's options Hash - [@ericproulx](https://github.com/ericproulx).
 * [#2859](https://github.com/ruby-grape/grape/pull/2859): Answer `Grape::Router::Route#success` and `#failure` from the description whichever way it was written - [@ericproulx](https://github.com/ericproulx).
+* [#2860](https://github.com/ruby-grape/grape/pull/2860): Read `Grape::Router::Route#default` from the description instead of from the options Hash's own default value, which was always `nil` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/lib/grape/router/base_route.rb
+++ b/lib/grape/router/base_route.rb
@@ -12,7 +12,7 @@ module Grape
       # +version+, +anchor+ and +requirements+ shape the matcher, so they are
       # read from the pattern rather than stored again on the route.
       def_delegators :@pattern, :path, :origin, :version, :anchor, :requirements
-      def_delegators :@options, :description, *Grape::Util::ApiDescription::DSL_METHODS
+      def_delegators :@options, :description, *(Grape::Util::ApiDescription::DSL_METHODS - %i[default])
 
       def initialize(pattern, options = {}, namespace: nil, prefix: nil, settings: nil)
         @pattern = pattern
@@ -33,6 +33,14 @@ module Grape
 
       def failure
         @options[:http_codes] || @options[:failure]
+      end
+
+      # +default+ is the one +desc+ key that cannot be delegated to +@options+.
+      # An ActiveSupport::OrderedOptions answers an unknown name with that key's
+      # value, but +default+ is not unknown to it — it is +Hash#default+, the
+      # Hash's own default value — so delegating it reported nil for every route.
+      def default
+        @options[:default]
       end
 
       # Assigned eagerly in {#to_regexp} (router compilation) rather than

--- a/spec/grape/router/route_spec.rb
+++ b/spec/grape/router/route_spec.rb
@@ -78,6 +78,27 @@ RSpec.describe Grape::Router::Route do
     end
   end
 
+  describe 'description attributes' do
+    subject(:route) { described_class.new(endpoint, :get, pattern, options, forward_match: false) }
+
+    let(:options) { { description: 'a route', default: { code: 400 }, tags: %w[a b] } }
+
+    it 'reads them from the options Hash' do
+      expect(route.description).to eq('a route')
+      expect(route.tags).to eq(%w[a b])
+    end
+
+    it 'returns nil for a key the description did not set' do
+      expect(route.summary).to be_nil
+    end
+
+    # +default+ is also Hash#default, so delegating it to the options Hash
+    # answered the Hash's own default value instead of the documented one.
+    it 'reads default as a description key, not as the Hash default value' do
+      expect(route.default).to eq(code: 400)
+    end
+  end
+
   describe '#success and #failure' do
     subject(:route) { described_class.new(endpoint, :get, pattern, options, forward_match: false) }
 


### PR DESCRIPTION
A route's `desc` keys are delegated to its options Hash, an `ActiveSupport::OrderedOptions`, whose `method_missing` answers an unknown name with that key's value. `default` is the one name in `Grape::Util::ApiDescription::DSL_METHODS` that is *not* unknown to it — it is `Hash#default`, the Hash's own default value — so delegating it reported `nil` for every route, whatever the description documented.

```ruby
route = Grape::Router::BaseRoute.new(pattern, { default: { code: 400 } })
route.default          # => nil                (Hash#default)
route.options[:default] # => { code: 400 }
```

`delegate_missing_to :@options` wouldn't have caught it either: `default` isn't missing on the Hash, so the fallback lands in the same place.

`default` is the only collision — all 17 delegated names were checked against `ActiveSupport::OrderedOptions.method_defined?` / `private_method_defined?`. It's dropped from the delegated list and read explicitly, alongside the `success` and `failure` readers that exist for the same reason. Subtracting it from the list rather than letting an explicit `def default` shadow the generated delegator keeps the suite's `--warnings` run free of a method-redefined warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
