### PR TITLE
Enable Style/MutableConstant's Recursive option

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,9 @@ Style/HashSyntax:
 Style/MultilineIfModifier:
   Enabled: false
 
+Style/MutableConstant:
+  Recursive: true
+
 Style/RaiseArgs:
   Enabled: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 #### Fixes
 
 * [#2767](https://github.com/ruby-grape/grape/pull/2767): Update rubocop to 1.88.0 and rubocop-rspec to 3.10.2 - [@ericproulx](https://github.com/ericproulx).
+* [#2863](https://github.com/ruby-grape/grape/pull/2863): Enable `Style/MutableConstant`'s `Recursive` option, so a literal nested inside a frozen constant has to be frozen too - [@ericproulx](https://github.com/ericproulx).
 * [#2816](https://github.com/ruby-grape/grape/pull/2816): Guard `length`, `same_as` and `oneof` validators against non-hash params (500 → 400) - [@ericproulx](https://github.com/ericproulx).
 * [#2815](https://github.com/ruby-grape/grape/pull/2815): Fix line-anchored regexes: `type: JSON` payloads containing a blank line were silently coerced to `nil` - [@ericproulx](https://github.com/ericproulx).
 * [#2817](https://github.com/ruby-grape/grape/pull/2817): Remove request-time mutable state from Array and custom-type coercers, which also makes an `Array`/`Set` of an uncoercible element type raise when the API is defined instead of on the first request that supplies it (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).


### PR DESCRIPTION
RuboCop 1.88 added a `Recursive` option to `Style/MutableConstant`. The cop already required the constant itself to be frozen; with `Recursive: true` it also requires the mutable literals nested inside it:

```ruby
FOO = [{ a: [] }].freeze              # allowed today
FOO = [{ a: [].freeze }.freeze].freeze # required with Recursive: true
```

Grape already treats constants and settings as deep-frozen — that is what `Grape::Util::DeepFreeze` exists for — so this matches the posture the codebase already holds itself to, and keeps a nested literal from being left mutable in new code.

**No existing constant is affected.** `lib` and `spec` report no offenses with the option on, so this is a guard for future code rather than a cleanup. Verified the option is actually in effect rather than silently ignored:

```
$ bundle exec rubocop --show-cops Style/MutableConstant | grep Recursive
  Recursive: true

$ printf 'FOO = [{ a: [] }].freeze\n' | bundle exec rubocop --only Style/MutableConstant --stdin lib/probe.rb
lib/probe.rb:1:8: C: [Correctable] Style/MutableConstant: Freeze mutable objects assigned to constants.
```

- [x] `bundle exec rubocop lib spec` clean.
- [x] Full RSpec suite unaffected (config-only change).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)