### PR TITLE
Take `as` as a keyword argument in `requires` and `optional`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [#2835](https://github.com/ruby-grape/grape/pull/2835): Return the compiled instance from `Grape::API::Instance.compile!` so `call` and `recognize_path` no longer re-read `@instance`, which a concurrent `change!` could nil between the two reads - [@ericproulx](https://github.com/ericproulx).
 * [#2849](https://github.com/ruby-grape/grape/pull/2849): Remove `http_digest`, which has had no strategy behind it since 2.0.0 and raised on the first request rather than when the API was defined (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2862](https://github.com/ruby-grape/grape/pull/2862): Rename the `desc` `default` key to `default_response`, the name grape-swagger reads, deprecating `default` (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
+* [#2866](https://github.com/ruby-grape/grape/pull/2866): Take `as` as a keyword argument in `requires` and `optional` instead of carrying it in the options Hash, where it was dispatched as a no-op `AsValidator` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -124,31 +124,33 @@ module Grape
       #         requires :name, type: String
       #       end
       #     end
-      def requires(*attrs, using: nil, except: nil, **opts, &block)
-        return redispatch_legacy_options(:requires, attrs, { using:, except: }.compact.merge(opts), &block) if legacy_options?(attrs)
+      def requires(*attrs, using: nil, except: nil, as: nil, **opts, &block)
+        return redispatch_legacy_options(:requires, attrs, { using:, except:, as: }.compact.merge(opts), &block) if legacy_options?(attrs)
 
         opts[:presence] = { value: true, message: opts[:message] }
         opts = @group.deep_merge(opts) if @group
+        as ||= opts[:as]
 
         return require_required_and_optional_fields(attrs.first, using:, except:) if using
 
         validate_attributes(attrs, **opts, &block)
-        block ? new_scope(attrs.first, type: opts[:type], as: opts[:as], &block) : push_declared_params(attrs, as: opts[:as])
+        block ? new_scope(attrs.first, type: opts[:type], as:, &block) : push_declared_params(attrs, as:)
       end
 
       # Allow, but don't require, one or more parameters for the current
       #   endpoint.
       # @param (see #requires)
       # @option (see #requires)
-      def optional(*attrs, using: nil, except: nil, **opts, &block)
-        return redispatch_legacy_options(:optional, attrs, { using:, except: }.compact.merge(opts), &block) if legacy_options?(attrs)
+      def optional(*attrs, using: nil, except: nil, as: nil, **opts, &block)
+        return redispatch_legacy_options(:optional, attrs, { using:, except:, as: }.compact.merge(opts), &block) if legacy_options?(attrs)
 
         opts = @group.deep_merge(opts) if @group
+        as ||= opts[:as]
 
         return require_optional_fields(attrs.first, using:, except:) if using
 
         validate_attributes(attrs, **opts, &block)
-        block ? new_scope(attrs.first, type: opts[:type], as: opts[:as], optional: true, &block) : push_declared_params(attrs, as: opts[:as])
+        block ? new_scope(attrs.first, type: opts[:type], as:, optional: true, &block) : push_declared_params(attrs, as:)
       end
 
       # Define common settings for one or more parameters

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -360,6 +360,36 @@ describe Grape::Validations::ParamsScope do
     end
   end
 
+  context 'when a parameter is renamed with as' do
+    # `as` is a DSL concern — the rename happens in push_declared_params and
+    # new_scope, both of which take it as a keyword. It reaches them from the
+    # declaration or from an enclosing `with`, the declaration winning.
+    it 'renames a parameter declared with as' do
+      subject.params { requires :a, as: :b, type: String }
+      subject.get('/rename') { declared(params).to_json }
+
+      get '/rename', a: 'x'
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq({ b: 'x' }.to_json)
+    end
+
+    it 'takes the name from an enclosing with block' do
+      subject.params { with(as: :z) { requires :c, type: String } }
+      subject.get('/group_rename') { declared(params).to_json }
+
+      get '/group_rename', c: 'x'
+      expect(last_response.body).to eq({ z: 'x' }.to_json)
+    end
+
+    it 'lets the declaration win over the group' do
+      subject.params { with(as: :z) { requires :c, as: :own, type: String } }
+      subject.get('/both') { declared(params).to_json }
+
+      get '/both', c: 'x'
+      expect(last_response.body).to eq({ own: 'x' }.to_json)
+    end
+  end
+
   context 'parameters in group' do
     it 'errors when no type is provided' do
       expect do


### PR DESCRIPTION
## Why

`as` renames a parameter, and the rename is performed by `push_declared_params` (via `push_renamed_param`) and by `new_scope` (as `element_renamed`). **Both already take it as a keyword.** It travelled inside the options Hash only so those two calls could read it back out:

```ruby
block ? new_scope(attrs.first, type: opts[:type], as: opts[:as], &block) : push_declared_params(attrs, as: opts[:as])
```

Nothing in the validation pipeline consumes it. `ValidationsSpec::SPEC_CONSUMED_KEYS` does not list `:as`, so the key falls through to validator dispatch and builds one `AsValidator` per renamed parameter:

```ruby
class AsValidator < Base
  # We use a validator for renaming parameters. This is just a marker for
  # the parameter scope to handle the renaming. No actual validation
  # happens here.
  def validate_param!(*); end
end
```

Its own comment calls it a marker for the parameter scope — but nothing anywhere reads that marker. Grepping for `AsValidator` outside its own file returns nothing. So it is an object allocated per renamed param that does nothing.

## The change

`requires` and `optional` accept `as:` as a keyword, defaulting to whatever an enclosing `with` supplied:

```ruby
as ||= opts[:as]
```

That line is load-bearing: the group merge is what makes `with(as: :z)` work, and reading the keyword without it would reintroduce the same pre-merge bug fixed in #2864 and #2865, in a third key. The declaration keeps winning over the group, as `deep_merge` gave it before.

The options Hash now carries only what the validation pipeline is meant to read.

## Behaviour

Unchanged in all three directions:

```
requires :a, as: :b            /t?a=x  => 200 {"b":"x"}
with(as: :z) { requires :c }   /u?c=x  => 200 {"z":"x"}
optional :d, as: :e            /v?d=x  => 200 {"e":"x"}
```

The one observable difference is that `AsValidator` is no longer instantiated, which is visible only to code inspecting a scope's validator list.

## Scope

`Grape::Validations::Validators::AsValidator` is left in place. It is now unused, but it is a public constant and removing it is a separate decision with its own UPGRADING note.

This is the DSL-only half of a distinction worth stating: a key that only the DSL consumes can become a keyword, while a key the validation pipeline reads — `type`, `message`, `values`, `default` — has to stay in the Hash. `type` in particular cannot make this move: `ValidationsSpec#parse_coerce` reads `raw[:type]`, so it would have to be extracted and merged back, and `merge(type: nil)` adds the key and trips `':type may not be supplied with :types'` on a bare `types:` declaration.

## Test plan

- [x] Full RSpec suite: 2616 examples, 0 failures.
- [x] Three specs added: rename from the declaration, rename from an enclosing `with`, and the declaration winning over the group.
- [x] RuboCop clean over `lib` and `spec`.
- [ ] CI green.

Independent of #2864 and #2865; no UPGRADING entry, as no documented behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)