### PR TITLE
Report per-release throughput deltas in the version benchmark

### DIFF
--- a/benchmark/version_throughput/README.md
+++ b/benchmark/version_throughput/README.md
@@ -14,11 +14,11 @@ Cross-version throughput benchmark for Grape. Measures `BenchAPI.call(env)` requ
 ## Usage
 
 ```sh
-# default: 3.0.0, 3.0.1, 3.1.0, 3.1.1, 3.2.0, 3.2.1, master
+# default: 3.0.0, 3.1.0, 3.2.0, 3.3.0, 3.3.5, master
 ruby benchmark/version_throughput/run.rb
 
 # subset
-GRAPE_VERSIONS="3.2.1,master" ruby benchmark/version_throughput/run.rb
+GRAPE_VERSIONS="3.3.5,master" ruby benchmark/version_throughput/run.rb
 
 # different Ruby (e.g. one built with YJIT)
 RBENV_VERSION=4.0.3 ruby benchmark/version_throughput/run.rb
@@ -28,13 +28,15 @@ RBENV_VERSION=4.0.3 ruby benchmark/version_throughput/run.rb
 
 ## Output
 
-Each version produces a row in `RESULTS.md`:
+Each version produces a row in `RESULTS.md`, listed oldest to newest so the table reads as a timeline:
 
-| Version | No-YJIT (i/s) | μs/req | YJIT (i/s) | μs/req | YJIT speedup |
-|---|---:|---:|---:|---:|---:|
-| … | … | … | … | … | … |
+| Version | No-YJIT (i/s) | μs/req | vs prev | vs 3.0.0 | YJIT (i/s) | μs/req | vs prev | vs 3.0.0 | YJIT speedup |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| … | … | … | … | … | … | … | … | … | … |
 
-YJIT columns are only emitted if the running Ruby was built with YJIT support (`run.rb` probes via `ruby --yjit -e 'exit(defined?(RubyVM::YJIT) ? 0 : 1)'`).
+The two delta columns per pass are the point of the report: `vs prev` is the release-over-release change, `vs <first>` the cumulative change since the oldest benched version (the header names it — `vs 3.0.0` with the default list, whatever comes first in `GRAPE_VERSIONS` otherwise). A one-line summary under the table restates first → last for both passes.
+
+YJIT columns are only emitted if the running Ruby was built with YJIT support (`run.rb` probes via `ruby --yjit -e 'exit(defined?(RubyVM::YJIT) ? 0 : 1)'`). Without YJIT the table keeps its `± stddev` column and still carries both deltas.
 
 ## Interpreting results
 
@@ -42,7 +44,9 @@ YJIT columns are only emitted if the running Ruby was built with YJIT support (`
 - **Run on a quiet machine.** Close other apps, plug in the laptop, don't touch the keyboard during the run. Each version takes ~14s of wall-clock measurement plus bundle install on first use.
 - **`master` vs released gems is not apples-to-apples for code paths that changed.** If a refactor moved code between files, both numbers still measure the same `app.rb` request — that's the point — but interpret deltas as "end-to-end request cost" rather than per-method.
 - **YJIT speedup is `(yjit_ips - no_yjit_ips) / no_yjit_ips`.** Both passes share the same Ruby binary; only the `--yjit` flag differs.
+- **Deltas are computed per pass, on i/s.** A version that failed to bench is skipped as a reference, so `vs prev` always points at the closest version that actually produced a number — an `error:` row never breaks the chain.
+- **Cumulative deltas compound the noise floor.** Read `vs 3.0.0` for the shape of the trend, not as a precise figure.
 
 ## Adding a version
 
