### PR TITLE
Compile the router's optimized map from the registered routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 * [#2864](https://github.com/ruby-grape/grape/pull/2864): Apply a group's type check to `optional` the same way as `requires`, so a type supplied by an enclosing `with` is no longer invisible to it (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2865](https://github.com/ruby-grape/grape/pull/2865): Pass `required` from `requires`/`optional` as an argument instead of writing a `presence` key into the caller's options, deprecating a user-supplied `presence` and letting a `with` block's `message` reach the presence validator (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2871](https://github.com/ruby-grape/grape/pull/2871): Move the endpoint replacement behind `mount`'s private re-mounting path, deprecating the undocumented `refresh_already_mounted` option, and recognise a mount mapping by `Hash` rather than by `respond_to?(:each_pair)` (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
+* [#2886](https://github.com/ruby-grape/grape/pull/2886): Compile the router's optimized map from the registered routes, so a route declared with a verb outside `Grape::HTTP_SUPPORTED_METHODS` is served instead of being advertised in `Allow` and answered with 405 - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -25,10 +25,14 @@ module Grape
 
       @union = Regexp.union(@neutral_regexes)
       @neutral_regexes = nil
-      (Grape::HTTP_SUPPORTED_METHODS + ['*']).each do |method|
-        next unless @map.key?(method)
-
-        routes = @map[method]
+      # Compiled from the routes actually registered rather than from
+      # Grape::HTTP_SUPPORTED_METHODS. A route declared with any other verb
+      # (`route :purge, '/cache'`) is accepted at definition time and is
+      # already collected into the resource's Allow header, so skipping it here
+      # left it in @map but out of @optimized_map — the only map #match? reads.
+      # The resource then advertised a method that could never be matched and
+      # answered every request for it with 405.
+      @map.each do |method, routes|
         optimized_map = routes.map.with_index { |route, index| route.to_regexp(index) }
         @optimized_map[method] = Regexp.union(optimized_map)
       end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -919,6 +919,25 @@ describe Grape::API do
       expect(last_response.headers['Allow']).to eql 'OPTIONS, GET, POST, HEAD'
     end
 
+    # Regression: a route declared with a verb outside Grape::HTTP_SUPPORTED_METHODS
+    # was listed in Allow but never compiled into the router's optimized map, so
+    # the resource advertised a method it answered with 405.
+    specify 'serves a method listed in the Allow header but outside the standard verbs' do
+      subject.get 'example' do
+        'example'
+      end
+      subject.route :purge, 'example' do
+        'purged'
+      end
+
+      custom_request 'PURGE', '/example'
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eql 'purged'
+
+      put '/example'
+      expect(last_response.headers['Allow']).to eql 'OPTIONS, GET, PURGE, HEAD'
+    end
+
     specify '405 responses includes an Content-Type header' do
       subject.get 'example' do
         'example'

--- a/spec/grape/router_spec.rb
+++ b/spec/grape/router_spec.rb
@@ -49,6 +49,41 @@ describe Grape::Router do
     end
   end
 
+  # Regression: the optimized map was compiled from Grape::HTTP_SUPPORTED_METHODS,
+  # so a route registered for any other verb stayed in @map and out of the map
+  # #match? reads. It was advertised in the resource's Allow header and then
+  # 405'd on every request.
+  describe 'routes registered with a non-standard HTTP method' do
+    subject(:router) { described_class.new }
+
+    let(:endpoint) { ->(_env) { [200, {}, ['purged']] } }
+    let(:pattern) do
+      Grape::Router::Pattern.new(origin: '/cache', suffix: '', anchor: true, params: {}, version: nil, requirements: {})
+    end
+
+    before do
+      router.append(Grape::Router::Route.new(endpoint, :purge, pattern, {}, forward_match: false))
+      router.compile!
+    end
+
+    it 'compiles the method into the optimized map' do
+      expect(router.instance_variable_get(:@optimized_map)).to have_key('PURGE')
+    end
+
+    it 'matches a request using that method' do
+      status, _, body = router.call(Rack::MockRequest.env_for('/cache', method: 'PURGE'))
+
+      expect(status).to eq(200)
+      expect(body.to_a).to eq(['purged'])
+    end
+
+    it 'still 404s a method that has no routes' do
+      status, = router.call(Rack::MockRequest.env_for('/cache', method: 'PROPFIND'))
+
+      expect(status).to eq(404)
+    end
+  end
+
   # Regression: a cascading route used to hand straight over to the greedy
   # neighbour — the *last* route registered for the path — so any route
   # between the first match and that last one was unreachable.


### PR DESCRIPTION
`Router#compile!` built `@optimized_map` by walking `Grape::HTTP_SUPPORTED_METHODS + ['*']`, but `#append` accepts a route for whatever verb `route` was given. A route declared with any other verb was kept in `@map` and left out of `@optimized_map` — the only map `#match?` consults — so it could never be matched.

The route was not merely inert. `collect_route_config_per_pattern` builds a resource's `Allow` header from the routes themselves, so the resource advertised the method and then rejected it:

```ruby
class API < Grape::API
  get('/cache') { 'get' }
  route(:purge, '/cache') { 'purged' }
end

# PURGE /cache -> 405, Allow: OPTIONS, GET, PURGE, HEAD
```

Listing a method in `Allow` and answering it with 405 contradicts [RFC 9110 §10.2.1](https://www.rfc-editor.org/rfc/rfc9110#section-10.2.1).

Compiling from `@map` instead makes the advertisement and the routing agree, drops the now-redundant `@map.key?` guard, and lets Grape serve methods it does not know about ahead of time. A method with no routes at all still 404s, unchanged, and the maps are still frozen after compilation.

Specs cover the router unit (compiled into the optimized map, matched, and no routes still 404s) and the API-level `Allow`/response agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)