### PR TITLE
Skip param extraction for a route whose pattern captures nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * [#2874](https://github.com/ruby-grape/grape/pull/2874): Test the `Grape::Util::PathNormalizer` fast path with two `String#include?` calls instead of a regexp - [@ericproulx](https://github.com/ericproulx).
 * [#2876](https://github.com/ruby-grape/grape/pull/2876): Return a bare Rack tuple from `Grape::Middleware::Formatter` instead of a `Rack::Response` the enclosing middleware immediately unwraps - [@ericproulx](https://github.com/ericproulx).
 * [#2875](https://github.com/ruby-grape/grape/pull/2875): Skip the query-string parse and the `script_name + path_info` concatenation during content negotiation when neither can affect the result - [@ericproulx](https://github.com/ericproulx).
+* [#2879](https://github.com/ruby-grape/grape/pull/2879): Skip path-param extraction for routes whose compiled pattern captures nothing, instead of re-running the regexp to build an empty Hash - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/router/pattern.rb
+++ b/lib/grape/router/pattern.rb
@@ -29,6 +29,21 @@ module Grape
         @path = PatternCache[[build_path_from_pattern(@origin, anchor), suffix]]
         @pattern = MustermannPattern.new(@path, uri_decode: true, params:, capture: extract_capture(version, requirements))
         @to_regexp = @pattern.to_regexp
+        @captures = @to_regexp.names.any?
+      end
+
+      # True when the compiled pattern has named captures to extract from a
+      # matched path. A fully static path has none — not even +format+, which
+      # the suffix spells as a literal — so asking Mustermann for its params
+      # would run the regexp a second time (the router's union already matched
+      # it) only to hand back an empty Hash.
+      #
+      # Resolved once here rather than per request: +Regexp#names+ builds an
+      # Array and a String per capture, and Ruby offers no predicate that skips
+      # that (+named_captures+ builds a Hash, and scanning the source for
+      # <tt>(?<</tt> would count lookbehinds, which name nothing).
+      def captures?
+        @captures
       end
 
       def captures_default

--- a/lib/grape/router/route.rb
+++ b/lib/grape/router/route.rb
@@ -45,7 +45,14 @@ module Grape
       end
 
       # Extract param values from a matched request path. Used by the router.
+      #
+      # A pattern with no named captures has nothing to extract, so it skips the
+      # match entirely and answers nil — the same way {GreedyRoute#params_for}
+      # does, and what the router already coerces into the Hash it builds
+      # routing args in.
       def params_for(input)
+        return unless pattern.captures?
+
         parsed = pattern.params(input)
         return unless parsed
 


### PR DESCRIPTION
`Router#process_route` asks every matched route for its path params:

```ruby
routing_args = route.params_for(input) || {}
```

`params_for` hands the input to Mustermann, which runs the route's regexp and builds a Hash of named captures; Grape then walks that into a second Hash keyed by Symbol.

**A fully static path has no named captures to find.** `/health`, an index route, anything whose params all arrive as query or body — the compiled regexp names nothing, not even `format`, which the suffix spells as a literal alternation:

| pattern | `to_regexp.names` | `params_for` |
|---|---|---|
| `/health(.json)` | `[]` | `{}` |
| `/users(.json)` | `[]` | `{}` |
| `/users/:id(.json)` | `["id"]` | `{id: …}` |

So for the first two the whole exchange runs the regexp a **second** time — the router's compiled union already matched it, which is how the route was chosen — to arrive at an empty Hash.

Resolve it once when the pattern is compiled (`Pattern#captures?`) and skip the round trip when there is nothing to extract.

### Measurements

Static route, median of 9 interleaved runs, Ruby 4.0.5 + YJIT:

| | master | this branch | |
|---|---:|---:|---:|
| throughput | 233,443 req/s | **263,742 req/s** | **+13.0%** |
| objects/request | 25.0 | **20.0** | −5 |

Routes that do capture are unaffected beyond one ivar read (−1.4% on a versioned route, inside the noise floor).

### Notes for review

- `params_for` answers **nil**, which is what `GreedyRoute#params_for` already does for the same reason — nothing to extract. The `|| {}` at the call site predates this change and already handled exactly that, so no caller observes a different value than before.
- `captures?` is resolved in `Pattern#initialize`, so `Regexp#names` is called once per route at boot, never per request. Confirmed by instrumenting `Regexp#names`: 0 calls across 1,000 requests.

> **On the numbers.** Per-operation figures are same-process `Benchmark.ips` A/B runs, valid under machine drift because both arms are affected equally. Allocation counts are deterministic (`GC.stat(:total_allocated_objects)`, GC disabled) measured end to end. End-to-end throughput is the median of 9 runs interleaved with master's, and is quoted only where it clears the harness noise floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)