-Edit `DEFAULT_VERSIONS` in `run.rb`. The orchestrator handles `bundle install` and gemfile generation; nothing else needs to change as long as the new version exposes the DSL `app.rb` uses (`prefix`, `format`, `version 'v1', using: :path`, `get`).
+Edit `DEFAULT_VERSIONS` in `run.rb`, keeping it in release order — the delta columns assume the list runs oldest to newest. The orchestrator handles `bundle install` and gemfile generation; nothing else needs to change as long as the new version exposes the DSL `app.rb` uses (`prefix`, `format`, `version 'v1', using: :path`, `get`).

--- a/benchmark/version_throughput/RESULTS.md
+++ b/benchmark/version_throughput/RESULTS.md
@@ -1,22 +1,26 @@
 # Grape throughput by version
 
-Generated: 2026-06-14 13:30:05 CEST  
+Generated: 2026-09-02 10:52:37 CEST  
 Ruby: ruby 4.0.5 (2026-05-20 revision 64336ffd0e) +PRISM [arm64-darwin25]  
-Host: Darwin 25.5.0 arm64  
-Machine: MacBook Pro (Mac14,9), Apple M2 Pro, 10 cores (6P + 4E), 32 GB RAM  
+Host: Darwin 25.6.0 arm64  
 YJIT available: true
 
 Single-threaded `Benchmark.ips`, 2s warmup + 5s measure, `BenchAPI.call(env)` against `/api/v1/hello` returning a small JSON object. Reproduce with `ruby benchmark/version_throughput/run.rb`.
 
-| Version | No-YJIT (i/s) | μs/req | YJIT (i/s) | μs/req | YJIT speedup |
-|---|---:|---:|---:|---:|---:|
-| 3.0.1 | 32,565 | 30.71 | 54,940 | 18.20 | +68.7% |
-| 3.1.1 | 46,641 | 21.44 | 85,694 | 11.67 | +83.7% |
-| 3.2.1 | 47,929 | 20.86 | 85,328 | 11.72 | +78.0% |
-| master | 66,149 | 15.12 | 133,760 | 7.48 | +102.2% |
+| Version | No-YJIT (i/s) | μs/req | vs prev | vs 3.0.0 | YJIT (i/s) | μs/req | vs prev | vs 3.0.0 | YJIT speedup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 3.0.0 | 34,131 | 29.30 | — | — | 55,526 | 18.01 | — | — | +62.7% |
+| 3.1.0 | 44,425 | 22.51 | +30.2% | +30.2% | 83,543 | 11.97 | +50.5% | +50.5% | +88.1% |
+| 3.2.0 | 46,148 | 21.67 | +3.9% | +35.2% | 85,855 | 11.65 | +2.8% | +54.6% | +86.0% |
+| 3.3.0 | 64,641 | 15.47 | +40.1% | +89.4% | 134,888 | 7.41 | +57.1% | +142.9% | +108.7% |
+| 3.3.5 | 64,426 | 15.52 | -0.3% | +88.8% | 134,141 | 7.45 | -0.6% | +141.6% | +108.2% |
+| master | 87,364 | 11.45 | +35.6% | +156.0% | 180,159 | 5.55 | +34.3% | +224.5% | +106.2% |
+
+Over time, 3.0.0 → master: **+156.0%** without YJIT, **+224.5%** with YJIT.
 
 ## Notes
 - All versions exercised through the same `BenchAPI` definition (kept stable in `app.rb`).
+- `vs prev` compares throughput against the previous benched version and `vs 3.0.0` against the first one; read those columns for improvement over time.
 - Results are noisy at this scale (±5-8%); rerun if a number looks off.
 - `YJIT speedup` is `(yjit_ips - no_yjit_ips) / no_yjit_ips`.
 - YJIT pass uses `ruby --yjit`; both passes share the same Ruby binary.

--- a/benchmark/version_throughput/run.rb
+++ b/benchmark/version_throughput/run.rb
@@ -6,14 +6,18 @@
 # benchmark/version_throughput/RESULTS.md.
 #
 # Each version is benched twice: once without YJIT, once with `--yjit`
