### PR TITLE
Remove the versioner's pattern option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * [#2876](https://github.com/ruby-grape/grape/pull/2876): Return a bare Rack tuple from `Grape::Middleware::Formatter` instead of a `Rack::Response` the enclosing middleware immediately unwraps - [@ericproulx](https://github.com/ericproulx).
 * [#2875](https://github.com/ruby-grape/grape/pull/2875): Skip the query-string parse and the `script_name + path_info` concatenation during content negotiation when neither can affect the result - [@ericproulx](https://github.com/ericproulx).
 * [#2879](https://github.com/ruby-grape/grape/pull/2879): Skip path-param extraction for routes whose compiled pattern captures nothing, instead of re-running the regexp to build an empty Hash - [@ericproulx](https://github.com/ericproulx).
+* [#2880](https://github.com/ruby-grape/grape/pull/2880): Remove `Grape::Middleware::Versioner`'s `pattern` option, a leftover of the 2010 versioner that `versions:` superseded and the `version` DSL never exposed (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,22 @@ Upgrading Grape
 
 ### Upgrading to >= 4.0.0
 
+#### The versioner's `pattern` option has been removed
+
+`Grape::Middleware::Versioner::Base` accepted a `pattern` option, which `Versioner::Path` matched the candidate version segment against before recording it. It dates from the original versioner (2010), where it was the only way to decide whether the first path segment was a version — there was no declared version list yet.
+
+`versions:` took that job over: a segment is checked against the versions the API declared, and an unrecognized one answers 404. `pattern` was never connected to the `version` DSL that arrived later — `DSL::Routing#version` does not accept a `pattern:` keyword and `Endpoint#build_stack` never passed one — so it could only be reached by inserting the middleware yourself:
+
+```ruby
+use Grape::Middleware::Versioner::Path, versions: %w[v1], pattern: /v.+/
+```
+
+which also meant forgoing what `version` does for routing. That now raises `ArgumentError: unknown keyword: :pattern`, at the point the middleware is built rather than on a request.
+
+`Grape::Middleware::Versioner::Base::DEFAULT_OPTIONS` no longer carries a `:pattern` key, and `Versioner::Base#pattern` is gone. An API that declares its version through `version 'v1', using: :path` is unaffected — it never had a pattern.
+
+The one behaviour that disappears with it: a hand-wired versioner could use `pattern` to say "this segment is not a version at all", leaving `api.version` unset and letting the request through, as distinct from "unknown version", which answers 404. Nothing in the `version` DSL exposed that distinction, and `versions:` cannot express it. If you relied on it, match the segment yourself in a small middleware ahead of the versioner rather than through this option.
+
 #### An error response carries a backtrace only when one was asked for
 
 Every error response used to materialize the raised exception's backtrace, even though the built-in error formatters render it only under `rescue_from ..., backtrace: true`. It is now assembled only when that option is set, since `Exception#backtrace` builds an Array of location Strings on every call and a Grape error is raised deep inside the request stack.

--- a/lib/grape/middleware/versioner/base.rb
+++ b/lib/grape/middleware/versioner/base.rb
@@ -8,12 +8,12 @@ module Grape
         include Grape::Middleware::PrecomputedContentTypes
 
         Options = Data.define(
-          :content_types, :format, :mount_path, :pattern, :prefix, :version_options, :versions
+          :content_types, :format, :mount_path, :prefix, :version_options, :versions
         ) do
           include Grape::Middleware::DeprecatedOptionsHashAccess
 
           def initialize(
-            content_types: nil, format: nil, mount_path: nil, pattern: /.*/i, prefix: nil,
+            content_types: nil, format: nil, mount_path: nil, prefix: nil,
             version_options: Grape::DSL::VersionOptions.new, versions: nil
           )
             super
@@ -33,7 +33,7 @@ module Grape
 
         attr_reader :available_media_types, :error_headers, :versions
 
-        def_delegators :config, :mount_path, :pattern, :prefix, :version_options
+        def_delegators :config, :mount_path, :prefix, :version_options
         def_delegators :version_options, :cascade, :parameter, :strict, :vendor
 
         def initialize(app, **options)

--- a/lib/grape/middleware/versioner/path.rb
+++ b/lib/grape/middleware/versioner/path.rb
@@ -40,8 +40,6 @@ module Grape
 
         def version_from_first_segment(path_info, slash_position)
           potential_version = path_info[1..(slash_position - 1)]
-          return unless potential_version.match?(pattern)
-
           version_not_found! unless potential_version_match?(potential_version)
           env[Grape::Env::API_VERSION] = potential_version
         end

--- a/spec/grape/middleware/versioner/path_spec.rb
+++ b/spec/grape/middleware/versioner/path_spec.rb
@@ -18,18 +18,6 @@ describe Grape::Middleware::Versioner::Path do
     expect(subject.call(Rack::PATH_INFO => '/').last).to be_nil
   end
 
-  context 'with a pattern' do
-    let(:options) { { pattern: /v./i } }
-
-    it 'sets the version if it matches' do
-      expect(subject.call(Rack::PATH_INFO => '/v1/awesome').last).to eq('v1')
-    end
-
-    it 'ignores the version if it fails to match' do
-      expect(subject.call(Rack::PATH_INFO => '/awesome/radical').last).to be_nil
-    end
-  end
-
   [%w[v1 v2], %i[v1 v2], [:v1, 'v2'], ['v1', :v2]].each do |versions|
     context "with specified versions as #{versions}" do
       let(:options) { { versions: } }
@@ -45,7 +33,7 @@ describe Grape::Middleware::Versioner::Path do
   end
 
   context 'with prefix, but requested version is not matched' do
-    let(:options) { { prefix: '/v1', pattern: /v./i } }
+    let(:options) { { prefix: '/v1' } }
 
     it 'recognizes potential version' do
       expect(subject.call(Rack::PATH_INFO => '/v3/foo').last).to eq('v3')


### PR DESCRIPTION
`Versioner::Path#version_from_first_segment` runs on every request of a path-versioned API and tested the candidate segment against `pattern`:

```ruby
return unless potential_version.match?(pattern)
```

`pattern` defaulted to `/.*/i` — matching any segment, including the empty one — so unless an API supplied its own, that regexp ran on every request to answer a question it could not answer with no.

### Nothing supplies one

The option dates from the **original versioner, August 2010** (`90d42780`), where it was the whole mechanism:

```ruby
def default_options = { pattern: /.*/i }

def before
  potential_version = env['PATH_INFO'].split('/')[1]
  if potential_version =~ options[:pattern]
    env['api.version'] = potential_version
    env['PATH_INFO']   = truncated_path
  end
end
```

There was no declared version list then, so a regexp was the only way to decide whether the first path segment was a version.

`versions:` took that job over — a segment is checked against what the API declared, and an unrecognized one answers 404 — and `pattern` was left behind. It was never connected to the `version` DSL that arrived later:

```ruby
version 'v1', using: :path, pattern: /v.+/
# => ArgumentError: unknown keyword: :pattern
```

`Endpoint#build_stack` never passed one either, so the only way to reach it was to insert the middleware yourself — which also meant forgoing what `version` does for routing, since adding a second versioner alongside `version` leaves the DSL-built one (with no pattern) to 404 the request anyway.

Fifteen years on, the two specs keeping it alive are still the two from that 2010 commit, asserting on the same `/v1/awesome` and `/awesome/radical`.

### The change

Remove the option, its delegator, the per-request test, and those specs.

```diff
- :content_types, :format, :mount_path, :pattern, :prefix, :version_options, :versions
+ :content_types, :format, :mount_path, :prefix, :version_options, :versions

- return unless potential_version.match?(pattern)
```

`version_from_first_segment` becomes:

```ruby
def version_from_first_segment(path_info, slash_position)
  potential_version = path_info[1..(slash_position - 1)]
  version_not_found! unless potential_version_match?(potential_version)
  env[Grape::Env::API_VERSION] = potential_version
end
```

### Contract

Passing `pattern:` now raises `ArgumentError: unknown keyword: :pattern` when the middleware is built, rather than being accepted and quietly doing nothing. `Versioner::Base::DEFAULT_OPTIONS` no longer carries the key and `Versioner::Base#pattern` is gone. An API declaring its version through `version 'v1', using: :path` is unaffected — it never had a pattern.

One behaviour goes with it, documented in UPGRADING: a hand-wired versioner could use `pattern` to distinguish *"this segment is not a version at all"* — leave `api.version` unset, let the request through — from *"unknown version"*, which answers 404. `versions:` cannot express that, and no DSL exposed it.

| request | `pattern: /v.+/` | no pattern (before and after) |
|---|---|---|
| `/v1/thing` | 200, `api.version = "v1"` | 200, `api.version = "v1"` |
| `/v9/thing` | 404 | 404 |
| `/x1/thing` | 200, `api.version` unset | 404 |

Anyone relying on the third row should match the segment in a small middleware ahead of the versioner.

Suite green (2650 — the two 2010 specs removed), RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
