### PR TITLE
Keep `refresh_already_mounted` out of `mount`'s public signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 * [#2861](https://github.com/ruby-grape/grape/pull/2861): Read `Grape::Router::Route#default` from the description instead of from the options Hash's own default value, which was always `nil` - [@ericproulx](https://github.com/ericproulx).
 * [#2864](https://github.com/ruby-grape/grape/pull/2864): Apply a group's type check to `optional` the same way as `requires`, so a type supplied by an enclosing `with` is no longer invisible to it (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2865](https://github.com/ruby-grape/grape/pull/2865): Pass `required` from `requires`/`optional` as an argument instead of writing a `presence` key into the caller's options, deprecating a user-supplied `presence` and letting a `with` block's `message` reach the presence validator (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
+* [#2871](https://github.com/ruby-grape/grape/pull/2871): Move the endpoint replacement behind `mount`'s private re-mounting path, deprecating the undocumented `refresh_already_mounted` option, and recognise a mount mapping by `Hash` rather than by `respond_to?(:each_pair)` (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [#2849](https://github.com/ruby-grape/grape/pull/2849): Remove `http_digest`, which has had no strategy behind it since 2.0.0 and raised on the first request rather than when the API was defined (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2862](https://github.com/ruby-grape/grape/pull/2862): Rename the `desc` `default` key to `default_response`, the name grape-swagger reads, deprecating `default` (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2866](https://github.com/ruby-grape/grape/pull/2866): Take `as` as a keyword argument in `requires` and `optional` instead of carrying it in the options Hash, where it was dispatched as a no-op `AsValidator` - [@ericproulx](https://github.com/ericproulx).
+* [#2867](https://github.com/ruby-grape/grape/pull/2867): Extract the shared body of `requires` and `optional` into one private declaration, and drop `validate_attributes`, whose only step defaulted a type that no declaration could reach - [@ericproulx](https://github.com/ericproulx).
 * [#2869](https://github.com/ruby-grape/grape/pull/2869): Add `Grape::PrecompiledJson`, a body wrapper the JSON formatters serve verbatim instead of encoding a second time - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -69,6 +69,30 @@ end
 ```
 
 An API that sets `message:` on a `with` block and relies on the generic wording for missing parameters will see its own message instead.
+#### `refresh_already_mounted` is no longer a `mount` option
+
+`mount` accepted an undocumented `refresh_already_mounted` option that replaced any endpoint already mounted for the same base API instead of adding a second one. It exists for Grape's own re-mounting machinery: when a class-level method runs after a `mount`, `Grape::API.refresh_mount_step` replays that mount, and replaying it naively would duplicate the endpoint.
+
+That decision belongs to the replay, not to the call, so the endpoint replacement moved into the private `refresh_mounted_api` which is the only caller that ever wanted it. Nothing changes for the re-mounting itself.
+
+Passing the option to `mount` still works and now warns; it will be ignored in a future release. There is no replacement, because an API has no reason to ask for it — mounting the same app twice on purpose is still two endpoints.
+
+#### A `mount` target is recognised as a mapping only when it is a `Hash`
+
+`mount` decided between "a Hash of app => path" and "a bare app mounted at /" with `mounts.respond_to?(:each_pair)`. A `Struct` and an `OpenStruct` answer that too, and neither can express an app => path mapping — their keys are member names — so a Rack app that happened to be one was read as a mapping and silently mounted its own field value as a path:
+
+```ruby
+RackStruct = Struct.new(:name) do
+  def call(env) = [200, {}, ['ok']]
+end
+
+mount RackStruct.new('x')
+
+# before: mounted at "/x", because :name => 'x' was read as app => path
+# now:    mounted at "/", as the Rack app it is
+```
+
+The test is now `mounts.is_a?(Hash)`. Every Hash-like people pass — `HashWithIndifferentAccess`, `Hashie::Mash`, `ActiveSupport::OrderedOptions` — subclasses `Hash` and is unaffected.
 
 #### `use`, `helpers`, `rescue_from` and other registrations no longer reach routes defined above them
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -69,6 +69,7 @@ end
 ```
 
 An API that sets `message:` on a `with` block and relies on the generic wording for missing parameters will see its own message instead.
+
 #### `refresh_already_mounted` is no longer a `mount` option
 
 `mount` accepted an undocumented `refresh_already_mounted` option that replaced any endpoint already mounted for the same base API instead of adding a second one. It exists for Grape's own re-mounting machinery: when a class-level method runs after a `mount`, `Grape::API.refresh_mount_step` replays that mount, and replaying it naively would duplicate the endpoint.

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -123,12 +123,18 @@ module Grape
         inheritable_setting.do_not_document!
       end
 
-      def mount(mounts, *opts)
-        mounts = { mounts => '/' } unless mounts.respond_to?(:each_pair)
-        mounts.each_pair do |app, path|
+      def mount(mounts, opts = {})
+        if opts[:refresh_already_mounted]
+          Grape.deprecator.warn('`refresh_already_mounted` is not a `mount` option and will be ignored in a future release.')
+          drop_endpoints_mounted_for(mounts)
+          # Dropped before the recursion below re-enters with the same options,
+          # so a Grape API does not warn once per mount and once per instance.
+          opts = opts.except(:refresh_already_mounted)
+        end
+
+        normalize_mounts(mounts).each_pair do |app, path|
           if app.respond_to?(:mount_instance)
-            opts_with = opts.any? ? opts.first[:with] : {}
-            mount({ app.mount_instance(configuration: opts_with) => path }, *opts)
+            mount({ app.mount_instance(configuration: opts[:with] || {}) => path }, opts)
             next
           end
           in_setting = inheritable_setting
@@ -145,15 +151,6 @@ module Grape
 
             app.change!
             change!
-          end
-
-          # When trying to mount multiple times the same endpoint, remove the previous ones
-          # from the list of endpoints if refresh_already_mounted parameter is true
-          refresh_already_mounted = opts.any? ? opts.first[:refresh_already_mounted] : false
-          if refresh_already_mounted && !endpoints.empty?
-            endpoints.delete_if do |endpoint|
-              same_mounted_app?(endpoint.mounted_app, app)
-            end
           end
 
           endpoints << Grape::Endpoint.new(
@@ -289,9 +286,31 @@ module Grape
         @endpoints = []
       end
 
-      def refresh_mounted_api(mounts, *opts)
-        opts << { refresh_already_mounted: true }
-        mount(mounts, *opts)
+      # Re-mount +mounts+, replacing any endpoint already mounted for the same
+      # base API rather than adding a second one. Called by
+      # {Grape::API.refresh_mount_step} when a class-level method runs after the
+      # API was mounted.
+      def refresh_mounted_api(mounts, opts = {})
+        drop_endpoints_mounted_for(mounts)
+        mount(mounts, opts)
+      end
+
+      # A mounted Grape API is stored as the throwaway instance +mount+ built
+      # for it, never as the class that was written, so endpoints are matched on
+      # the base API both of them share.
+      def drop_endpoints_mounted_for(mounts)
+        normalize_mounts(mounts).each_key do |app|
+          endpoints.delete_if { |endpoint| same_mounted_app?(endpoint.mounted_app, app) }
+        end
+      end
+
+      # A bare app mounts at the root. The test is +Hash+ rather than
+      # +respond_to?(:each_pair)+ because a Struct or an OpenStruct answers that
+      # too, and neither can express an app => path mapping — their keys are
+      # member names. Reading one as a mapping would silently mount nonsense
+      # instead of mounting the app itself.
+      def normalize_mounts(mounts)
+        mounts.is_a?(Hash) ? mounts : { mounts => '/' }
       end
 
       # Two mounts refer to the same app when they share the same base Grape

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -3938,19 +3938,15 @@ describe Grape::API do
       end
     end
 
-    context 'with refresh_already_mounted' do
+    # `Grape::API.refresh_mount_step` replays every mount through the private
+    # `refresh_mounted_api` whenever a class-level method runs after the mount,
+    # which has to replace the endpoint rather than add a second one.
+    context 'when a class-level method runs after a mount' do
       let(:app) { Class.new(described_class) { get('/x') { 'x' } } }
 
-      it 'replaces a previously mounted app instead of duplicating it' do
+      it 'replaces the mounted endpoint instead of duplicating it' do
         subject.mount app => '/thing'
-        expect { subject.mount({ app => '/thing' }, refresh_already_mounted: true) }
-          .not_to(change { subject.endpoints.count })
-      end
-
-      it 'duplicates the endpoint without the flag' do
-        subject.mount app => '/thing'
-        expect { subject.mount app => '/thing' }
-          .to change { subject.endpoints.count }.by(1)
+        expect { subject.format :json }.not_to(change { subject.endpoints.count })
       end
 
       it 'does not confuse two distinct apps that share a name' do
@@ -3961,8 +3957,33 @@ describe Grape::API do
         allow(other).to receive(:to_s).and_return('SameName')
 
         subject.mount app => '/thing'
-        expect { subject.mount({ other => '/thing' }, refresh_already_mounted: true) }
+        subject.mount other => '/thing'
+        expect { subject.format :json }.not_to(change { subject.endpoints.count })
+        expect(subject.endpoints.count).to eq(2)
+      end
+
+      it 'duplicates the endpoint when the same app is mounted twice' do
+        subject.mount app => '/thing'
+        expect { subject.mount app => '/thing' }
           .to change { subject.endpoints.count }.by(1)
+      end
+    end
+
+    context 'when mount is passed refresh_already_mounted' do
+      let(:app) { Class.new(described_class) { get('/x') { 'x' } } }
+
+      it 'is deprecated' do
+        subject.mount app => '/thing'
+        expect { subject.mount({ app => '/thing' }, refresh_already_mounted: true) }
+          .to raise_error(ActiveSupport::DeprecationException, /refresh_already_mounted/)
+      end
+
+      it 'still replaces the endpoint when deprecations are silenced' do
+        subject.mount app => '/thing'
+        Grape.deprecator.silence do
+          expect { subject.mount({ app => '/thing' }, refresh_already_mounted: true) }
+            .not_to(change { subject.endpoints.count })
+        end
       end
     end
 


### PR DESCRIPTION
## The option

`mount` accepts an undocumented `refresh_already_mounted` option that replaces any endpoint already mounted for the same base API instead of adding a second one.

**The behaviour is essential.** `Grape::API.refresh_mount_step` replays every earlier mount whenever a class-level method runs after one, so the mounted API picks up the new setting. Replaying a mount naively appends a second endpoint, so without the replacement a single `format :json` after a mount does this:

```
with the replacement:     endpoints=1  routes=["/thing/x(.json)"]
without it:               endpoints=3  routes=["/thing/x(.:format)", "/thing/x(.:format)",
                                               "/thing/x(.json)",    "/thing/x(.json)"]
```

**The option is not.** Its only legitimate caller is `refresh_mounted_api`, which is private, is not even reachable from an API class (`NoMethodError` — `refresh_mount_step` reaches it on the instance via `__send__`), and always passes `true`. So a constant belonging to a private method was threaded out through a public one, where any user could reach it and no documentation mentioned it.

## The change

The replacement moves into `refresh_mounted_api`. That works because a mounted Grape API's throwaway instance and the class that was written share a base — the same signal `same_mounted_app?` already keys on:

```
stored mounted_app.base  → #<Class:0x…ecf8>
original app.base        → #<Class:0x…ecf8>   equal? true
```

Passing `refresh_already_mounted` to `mount` still works and now warns. There is no replacement to point users at, because an API has no reason to ask for it — mounting the same app twice on purpose is still two endpoints.

## Two things that fall out

Once an internal flag is no longer threaded through the signature, two oddities in it stop paying for themselves.

**`respond_to?(:each_pair)` → `is_a?(Hash)`.** A `Struct` and an `OpenStruct` answer `each_pair` without being able to express an app => path mapping — their keys are member names. So a Rack app that happened to be one was read as a mapping:

```ruby
RackStruct = Struct.new(:name) do
  def call(env) = [200, { 'content-type' => 'text/plain' }, ['from struct']]
end

mount RackStruct.new('x')

# before => routes ["/x/?*path(.:format)"]        the field value became the path
# after  => 200 "from struct", routes ["/?*path(.:format)"]
```

Every Hash-like people actually pass — `HashWithIndifferentAccess`, `Hashie::Mash`, `ActiveSupport::OrderedOptions` — subclasses `Hash`. The `respond_to?` dates to `b5df2f84`, the original Rack-mounting commit. The normalisation is now shared with the endpoint replacement instead of written twice.

**`*opts` → `opts = {}`.** The splat could only ever hold zero or one element, so every read spelled `opts.any? ? opts.first[:key] : default`. An optional positional Hash accepts exactly the same call forms:

| call | `*opts` | `opts = {}` |
| --- | --- | --- |
| `mount App` | `mounts=App opts=[]` | `mounts=App opts={}` |
| `mount App => path` | `mounts={…} opts=[]` | `mounts={…} opts={}` |
| `mount({…}, with: …)` | `opts=[{with: …}]` | `opts={with: …}` |
| `mount({…}, {with: …})` | `opts=[{with: …}]` | `opts={with: …}` |

It stays **positional** deliberately. `mount` must declare no keyword parameters: Ruby routes the brace-less Hash of `mount App => '/path'` to keywords when any are declared, and the mount itself goes missing (`wrong number of arguments (given 0, expected 1)`). That also rules out `with:` as a keyword, and rules out `**mounts`, which additionally breaks `mount App` and `mount({App => path}, with: …)`.

## Specs

The two existing specs asserted the flag rather than the feature — both called `mount(…, refresh_already_mounted: true)` directly, which no longer exercises the real path. Rewritten to go through it: mount, then a class-level method, which is what triggers `refresh_mount_step`. Plus two for the deprecation itself.

One detail worth noting: the deprecation fired twice per mount at first, because `mount` recurses for a Grape API and the recursion re-entered with the same options. The flag is dropped before recursing.

## Test plan

- [x] Full RSpec suite: 2615 examples, 0 failures.
- [x] RuboCop clean over `lib` and `spec`.
- [x] All four `mount` call forms verified end to end, including that `with:` still reaches `configuration` in both the keyword and explicitly-braced spellings.
- [x] UPGRADING entries for the deprecation and for the `Struct`/`OpenStruct` change.
- [ ] CI green.

Independent of #2870.

## Also here: the CHANGELOG line #2867 never got (`e2daea11`)

Unrelated to the rest of this PR, riding along because it is one line. #2867 was merged as a squash of a branch that also carried #2865's commit, so its merge shipped that PR's `presence` deprecation as well as its own refactor. The CHANGELOG ended up crediting #2865, which is still open, and saying nothing about #2867, which is what actually landed. The #2865 line stays — it describes behaviour that is in master and links to a real PR — and this adds the missing one for #2867.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
