### PR TITLE
Pass `required` as an argument instead of writing a presence key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 * [#2859](https://github.com/ruby-grape/grape/pull/2859): Answer `Grape::Router::Route#success` and `#failure` from the description whichever way it was written - [@ericproulx](https://github.com/ericproulx).
 * [#2861](https://github.com/ruby-grape/grape/pull/2861): Read `Grape::Router::Route#default` from the description instead of from the options Hash's own default value, which was always `nil` - [@ericproulx](https://github.com/ericproulx).
 * [#2864](https://github.com/ruby-grape/grape/pull/2864): Apply a group's type check to `optional` the same way as `requires`, so a type supplied by an enclosing `with` is no longer invisible to it (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
+* [#2865](https://github.com/ruby-grape/grape/pull/2865): Pass `required` from `requires`/`optional` as an argument instead of writing a `presence` key into the caller's options, deprecating a user-supplied `presence` and letting a `with` block's `message` reach the presence validator (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -42,6 +42,33 @@ end
 Both are accepted now. A group with no type from either the declaration or an enclosing `with` still raises `Grape::Exceptions::MissingGroupType`, and an unsupported type still raises `Grape::Exceptions::UnsupportedGroupType`.
 
 One case stops raising. `optional :a, using: SomeEntity do ... end` — a block *and* `using:` — raised `MissingGroupType` before; it now ignores the block and documents the entity's params, which is what `requires` has always done with that combination. If you have such a declaration, the block was never going to be applied; delete it or drop `using:`.
+#### The `presence` option of `requires` and `optional` is deprecated
+
+`presence` is how the params DSL tells the validation pipeline that a parameter is required. It travelled as a key written into the same options Hash that carries an API's own options, so an API could set it — and got opposite results depending on which method it was passed to, because `requires` overwrote it while nothing overwrote it for `optional`:
+
+```ruby
+requires :a, presence: false   # ignored: :a is still required
+optional :a, presence: true    # honoured: :a is actually required
+```
+
+Both still resolve exactly as they did, and now emit a deprecation warning. Declare the parameter with `requires` to make it required and `optional` to make it optional; the option will be ignored outright in a future release.
+
+#### A `with` block's `message` now reaches the presence validator
+
+The presence entry for a `requires` was built before the attributes of an enclosing `with` were merged in, so a group-level `message:` never reached it. It does now:
+
+```ruby
+params do
+  with(message: 'custom missing') do
+    requires :a
+  end
+end
+
+# before: "a is missing"
+# now:    "a custom missing"
+```
+
+An API that sets `message:` on a `with` block and relies on the generic wording for missing parameters will see its own message instead.
 
 #### `use`, `helpers`, `rescue_from` and other registrations no longer reach routes defined above them
 

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -127,13 +127,12 @@ module Grape
       def requires(*attrs, using: nil, except: nil, as: nil, **opts, &block)
         return redispatch_legacy_options(:requires, attrs, { using:, except:, as: }.compact.merge(opts), &block) if legacy_options?(attrs)
 
-        opts[:presence] = { value: true, message: opts[:message] }
         opts = @group.deep_merge(opts) if @group
         as ||= opts[:as]
 
         return require_required_and_optional_fields(attrs.first, using:, except:) if using
 
-        validate_attributes(attrs, **opts, &block)
+        validate_attributes(attrs, opts, required: true, &block)
         block ? new_scope(attrs.first, type: opts[:type], as:, &block) : push_declared_params(attrs, as:)
       end
 
@@ -149,7 +148,7 @@ module Grape
 
         return require_optional_fields(attrs.first, using:, except:) if using
 
-        validate_attributes(attrs, **opts, &block)
+        validate_attributes(attrs, opts, required: false, &block)
         block ? new_scope(attrs.first, type: opts[:type], as:, optional: true, &block) : push_declared_params(attrs, as:)
       end
 
@@ -163,7 +162,7 @@ module Grape
 
       %i[mutually_exclusive exactly_one_of at_least_one_of all_or_none_of].each do |validator|
         define_method validator do |*attrs, message: nil|
-          validates(attrs, validator => { value: true, message: })
+          validates(attrs, { validator => { value: true, message: } })
         end
       end
 

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -263,9 +263,9 @@ module Grape
         end
       end
 
-      def validate_attributes(attrs, **opts, &block)
-        opts[:type] ||= Array if block
-        validates(attrs, opts)
+      def validate_attributes(attrs, opts, required:, &block)
+        opts = opts.merge(type: Array) if block && opts[:type].nil?
+        validates(attrs, opts, required:)
       end
 
       # Returns a new parameter scope, subordinate to the current one and nested
@@ -349,7 +349,24 @@ module Grape
         (iterates_elements? ? 1 : 0) + (@parent&.array_depth || 0)
       end
 
-      def validates(attrs, validations)
+      # +required+ is the DSL's own signal — +requires+ passes true, +optional+
+      # false. It used to travel as a +:presence+ key that +requires+ wrote into
+      # the caller's option Hash, which is why a user-supplied +presence:+ was
+      # silently overwritten there and silently honoured by +optional+, where
+      # nothing overwrote it. The key is built here from the flag instead, after
+      # the caller has merged in any enclosing +with+ attributes, so a
+      # group-level +message:+ reaches the presence validator.
+      #
+      # A +presence:+ supplied by an API still decides the outcome exactly as it
+      # used to — deprecated rather than dropped, so nothing changes under an
+      # API that relies on it until the key is ignored outright.
+      def validates(attrs, validations, required: false)
+        if validations.key?(:presence)
+          Grape.deprecator.warn('Passing a `presence` option is deprecated and it will be ignored in a future release. Declare the parameter with `requires` to make it required, `optional` to make it optional.')
+        end
+
+        validations = validations.merge(presence: { value: true, message: validations[:message] }) if required
+
         process_oneof!(validations) if validations.key?(:oneof)
         spec = ValidationsSpec.from(validations)
 

--- a/spec/grape/dsl/parameters_spec.rb
+++ b/spec/grape/dsl/parameters_spec.rb
@@ -13,12 +13,17 @@ describe Grape::DSL::Parameters do
         @validate_attributes = []
       end
 
-      def validate_attributes(*args)
+      def validate_attributes(*args, **kwargs)
         @validate_attributes.push(*args)
+        @validate_attributes_kwargs = kwargs
       end
 
       def validate_attributes_reader
         @validate_attributes
+      end
+
+      def validate_attributes_kwargs_reader
+        @validate_attributes_kwargs
       end
 
       def push_declared_params(args, _opts)
@@ -85,12 +90,18 @@ describe Grape::DSL::Parameters do
     it 'adds a required parameter' do
       subject.requires :id, type: Integer, desc: 'Identity.'
 
-      expect(subject.validate_attributes_reader).to eq([[:id], { type: Integer, desc: 'Identity.', presence: { value: true, message: nil } }])
+      expect(subject.validate_attributes_reader).to eq([[:id], { type: Integer, desc: 'Identity.' }])
+      expect(subject.validate_attributes_kwargs_reader).to eq(required: true)
       expect(subject.push_declared_params_reader).to eq([:id])
     end
   end
 
   describe '#optional' do
+    it 'signals that the parameter is not required' do
+      subject.optional :id, type: Integer
+      expect(subject.validate_attributes_kwargs_reader).to eq(required: false)
+    end
+
     it 'adds an optional parameter' do
       subject.optional :id, type: Integer, desc: 'Identity.'
 
@@ -250,7 +261,8 @@ describe Grape::DSL::Parameters do
         .to raise_error(ActiveSupport::DeprecationException, /positional options Hash to `requires`/)
 
       Grape.deprecator.silence { subject.requires :id, { type: Integer, desc: 'Identity.' } }
-      expect(subject.validate_attributes_reader).to eq([[:id], { type: Integer, desc: 'Identity.', presence: { value: true, message: nil } }])
+      expect(subject.validate_attributes_reader).to eq([[:id], { type: Integer, desc: 'Identity.' }])
+      expect(subject.validate_attributes_kwargs_reader).to eq(required: true)
       expect(subject.push_declared_params_reader).to eq([:id])
     end
 
@@ -277,7 +289,8 @@ describe Grape::DSL::Parameters do
     it 'keeps the options of the positional Hash applying to every attribute' do
       Grape.deprecator.silence { subject.requires :a, :b, { type: Integer } }
 
-      expect(subject.validate_attributes_reader).to eq([%i[a b], { type: Integer, presence: { value: true, message: nil } }])
+      expect(subject.validate_attributes_reader).to eq([%i[a b], { type: Integer }])
+      expect(subject.validate_attributes_kwargs_reader).to eq(required: true)
       expect(subject.push_declared_params_reader).to eq(%i[a b])
     end
 

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -390,6 +390,32 @@ describe Grape::Validations::ParamsScope do
     end
   end
 
+  context 'when a presence option is supplied' do
+    # `presence` is how the DSL tells the pipeline a param is required;
+    # `requires` overwrote whatever an API passed, and `optional` honoured it.
+    # Both still resolve exactly as they did, with a warning.
+    it 'is deprecated' do
+      expect do
+        subject.params { requires :a, presence: false }
+      end.to raise_error(ActiveSupport::DeprecationException, /presence/)
+
+      expect do
+        subject.params { optional :a, presence: true }
+      end.to raise_error(ActiveSupport::DeprecationException, /presence/)
+    end
+
+    it 'keeps deciding the outcome the way it always did' do
+      Grape.deprecator.silence do
+        subject.params { optional :a, presence: true }
+      end
+      subject.get('/presence') { 'ok' }
+
+      get '/presence'
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq('a is missing')
+    end
+  end
+
   context 'parameters in group' do
     it 'errors when no type is provided' do
       expect do


### PR DESCRIPTION
## The problem

`requires` announced that a parameter is required by writing into the options Hash it had just been handed:

```ruby
opts[:presence] = { value: true, message: opts[:message] }
```

That puts an internal signal in the same namespace as an API's own options, and the two share a key. Which one wins depends on which method you called, and neither outcome is documented:

```ruby
requires :a, presence: false   # ignored   — :a is still required (requires overwrites it)
optional :a, presence: true    # honoured  — :a is actually required (nothing overwrites it)
```

So `presence:` is silently discarded where someone might plausibly mean it, and silently effective as an undocumented way to turn `optional` into `requires`.

## The fix

The flag travels as an argument — `required: true` from `requires`, `false` from `optional` — through `validate_attributes` to `validates`, which builds the presence entry itself. The DSL stops writing into the caller's Hash.

```ruby
validate_attributes(attrs, opts, required: true, &block)
```

`required?` already existed on `ValidationsSpec`; it just derived from the smuggled key. This makes the existing concept explicit rather than inventing one.

## A second bug, fixed on the way

The presence entry was assembled from `opts[:message]` *before* the enclosing `with` attributes were merged in, so a group-level `message:` never reached the presence validator:

```ruby
params do
  with(message: 'custom missing') { requires :a }
end

# before => {"error":"a is missing"}
# now    => {"error":"a custom missing"}
```

Same shape as the pre-merge read fixed in #2864, in a different key.

## Nothing changes behaviourally

A `presence:` supplied by an API still decides the outcome exactly as it used to — deprecated rather than dropped, so this is a full deprecation cycle rather than a break:

```
requires :a, presence: false   => 400  (unchanged)  + deprecation warning
optional :a, presence: true    => 400  (unchanged)  + deprecation warning
optional :a                    => 200  (unchanged)
```

The removal is one `.except(:presence)` line in a future major.

## A note on where the flag lives

I first put `required:` on `ValidationsSpec.from`, which broke 19 specs: `from(type: Integer)` is a brace-less Hash, and Ruby 3 passes that as keywords, so the positional argument got nothing. The same trap is why `validates(attrs, validator => {...})` needed explicit braces in this diff. A method whose Hash argument is normally written brace-less is a poor place for a new keyword, so the flag lives on `validates` and `ValidationsSpec` is untouched.

## Test plan

- [x] Full RSpec suite: 2616 examples, 0 failures.
- [x] Specs added: both spellings warn; `optional :a, presence: true` still answers 400 with deprecations silenced (pinning that the cycle preserves behaviour); `optional` signals `required: false` (nothing covered that before).
- [x] RuboCop clean over `lib` and `spec`.
- [x] UPGRADING entries for the deprecation and for the `with(message:)` change.
- [ ] CI green.

Independent of #2864 — the two apply cleanly on top of each other in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)