### PR TITLE
Add support for the HTTP QUERY method (RFC 10008)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * [#2882](https://github.com/ruby-grape/grape/pull/2882): Strip mount path and prefix in `Grape::Middleware::Versioner::Path` with `each` instead of `Enumerable#reduce` - [@ericproulx](https://github.com/ericproulx).
 * [#2881](https://github.com/ruby-grape/grape/pull/2881): Decide whether a request carries a body from the env, so `Grape::Middleware::Formatter` no longer builds a `Rack::Request` for GET, HEAD and OPTIONS - [@ericproulx](https://github.com/ericproulx).
 * [#2883](https://github.com/ruby-grape/grape/pull/2883): Resolve a format's content type through a plain Hash carrying both spellings instead of a `HashWithIndifferentAccess` that converts the key on every read - [@ericproulx](https://github.com/ericproulx).
+* [#2887](https://github.com/ruby-grape/grape/pull/2887): Add support for the HTTP `QUERY` method (RFC 10008), including the `query` DSL verb and parsing the request content into `params` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ get :public_timeline do
 end
 ```
 
-Parameters are automatically populated from the request body on `POST` and `PUT` for form input, JSON and XML content-types.
+Parameters are automatically populated from the request body on `POST`, `PUT` and `QUERY` for form input, JSON and XML content-types.
 
 The request:
 
@@ -2301,6 +2301,26 @@ namespace :outer, requirements: { id: /[0-9]*/ } do
   end
 end
 ```
+
+### The QUERY Method
+
+Grape supports [`QUERY`](https://www.rfc-editor.org/info/rfc10008/), a safe and idempotent method that carries its query in the request content rather than in the URI. It is the method to reach for when a query is too large, too structured, or too sensitive to encode into a query string.
+
+```ruby
+params do
+  requires :q, type: String
+  optional :limit, type: Integer
+end
+query '/search' do
+  Status.search(params[:q], limit: params[:limit])
+end
+```
+
+```
+curl -X QUERY 'http://localhost:9292/search' -H Content-Type:application/json -d '{"q": "grape", "limit": 10}'
+```
+
+The content is parsed into `params` exactly as it is for `POST`, and a successful response defaults to `200`, not `201`. Because the content *is* the query, a `QUERY` request that arrives without a `Content-Type` is rejected with `400` instead of falling back to the API's default format.
 
 ## Helpers
 

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -57,8 +57,13 @@ module Grape
   # middleware stack instead of being answered with a failsafe 500.
   setting :raise_rendering_errors, default: false
 
+  # The HTTP QUERY method (RFC 10008): a safe, idempotent request whose content
+  # carries the query. Rack has no constant for it yet, hence the literal.
+  QUERY = 'QUERY'
+
   HTTP_SUPPORTED_METHODS = [
     Rack::GET,
+    QUERY,
     Rack::POST,
     Rack::PUT,
     Rack::PATCH,

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -22,8 +22,9 @@ module Grape
 
       # The request methods that can carry a body worth parsing. See
       # {#read_body_input?}, which tests the env against this before anything
-      # asks for a Rack::Request.
-      BODY_CARRYING_METHODS = [Rack::POST, Rack::PUT, Rack::PATCH, Rack::DELETE].freeze
+      # asks for a Rack::Request. QUERY is here because its content *is* the
+      # query (RFC 10008, Section 2), not an optional payload.
+      BODY_CARRYING_METHODS = [Rack::POST, Rack::PUT, Rack::PATCH, Rack::DELETE, Grape::QUERY].freeze
 
       def_delegators :config, :default_format, :format, :formatters, :parsers
 
@@ -115,6 +116,13 @@ module Grape
         return if body.empty?
 
         media_type = rack_request.media_type
+
+        # RFC 10008, Sections 2 and 2.1: a QUERY carries its query in the
+        # content, so a request that never says what that content is cannot be
+        # interpreted and must fail rather than be read as the default format.
+        # Every other method keeps that fallback.
+        throw :error, Grape::Exceptions::ErrorResponse.new(status: 400, message: 'The QUERY method requires a content-type.') if media_type.nil? && env[Rack::REQUEST_METHOD] == Grape::QUERY
+
         fmt = media_type ? mime_types[media_type] : default_format
 
         throw :error, Grape::Exceptions::ErrorResponse.new(status: 415, message: "The provided content-type '#{media_type}' is not supported.") unless content_type_for(fmt)

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -745,6 +745,55 @@ describe Grape::API do
       end
     end
 
+    # RFC 10008: QUERY is a safe, idempotent method whose content carries the
+    # query, so the body is parsed the way POST's is while the response keeps
+    # GET's default 200.
+    describe 'the QUERY method' do
+      before do
+        subject.format :json
+        subject.params { requires :q, type: String }
+        subject.query('/search') { { found: params[:q] } }
+      end
+
+      def query_request(body, content_type: 'application/json')
+        custom_request 'QUERY', '/search', {}, 'CONTENT_TYPE' => content_type, input: body
+      end
+
+      it 'reads the query from the request content' do
+        query_request '{"q":"grape"}'
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eql '{"found":"grape"}'
+      end
+
+      it 'validates the parsed content' do
+        query_request '{}'
+
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eql '{"error":"q is missing"}'
+      end
+
+      it 'rejects content sent without a content-type' do
+        custom_request 'QUERY', '/search', {}, input: '{"q":"grape"}'
+
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eql '{"error":"The QUERY method requires a content-type."}'
+      end
+
+      it 'rejects an unsupported content-type' do
+        query_request '{"q":"grape"}', content_type: 'application/x-yaml'
+
+        expect(last_response.status).to eq(415)
+      end
+
+      it 'is listed in the Allow header alongside the other verbs' do
+        subject.get('/search') { 'get' }
+
+        put '/search'
+        expect(last_response.headers['Allow']).to eql 'OPTIONS, QUERY, GET, HEAD'
+      end
+    end
+
     it 'allows for catch-all in a namespace' do
       subject.namespace :nested do
         get do

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -264,7 +264,7 @@ describe Grape::Middleware::Formatter do
 
   context 'input' do
     content_types = ['application/json', 'application/json; charset=utf-8'].freeze
-    %w[POST PATCH PUT DELETE].each do |method|
+    %w[POST PATCH PUT DELETE QUERY].each do |method|
       context 'when body is not nil or empty' do
         context 'when Content-Type is supported' do
           let(:io) { StringIO.new('{"is_boolean":true,"string":"thing"}') }
@@ -412,6 +412,34 @@ describe Grape::Middleware::Formatter do
           )
           expect(subject.env[Rack::RACK_REQUEST_FORM_HASH]).to be_nil
         end
+      end
+    end
+
+    # RFC 10008, Sections 2 and 2.1: a QUERY carries the query in its content,
+    # so a body that never says what it is cannot be read as the default format.
+    context 'when a body is sent without a Content-Type' do
+      def error_from(method)
+        io = StringIO.new('{"is_boolean":true,"string":"thing"}')
+        catch(:error) do
+          subject.call(
+            Rack::PATH_INFO => '/info',
+            Rack::REQUEST_METHOD => method,
+            Rack::RACK_INPUT => io,
+            'CONTENT_LENGTH' => io.length.to_s
+          )
+          nil
+        end
+      end
+
+      it 'rejects a QUERY with a 400 HTTP error status' do
+        error = error_from(Grape::QUERY)
+
+        expect(error.status).to eq(400)
+        expect(error.message).to eq('The QUERY method requires a content-type.')
+      end
+
+      it 'leaves the default-format fallback in place for the other methods' do
+        expect(%w[POST PATCH PUT DELETE].map { |method| error_from(method) }).to all(be_nil)
       end
     end
   end


### PR DESCRIPTION
[RFC 10008](https://www.rfc-editor.org/info/rfc10008/) defines `QUERY`: a **safe and idempotent** method whose *content* carries the query, for when a query is too voluminous, too structured, or too sensitive to encode into a request URI. It sits between `GET` (which cannot carry a body) and `POST` (which is neither safe nor idempotent, so it cannot be retried or cached).

Grape had no support for it. `query` was not a verb, and a route declared as `route :query` was answered with 405 while still being listed in `Allow`.

### Changes

* **`Grape::HTTP_SUPPORTED_METHODS` gains `QUERY`**, which mints the `query` DSL verb, routes the method, and lists it in the resource's `Allow` header. Rack has no constant for the method yet, so `Grape::QUERY` holds the literal.
* **`Formatter::BODY_CARRYING_METHODS` gains `QUERY`**, so the content is parsed into `params` the way a `POST` body is. Without this the request that *is* a query arrived with `params` empty — the urlencoded case worked only by accident, since Rack's own `form_data?` keys off media type rather than method.
* **A `QUERY` sending content without a `Content-Type` is rejected with 400** rather than read as the API's default format ([Sections 2 and 2.1](https://www.rfc-editor.org/rfc/rfc10008#section-2)). Every other method keeps the fallback.

```ruby
params do
  requires :q, type: String
  optional :limit, type: Integer
end
query '/search' do
  Status.search(params[:q], limit: params[:limit])
end
```

```
curl -X QUERY 'http://localhost:9292/search' -H Content-Type:application/json -d '{"q": "grape", "limit": 10}'
```

### Already correct, now reachable

`default_status` answers 200 rather than 201 for `QUERY`, matching Section 2. The unsupported-media-type (415), unparseable-content (400) and unacceptable-`Accept` (406) paths all behave as Section 2.1 requires — they simply were never reached, because the body was never read.

### Not included

The `Accept-Query` response header ([Section 3](https://www.rfc-editor.org/rfc/rfc10008#section-3)) is optional in the spec ("can be used"), and its Structured Fields serialization plus the question of which responses should carry it are worth their own change.

### Compatibility

Additive. `Allow` is built from the routes an API actually declares, so nothing changes for an API that defines no `QUERY` route. A user-defined `def self.query` on an API subclass still wins over the DSL verb, since the DSL is reached through `method_missing`. grape-swagger reads `route.request_method` from declared routes and never the supported-method list, so its output is unchanged unless a `query` route is declared.

Adding `QUERY` to the existing `%w[POST PATCH PUT DELETE]` loop in the formatter spec runs the whole body-parsing suite against it; the API-level specs cover the verb end to end, and the missing/unsupported content-type rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)