### PR TITLE
Share content-type tables between middleware instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * [#2881](https://github.com/ruby-grape/grape/pull/2881): Decide whether a request carries a body from the env, so `Grape::Middleware::Formatter` no longer builds a `Rack::Request` for GET, HEAD and OPTIONS - [@ericproulx](https://github.com/ericproulx).
 * [#2883](https://github.com/ruby-grape/grape/pull/2883): Resolve a format's content type through a plain Hash carrying both spellings instead of a `HashWithIndifferentAccess` that converts the key on every read - [@ericproulx](https://github.com/ericproulx).
 * [#2887](https://github.com/ruby-grape/grape/pull/2887): Add support for the HTTP `QUERY` method (RFC 10008), including the `query` DSL verb and parsing the request content into `params` - [@ericproulx](https://github.com/ericproulx).
+* [#2885](https://github.com/ruby-grape/grape/pull/2885): Share the content-type lookup and mime-type tables between middleware instances that register the same content types, instead of building a copy per API - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/content_types.rb
+++ b/lib/grape/content_types.rb
@@ -22,7 +22,20 @@ module Grape
     def mime_types_for(from_settings)
       return MIME_TYPES if from_settings == Grape::ContentTypes::DEFAULTS
 
-      from_settings.invert.transform_keys! { |k| media_type(k) }
+      MimeTypesCache[from_settings]
+    end
+
+    # Every format under both spellings in one plain Hash, so a lookup is a
+    # single +Hash#[]+. +HashWithIndifferentAccess+ converted the key on every
+    # read instead, and this is read two or three times per request — to
+    # negotiate the format, and again to set the response content type.
+    #
+    # Keys arrive as Symbols: the +content_type+ DSL symbolizes what it is
+    # given and the defaults are Symbols. The key is stored as it came too,
+    # so a middleware constructed directly with String keys still answers to
+    # either spelling, as the indifferent hash did.
+    def lookup_for(from_settings)
+      LookupCache[from_settings]
     end
 
     # The media type of a content-type header: the part before any `;`
@@ -35,6 +48,39 @@ module Grape
 
       base = content_type.include?(';') ? content_type.split(';', 2).first : content_type
       base.strip
+    end
+
+    # Both tables below are derived from nothing but the content-type registry,
+    # and one content-type-aware middleware is built per API instance — so an
+    # app mounting N APIs held N copies of tables it only ever reads. Keying
+    # the cache on the registry itself collapses them: Hash keys compare by
+    # value, so every API that registers the same content types shares one
+    # table.
+    #
+    # Both the key and the table are frozen: the caller's registry stays
+    # reachable (through +middleware.options[:content_types]+, among others)
+    # and mutating a live key would corrupt a cache that is now shared
+    # process-wide.
+
+    class MimeTypesCache < Grape::Util::Cache
+      def initialize
+        super
+        @cache = Hash.new do |h, from_settings|
+          h[from_settings.dup.freeze] = from_settings.invert.transform_keys! { |mime_type| Grape::ContentTypes.media_type(mime_type) }.freeze
+        end
+      end
+    end
+
+    class LookupCache < Grape::Util::Cache
+      def initialize
+        super
+        @cache = Hash.new do |h, from_settings|
+          h[from_settings.dup.freeze] = from_settings.each_with_object({}) do |(format, media_type), lookup|
+            lookup[format] = media_type
+            lookup[format.is_a?(String) ? format.to_sym : format.to_s] = media_type
+          end.freeze
+        end
+      end
     end
   end
 end

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -28,6 +28,14 @@ module Grape
 
       def_delegators :config, :default_format, :format, :formatters, :parsers
 
+      # The formatter is the only middleware that maps an incoming media type
+      # back to a format, so it warms +mime_types+ itself rather than making
+      # every content-type-aware middleware build a table none of them read.
+      def initialize(app, **options)
+        super
+        mime_types
+      end
+
       def before
         negotiate_content_type
         read_body_input

--- a/lib/grape/middleware/precomputed_content_types.rb
+++ b/lib/grape/middleware/precomputed_content_types.rb
@@ -10,13 +10,18 @@ module Grape
     # at initialization so per-request +dup+s inherit them rather than
     # rebuilding them.
     #
+    # +mime_types+ is not warmed here: Formatter is the only middleware that
+    # reads it, and it warms it itself. The tables behind +mime_types+ and
+    # +content_type_for+ are shared process-wide per content-type registry
+    # (see Grape::ContentTypes), so the ivars below memoize a lookup, not a
+    # copy.
+    #
     # Opt-in: plain +Grape::Middleware::Base+ subclasses that don't need
     # content-type-aware helpers don't pay for them.
     module PrecomputedContentTypes
       def initialize(app, **options)
         super
         content_types
-        mime_types
         content_types_lookup
       end
 
@@ -38,20 +43,8 @@ module Grape
 
       private
 
-      # Every format under both spellings in one plain Hash, so a lookup is a
-      # single +Hash#[]+. +HashWithIndifferentAccess+ converted the key on every
-      # read instead, and this is read two or three times per request — to
-      # negotiate the format, and again to set the response content type.
-      #
-      # Keys arrive as Symbols: the +content_type+ DSL symbolizes what it is
-      # given and the defaults are Symbols. The key is stored as it came too,
-      # so a middleware constructed directly with String keys still answers to
-      # either spelling, as the indifferent hash did.
       def content_types_lookup
-        @content_types_lookup ||= content_types.each_with_object({}) do |(format, media_type), lookup|
-          lookup[format] = media_type
-          lookup[format.is_a?(String) ? format.to_sym : format.to_s] = media_type
-        end.freeze
+        @content_types_lookup ||= Grape::ContentTypes.lookup_for(content_types)
       end
     end
   end

--- a/spec/grape/content_types_spec.rb
+++ b/spec/grape/content_types_spec.rb
@@ -73,6 +73,46 @@ describe Grape::ContentTypes do
       end
 
       it { is_expected.to eq('application/xml' => :xml) }
+
+      it { is_expected.to be_frozen }
+
+      it 'returns the same table for an equal registry' do
+        expect(subject).to be(described_class.mime_types_for({ xml: 'application/xml;charset=utf-8' }))
+      end
+    end
+  end
+
+  describe '.lookup_for' do
+    subject { described_class.lookup_for(from_settings) }
+
+    let(:from_settings) { { json: 'application/json' } }
+
+    it 'holds every format under both spellings' do
+      expect(subject).to eq(json: 'application/json', 'json' => 'application/json')
+    end
+
+    it { is_expected.to be_frozen }
+
+    context 'with String keys' do
+      let(:from_settings) { { 'json' => 'application/json' } }
+
+      it 'answers to either spelling' do
+        expect(subject).to eq('json' => 'application/json', json: 'application/json')
+      end
+    end
+
+    context 'when another registry has the same content types' do
+      it 'returns the same table' do
+        expect(subject).to be(described_class.lookup_for({ json: 'application/json' }))
+      end
+    end
+
+    context 'when the registry is mutated after being looked up' do
+      it 'keeps answering the original registry' do
+        subject
+        from_settings[:xml] = 'application/xml'
+        expect(described_class.lookup_for({ json: 'application/json' })).to eq(json: 'application/json', 'json' => 'application/json')
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Grape builds one content-type-aware middleware per API instance, and each one memoized its own derived tables. Both tables are derived from nothing but the content-type registry, so they now live in value-keyed caches on `Grape::ContentTypes` — Hash keys compare by value, so every API registering the same content types shares one table.

- `Grape::ContentTypes::LookupCache` / `MimeTypesCache` follow the `PartsCache` / `PatternCache` / `CoercerCache` idiom already in the codebase. `lookup_for` moved here from `Grape::Middleware::PrecomputedContentTypes`.
- `Grape::Middleware::Formatter` warms `mime_types` itself. It is the only reader — `Error` resolves `content_type` through the lookup, and the versioners read the registry directly — so `PrecomputedContentTypes` no longer builds that table for every instance that includes it.
- The `== DEFAULTS` fast path in `mime_types_for` stays, so `Grape::ContentTypes::MIME_TYPES` is still returned by identity for a default registry.

## Memory

A `memory_profiler` run over an app mounting 13 APIs held 42 content-type-aware middleware (20 `Formatter`, 20 `Error`, 2 `Versioner`) covering **four** distinct content-type registrations:

| | live objects before → after | held before → after |
|---|---:|---:|
| `@content_types_lookup` | 42 → 4 | 7,488 B → 1,024 B |
| `@mime_types` | 41 → 3 | 6,560 B → 480 B |
| `@content_types` | 21 → 21 | 3,360 B (unchanged) |

17.4 kB → 4.9 kB, of which the duplicated portion goes from 15.1 kB to 2.7 kB. It scales with the number of mounted APIs — this app held roughly 750 B of duplicate tables per API instance. What is left is the registry Hash itself, which `InheritableSetting` builds fresh per API instance; deduplicating that belongs in `InheritableSetting`, not here.

Nothing moves per request: the tables are still warmed at middleware construction and read from an ivar, so `dup.call!(env)` inherits them exactly as before.

## Backward compatibility

`Grape::ContentTypes.mime_types_for` now returns a frozen Hash shared between callers with equal content types, where it previously returned a fresh mutable one — except for a default registry, where it already returned the frozen `MIME_TYPES` constant. Each cache also stores a frozen copy of the registry as its key rather than the caller's Hash: the caller's registry stays reachable through `middleware.options[:content_types]`, and mutating a live key would corrupt a cache that is now process-wide. A spec pins that a post-lookup mutation of the registry leaves the cached table alone.

## Test plan
- [x] Full RSpec suite passes locally (2657 examples, 0 failures).
- [x] RuboCop clean on the changed files.
- [x] Ran a real mounted app's suite against the patched gem; failures are byte-identical to the same run without this change (live-server integration specs and a `grape-swagger` parser error).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)