### PR TITLE
Skip the query parse and the path concatenation in content negotiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [#2862](https://github.com/ruby-grape/grape/pull/2862): Rename the `desc` `default` key to `default_response`, the name grape-swagger reads, deprecating `default` (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2866](https://github.com/ruby-grape/grape/pull/2866): Take `as` as a keyword argument in `requires` and `optional` instead of carrying it in the options Hash, where it was dispatched as a no-op `AsValidator` - [@ericproulx](https://github.com/ericproulx).
 * [#2869](https://github.com/ruby-grape/grape/pull/2869): Add `Grape::PrecompiledJson`, a body wrapper the JSON formatters serve verbatim instead of encoding a second time - [@ericproulx](https://github.com/ericproulx).
+* [#2875](https://github.com/ruby-grape/grape/pull/2875): Skip the query-string parse and the `script_name + path_info` concatenation during content negotiation when neither can affect the result - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -141,19 +141,42 @@ module Grape
       end
 
       def negotiate_content_type
-        fmt = format_from_extension || query_params['format'] || format || format_from_header || default_format
+        fmt = format_from_extension || format_from_query || format || format_from_header || default_format
         return env[Grape::Env::API_FORMAT] = fmt.to_sym if content_type_for(fmt)
 
         throw :error, Grape::Exceptions::ErrorResponse.new(status: 406, message: "The requested format '#{fmt}' is not supported.")
       end
 
       def format_from_extension
-        request_path = try_scrub(rack_request.path)
+        request_path = try_scrub(path_for_extension)
         dot_pos = request_path.rindex('.')
         return unless dot_pos
 
         extension = request_path[(dot_pos + 1)..]
         extension if content_type_for(extension)
+      end
+
+      # The extension is the tail of the request path, so PATH_INFO answers it
+      # on its own whenever there is one: a dot in SCRIPT_NAME is followed by
+      # the slash that opens PATH_INFO, and no registered extension holds a
+      # slash. Only an empty PATH_INFO needs +Rack::Request#path+ — and with it
+      # the String its concatenation allocates. Tested with +empty?+ rather
+      # than +blank?+: the path is not scrubbed yet, and a regexp match on an
+      # invalid byte sequence raises.
+      def path_for_extension
+        path_info = env[Rack::PATH_INFO]
+        return rack_request.path if path_info.nil? || path_info.empty?
+
+        path_info
+      end
+
+      # +?format=+ can only be there when there is a query string at all, so
+      # the common query-less request skips parsing one.
+      def format_from_query
+        query_string = env[Rack::QUERY_STRING]
+        return if query_string.nil? || query_string.empty?
+
+        query_params['format']
       end
 
       # Media types are case-insensitive (RFC 9110 §8.3.1) but the registered


### PR DESCRIPTION
`Formatter#negotiate_content_type` runs on every request and reads two things before it can fall back to the API's declared format:

```ruby
fmt = format_from_extension || query_params['format'] || format || format_from_header || default_format
```

`query_params` is `Rack::Request#GET`, so a request with **no query string at all** still parsed one. And `format_from_extension` read `rack_request.path` — `script_name + path_info`, a String built to be scanned once for a dot and thrown away.

Both are now skipped in the common case:

- `?format=` cannot be present without a query string, so an empty QUERY_STRING returns early.
- The extension is the tail of the path, so PATH_INFO answers it on its own whenever there is one: a dot in SCRIPT_NAME is followed by the slash that opens PATH_INFO, and no registered extension holds a slash. Only an empty PATH_INFO needs the concatenation.

| | time |
|---|---:|
| `rack_request.path` | 97 ns |
| `env[PATH_INFO]` | **39 ns** (2.5x) |

Three fewer objects per request on a bare JSON GET (46.1 → 43.1), counted deterministically end to end.

Both guards test `nil?`/`empty?` rather than `blank?` on purpose: neither value has been scrubbed at this point, and `String#blank?` runs a regexp, which raises on an invalid byte sequence — the case `formatter_spec.rb` covers with `"/info.\x80"`.

### Behaviour

Unchanged. Extension, `?format=`, declared format, `Accept` header and default still resolve in that order, and a 21-case response diff against master — extension, query, Accept casing, `*/*`, SCRIPT_NAME with a dot, empty PATH_INFO, 204/404/405/406 — is byte-identical.

> Touches the same file as the formatter Rack-tuple PR; they are independent but will want merging one after the other.

> **On the numbers.** The per-operation figures are same-process `Benchmark.ips` A/B runs, which stay valid under machine drift because both arms are affected equally. Allocation counts are deterministic (`GC.stat(:total_allocated_objects)`, GC disabled) measured end to end against a small API. End-to-end throughput is quoted only where the effect clears this harness's noise floor (±5% on a laptop); for a change worth 1-3% of a request it does not, so it is not claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)