### PR TITLE
Resolve an API instance's cascade setting once instead of per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 * [#2887](https://github.com/ruby-grape/grape/pull/2887): Add support for the HTTP `QUERY` method (RFC 10008), including the `query` DSL verb and parsing the request content into `params` - [@ericproulx](https://github.com/ericproulx).
 * [#2885](https://github.com/ruby-grape/grape/pull/2885): Share the content-type lookup and mime-type tables between middleware instances that register the same content types, instead of building a copy per API - [@ericproulx](https://github.com/ericproulx).
 * [#2891](https://github.com/ruby-grape/grape/pull/2891): Look registrations up in a plain Hash carrying both spellings instead of a `HashWithIndifferentAccess` - [@ericproulx](https://github.com/ericproulx).
+* [#2888](https://github.com/ruby-grape/grape/pull/2888): Resolve an API instance's cascade setting once at compile time instead of walking the settings chain on every request - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/api/instance.rb
+++ b/lib/grape/api/instance.rb
@@ -111,12 +111,13 @@ module Grape
 
         @router.compile!
         @router.freeze
+        @cascade = resolve_cascade
       end
 
       # Handle a request. See Rack documentation for what `env` is.
       def call(env)
         status, headers, response = @router.call(env)
-        unless cascade?
+        unless @cascade
           headers = Grape::Util::Header.new.merge(headers)
           headers.delete('X-Cascade')
         end
@@ -132,12 +133,13 @@ module Grape
       # In some applications (e.g. mounting grape on rails), one might need to trap
       # errors from reaching upstream. This is effectivelly done by unsetting
       # X-Cascade. Default :cascade is true.
+      #
+      # Resolved in the constructor rather than per request: answering it walks
+      # the whole scope chain twice, and it reads the same settings the routes
+      # were compiled and frozen from -- changing those has to go through
+      # +change!+, which discards this instance.
       def cascade?
-        setting = self.class.inheritable_setting
-        return setting.cascade if setting.cascade_defined?
-        return setting.version_options.cascade if setting.version_options
-
-        true
+        @cascade
       end
 
       reset!
@@ -174,6 +176,15 @@ module Grape
           greedy_route = Grape::Router::GreedyRoute.new(last_route.pattern, endpoint: last_route.app, allow_header:)
           @router.associate_routes(greedy_route)
         end
+      end
+
+      # Backs {#cascade?}; called once, from the constructor.
+      def resolve_cascade
+        setting = self.class.inheritable_setting
+        return setting.cascade if setting.cascade_defined?
+        return setting.version_options.cascade if setting.version_options
+
+        true
       end
     end
   end


### PR DESCRIPTION
`Grape::API::Instance#call` asks `cascade?` on the way out of every request, and answering it walks the `InheritableSetting` scope chain twice — once through `cascade_defined?`, once through `version_options`. The answer cannot change while the instance is alive: it comes off the same settings the routes were compiled and frozen from, and a settings change goes through `change!`, which drops the instance. So it is resolved in the constructor, next to the router it is consistent with.

`cascade?` keeps its name, its visibility and its meaning — it reports what was resolved instead of resolving again.

## Measurements

On an API with a prefix, path versioning and three nested namespaces:

```
resolve per request  323.5 ns  ->  memoized reader  41.0 ns   7.90x
```

End to end (`Benchmark.ips`, median of 5 interleaved subprocess runs against master, Ruby 4.0.5):

| scenario | delta |
|---|---:|
| minimal versioned GET | **+4.0%** |
| GET with params + validations | **+8.4%** |

## Test plan
- [x] Full RSpec suite (2650 examples, 0 failures)
- [x] RuboCop clean
- [x] Response byte-identical to master (status, headers, body) across a 66-case request matrix, including `cascade false`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)