### PR TITLE
Look content types up in a plain Hash instead of an indifferent one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * [#2872](https://github.com/ruby-grape/grape/pull/2872): Include an endpoint's helpers once at compile time instead of on every request, so a request no longer builds a singleton class whose method cache starts cold (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2882](https://github.com/ruby-grape/grape/pull/2882): Strip mount path and prefix in `Grape::Middleware::Versioner::Path` with `each` instead of `Enumerable#reduce` - [@ericproulx](https://github.com/ericproulx).
 * [#2881](https://github.com/ruby-grape/grape/pull/2881): Decide whether a request carries a body from the env, so `Grape::Middleware::Formatter` no longer builds a `Rack::Request` for GET, HEAD and OPTIONS - [@ericproulx](https://github.com/ericproulx).
+* [#2883](https://github.com/ruby-grape/grape/pull/2883): Resolve a format's content type through a plain Hash carrying both spellings instead of a `HashWithIndifferentAccess` that converts the key on every read - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/middleware/precomputed_content_types.rb
+++ b/lib/grape/middleware/precomputed_content_types.rb
@@ -7,8 +7,8 @@ module Grape
     # +content_type+ resolved from +config.content_types+ and
     # +config.format+ — so the consuming middleware's +Options+ Data class
     # must declare both fields. Warms those caches on the parent instance
-    # at initialization so per-request +dup+s inherit them (avoiding
-    # ~1 µs/request of +with_indifferent_access+ recomputation).
+    # at initialization so per-request +dup+s inherit them rather than
+    # rebuilding them.
     #
     # Opt-in: plain +Grape::Middleware::Base+ subclasses that don't need
     # content-type-aware helpers don't pay for them.
@@ -17,7 +17,7 @@ module Grape
         super
         content_types
         mime_types
-        content_types_indifferent_access
+        content_types_lookup
       end
 
       def content_types
@@ -29,7 +29,7 @@ module Grape
       end
 
       def content_type_for(format)
-        content_types_indifferent_access[format]
+        content_types_lookup[format]
       end
 
       def content_type
@@ -38,8 +38,20 @@ module Grape
 
       private
 
-      def content_types_indifferent_access
-        @content_types_indifferent_access ||= ActiveSupport::HashWithIndifferentAccess.new(content_types)
+      # Every format under both spellings in one plain Hash, so a lookup is a
+      # single +Hash#[]+. +HashWithIndifferentAccess+ converted the key on every
+      # read instead, and this is read two or three times per request — to
+      # negotiate the format, and again to set the response content type.
+      #
+      # Keys arrive as Symbols: the +content_type+ DSL symbolizes what it is
+      # given and the defaults are Symbols. The key is stored as it came too,
+      # so a middleware constructed directly with String keys still answers to
+      # either spelling, as the indifferent hash did.
+      def content_types_lookup
+        @content_types_lookup ||= content_types.each_with_object({}) do |(format, media_type), lookup|
+          lookup[format] = media_type
+          lookup[format.is_a?(String) ? format.to_sym : format.to_s] = media_type
+        end.freeze
       end
     end
   end


### PR DESCRIPTION
`PrecomputedContentTypes#content_type_for` answers what media type a format maps to, and backed that with a `HashWithIndifferentAccess`:

```ruby
def content_type_for(format)
  content_types_indifferent_access[format]
end
```

Every read ran `convert_key` before the lookup, because the callers genuinely disagree on spelling — a format negotiated from a path extension, a `?format=` or an `Accept` header arrives as a **String**, while the API's declared format and the value stashed in `api.format` are **Symbols**.

Both spellings can live in the same Hash instead. It is built once per middleware and never written again, so that conversion is work with only one possible answer.

### Measurements

Same-process A/B on the lookup:

| | HWIA | plain Hash | |
|---|---:|---:|---:|
| `[:json]` | 42.3 ns | **25.5 ns** | 1.66x |
| `['json']` | 38.8 ns | **33.7 ns** | 1.15x |

`content_type_for` runs **twice per request** — once to negotiate the format, once to set the response content type — and three times when the path carries a format extension (measured by instrumenting the method).

That is about **34 ns per request**, roughly 0.6% of a minimal one. **End to end this is below what the harness can resolve** — repeated runs straddle zero — so no end-to-end figure is claimed. Allocation counts are unchanged: `convert_key` used `Symbol#name`, which allocates nothing.

### Equivalence

Keys arrive as Symbols — `DSL::RequestResponse#content_type` calls `key.to_sym`, and `ContentTypes::DEFAULTS` are Symbols — but the key is stored as it came as well, so a middleware constructed directly with String keys still answers to either spelling, exactly as the indifferent hash did.

Checked against `HashWithIndifferentAccess` over the default content types plus unknown, `nil` and empty keys (16 probes, identical answers), and over a string-keyed hash looked up both ways:

```
equivalent on 16 probe keys (incl. unknown, nil, empty)
string-keyed: symbol lookup true, string lookup true
```

Suite green (2652), RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
