### PR TITLE
Extract the shared body of `requires` and `optional`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 * [#2859](https://github.com/ruby-grape/grape/pull/2859): Answer `Grape::Router::Route#success` and `#failure` from the description whichever way it was written - [@ericproulx](https://github.com/ericproulx).
 * [#2861](https://github.com/ruby-grape/grape/pull/2861): Read `Grape::Router::Route#default` from the description instead of from the options Hash's own default value, which was always `nil` - [@ericproulx](https://github.com/ericproulx).
 * [#2864](https://github.com/ruby-grape/grape/pull/2864): Apply a group's type check to `optional` the same way as `requires`, so a type supplied by an enclosing `with` is no longer invisible to it (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
+* [#2865](https://github.com/ruby-grape/grape/pull/2865): Pass `required` from `requires`/`optional` as an argument instead of writing a `presence` key into the caller's options, deprecating a user-supplied `presence` and letting a `with` block's `message` reach the presence validator (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -42,6 +42,33 @@ end
 Both are accepted now. A group with no type from either the declaration or an enclosing `with` still raises `Grape::Exceptions::MissingGroupType`, and an unsupported type still raises `Grape::Exceptions::UnsupportedGroupType`.
 
 One case stops raising. `optional :a, using: SomeEntity do ... end` — a block *and* `using:` — raised `MissingGroupType` before; it now ignores the block and documents the entity's params, which is what `requires` has always done with that combination. If you have such a declaration, the block was never going to be applied; delete it or drop `using:`.
+#### The `presence` option of `requires` and `optional` is deprecated
+
+`presence` is how the params DSL tells the validation pipeline that a parameter is required. It travelled as a key written into the same options Hash that carries an API's own options, so an API could set it — and got opposite results depending on which method it was passed to, because `requires` overwrote it while nothing overwrote it for `optional`:
+
+```ruby
+requires :a, presence: false   # ignored: :a is still required
+optional :a, presence: true    # honoured: :a is actually required
+```
+
+Both still resolve exactly as they did, and now emit a deprecation warning. Declare the parameter with `requires` to make it required and `optional` to make it optional; the option will be ignored outright in a future release.
+
+#### A `with` block's `message` now reaches the presence validator
+
+The presence entry for a `requires` was built before the attributes of an enclosing `with` were merged in, so a group-level `message:` never reached it. It does now:
+
+```ruby
+params do
+  with(message: 'custom missing') do
+    requires :a
+  end
+end
+
+# before: "a is missing"
+# now:    "a custom missing"
+```
+
+An API that sets `message:` on a `with` block and relies on the generic wording for missing parameters will see its own message instead.
 
 #### `use`, `helpers`, `rescue_from` and other registrations no longer reach routes defined above them
 

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -219,7 +219,7 @@ module Grape
           return require_optional_fields(attrs.first, using:, except:)
         end
 
-        validate_attributes(attrs, opts, required:, &block)
+        validates(attrs, opts, required:)
         return push_declared_params(attrs, as:) unless block
 
         new_scope(attrs.first, type: opts[:type], as:, optional: !required, &block)

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -127,13 +127,12 @@ module Grape
       def requires(*attrs, using: nil, except: nil, as: nil, **opts, &block)
         return redispatch_legacy_options(:requires, attrs, { using:, except:, as: }.compact.merge(opts), &block) if legacy_options?(attrs)
 
-        opts[:presence] = { value: true, message: opts[:message] }
         opts = @group.deep_merge(opts) if @group
         as ||= opts[:as]
 
         return require_required_and_optional_fields(attrs.first, using:, except:) if using
 
-        validate_attributes(attrs, **opts, &block)
+        validate_attributes(attrs, opts, required: true, &block)
         block ? new_scope(attrs.first, type: opts[:type], as:, &block) : push_declared_params(attrs, as:)
       end
 
@@ -149,7 +148,7 @@ module Grape
 
         return require_optional_fields(attrs.first, using:, except:) if using
 
-        validate_attributes(attrs, **opts, &block)
+        validate_attributes(attrs, opts, required: false, &block)
         block ? new_scope(attrs.first, type: opts[:type], as:, optional: true, &block) : push_declared_params(attrs, as:)
       end
 
@@ -163,7 +162,7 @@ module Grape
 
       %i[mutually_exclusive exactly_one_of at_least_one_of all_or_none_of].each do |validator|
         define_method validator do |*attrs, message: nil|
-          validates(attrs, validator => { value: true, message: })
+          validates(attrs, { validator => { value: true, message: } })
         end
       end
 

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -124,32 +124,20 @@ module Grape
       #         requires :name, type: String
       #       end
       #     end
-      def requires(*attrs, using: nil, except: nil, as: nil, **opts, &block)
-        return redispatch_legacy_options(:requires, attrs, { using:, except:, as: }.compact.merge(opts), &block) if legacy_options?(attrs)
+      def requires(*attrs, using: nil, except: nil, as: nil, **opts, &)
+        return redispatch_legacy_options(:requires, attrs, { using:, except:, as: }.compact.merge(opts), &) if legacy_options?(attrs)
 
-        opts = @group.deep_merge(opts) if @group
-        as ||= opts[:as]
-
-        return require_required_and_optional_fields(attrs.first, using:, except:) if using
-
-        validate_attributes(attrs, opts, required: true, &block)
-        block ? new_scope(attrs.first, type: opts[:type], as:, &block) : push_declared_params(attrs, as:)
+        declare(attrs, opts, required: true, using:, except:, as:, &)
       end
 
       # Allow, but don't require, one or more parameters for the current
       #   endpoint.
       # @param (see #requires)
       # @option (see #requires)
-      def optional(*attrs, using: nil, except: nil, as: nil, **opts, &block)
-        return redispatch_legacy_options(:optional, attrs, { using:, except:, as: }.compact.merge(opts), &block) if legacy_options?(attrs)
+      def optional(*attrs, using: nil, except: nil, as: nil, **opts, &)
+        return redispatch_legacy_options(:optional, attrs, { using:, except:, as: }.compact.merge(opts), &) if legacy_options?(attrs)
 
-        opts = @group.deep_merge(opts) if @group
-        as ||= opts[:as]
-
-        return require_optional_fields(attrs.first, using:, except:) if using
-
-        validate_attributes(attrs, opts, required: false, &block)
-        block ? new_scope(attrs.first, type: opts[:type], as:, optional: true, &block) : push_declared_params(attrs, as:)
+        declare(attrs, opts, required: false, using:, except:, as:, &)
       end
 
       # Define common settings for one or more parameters
@@ -214,6 +202,29 @@ module Grape
       #   arguments instead. Before Ruby 3 keyword separation this Hash was pulled
       #   off the argument list by `extract_options!`; now it lands in the splat and
       #   would silently be treated as a parameter name.
+      # +requires+ and +optional+ differ only in whether what they declare is
+      # required, so the declaration itself lives here.
+      #
+      # The two +using:+ helpers stay separate. They are not one computation
+      # with a flag flipped: +requires+ treats +except+ as "these go in the
+      # other bucket", while +optional+ has no other bucket — +:all+ ignores
+      # +except+ and +:none+ uses it to drop fields entirely.
+      def declare(attrs, opts, required:, using:, except:, as:, &block)
+        opts = @group.deep_merge(opts) if @group
+        as ||= opts[:as]
+
+        if using
+          return require_required_and_optional_fields(attrs.first, using:, except:) if required
+
+          return require_optional_fields(attrs.first, using:, except:)
+        end
+
+        validate_attributes(attrs, opts, required:, &block)
+        return push_declared_params(attrs, as:) unless block
+
+        new_scope(attrs.first, type: opts[:type], as:, optional: !required, &block)
+      end
+
       def legacy_options?(args)
         args.size > 1 && args.last.is_a?(Hash)
       end

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -210,8 +210,8 @@ module Grape
       # other bucket", while +optional+ has no other bucket — +:all+ ignores
       # +except+ and +:none+ uses it to drop fields entirely.
       def declare(attrs, opts, required:, using:, except:, as:, &block)
-        opts = @group.deep_merge(opts) if @group
-        as ||= opts[:as]
+        merged_opts = @group&.deep_merge(opts) || opts
+        as ||= merged_opts[:as]
 
         if using
           return require_required_and_optional_fields(attrs.first, using:, except:) if required
@@ -219,10 +219,10 @@ module Grape
           return require_optional_fields(attrs.first, using:, except:)
         end
 
-        validates(attrs, opts, required:)
+        validates(attrs, merged_opts, required:)
         return push_declared_params(attrs, as:) unless block
 
-        new_scope(attrs.first, type: opts[:type], as:, optional: !required, &block)
+        new_scope(attrs.first, type: merged_opts[:type], as:, optional: !required, &block)
       end
 
       def legacy_options?(args)

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -263,9 +263,9 @@ module Grape
         end
       end
 
-      def validate_attributes(attrs, **opts, &block)
-        opts[:type] ||= Array if block
-        validates(attrs, opts)
+      def validate_attributes(attrs, opts, required:, &block)
+        opts = opts.merge(type: Array) if block && opts[:type].nil?
+        validates(attrs, opts, required:)
       end
 
       # Returns a new parameter scope, subordinate to the current one and nested
@@ -349,7 +349,24 @@ module Grape
         (iterates_elements? ? 1 : 0) + (@parent&.array_depth || 0)
       end
 
-      def validates(attrs, validations)
+      # +required+ is the DSL's own signal — +requires+ passes true, +optional+
+      # false. It used to travel as a +:presence+ key that +requires+ wrote into
+      # the caller's option Hash, which is why a user-supplied +presence:+ was
+      # silently overwritten there and silently honoured by +optional+, where
+      # nothing overwrote it. The key is built here from the flag instead, after
+      # the caller has merged in any enclosing +with+ attributes, so a
+      # group-level +message:+ reaches the presence validator.
+      #
+      # A +presence:+ supplied by an API still decides the outcome exactly as it
+      # used to — deprecated rather than dropped, so nothing changes under an
+      # API that relies on it until the key is ignored outright.
+      def validates(attrs, validations, required: false)
+        if validations.key?(:presence)
+          Grape.deprecator.warn('Passing a `presence` option is deprecated and it will be ignored in a future release. Declare the parameter with `requires` to make it required, `optional` to make it optional.')
+        end
+
+        validations = validations.merge(presence: { value: true, message: validations[:message] }) if required
+
         process_oneof!(validations) if validations.key?(:oneof)
         spec = ValidationsSpec.from(validations)
 

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -263,11 +263,6 @@ module Grape
         end
       end
 
-      def validate_attributes(attrs, opts, required:, &block)
-        opts = opts.merge(type: Array) if block && opts[:type].nil?
-        validates(attrs, opts, required:)
-      end
-
       # Returns a new parameter scope, subordinate to the current one and nested
       # under the given element.
       # @param element [Symbol] the parameter name under which this scope is nested

--- a/spec/grape/dsl/parameters_spec.rb
+++ b/spec/grape/dsl/parameters_spec.rb
@@ -13,12 +13,17 @@ describe Grape::DSL::Parameters do
         @validate_attributes = []
       end
 
-      def validate_attributes(*args)
+      def validate_attributes(*args, **kwargs)
         @validate_attributes.push(*args)
+        @validate_attributes_kwargs = kwargs
       end
 
       def validate_attributes_reader
         @validate_attributes
+      end
+
+      def validate_attributes_kwargs_reader
+        @validate_attributes_kwargs
       end
 
       def push_declared_params(args, _opts)
@@ -85,12 +90,18 @@ describe Grape::DSL::Parameters do
     it 'adds a required parameter' do
       subject.requires :id, type: Integer, desc: 'Identity.'
 
-      expect(subject.validate_attributes_reader).to eq([[:id], { type: Integer, desc: 'Identity.', presence: { value: true, message: nil } }])
+      expect(subject.validate_attributes_reader).to eq([[:id], { type: Integer, desc: 'Identity.' }])
+      expect(subject.validate_attributes_kwargs_reader).to eq(required: true)
       expect(subject.push_declared_params_reader).to eq([:id])
     end
   end
 
   describe '#optional' do
+    it 'signals that the parameter is not required' do
+      subject.optional :id, type: Integer
+      expect(subject.validate_attributes_kwargs_reader).to eq(required: false)
+    end
+
     it 'adds an optional parameter' do
       subject.optional :id, type: Integer, desc: 'Identity.'
 
@@ -250,7 +261,8 @@ describe Grape::DSL::Parameters do
         .to raise_error(ActiveSupport::DeprecationException, /positional options Hash to `requires`/)
 
       Grape.deprecator.silence { subject.requires :id, { type: Integer, desc: 'Identity.' } }
-      expect(subject.validate_attributes_reader).to eq([[:id], { type: Integer, desc: 'Identity.', presence: { value: true, message: nil } }])
+      expect(subject.validate_attributes_reader).to eq([[:id], { type: Integer, desc: 'Identity.' }])
+      expect(subject.validate_attributes_kwargs_reader).to eq(required: true)
       expect(subject.push_declared_params_reader).to eq([:id])
     end
 
@@ -277,7 +289,8 @@ describe Grape::DSL::Parameters do
     it 'keeps the options of the positional Hash applying to every attribute' do
       Grape.deprecator.silence { subject.requires :a, :b, { type: Integer } }
 
-      expect(subject.validate_attributes_reader).to eq([%i[a b], { type: Integer, presence: { value: true, message: nil } }])
+      expect(subject.validate_attributes_reader).to eq([%i[a b], { type: Integer }])
+      expect(subject.validate_attributes_kwargs_reader).to eq(required: true)
       expect(subject.push_declared_params_reader).to eq(%i[a b])
     end
 

--- a/spec/grape/dsl/parameters_spec.rb
+++ b/spec/grape/dsl/parameters_spec.rb
@@ -10,20 +10,20 @@ describe Grape::DSL::Parameters do
       attr_accessor :api, :element, :parent
 
       def initialize
-        @validate_attributes = []
+        @validates = []
       end
 
-      def validate_attributes(*args, **kwargs)
-        @validate_attributes.push(*args)
-        @validate_attributes_kwargs = kwargs
+      def validates(*args, **kwargs)
+        @validates.push(*args)
+        @validates_kwargs = kwargs
       end
 
-      def validate_attributes_reader
-        @validate_attributes
+      def validates_reader
+        @validates
       end
 
-      def validate_attributes_kwargs_reader
-        @validate_attributes_kwargs
+      def validates_kwargs_reader
+        @validates_kwargs
       end
 
       def push_declared_params(args, _opts)
@@ -32,14 +32,6 @@ describe Grape::DSL::Parameters do
 
       def push_declared_params_reader
         @push_declared_params
-      end
-
-      def validates(*args)
-        @validates = *args
-      end
-
-      def validates_reader
-        @validates
       end
 
       def new_scope(element, **_opts, &block)
@@ -90,8 +82,8 @@ describe Grape::DSL::Parameters do
     it 'adds a required parameter' do
       subject.requires :id, type: Integer, desc: 'Identity.'
 
-      expect(subject.validate_attributes_reader).to eq([[:id], { type: Integer, desc: 'Identity.' }])
-      expect(subject.validate_attributes_kwargs_reader).to eq(required: true)
+      expect(subject.validates_reader).to eq([[:id], { type: Integer, desc: 'Identity.' }])
+      expect(subject.validates_kwargs_reader).to eq(required: true)
       expect(subject.push_declared_params_reader).to eq([:id])
     end
   end
@@ -99,13 +91,13 @@ describe Grape::DSL::Parameters do
   describe '#optional' do
     it 'signals that the parameter is not required' do
       subject.optional :id, type: Integer
-      expect(subject.validate_attributes_kwargs_reader).to eq(required: false)
+      expect(subject.validates_kwargs_reader).to eq(required: false)
     end
 
     it 'adds an optional parameter' do
       subject.optional :id, type: Integer, desc: 'Identity.'
 
-      expect(subject.validate_attributes_reader).to eq([[:id], { type: Integer, desc: 'Identity.' }])
+      expect(subject.validates_reader).to eq([[:id], { type: Integer, desc: 'Identity.' }])
       expect(subject.push_declared_params_reader).to eq([:id])
     end
   end
@@ -114,14 +106,14 @@ describe Grape::DSL::Parameters do
     it 'creates a scope with group attributes' do
       subject.with(type: Integer) { subject.optional :id, desc: 'Identity.' }
 
-      expect(subject.validate_attributes_reader).to eq([[:id], { type: Integer, desc: 'Identity.' }])
+      expect(subject.validates_reader).to eq([[:id], { type: Integer, desc: 'Identity.' }])
       expect(subject.push_declared_params_reader).to eq([:id])
     end
 
     it 'merges the group attributes' do
       subject.with(documentation: { in: 'body' }) { subject.optional :vault, documentation: { default: 33 } }
 
-      expect(subject.validate_attributes_reader).to eq([[:vault], { documentation: { in: 'body', default: 33 } }])
+      expect(subject.validates_reader).to eq([[:vault], { documentation: { in: 'body', default: 33 } }])
       expect(subject.push_declared_params_reader).to eq([:vault])
     end
 
@@ -131,7 +123,7 @@ describe Grape::DSL::Parameters do
         subject.optional :allowed_vaults, type: [Integer], documentation: { default: [31, 32, 33], is_array: true }
       end
 
-      expect(subject.validate_attributes_reader).to eq(
+      expect(subject.validates_reader).to eq(
         [
           [:vault], { type: Integer, documentation: { in: 'body', default: 33 } },
           [:allowed_vaults], { type: [Integer], documentation: { in: 'body', default: [31, 32, 33], is_array: true } }
@@ -144,7 +136,7 @@ describe Grape::DSL::Parameters do
         subject.optional :vault, type: Integer, documentation: { x: nil }
       end
 
-      expect(subject.validate_attributes_reader).to eq(
+      expect(subject.validates_reader).to eq(
         [
           [:vault], { type: Integer, documentation: { x: nil } }
         ]
@@ -157,7 +149,7 @@ describe Grape::DSL::Parameters do
         subject.optional :role, type: String, documentation: { default: 'resident' }
       end
 
-      expect(subject.validate_attributes_reader).to eq(
+      expect(subject.validates_reader).to eq(
         [
           [:info], { type: Hash, documentation: { default: { vault: '33' } } },
           [:role], { type: String, documentation: { default: 'resident' } }
@@ -170,7 +162,7 @@ describe Grape::DSL::Parameters do
         subject.optional :vault, documentation: { details: { desc: 'The vault number' } }
       end
 
-      expect(subject.validate_attributes_reader).to eq(
+      expect(subject.validates_reader).to eq(
         [
           [:vault], { documentation: { details: { in: 'body', hidden: false, desc: 'The vault number' } } }
         ]
@@ -191,7 +183,7 @@ describe Grape::DSL::Parameters do
         end
       end
 
-      expect(subject.validate_attributes_reader).to eq(
+      expect(subject.validates_reader).to eq(
         [
           [:pipboy_id], { type: Integer, documentation: { in: 'body' } },
           [:vault], { type: Integer, documentation: { in: 'body', default: 33 } },
@@ -208,7 +200,7 @@ describe Grape::DSL::Parameters do
         end
       end
 
-      expect(subject.validate_attributes_reader).to eq(
+      expect(subject.validates_reader).to eq(
         [
           [:info], { type: Hash, documentation: { in: 'body', desc: 'The info', x: { nullable: true } } },
           [:vault], { type: Integer, documentation: { in: 'body', default: 33, desc: 'The vault number' } }
@@ -261,8 +253,8 @@ describe Grape::DSL::Parameters do
         .to raise_error(ActiveSupport::DeprecationException, /positional options Hash to `requires`/)
 
       Grape.deprecator.silence { subject.requires :id, { type: Integer, desc: 'Identity.' } }
-      expect(subject.validate_attributes_reader).to eq([[:id], { type: Integer, desc: 'Identity.' }])
-      expect(subject.validate_attributes_kwargs_reader).to eq(required: true)
+      expect(subject.validates_reader).to eq([[:id], { type: Integer, desc: 'Identity.' }])
+      expect(subject.validates_kwargs_reader).to eq(required: true)
       expect(subject.push_declared_params_reader).to eq([:id])
     end
 
@@ -271,7 +263,7 @@ describe Grape::DSL::Parameters do
         .to raise_error(ActiveSupport::DeprecationException, /positional options Hash to `optional`/)
 
       Grape.deprecator.silence { subject.optional :id, { type: Integer, desc: 'Identity.' } }
-      expect(subject.validate_attributes_reader).to eq([[:id], { type: Integer, desc: 'Identity.' }])
+      expect(subject.validates_reader).to eq([[:id], { type: Integer, desc: 'Identity.' }])
       expect(subject.push_declared_params_reader).to eq([:id])
     end
 
@@ -289,8 +281,8 @@ describe Grape::DSL::Parameters do
     it 'keeps the options of the positional Hash applying to every attribute' do
       Grape.deprecator.silence { subject.requires :a, :b, { type: Integer } }
 
-      expect(subject.validate_attributes_reader).to eq([%i[a b], { type: Integer }])
-      expect(subject.validate_attributes_kwargs_reader).to eq(required: true)
+      expect(subject.validates_reader).to eq([%i[a b], { type: Integer }])
+      expect(subject.validates_kwargs_reader).to eq(required: true)
       expect(subject.push_declared_params_reader).to eq(%i[a b])
     end
 

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -390,6 +390,32 @@ describe Grape::Validations::ParamsScope do
     end
   end
 
+  context 'when a presence option is supplied' do
+    # `presence` is how the DSL tells the pipeline a param is required;
+    # `requires` overwrote whatever an API passed, and `optional` honoured it.
+    # Both still resolve exactly as they did, with a warning.
+    it 'is deprecated' do
+      expect do
+        subject.params { requires :a, presence: false }
+      end.to raise_error(ActiveSupport::DeprecationException, /presence/)
+
+      expect do
+        subject.params { optional :a, presence: true }
+      end.to raise_error(ActiveSupport::DeprecationException, /presence/)
+    end
+
+    it 'keeps deciding the outcome the way it always did' do
+      Grape.deprecator.silence do
+        subject.params { optional :a, presence: true }
+      end
+      subject.get('/presence') { 'ok' }
+
+      get '/presence'
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq('a is missing')
+    end
+  end
+
   context 'parameters in group' do
     it 'errors when no type is provided' do
       expect do


### PR DESCRIPTION
**Stacked.** Depends on #2864, #2865 and #2866, all three merged into this branch. Base is #2866's branch, so the diff shows the other two as well until they land — this PR's own work is the last three commits, `e7924e4f`, `0a505164` and `e7ac88ec`. Happy to rebase onto master once the stack merges.

Three commits: extract the shared body, delete a private method the extraction exposed as dead, then stop one local name meaning two things.

## Why now

`requires` and `optional` have always been near-duplicates, but three things kept them from collapsing. All three are now fixed on their own merits:

| | before | after |
|---|---|---|
| group-type check | inline in `optional`, in `new_scope` for `requires` | one check in `new_scope` (#2864) |
| requiredness | `requires` wrote `opts[:presence]`, `optional` wrote nothing | `required:` argument (#2865) |
| `as` | read back out of the options Hash by each | keyword argument (#2866) |

With those in place the two methods differ only in the name they redispatch a legacy Hash under, and in `required: true`/`false`.

## The change

```ruby
def requires(*attrs, using: nil, except: nil, as: nil, **opts, &)
  return redispatch_legacy_options(:requires, attrs, { using:, except:, as: }.compact.merge(opts), &) if legacy_options?(attrs)

  declare(attrs, opts, required: true, using:, except:, as:, &)
end

def optional(*attrs, using: nil, except: nil, as: nil, **opts, &)
  return redispatch_legacy_options(:optional, attrs, { using:, except:, as: }.compact.merge(opts), &) if legacy_options?(attrs)

  declare(attrs, opts, required: false, using:, except:, as:, &)
end
```

with the body they shared — the group merge, the `using:` handover, attribute validation, and the choice between a nested scope and a leaf declaration — in one private `declare`.

`optional: !required` on the nested scope deserves a note: it is only correct because #2864 stopped `new_scope` keying its type check off that flag. While the guard still read `element && !optional`, deriving `optional:` from `required` would have re-coupled requiredness to the group-type check — the exact tangle #2864 removes.

The named `&block` is no longer needed in the DSL methods, so `Style/ArgumentsForwarding` collapses them to anonymous `&`.

## What is deliberately *not* unified

`require_optional_fields` and `require_required_and_optional_fields` look like the same method with a flag, and they are not:

```
optional :all  using: {a,b}, except: [:b] => declares ["a", "b"]   # except ignored
optional :none using: {a,b}, except: [:b] => declares ["a"]        # b not declared at all
requires :all  ... => a required, b optional
requires :none ... => b required, a optional
```

`requires` treats `except` as "these go in the other bucket"; `optional` has no other bucket. Folding them would either need an `if required` branch inside — no gain — or would silently stop declaring `b` for `optional :all, except: [:b]`. `declare` dispatches between them and leaves them alone.

## `validate_attributes` turned out to be dead (`0a505164`)

Once the two bodies sat side by side, the private method they both called had nothing in it:

```ruby
def validate_attributes(attrs, opts, required:, &block)
  opts = opts.merge(type: Array) if block && opts[:type].nil?
  validates(attrs, opts, required:)
end
```

That condition — a block with no type — is exactly the condition `new_scope` raises `MissingGroupType` on two lines later, so the defaulted type never reached anything that outlived the exception. Instrumenting the branch and running the full suite fires it **three times, all from the specs asserting that raise**.

The one case that does not raise is a block with no attrs, where `element` is nil and the guard is skipped. `new_scope` already defaults the type for itself there:

```ruby
type: type || Array
```

and a paramless group answers identically with the step removed:

```
params { requires(type: Hash) { requires :b, type: String } }

before => 200 {"b":"x"}
after  => 200 {"b":"x"}
```

So `declare` calls `validates` directly. **Nothing rewrites the options Hash on the way through any more** — `declare` merges the group once and everything downstream reads it.

Knock-on in the specs: the parameters DSL harness stubbed `validate_attributes` and `validates` separately. With one seam left they collapse into a single double, which is a net −13 lines of harness and removes a `Lint/DuplicateMethods` pair.

## Naming the merged options (`e7ac88ec`)

`declare` opened with a rebind:

```ruby
opts = @group.deep_merge(opts) if @group
```

That never modified what the caller passed — `deep_merge` returns a new Hash (it works on a frozen input and leaves it unchanged), and the assignment only rebinds a local. But it left one name meaning two things: the options *as declared* above the line, and the options *resolved against the enclosing `with`* below it. Every read then has to know which side of the line it is on — and that is precisely what went wrong twice already, with the group type in #2864 and the presence message in #2865 both read on the wrong side.

The resolved value gets its own name, following what `with` already does two methods up:

```ruby
merged_opts = @group&.deep_merge(opts) || opts
```

## Test plan

- [x] Full RSpec suite: 2621 examples, 0 failures.
- [x] RuboCop clean over `lib` and `spec`.
- [x] No behaviour change: pure extraction plus the removal of an unreachable default, verified by instrumenting it and by comparing the one non-raising case before and after.
- [ ] CI green.

No CHANGELOG or UPGRADING entry — nothing user-visible changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

