### PR TITLE
Test the path-normalizer fast path without a regexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [#2862](https://github.com/ruby-grape/grape/pull/2862): Rename the `desc` `default` key to `default_response`, the name grape-swagger reads, deprecating `default` (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2866](https://github.com/ruby-grape/grape/pull/2866): Take `as` as a keyword argument in `requires` and `optional` instead of carrying it in the options Hash, where it was dispatched as a no-op `AsValidator` - [@ericproulx](https://github.com/ericproulx).
 * [#2869](https://github.com/ruby-grape/grape/pull/2869): Add `Grape::PrecompiledJson`, a body wrapper the JSON formatters serve verbatim instead of encoding a second time - [@ericproulx](https://github.com/ericproulx).
+* [#2874](https://github.com/ruby-grape/grape/pull/2874): Test the `Grape::Util::PathNormalizer` fast path with two `String#include?` calls instead of a regexp - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/util/path_normalizer.rb
+++ b/lib/grape/util/path_normalizer.rb
@@ -14,8 +14,10 @@ module Grape
         return '/' unless path
         return path if path == '/'
 
-        # Fast path for the overwhelming majority of paths that don't need to be normalized
-        return path if path.start_with?('/') && !(path.end_with?('/') || path.match?(%r{%|//}))
+        # Fast path for the overwhelming majority of paths that don't need to be
+        # normalized. Two String#include? calls rather than one `%|//` regexp:
+        # same predicate, and the scan stays in C without building a match.
+        return path if path.start_with?('/') && !(path.end_with?('/') || path.include?('%') || path.include?('//'))
 
         # Slow path
         encoding = path.encoding


### PR DESCRIPTION
`Grape::Util::PathNormalizer.call` runs twice per request — once in `Versioner::Path#before`, once in `Router#call` — and almost always returns the path untouched. The guard deciding that matched `%r{%|//}`, one alternation over the whole string:

```ruby
return path if path.start_with?('/') && !(path.end_with?('/') || path.match?(%r{%|//}))
```

Two `String#include?` calls answer the same question and stay in C without building a match.

| path | regexp | `include?` | |
|---|---:|---:|---:|
| realistic (41 chars) | 313 ns | **217 ns** | 1.44x |
| short (13 chars) | 194 ns | **181 ns** | 1.07x |

The gain grows with path length, which is the direction real APIs go. No allocation change either way.

### Behaviour

One difference worth naming: `String#include?` does not validate encoding, `String#match?` does. A PATH_INFO holding an invalid byte sequence used to raise `ArgumentError` here; it now raises the same `ArgumentError` from `Router#match?` instead, one frame later. A path served by a forward-match route (a bare Rack app mounted with `mount`) never reaches a regexp, so it now goes through rather than raising.

Nothing percent-encodes to invalid UTF-8, so reaching this needs a client putting raw bytes in the request target. Flagging it rather than burying it — happy to keep the regexp if you would rather the normalizer stay the place that rejects them.

> **On the numbers.** The per-operation figures are same-process `Benchmark.ips` A/B runs, which stay valid under machine drift because both arms are affected equally. Allocation counts are deterministic (`GC.stat(:total_allocated_objects)`, GC disabled) measured end to end against a small API. End-to-end throughput is quoted only where the effect clears this harness's noise floor (±5% on a laptop); for a change worth 1-3% of a request it does not, so it is not claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)