### PR TITLE
Read the params builder setting with `[]` instead of `method_missing`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [#2862](https://github.com/ruby-grape/grape/pull/2862): Rename the `desc` `default` key to `default_response`, the name grape-swagger reads, deprecating `default` (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2866](https://github.com/ruby-grape/grape/pull/2866): Take `as` as a keyword argument in `requires` and `optional` instead of carrying it in the options Hash, where it was dispatched as a no-op `AsValidator` - [@ericproulx](https://github.com/ericproulx).
 * [#2869](https://github.com/ruby-grape/grape/pull/2869): Add `Grape::PrecompiledJson`, a body wrapper the JSON formatters serve verbatim instead of encoding a second time - [@ericproulx](https://github.com/ericproulx).
+* [#2873](https://github.com/ruby-grape/grape/pull/2873): Read `Grape.config[:param_builder]` instead of routing the per-request lookup through dry-configurable's `method_missing` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/request.rb
+++ b/lib/grape/request.rb
@@ -141,7 +141,7 @@ module Grape
 
     def initialize(env, build_params_with: nil)
       super(env)
-      @params_builder = Grape::ParamsBuilder.params_builder_for(build_params_with || Grape.config.param_builder)
+      @params_builder = Grape::ParamsBuilder.params_builder_for(build_params_with || Grape.config[:param_builder])
     end
 
     def params


### PR DESCRIPTION
Read the params builder setting with `[]` instead of `method_missing`.

`Grape::Request#initialize` runs once per request and resolves the default params builder through `Grape.config.param_builder`. dry-configurable's `Config` defines no readers for its settings — the call lands in `method_missing`, which derives the setting name with `method_name.to_s.tr("=", "").to_sym`: two throwaway Strings and a slow dispatch, on every request.

`Config#[]` is the same lookup without either.

| | time | objects |
|---|---:|---:|
| `Grape.config.param_builder` | 282 ns | 3 |
| `Grape.config[:param_builder]` | **44 ns** | **0** |

6.4x on the lookup, and three fewer objects allocated per request on every endpoint — 46.1 → 43.1 for a bare JSON GET, counted deterministically end to end.

`method_missing` resolves `param_builder` to exactly this lookup, so a `Grape.config.param_builder = ...` set anywhere still takes effect the same way. No behaviour change.

> **On the numbers.** The per-operation figures are same-process `Benchmark.ips` A/B runs, which stay valid under machine drift because both arms are affected equally. Allocation counts are deterministic (`GC.stat(:total_allocated_objects)`, GC disabled) measured end to end against a small API. End-to-end throughput is quoted only where the effect clears this harness's noise floor (±5% on a laptop); for a change worth 1-3% of a request it does not, so it is not claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)