-# (skipped if the running Ruby wasn't built with YJIT). Results show both
-# columns plus the YJIT speedup.
+# (skipped if the running Ruby wasn't built with YJIT). Each pass reports
+# throughput plus two deltas — against the previous benched version and
+# against the first one — so the table reads as improvement over time.
 #
 # Usage:
 #   ruby benchmark/version_throughput/run.rb
 #
 # To bench against a specific subset:
-#   GRAPE_VERSIONS="3.0.0,3.2.1,master" ruby benchmark/version_throughput/run.rb
+#   GRAPE_VERSIONS="3.0.0,3.3.5,master" ruby benchmark/version_throughput/run.rb
+#
+# Versions must be listed oldest to newest: the delta columns compare each
+# row against the one above it and against the first row.
 #
 # To run a YJIT-enabled Ruby that isn't the project default:
 #   RBENV_VERSION=4.0.3 ruby benchmark/version_throughput/run.rb
@@ -26,7 +30,7 @@ ROOT = File.expand_path('../..', __dir__)
 HERE = __dir__
 TMP  = File.join(ROOT, 'tmp', 'bench-versions')
 
-DEFAULT_VERSIONS = %w[3.0.0 3.0.1 3.1.0 3.1.1 3.2.0 3.2.1 master].freeze
+DEFAULT_VERSIONS = %w[3.0.0 3.1.0 3.2.0 3.3.0 3.3.5 master].freeze
 versions = (ENV['GRAPE_VERSIONS']&.split(',')&.map(&:strip) || DEFAULT_VERSIONS).freeze
 
 def gemfile_for(version)
@@ -125,8 +129,74 @@ host_desc = `uname -mrs 2>/dev/null`.strip
 report_path = File.join(HERE, 'RESULTS.md')
 
 format_ips = ->(n) { n.round.to_s.reverse.scan(/\d{1,3}/).join(',').reverse }
+ips_cell    = ->(pass) { pass&.dig(:ips)    ? format_ips.call(pass[:ips]) : 'err' }
+us_cell     = ->(pass) { pass&.dig(:us)     ? format('%.2f', pass[:us]) : '' }
+stddev_cell = ->(pass) { pass&.dig(:stddev) ? format('±%.2f%%', pass[:stddev]) : '' }
+
+# Throughput of `version` in a given pass (:no_yjit / :yjit), or nil when it produced no number.
+ips_of = ->(version, pass) { results.dig(version, pass, :ips) }
+
+# Newest version benched before `version` in this pass — the reference of `vs prev`.
+previous_of = lambda do |version, pass|
+  versions[0...versions.index(version)].reverse_each.find { |v| ips_of.call(v, pass) }
+end
+
+# Oldest version benched in this pass — the reference of `vs <first>`.
+baseline_of = ->(pass) { versions.find { |v| ips_of.call(v, pass) } }
+
+percent = lambda do |current, reference|
+  return '—' unless current && reference&.positive?
+
+  format('%+.1f%%', (current - reference) / reference * 100.0)
+end
+
+# [vs previous version, vs first version] for one pass — the improvement-over-time columns.
+deltas_of = lambda do |version, pass|
+  current = ips_of.call(version, pass)
+  previous = previous_of.call(version, pass)
+  baseline = baseline_of.call(pass)
+  [
+    previous ? percent.call(current, ips_of.call(previous, pass)) : '—',
+    baseline && baseline != version ? percent.call(current, ips_of.call(baseline, pass)) : '—'
+  ]
+end
+
+first_version = baseline_of.call(:no_yjit) || baseline_of.call(:yjit) || versions.first
+last_version = versions.reverse_each.find { |v| ips_of.call(v, :no_yjit) || ips_of.call(v, :yjit) }
+
+headers =
+  if with_yjit
+    ['Version', 'No-YJIT (i/s)', 'μs/req', 'vs prev', "vs #{first_version}",
+     'YJIT (i/s)', 'μs/req', 'vs prev', "vs #{first_version}", 'YJIT speedup']
+  else
+    ['Version', 'Throughput (i/s)', 'μs/req', '± stddev', 'vs prev', "vs #{first_version}"]
+  end
+
+row_for = lambda do |version|
+  r = results[version]
+  return [version, "error: #{r[:error]}"] + Array.new(headers.size - 2, '') if r.is_a?(Hash) && r[:error]
+
+  no_yjit = r[:no_yjit]
+  yjit = r[:yjit]
+  head = [version, ips_cell.call(no_yjit), us_cell.call(no_yjit)]
+  return head + [stddev_cell.call(no_yjit)] + deltas_of.call(version, :no_yjit) unless with_yjit
+
+  head + deltas_of.call(version, :no_yjit) + [ips_cell.call(yjit), us_cell.call(yjit)] +
+    deltas_of.call(version, :yjit) + [percent.call(yjit&.dig(:ips), no_yjit&.dig(:ips))]
+end
+
+# One-line summary of the whole timeline: first benched version to last, per pass.
+overall = %i[no_yjit yjit].filter_map do |pass|
+  current = ips_of.call(last_version, pass)
+  reference = ips_of.call(first_version, pass)
+  next unless current && reference && last_version != first_version
+
+  "**#{percent.call(current, reference)}** #{pass == :yjit ? 'with' : 'without'} YJIT"
+end
 
 File.open(report_path, 'w') do |f|
