### PR TITLE
Include endpoint helpers once instead of on every request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * [#2875](https://github.com/ruby-grape/grape/pull/2875): Skip the query-string parse and the `script_name + path_info` concatenation during content negotiation when neither can affect the result - [@ericproulx](https://github.com/ericproulx).
 * [#2879](https://github.com/ruby-grape/grape/pull/2879): Skip path-param extraction for routes whose compiled pattern captures nothing, instead of re-running the regexp to build an empty Hash - [@ericproulx](https://github.com/ericproulx).
 * [#2880](https://github.com/ruby-grape/grape/pull/2880): Remove `Grape::Middleware::Versioner`'s `pattern` option, a leftover of the 2010 versioner that `versions:` superseded and the `version` DSL never exposed (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
+* [#2872](https://github.com/ruby-grape/grape/pull/2872): Include an endpoint's helpers once at compile time instead of on every request, so a request no longer builds a singleton class whose method cache starts cold (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -37,6 +37,33 @@ error.original_exception&.backtrace || []
 
 `Grape::Exceptions::ErrorResponse.from_exception` no longer stores a backtrace either, for the same reason; `original_exception` is set, so nothing is lost.
 
+#### An endpoint that declares helpers is served from a subclass of `Grape::Endpoint`
+
+Helpers were included into the singleton class of the per-request copy of an endpoint, which meant every request built a fresh singleton class and re-ran `Module#include`. They are now included once, when the API is compiled, into a subclass owned by that endpoint, and each request copies an instance of it.
+
+The endpoint exposed as `env['api.endpoint']` (and handed to `before`/`after` filters, `rescue_from` blocks and middleware) is therefore an instance of that subclass rather than of `Grape::Endpoint` itself, for any endpoint whose scope declares `helpers`. Endpoints with no helpers are unaffected.
+
+Inheritance-based checks are unchanged:
+
+```ruby
+endpoint.is_a?(Grape::Endpoint)      # => true, as before
+endpoint.kind_of?(Grape::Endpoint)   # => true, as before
+Grape::Endpoint === endpoint         # => true, as before
+```
+
+Exact-class checks are not, and have no equivalent — use `is_a?`:
+
+```ruby
+# before => true, now => false
+endpoint.instance_of?(Grape::Endpoint)
+endpoint.class == Grape::Endpoint
+
+# before => "Grape::Endpoint", now => "Grape::Endpoint(helpers)"
+endpoint.class.name
+endpoint.class.to_s
+```
+
+The subclass carries a temporary name (`Module#set_temporary_name`), so it never answers `nil` to `#name` or renders as a bare `#<Class:0x...>` address. Code that logs or groups by `endpoint.class.name` — an error tracker keying on it, say — will see `Grape::Endpoint(helpers)` for these endpoints, and should match on `is_a?` if it needs to treat both kinds alike.
 #### The `desc` `default` key is renamed to `default_response`
 
 grape-swagger reads a route's default response as `route.default_response`, a name Grape never defined — the `desc` DSL wrote the key as `default`, and the reader for it resolved to `Hash#default` on the route's options bag, so it answered `nil` for every route. A default response declared the way the README documented it therefore never reached the generated OpenAPI document.

--- a/lib/grape/endpoint.rb
+++ b/lib/grape/endpoint.rb
@@ -123,14 +123,12 @@ module Grape
     end
 
     def call(env)
-      dup.call!(env)
+      @prototype.dup.call!(env)
     end
 
     def call!(env)
       env[Grape::Env::API_ENDPOINT] = self
       @env = env
-      # this adds the helpers only to the instance
-      singleton_class.include(@helpers) if @helpers
       @app.call(env)
     end
 
@@ -281,6 +279,48 @@ module Grape
       @afters             = callbacks.fetch(:after)
       @finallies          = callbacks.fetch(:finally)
       @build_params_with  = inheritable_setting.build_params_with
+      @prototype          = build_prototype
+    end
+
+    # The object each request is copied from.
+    #
+    # Helpers reach an endpoint by module inclusion, and +Object#dup+ does not
+    # carry a singleton class over — so including them on the per-request copy
+    # meant giving every request a brand-new singleton class, whose method
+    # cache then started cold for the helpers, the route block and every DSL
+    # method the endpoint answers. Include them once into a subclass owned by
+    # this endpoint instead, and copy this endpoint's state onto an instance of
+    # it: the per-request copy already answers to the helpers, against a class
+    # that has been warm since boot. It also keeps request handling free of
+    # class mutation.
+    #
+    # Endpoints with no helpers are their own prototype, exactly as before.
+    #
+    # +allocate+ rather than +new+ because the constructor rebuilds state from
+    # the DSL's arguments — a fresh settings copy, a fresh +@config+, another
+    # +block_to_unbound_method+ — and would still not hold what +compile!+ has
+    # just computed. What is wanted is what +dup+ itself does (allocate, then
+    # copy the ivars over) across a class boundary, which neither +dup+ nor
+    # +initialize_copy+ will do: both insist on the receiver's own class. So
+    # the copy is written out here. Taking all of them is safe because
+    # everything set past this point (+routes+, +namespace+) is route-building
+    # memoization the request path never reads.
+    def build_prototype
+      return self unless @helpers
+
+      klass = Class.new(self.class)
+      # Anonymous classes answer nil to +name+ and render as a bare address,
+      # which would reach anything that reports on the endpoint — +inspect+
+      # here, a logger or an error tracker elsewhere. The annotation is what
+      # +set_temporary_name+ is for; a plain constant path is rejected, which
+      # is right, since this class is not reachable under that name.
+      klass.set_temporary_name("#{self.class}(helpers)")
+      klass.include(@helpers)
+      prototype = klass.allocate
+      # Everything but the prototype slot itself, so that recompiling (a
+      # remount) does not leave the new prototype holding the one it replaces.
+      (instance_variables - [:@prototype]).each { |name| prototype.instance_variable_set(name, instance_variable_get(name)) }
+      prototype
     end
 
     def to_routes


### PR DESCRIPTION
Helpers are instance methods on the endpoint, because the route block is bound to the endpoint and runs against it. They are also per-endpoint — including them into `Grape::Endpoint` itself would leak one API's helpers into every endpoint in the process — so they went onto the per-request copy:

```ruby
def call(env)
  dup.call!(env)
end

def call!(env)
  ...
  singleton_class.include(@helpers) if @helpers
```

That had to happen per request rather than once: `Object#dup` deliberately does not carry a singleton class over, so including the helpers on the shared endpoint would never reach the copies that actually serve requests.

### Why it costs so much

Not the `include`. `dup` plus `include` measures ~510 ns against ~110 ns for `dup` alone — under 2% of a request. The expense is that `singleton_class` on a fresh copy *creates a class*, and a class nothing has called through yet has no method cache. Counting allocations:

| | objects |
|---|---:|
| `dup` alone | 1 |
| `dup` + `singleton_class` | 2 |
| `dup` + `singleton_class.include(helpers)` | 4 |
| … + first call to one method through it | 7 |
| … + first call to three methods | 11 |

Repeat calls to the same method are free, but that first-call cost is paid again on the next request — for every helper, for the route block, and for every DSL method the endpoint answers.

### The change

Include the helpers once, at `compile!` time, into a subclass owned by this endpoint, and copy the endpoint's state onto an instance of it. Each request then copies an object whose class has been warm since boot, and request handling no longer mutates a class at all.

An endpoint that declares no helpers is its own prototype, so nothing changes for it.

### Measurements

Small API with helpers, params and validations. Median of 9 runs, Ruby 4.0.5, single-threaded `Benchmark.ips`, this branch vs `master` in the same process via a load-path switch:

| | YJIT | no-YJIT | objects/req |
|---|---|---|---|
| `GET /users/:id` | 40,853 → **51,605** (+26%) | 19,574 → **21,368** (+9%) | 154 → **121** |
| `POST /users` | 40,045 → **51,009** (+27%) | 19,657 → **21,711** (+10%) | 157 → **123** |
| bare `GET` (no helpers) | 136,006 → 137,010 (flat) | 67,383 → 67,207 (flat) | 46.1 → 46.1 |

### Class identity

`env['api.endpoint']` for an endpoint with helpers is an instance of the subclass, so:

| check | holds? |
|---|---|
| `is_a?` / `kind_of?` / `===` | ✅ — inherited from `Grape::Endpoint` |
| `instance_of?` / `endpoint.class == Grape::Endpoint` | ❌ |
| `.class.name` / `.class.to_s` | ✅ `Grape::Endpoint(helpers)` |

The subclass gets a temporary name (`Module#set_temporary_name`, Ruby 3.3+, which is already the gem's minimum) so it never answers `nil` to `#name` or renders as a bare address — in `#inspect`, or anywhere else that reports on an endpoint, such as a logger or an error tracker. `set_temporary_name` rejects a plain `"Grape::Endpoint"` as a constant path, which is right: the class is not reachable under that name.

See UPGRADING for the user-facing note.

### Other notes for review

- `allocate` rather than `new`: the constructor rebuilds state from the DSL's arguments and would not hold what `compile!` just computed. What is wanted is what `dup` does — allocate, then copy the ivars — across a class boundary, which neither `dup` nor `initialize_copy` will do.
- The state copy is wholesale because everything set past `compile!` (`routes`, `namespace`) is route-building memoization the request path never reads.

Full suite green (2650 examples), RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)