### PR TITLE
Build an error response's backtrace only when it will be rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [#2862](https://github.com/ruby-grape/grape/pull/2862): Rename the `desc` `default` key to `default_response`, the name grape-swagger reads, deprecating `default` (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2866](https://github.com/ruby-grape/grape/pull/2866): Take `as` as a keyword argument in `requires` and `optional` instead of carrying it in the options Hash, where it was dispatched as a no-op `AsValidator` - [@ericproulx](https://github.com/ericproulx).
 * [#2869](https://github.com/ruby-grape/grape/pull/2869): Add `Grape::PrecompiledJson`, a body wrapper the JSON formatters serve verbatim instead of encoding a second time - [@ericproulx](https://github.com/ericproulx).
+* [#2878](https://github.com/ruby-grape/grape/pull/2878): Build an error response's backtrace only when `rescue_from ..., backtrace: true` asked for one (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,24 @@ Upgrading Grape
 
 ### Upgrading to >= 4.0.0
 
+#### An error response carries a backtrace only when one was asked for
+
+Every error response used to materialize the raised exception's backtrace, even though the built-in error formatters render it only under `rescue_from ..., backtrace: true`. It is now assembled only when that option is set, since `Exception#backtrace` builds an Array of location Strings on every call and a Grape error is raised deep inside the request stack.
+
+`Grape::Exceptions::ErrorResponse#backtrace` is therefore an empty Array on the payload handed to an error formatter unless the API asked for backtraces. The built-in formatters are unaffected — they already guarded on the `include_backtrace:` argument they are passed.
+
+A custom error formatter that reads `error.backtrace` while ignoring that argument will now see an empty Array. Read it from the exception instead, which still travels on the payload:
+
+```ruby
+# before
+error.backtrace
+
+# after — equivalent regardless of the rescue options
+error.original_exception&.backtrace || []
+```
+
+`Grape::Exceptions::ErrorResponse.from_exception` no longer stores a backtrace either, for the same reason; `original_exception` is set, so nothing is lost.
+
 #### The `desc` `default` key is renamed to `default_response`
 
 grape-swagger reads a route's default response as `route.default_response`, a name Grape never defined — the `desc` DSL wrote the key as `default`, and the reader for it resolved to `Hash#default` on the route's options bag, so it answered `nil` for every route. A default response declared the way the README documented it therefore never reached the generated OpenAPI document.

--- a/lib/grape/exceptions/error_response.rb
+++ b/lib/grape/exceptions/error_response.rb
@@ -15,12 +15,15 @@ module Grape
         "#<#{self.class.name} status=#{status.inspect} message=#{message.inspect} headers=#{headers.inspect}>"
       end
 
+      # The backtrace is deliberately left unset: +Exception#backtrace+ builds
+      # the whole Array of location strings, and the response only renders one
+      # when the API asked for it. The exception travels along, so
+      # +Middleware::Error#error_response+ can still materialize it there.
       def self.from_exception(exception)
         new(
           status: exception.status,
           message: exception.message,
           headers: exception.headers,
-          backtrace: exception.backtrace,
           original_exception: exception
         )
       end

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -111,10 +111,21 @@ module Grape
           status: raw.status || default_status,
           message: raw.message || default_message,
           headers:,
-          backtrace: raw.backtrace || raw.original_exception&.backtrace || []
+          backtrace: resolved_backtrace(raw)
         )
         env[Grape::Env::API_ENDPOINT].status(payload.status) # error! may not have been called
         render_response(payload)
+      end
+
+      # The backtrace an error formatter is handed. Assembled only when the API
+      # asked for one with `rescue_from ..., backtrace: true`: reading it off
+      # the exception is not free — +Exception#backtrace+ builds the whole Array
+      # of location strings — and every built-in formatter drops it otherwise.
+      # A formatter that wants one regardless still has +original_exception+.
+      def resolved_backtrace(raw)
+        return [] unless include_backtrace
+
+        raw.backtrace || raw.original_exception&.backtrace || []
       end
 
       # Rendering runs inside #call!'s own rescue clause, so it is not covered by


### PR DESCRIPTION
Every error response materialized the raised exception's backtrace. `ErrorResponse.from_exception` read `exception.backtrace` to store it, and `Middleware::Error#error_response` re-derived it with `raw.backtrace || raw.original_exception&.backtrace || []`.

`Exception#backtrace` is not a field read — it converts the captured frames into an Array of location Strings, one per frame, and a Grape error is raised deep inside the validation stack. Meanwhile every built-in error formatter drops the result unless the API asked for it:

```ruby
wrapped_message[:backtrace] = error.backtrace if include_backtrace && error.backtrace.present?
```

`include_backtrace` is `rescue_from ..., backtrace: true`, off by default. So the common 400 paid to build a backtrace that was then thrown away — a `stackprof` run put `Exception#backtrace` at **11% of wall time** on a validation-failure request, all of it under `ErrorResponse.from_exception`.

`from_exception` no longer reads it (the exception travels on the payload as `original_exception`, so nothing is lost), and `error_response` assembles one only when `include_backtrace` is set.

### Measurements

Small API answering a validation failure (400), median of 9 **interleaved** runs, Ruby 4.0.5 + YJIT:

| | master | this branch | |
|---|---:|---:|---:|
| throughput | 8,749 req/s | **11,878 req/s** | **+36%** |
| objects/request | 333 | **266** | −67 |

This one clears the noise floor comfortably; the allocation count is deterministic.

### Behaviour

`rescue_from ..., backtrace: true` and `original_exception: true` render exactly as before — the specs covering both are unchanged.

A custom error formatter that reads `error.backtrace` while ignoring the `include_backtrace:` argument it is passed now receives an empty Array. It still has `error.original_exception` and can call `#backtrace` on that. Documented in UPGRADING.

### Related

`perf/skip-validation-backtrace` (Apr 2026) attacks the other half: it seeds an empty backtrace on `Grape::Exceptions::Validation` and `ValidationArrayErrors` so `raise` skips *capture* for the per-attribute exceptions collected inside `run_validators`. Complementary, not overlapping — and worth noting it does not touch `Grape::Exceptions::ValidationErrors`, which is the one `endpoint.rb:224` actually raises and the middleware renders, so it would not have covered this path.

> **On the numbers.** Allocation counts are deterministic (`GC.stat(:total_allocated_objects)`, GC disabled). Throughput is the median of 9 runs interleaved with master's, so machine drift affects both equally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)