### PR TITLE
Read the path version off the route the router already matched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 * [#2887](https://github.com/ruby-grape/grape/pull/2887): Add support for the HTTP `QUERY` method (RFC 10008), including the `query` DSL verb and parsing the request content into `params` - [@ericproulx](https://github.com/ericproulx).
 * [#2885](https://github.com/ruby-grape/grape/pull/2885): Share the content-type lookup and mime-type tables between middleware instances that register the same content types, instead of building a copy per API - [@ericproulx](https://github.com/ericproulx).
 * [#2889](https://github.com/ruby-grape/grape/pull/2889): Constrain the `:version` capture with a `Regexp` so Mustermann stops registering an identity param converter, which was defeating its `identity_params?` fast path on every path-versioned request - [@ericproulx](https://github.com/ericproulx).
+* [#2890](https://github.com/ruby-grape/grape/pull/2890): Read the path version off the route the router already matched instead of re-deriving it from `PATH_INFO` in `Grape::Middleware::Versioner::Path` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/env.rb
+++ b/lib/grape/env.rb
@@ -11,6 +11,7 @@ module Grape
     API_VENDOR = 'api.vendor'
     API_FORMAT = 'api.format'
 
+    GRAPE_NORMALIZED_PATH = 'grape.normalized_path'
     GRAPE_ROUTING_ARGS = 'grape.routing_args'
     GRAPE_ALLOWED_METHODS = 'grape.allowed_methods'
     GRAPE_EXCEPTION = 'grape.exception'

--- a/lib/grape/middleware/versioner/path.rb
+++ b/lib/grape/middleware/versioner/path.rb
@@ -23,7 +23,10 @@ module Grape
         end
 
         def before
-          path_info = Grape::Util::PathNormalizer.call(env[Rack::PATH_INFO])
+          routed = routed_version
+          return env[Grape::Env::API_VERSION] = routed if routed
+
+          path_info = env[Grape::Env::GRAPE_NORMALIZED_PATH] || Grape::Util::PathNormalizer.call(env[Rack::PATH_INFO])
           return if path_info == '/'
 
           # `each` rather than `reduce`: Array does not override Enumerable's,
@@ -39,6 +42,24 @@ module Grape
         end
 
         private
+
+        # Under path versioning every route pattern carries the version as a
+        # named capture (Pattern::Path#build_parts inserts it), constrained to
+        # the declared versions -- so the router has already sliced the segment
+        # out and validated it, and re-deriving it from PATH_INFO would repeat
+        # the normalize, prefix-strip and slice below for the same answer.
+        #
+        # Nil, and the path parsed as before, when there are no routing args at
+        # all (the middleware used outside a Grape router) and for the greedy
+        # routes behind auto-OPTIONS and 405, which capture nothing. An Array
+        # means the route declared a +:version+ segment of its own on top of the
+        # versioning one: Mustermann then reports the capture as every position
+        # it matched rather than the single segment recorded here, so that too
+        # is left to the path parse.
+        def routed_version
+          version = env[Grape::Env::GRAPE_ROUTING_ARGS]&.[](:version)
+          version if version.is_a?(String)
+        end
 
         def version_from_first_segment(path_info, slash_position)
           potential_version = path_info[1..(slash_position - 1)]

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -52,7 +52,10 @@ module Grape
 
     def call(env)
       with_optimization do
-        input = Grape::Util::PathNormalizer.call(env[Rack::PATH_INFO])
+        # Published on the env so the middleware the matched route runs -- the
+        # path versioner above all -- reads the path this routed on instead of
+        # normalizing PATH_INFO a second time.
+        input = env[Grape::Env::GRAPE_NORMALIZED_PATH] = Grape::Util::PathNormalizer.call(env[Rack::PATH_INFO])
         transaction(input, env[Rack::REQUEST_METHOD], env)
       end
     end


### PR DESCRIPTION
> **Depends on #2889** — this is opened against `perf/version-capture-regexp`, and needs it for correctness (see *Ordering* below). Rebase onto `master` once that merges.

Under path versioning the version is a named capture in every route pattern — `Pattern::Path#build_parts` inserts `:version` ahead of the namespace — constrained to the declared versions. By the time a request reaches the endpoint's middleware stack the router has already sliced the segment out, validated it, and left it in `env['grape.routing_args'][:version]`.

`Versioner::Path#before` derived it a second time from scratch: normalize `PATH_INFO`, strip the mount path and prefix, find the first slash, slice. This reads it off the env instead.

The path parse stays, and answers three cases the routing args cannot:

* no routing args at all — the middleware used outside a Grape router;
* the greedy routes behind auto-OPTIONS and 405, which capture nothing;
* a route declaring a `:version` segment of its own on top of the versioning one, where Mustermann reports the capture as every position it matched rather than the single segment recorded here (hence the `is_a?(String)` guard).

`Router#call` also publishes the path it routed on as `env['grape.normalized_path']`, so that fallback does not normalize `PATH_INFO` a second time either. It is the same string the router matched against, which is what the versioner wants to agree with.

## Ordering

This leans on the version capture being strict. Before #2889 a percent-encoded segment matched the route and Mustermann decoded it, so `routing_args[:version]` would have been `"v1"` for `/api/%76%31/x` and the versioner would now accept what it used to reject. With #2889 the route does not match at all and the router 404s, as before.

## Measurements

`Benchmark.ips`, median of 5 interleaved subprocess runs against master, Ruby 4.0.5, both commits together:

| scenario | delta |
|---|---:|
| minimal versioned GET | **+9.8%** |
| GET with params + validations | **+9.9%** |

## Test plan
- [x] Full RSpec suite (2650 examples, 0 failures)
- [x] RuboCop clean
- [x] Byte-identical to master (status, headers, body) across a 66-case matrix covering all four versioners, mounting, `cascade false`, auto-OPTIONS, 405, HEAD, splats, `requirements:`, percent-encoded paths, invalid UTF-8 paths, and a route with a duplicate `:version` capture
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)