### PR TITLE
Take `declared_params_scope` as a keyword instead of stamping it into opts

### DIFF
--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -200,12 +200,16 @@ module Grape
 
       # Adds a parameter declaration to our list of validations.
       # @param attrs [Array] (see Grape::DSL::Parameters#requires)
-      def push_declared_params(attrs, **opts)
-        opts[:declared_params_scope] = self unless opts.key?(:declared_params_scope)
-        return @parent.push_declared_params(attrs, **opts) if lateral?
+      # +declared_params_scope+ is the scope an attribute is recorded against.
+      # It defaults to the receiver and is forwarded unchanged when a lateral
+      # scope hands the push to its parent, so an attribute declared inside a
+      # +given+ block stays attributed to the lateral scope that declared it
+      # rather than to the parent that stores it.
+      def push_declared_params(attrs, as: nil, declared_params_scope: self)
+        return @parent.push_declared_params(attrs, as:, declared_params_scope:) if lateral?
 
-        push_renamed_param(full_path + [attrs.first], opts[:as]) if opts[:as]
-        @declared_params.concat(attrs.map { |attr| ::Grape::Validations::ParamsScope::Attr.new(attr, opts[:declared_params_scope]) })
+        push_renamed_param(full_path + [attrs.first], as) if as
+        @declared_params.concat(attrs.map { |attr| ::Grape::Validations::ParamsScope::Attr.new(attr, declared_params_scope) })
       end
 
       private


### PR DESCRIPTION
## What it looked like

```ruby
def push_declared_params(attrs, **opts)
  opts[:declared_params_scope] = self unless opts.key?(:declared_params_scope)
  return @parent.push_declared_params(attrs, **opts) if lateral?

  push_renamed_param(full_path + [attrs.first], opts[:as]) if opts[:as]
  @declared_params.concat(attrs.map { |attr| Attr.new(attr, opts[:declared_params_scope]) })
end
```

A write into the options Hash, plus a guard that stops the write happening twice.

## What it was doing

Not defaulting — remembering. A lateral scope, the kind a `given` block opens, does not store its own declared params; it hands them to its parent. The stamp is how an attribute stays attributed to the scope that *declared* it rather than the one that *stores* it, and the `unless key?` guard is what stops the parent overwriting the stamp on the way through.

That attribution is read later by `declared(evaluate_given: true)`, through `declared_param_attr.scope.attr_meets_dependency?`. None of it is stated: you have to reconstruct the intent from a write and a guard three lines apart.

## What it looks like now

```ruby
def push_declared_params(attrs, as: nil, declared_params_scope: self)
  return @parent.push_declared_params(attrs, as:, declared_params_scope:) if lateral?

  push_renamed_param(full_path + [attrs.first], as) if as
  @declared_params.concat(attrs.map { |attr| Attr.new(attr, declared_params_scope) })
end
```

Ruby evaluates a default argument in the receiver's context, so `declared_params_scope: self` is the receiver when nobody supplied one, and the lateral scope's own value when it forwards. Identical semantics, without the write or the guard.

`as` becomes explicit at the same time, so there is no `**opts` left to inspect — both options a caller may pass are in the signature.

## Verification

The full suite passing is not enough on its own here, since the guard exists for one specific path. Compared that path directly against master:

```ruby
params do
  optional :kind, type: String, values: %w[a b]
  given kind: ->(v) { v == 'a' } do
    requires :only_for_a, type: String
  end
end
get('/t') { declared(params, evaluate_given: true, include_missing: true).to_json }
```

| | this branch | master |
| --- | --- | --- |
| `?kind=a&only_for_a=x` | `{"kind":"a","only_for_a":"x"}` | same |
| `?kind=b` | `{"kind":"b"}` | same |

- [x] Full RSpec suite: 2613 examples, 0 failures.
- [x] RuboCop clean over `lib` and `spec`.
- [ ] CI green.

Independent of #2861, #2864, #2865, #2866 and #2867 — the signature still accepts `as:`, so no call site changes, on master or on any of those branches.

No CHANGELOG or UPGRADING entry: `push_declared_params` is private and nothing user-visible changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)