+  row = ->(cells) { f.puts("| #{cells.join(' | ')} |") }
+
   f.puts "# Grape throughput by version\n\n"
   f.puts "Generated: #{Time.now.strftime('%Y-%m-%d %H:%M:%S %Z')}  "
   f.puts "Ruby: #{ruby_desc}  "
@@ -136,43 +206,16 @@ File.open(report_path, 'w') do |f|
          '`BenchAPI.call(env)` against `/api/v1/hello` returning a small JSON object. ' \
          "Reproduce with `ruby benchmark/version_throughput/run.rb`.\n\n"
 
-  if with_yjit
-    f.puts '| Version | No-YJIT (i/s) | μs/req | YJIT (i/s) | μs/req | YJIT speedup |'
-    f.puts '|---|---:|---:|---:|---:|---:|'
-  else
-    f.puts '| Version | Throughput (i/s) | μs/req | ± stddev |'
-    f.puts '|---|---:|---:|---:|'
-  end
+  row.call(headers)
+  row.call(['---'] + Array.new(headers.size - 1, '---:'))
+  versions.each { |version| row.call(row_for.call(version)) }
 
-  versions.each do |version|
-    r = results[version]
-    if r.is_a?(Hash) && r[:error]
-      cols = with_yjit ? 5 : 3
-      f.puts "| #{version} | error: #{r[:error]} #{'|' * cols}"
-      next
-    end
-
-    no_yjit = r[:no_yjit]
-    yjit = r[:yjit]
-
-    if with_yjit
-      no_yjit_cell = no_yjit&.dig(:ips) ? format_ips.call(no_yjit[:ips]) : 'err'
-      no_yjit_us   = no_yjit&.dig(:us)  ? format('%.2f', no_yjit[:us]) : ''
-      yjit_cell    = yjit&.dig(:ips)    ? format_ips.call(yjit[:ips]) : 'err'
-      yjit_us      = yjit&.dig(:us)     ? format('%.2f', yjit[:us]) : ''
-      speedup = (no_yjit&.dig(:ips) && yjit&.dig(:ips)) ?
-        format('%+.1f%%', (yjit[:ips] - no_yjit[:ips]) / no_yjit[:ips] * 100.0) : '—'
-      f.puts "| #{version} | #{no_yjit_cell} | #{no_yjit_us} | #{yjit_cell} | #{yjit_us} | #{speedup} |"
-    else
-      cell = no_yjit&.dig(:ips) ? format_ips.call(no_yjit[:ips]) : 'err'
-      us = no_yjit&.dig(:us) ? format('%.2f', no_yjit[:us]) : ''
-      stddev = no_yjit&.dig(:stddev) ? format('±%.2f%%', no_yjit[:stddev]) : ''
-      f.puts "| #{version} | #{cell} | #{us} | #{stddev} |"
-    end
-  end
+  f.puts "\nOver time, #{first_version} → #{last_version}: #{overall.join(', ')}." unless overall.empty?
 
   f.puts "\n## Notes"
   f.puts '- All versions exercised through the same `BenchAPI` definition (kept stable in `app.rb`).'
