### PR TITLE
Check a group's type in one place for `requires` and `optional`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 * [#2858](https://github.com/ruby-grape/grape/pull/2858): Define `Grape::Router::GreedyRoute#params_for` instead of letting the call fall through to the route's options Hash - [@ericproulx](https://github.com/ericproulx).
 * [#2859](https://github.com/ruby-grape/grape/pull/2859): Answer `Grape::Router::Route#success` and `#failure` from the description whichever way it was written - [@ericproulx](https://github.com/ericproulx).
 * [#2861](https://github.com/ruby-grape/grape/pull/2861): Read `Grape::Router::Route#default` from the description instead of from the options Hash's own default value, which was always `nil` - [@ericproulx](https://github.com/ericproulx).
+* [#2864](https://github.com/ruby-grape/grape/pull/2864): Apply a group's type check to `optional` the same way as `requires`, so a type supplied by an enclosing `with` is no longer invisible to it (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -26,6 +26,22 @@ route.default_response
 ```
 
 A `desc 'x', default: ...` keyword is stored under `:default_response`, so a route carries one key under one name. Code reading `route.options[:default]` directly — rather than through the reader — has to read `route.options[:default_response]` instead.
+#### A group's type check is now the same for `requires` and `optional`
+
+The rule that a group declaration needs a type (`Array`, `Hash`, `JSON` or `Array[JSON]`) was implemented twice — once in `ParamsScope#new_scope` for `requires`, once inline in `optional` — and the two copies had drifted. `optional` read the type before merging in the attributes of an enclosing `with`, so a group type supplied by `with` was invisible to it:
+
+```ruby
+params do
+  with(type: Hash) do
+    requires(:a) { requires :b, type: String }   # accepted
+    optional(:a) { optional :b, type: String }   # raised MissingGroupType
+  end
+end
+```
+
+Both are accepted now. A group with no type from either the declaration or an enclosing `with` still raises `Grape::Exceptions::MissingGroupType`, and an unsupported type still raises `Grape::Exceptions::UnsupportedGroupType`.
+
+One case stops raising. `optional :a, using: SomeEntity do ... end` — a block *and* `using:` — raised `MissingGroupType` before; it now ignores the block and documents the entity's params, which is what `requires` has always done with that combination. If you have such a declaration, the block was never going to be applied; delete it or drop `using:`.
 
 #### `use`, `helpers`, `rescue_from` and other registrations no longer reach routes defined above them
 

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -143,14 +143,7 @@ module Grape
       def optional(*attrs, using: nil, except: nil, **opts, &block)
         return redispatch_legacy_options(:optional, attrs, { using:, except: }.compact.merge(opts), &block) if legacy_options?(attrs)
 
-        type = opts[:type]
         opts = @group.deep_merge(opts) if @group
-
-        # check type for optional parameter group
-        if attrs && block
-          raise Grape::Exceptions::MissingGroupType if type.nil?
-          raise Grape::Exceptions::UnsupportedGroupType unless Grape::Validations::Types.group?(type)
-        end
 
         return require_optional_fields(attrs.first, using:, except:) if using
 

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -277,8 +277,11 @@ module Grape
       #   is optional or not (and hence, whether this block's params will be).
       # @yield parameter scope
       def new_scope(element, type:, as:, optional: false, &)
-        # if required params are grouped and no type or unsupported type is provided, raise an error
-        if element && !optional
+        # A group needs a type: it says whether the nested params sit under one
+        # object or repeat in a list, and without it the `type || Array` below
+        # would quietly pick one. Checked here for `requires` and `optional`
+        # alike — `new_scope` is only reached from their block branch.
+        if element
           raise Grape::Exceptions::MissingGroupType if type.nil?
           raise Grape::Exceptions::UnsupportedGroupType unless Grape::Validations::Types.group?(type)
         end

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -379,6 +379,33 @@ describe Grape::Validations::ParamsScope do
       end.to raise_error Grape::Exceptions::MissingGroupType
     end
 
+    # `requires` read the group's type through the `with` merge and `optional`
+    # did not, so the same declaration was accepted for one and rejected for
+    # the other.
+    it 'takes the type from an enclosing with block' do
+      expect do
+        subject.params do
+          with(type: Hash) do
+            optional :a do
+              requires :b, type: String
+            end
+          end
+        end
+      end.not_to raise_error
+    end
+
+    it 'still errors when neither the declaration nor the group provides a type' do
+      expect do
+        subject.params do
+          with(documentation: { in: 'body' }) do
+            optional :a do
+              requires :b, type: String
+            end
+          end
+        end
+      end.to raise_error Grape::Exceptions::MissingGroupType
+    end
+
     it 'allows Hash as type' do
       subject.params do
         group :a, type: Hash do


### PR DESCRIPTION
## The bug

`with(type: Hash)` supplies a group type to everything declared inside it. `requires` sees it; `optional` did not. The same declaration, in the same `with`, was accepted for one and rejected for the other:

```ruby
params do
  with(type: Hash) do
    requires(:a) { requires :b, type: String }   # accepted
    optional(:a) { optional :b, type: String }   # Grape::Exceptions::MissingGroupType
  end
end
```

## Why

The rule that a group declaration needs a type is written **twice**.

Once in `ParamsScope#new_scope`, guarded so it only ever applied to `requires`:

```ruby
def new_scope(element, type:, as:, optional: false, &)
  if element && !optional          # ← `optional` passes optional: true, so it skips
    raise Grape::Exceptions::MissingGroupType if type.nil?
    raise Grape::Exceptions::UnsupportedGroupType unless Types.group?(type)
  end
```

and once inline in `optional` — which is the only reason that `!optional` clause exists. Two copies of one rule, in two files, and they drifted:

```ruby
type = opts[:type]                      # ← read BEFORE the group merge
opts = @group.deep_merge(opts) if @group
```

`requires` reads the same key *after* the merge (`new_scope(attrs.first, type: opts[:type], …)`), so it sees what `with` provided. `optional` read it one line too early and saw only what the declaration itself said.

## The fix

Delete the inline copy, drop `!optional` from the guard. One check now covers both DSL methods.

`element` alone is a sufficient guard because `new_scope` is only ever reached from the block branch of `requires`/`optional` — both call sites are `block ? new_scope(...) : push_declared_params(...)`.

The `type` local in `optional` went with the check; it existed only to feed those two raises. So the early read that caused the bug is **gone rather than reordered** — there is no second copy left to drift.

```
 lib/grape/dsl/parameters.rb            | 8 +-------
 lib/grape/validations/params_scope.rb  | 7 +++++--
```

## What still raises

- A group with no type from either the declaration or an enclosing `with` → `MissingGroupType`.
- A group with a type outside `Array`, `Hash`, `JSON`, `Array[JSON]` → `UnsupportedGroupType`.

Both are covered by existing specs plus one added here.

## One case stops raising

`optional :a, using: SomeEntity do ... end` — a block *and* `using:` — raised `MissingGroupType` before, because the inline check ran ahead of the `using` early-return. It now ignores the block and documents the entity's params.

That is an alignment, not a regression: `requires` has always behaved that way, since its own `using:` return also sits ahead of `new_scope`.

```
requires :a, using: {} + block => no raise (block ignored)
optional :a, using: {} + block => no raise (block ignored)
```

Nothing in the suite covered that combination either way. Documented in UPGRADING.

## Test plan

- [x] Full RSpec suite: 2615 examples, 0 failures.
- [x] Two specs added: `optional` takes the type from an enclosing `with`, and a group with no type from either source still raises. The first fails against the unfixed lib (verified) so it is not vacuous.
- [x] RuboCop clean over `lib` and `spec`.
- [x] UPGRADING entry.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)