### PR TITLE
Add Grape::PrecompiledJson for bodies that are already JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [#2849](https://github.com/ruby-grape/grape/pull/2849): Remove `http_digest`, which has had no strategy behind it since 2.0.0 and raised on the first request rather than when the API was defined (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2862](https://github.com/ruby-grape/grape/pull/2862): Rename the `desc` `default` key to `default_response`, the name grape-swagger reads, deprecating `default` (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2866](https://github.com/ruby-grape/grape/pull/2866): Take `as` as a keyword argument in `requires` and `optional` instead of carrying it in the options Hash, where it was dispatched as a no-op `AsValidator` - [@ericproulx](https://github.com/ericproulx).
+* [#2869](https://github.com/ruby-grape/grape/pull/2869): Add `Grape::PrecompiledJson`, a body wrapper the JSON formatters serve verbatim instead of encoding a second time - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -3259,6 +3259,41 @@ Built-in formatters are the following.
 * `:serializable_hash`: use object's `serializable_hash` when available, otherwise fallback to `:json`
 * `:binary`: data will be returned "as is"
 
+#### Serving pre-rendered JSON
+
+The `:json` and `:serializable_hash` formatters encode whatever the endpoint returned,
+so a String that already holds JSON gets encoded a second time. Wrap the body in
+`Grape::PrecompiledJson` to opt that response out of encoding.
+
+```ruby
+class API < Grape::API
+  format :json
+
+  get '/cached' do
+    body Grape::PrecompiledJson.new(Rails.cache.read('payload')) # => '{"id":1}', served as-is
+  end
+end
+```
+
+An `Array` is joined into a JSON array without its members being parsed, so a cached
+collection is spliced together rather than round-tripped. Members may themselves be
+`Grape::PrecompiledJson` instances.
+
+```ruby
+Grape::PrecompiledJson.new(['{"id":1}', '{"id":2}']).to_s # => '[{"id":1},{"id":2}]'
+```
+
+Bodies that are not wrapped keep encoding exactly as before, so this is opt-in per
+response rather than a mode the whole API is in. Wrap only the whole body: a wrapper
+nested inside a Hash or Array that is then handed to an encoder is serialized as an
+ordinary object, because no encoder knows to unwrap it. A value that is neither a
+String nor an Array raises `Grape::Exceptions::InvalidFormatter` and answers 500,
+rather than handing Rack a body it cannot serve. Nothing checks that the String
+actually holds JSON — that is the caller's responsibility.
+
+Errors are unaffected: they are rendered by the error formatter, so `error!` still
+returns properly encoded JSON.
+
 If a body is present in a request to an API, with a Content-Type header value that is of an unsupported type a "415 Unsupported Media Type" error code will be returned by Grape.
 
 Response statuses that indicate no content as defined by [Rack](https://github.com/rack) [here](https://github.com/rack/rack/blob/master/lib/rack/utils.rb#L567) will bypass serialization and the body entity - though there should be none - will not be modified.

--- a/lib/grape/formatter/json.rb
+++ b/lib/grape/formatter/json.rb
@@ -4,6 +4,7 @@ module Grape
   module Formatter
     class Json < Base
       def self.call(object, _env)
+        return object.to_s if object.is_a?(Grape::PrecompiledJson)
         return object.to_json if object.respond_to?(:to_json)
 
         ::Grape::Json.dump(object)

--- a/lib/grape/formatter/serializable_hash.rb
+++ b/lib/grape/formatter/serializable_hash.rb
@@ -5,6 +5,7 @@ module Grape
     class SerializableHash < Base
       class << self
         def call(object, _env)
+          return object.to_s if object.is_a?(Grape::PrecompiledJson)
           return object if object.is_a?(String)
           return ::Grape::Json.dump(serialize(object)) if serializable?(object)
           return object.to_json if object.respond_to?(:to_json)

--- a/lib/grape/precompiled_json.rb
+++ b/lib/grape/precompiled_json.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Grape
+  # Marks a body as JSON that has already been rendered, so the JSON formatters
+  # serve it verbatim instead of encoding it a second time.
+  #
+  # +Grape::Formatter::Json+ calls +to_json+ on whatever the endpoint returned, so a
+  # String holding pre-rendered JSON — a blob cached in Redis, a +json_agg+ column read
+  # straight from Postgres, output from another serializer — comes back encoded twice:
+  #
+  #   '{"a":1}'  =>  "\"{\\\"a\\\":1}\""
+  #
+  # Wrapping the body opts that one response out of encoding:
+  #
+  #   get '/cached' do
+  #     body Grape::PrecompiledJson.new(Rails.cache.read('payload'))
+  #   end
+  #
+  # An Array is joined into a JSON array without its members being parsed, which is
+  # what makes a cached collection cheap — N rendered blobs are spliced together
+  # rather than round-tripped:
+  #
+  #   Grape::PrecompiledJson.new(['{"id":1}', '{"id":2}']).to_s # => '[{"id":1},{"id":2}]'
+  #
+  # +Array#join+ calls +to_s+ on each member, so members may themselves be
+  # +PrecompiledJson+ instances.
+  #
+  # Wrap only the whole body. A wrapper nested inside a Hash or Array that is then
+  # handed to an encoder is serialized as an ordinary object — +ActiveSupport::JSON+
+  # renders it through +as_json+ as +{"value":"{\"a\":1}"}+ — because no encoder knows
+  # to unwrap it. Nothing checks that the String actually holds JSON; that is the
+  # caller's responsibility.
+  class PrecompiledJson
+    # @param value [String, Array<String>] pre-rendered JSON
+    def initialize(value)
+      @value = value
+    end
+
+    # @return [String] the JSON to serve
+    # @raise [Grape::Exceptions::InvalidFormatter] if the value is neither a String
+    #   nor an Array; the formatter middleware turns this into a 500 rather than
+    #   letting a body Rack cannot serve reach the SPEC check.
+    def to_s
+      return @value if @value.is_a?(String)
+      return "[#{@value.join(',')}]" if @value.is_a?(Array)
+
+      raise Grape::Exceptions::InvalidFormatter.new(@value.class, 'json')
+    end
+  end
+end

--- a/spec/grape/precompiled_json_spec.rb
+++ b/spec/grape/precompiled_json_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+describe Grape::PrecompiledJson do
+  describe '#to_s' do
+    it 'returns a String value untouched' do
+      json = '{"a":1,"b":[2,3]}'
+      expect(described_class.new(json).to_s).to be(json)
+    end
+
+    it 'joins an Array into a JSON array without parsing its members' do
+      expect(described_class.new(['{"id":1}', '{"id":2}']).to_s).to eq('[{"id":1},{"id":2}]')
+    end
+
+    it 'accepts members that are themselves precompiled' do
+      members = [described_class.new('{"id":1}'), described_class.new('{"id":2}')]
+      expect(described_class.new(members).to_s).to eq('[{"id":1},{"id":2}]')
+    end
+
+    it 'renders an empty Array as an empty JSON array' do
+      expect(described_class.new([]).to_s).to eq('[]')
+    end
+
+    it 'does not check that the String holds JSON' do
+      expect(described_class.new('not json at all').to_s).to eq('not json at all')
+    end
+
+    it 'raises for a value it cannot serve' do
+      expect { described_class.new(a: 1).to_s }
+        .to raise_error(Grape::Exceptions::InvalidFormatter, /cannot convert Hash to json/)
+    end
+
+    it 'raises for nil rather than serving an empty body' do
+      expect { described_class.new(nil).to_s }
+        .to raise_error(Grape::Exceptions::InvalidFormatter, /cannot convert NilClass to json/)
+    end
+  end
+
+  describe 'through the JSON formatters' do
+    it 'is served verbatim by the json formatter' do
+      expect(Grape::Formatter::Json.call(described_class.new('{"a":1}'), {})).to eq('{"a":1}')
+    end
+
+    it 'is served verbatim by the serializable_hash formatter' do
+      expect(Grape::Formatter::SerializableHash.call(described_class.new('{"a":1}'), {})).to eq('{"a":1}')
+    end
+
+    it 'leaves an unwrapped String encoded as before' do
+      expect(Grape::Formatter::Json.call('hello', {})).to eq('"hello"')
+    end
+
+    it 'leaves an unwrapped Hash encoded as before' do
+      expect(Grape::Formatter::Json.call({ a: 1 }, {})).to eq('{"a":1}')
+    end
+  end
+
+  describe 'in an endpoint' do
+    include Rack::Test::Methods
+
+    let(:app) do
+      Class.new(Grape::API) do
+        format :json
+
+        get('/cached') { body Grape::PrecompiledJson.new('{"a":1,"b":[2,3]}') }
+        get('/collection') { body Grape::PrecompiledJson.new(['{"id":1}', '{"id":2}']) }
+        get('/plain') { 'hello' }
+        get('/oops') { body Grape::PrecompiledJson.new(a: 1) }
+        get('/boom') { error!('nope', 422) }
+      end
+    end
+
+    it 'serves pre-rendered JSON without encoding it twice' do
+      get '/cached'
+
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq('{"a":1,"b":[2,3]}')
+      expect(last_response.content_type).to eq('application/json')
+    end
+
+    it 'splices a collection of rendered blobs' do
+      get '/collection'
+
+      expect(last_response.body).to eq('[{"id":1},{"id":2}]')
+    end
+
+    it 'still encodes an unwrapped body' do
+      get '/plain'
+
+      expect(last_response.body).to eq('"hello"')
+    end
+
+    it 'answers 500 rather than handing Rack a body it cannot serve' do
+      get '/oops'
+
+      expect(last_response.status).to eq(500)
+      expect(last_response.body).to include('cannot convert Hash to json')
+    end
+
+    it 'leaves error bodies to the error formatter' do
+      get '/boom'
+
+      expect(last_response.status).to eq(422)
+      expect(last_response.body).to eq('{"error":"nope"}')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The JSON formatters encode whatever the endpoint returned, so a String that already holds JSON is encoded a second time — `'{"a":1}'` comes back as `"\"{\\\"a\\\":1}\""`. This comes up whenever the JSON was rendered somewhere else: a blob cached in Redis, a `json_agg` column read straight from Postgres, output from another serializer.

`Grape::PrecompiledJson` marks one body as already rendered:

```ruby
class API < Grape::API
  format :json

  get '/cached' do
    body Grape::PrecompiledJson.new(Rails.cache.read('payload')) # => '{"id":1}', served as-is
  end
end
```

`Formatter::Json` and `Formatter::SerializableHash` return it verbatim; everything unwrapped encodes exactly as before.

An `Array` is joined without its members being parsed, so a cached collection is spliced together rather than round-tripped. `Array#join` calls `to_s`, so members may themselves be wrappers.

```ruby
Grape::PrecompiledJson.new(['{"id":1}', '{"id":2}']).to_s # => '[{"id":1},{"id":2}]'
```

## Why a wrapper rather than a passthrough formatter

The opt-in is per response rather than per API on purpose. A formatter that passed every String through cannot tell pre-rendered JSON from an endpoint that returns `'hello'`, and would answer with a bare `hello` — invalid JSON, silently. No type check catches that, since a String is precisely what such a formatter is looking for. A marker never has to guess.

The `Array` join is load-bearing rather than a convenience. Handing an encoder an array of wrappers renders them as ordinary objects:

```ruby
[w, w].to_json                     # => [{"value":"..."},{"value":"..."}]
ActiveSupport::JSON.encode(a: w)   # => {"a":{"value":"{\"a\":1}"}}
```

So the join has to happen in the wrapper, and for the same reason a wrapper is only valid as the whole body — nesting one inside a Hash is documented as unsupported, because no encoder knows to unwrap it.

A value that is neither a String nor an Array raises `Grape::Exceptions::InvalidFormatter`, which `Middleware::Formatter#build_formatted_response` already rescues into a 500, rather than letting a body Rack cannot serve reach the SPEC check. Errors are untouched — they are rendered by the error formatter, so `error!` still returns properly encoded JSON.

## Naming

`Grape::PrecompiledJson` rather than `Grape::Json::Precompiled`: `Grape::Json` is stdlib `::JSON` itself unless multi_json is loaded, so the nested name would define `JSON::Precompiled` in the stdlib namespace, and only in some bundles.

## Prior art

GitLab has carried this for years as `Gitlab::Json::Precompiled` plus a custom `Gitlab::Json::GrapeFormatter` installed with `formatter :json, ...` in `lib/api/api.rb`. Honouring the wrapper in the built-in formatters means no formatter declaration is needed.

## Backward compatibility

Purely additive — a new guard for a new class in front of the existing formatter bodies. Nothing that does not use the wrapper behaves differently, so no UPGRADING entry.

## Test plan

- [x] Full RSpec suite passes locally (2629 examples, 0 failures).
- [x] RuboCop clean (340 files, no offenses).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