+  f.puts "- `vs prev` compares throughput against the previous benched version and `vs #{first_version}` " \
+         'against the first one; read those columns for improvement over time.'
   f.puts '- Results are noisy at this scale (±5-8%); rerun if a number looks off.'
   if with_yjit
     f.puts '- `YJIT speedup` is `(yjit_ips - no_yjit_ips) / no_yjit_ips`.'


### PR DESCRIPTION
## Summary

`benchmark/version_throughput` reported one absolute i/s number per version and left the reader to divide. The question the table exists to answer is how much faster Grape got over time, so each pass (no-YJIT and `--yjit`) now carries two extra columns — `vs prev` against the previous benched version, and `vs <first>` against the oldest one — plus a one-line first-to-last summary under the table.

- Deltas are computed per pass on i/s. A version that fails to bench is skipped as a reference, so `vs prev` always points at the closest version that produced a number and an `error:` row never breaks the chain.
- The baseline column names whichever version comes first in the list instead of hardcoding `3.0.0`, so a custom `GRAPE_VERSIONS` labels itself correctly.
- `DEFAULT_VERSIONS` moves from `3.0.0, 3.0.1, 3.1.0, 3.1.1, 3.2.0, 3.2.1, master` to `3.0.0, 3.1.0, 3.2.0, 3.3.0, 3.3.5, master`: the old list predates 3.3, and the patch releases doubled the runtime without adding a point to the trend.

No library code is touched — this is the benchmark harness, its README, and the generated report.

## Results

Regenerated on Ruby 4.0.5, arm64-darwin25:

| Version | No-YJIT (i/s) | μs/req | vs prev | vs 3.0.0 | YJIT (i/s) | μs/req | vs prev | vs 3.0.0 | YJIT speedup |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 3.0.0 | 34,131 | 29.30 | — | — | 55,526 | 18.01 | — | — | +62.7% |
| 3.1.0 | 44,425 | 22.51 | +30.2% | +30.2% | 83,543 | 11.97 | +50.5% | +50.5% | +88.1% |
| 3.2.0 | 46,148 | 21.67 | +3.9% | +35.2% | 85,855 | 11.65 | +2.8% | +54.6% | +86.0% |
| 3.3.0 | 64,641 | 15.47 | +40.1% | +89.4% | 134,888 | 7.41 | +57.1% | +142.9% | +108.7% |
| 3.3.5 | 64,426 | 15.52 | -0.3% | +88.8% | 134,141 | 7.45 | -0.6% | +141.6% | +108.2% |
| master | 87,364 | 11.45 | +35.6% | +156.0% | 180,159 | 5.55 | +34.3% | +224.5% | +106.2% |

3.0.0 → master: **+156.0%** without YJIT, **+224.5%** with YJIT.

Cumulative deltas compound six noisy measurements, so `vs 3.0.0` is best read as the shape of the trend rather than a precise figure — the README now says so. Two runs back to back agreed within ±4% on every row.

## Test plan
- [x] `ruby benchmark/version_throughput/run.rb` run twice end to end; both produced a complete table.
- [x] Report generation exercised separately against stubbed results, including a failed-bench row, to check the `—` cells and column counts.
- [x] RuboCop unchanged (`benchmark/**/*` is excluded in `.rubocop.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)