### PR TITLE
Decide whether a request has a body before building a Rack::Request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * [#2880](https://github.com/ruby-grape/grape/pull/2880): Remove `Grape::Middleware::Versioner`'s `pattern` option, a leftover of the 2010 versioner that `versions:` superseded and the `version` DSL never exposed (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2872](https://github.com/ruby-grape/grape/pull/2872): Include an endpoint's helpers once at compile time instead of on every request, so a request no longer builds a singleton class whose method cache starts cold (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2882](https://github.com/ruby-grape/grape/pull/2882): Strip mount path and prefix in `Grape::Middleware::Versioner::Path` with `each` instead of `Enumerable#reduce` - [@ericproulx](https://github.com/ericproulx).
+* [#2881](https://github.com/ruby-grape/grape/pull/2881): Decide whether a request carries a body from the env, so `Grape::Middleware::Formatter` no longer builds a `Rack::Request` for GET, HEAD and OPTIONS - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -20,6 +20,11 @@ module Grape
 
       ALL_MEDIA_TYPES = '*/*'
 
+      # The request methods that can carry a body worth parsing. See
+      # {#read_body_input?}, which tests the env against this before anything
+      # asks for a Rack::Request.
+      BODY_CARRYING_METHODS = [Rack::POST, Rack::PUT, Rack::PATCH, Rack::DELETE].freeze
+
       def_delegators :config, :default_format, :format, :formatters, :parsers
 
       def before
@@ -90,9 +95,10 @@ module Grape
       end
 
       def read_body_input
+        return unless read_body_input?
+
         input = rack_request.body # reads RACK_INPUT
         return if input.nil?
-        return unless read_body_input?
 
         rewind = input.respond_to?(:rewind)
 
@@ -139,11 +145,15 @@ module Grape
       # - multipart/related
       # - multipart/mixed
       def read_body_input?
-        return false unless rack_request.post? || rack_request.put? || rack_request.patch? || rack_request.delete?
+        # Read off the env rather than through Rack::Request's predicates: this
+        # is what decides the question for every request, and on the GET, HEAD
+        # and OPTIONS majority it is the only thing the formatter would have
+        # built a Rack::Request for.
+        return false unless BODY_CARRYING_METHODS.include?(env[Rack::REQUEST_METHOD])
         return false if rack_request.form_data? && rack_request.content_type
         return false if rack_request.parseable_data?
 
-        rack_request.content_length.to_i.positive? || rack_request.env['HTTP_TRANSFER_ENCODING'] == 'chunked'
+        rack_request.content_length.to_i.positive? || env['HTTP_TRANSFER_ENCODING'] == 'chunked'
       end
 
       def negotiate_content_type


### PR DESCRIPTION
`Formatter#read_body_input` opened with:

```ruby
input = rack_request.body # reads RACK_INPUT
return if input.nil?
return unless read_body_input?
```

So every request built a `Rack::Request` to reach `rack.input` — and then `read_body_input?` returned false for anything that is not a POST, PUT, PATCH or DELETE. On the GET, HEAD and OPTIONS majority the object was constructed, asked for one env key, and thrown away. `stackprof` put `Rack::Request#initialize` under `read_body_input` on a request with no body at all.

`read_body_input?` in turn opened with four `Rack::Request` predicates:

```ruby
return false unless rack_request.post? || rack_request.put? || rack_request.patch? || rack_request.delete?
```

each of which is a comparison against `env['REQUEST_METHOD']`. Reading that key directly answers the same question without the object — and it is the first thing the method needs to know.

### The change

Test the method off the env, and fetch the input only once the answer is yes. A body-carrying request builds the `Rack::Request` exactly as before, for the `form_data?` / `parseable_data?` / `content_length` checks that genuinely need one; everything else never touches it.

Counted over 20 GETs, the formatter's copy is gone — 20 objects of the `Rack::Request` family are created rather than 40, the survivor being the `Grape::Request` the endpoint builds for itself.

### Measurements

Median of 9 runs interleaved with master's, Ruby 4.0.5 + YJIT:

| | master | this branch | | objects/req |
|---|---:|---:|---:|---:|
| bare JSON GET | 166,376 | **168,173** | +1.1% | 36.1 → **35.1** |
| static route | 257,731 | **261,704** | +1.5% | 20.0 → **19.0** |

### Behaviour

The reordering is preserving. Nothing between the two guards depends on the input having been read, and `read_body_input?` consults only the request method, the content type and the content length — never the body. A body-carrying request with no `rack.input` still falls out at `input.nil?`, just one guard later.

> Per-operation figures are same-process A/B runs; allocation counts are deterministic (`GC.stat`, GC disabled) measured end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
