### PR TITLE
Look registrations up in a plain Hash instead of an indifferent one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 * [#2883](https://github.com/ruby-grape/grape/pull/2883): Resolve a format's content type through a plain Hash carrying both spellings instead of a `HashWithIndifferentAccess` that converts the key on every read - [@ericproulx](https://github.com/ericproulx).
 * [#2887](https://github.com/ruby-grape/grape/pull/2887): Add support for the HTTP `QUERY` method (RFC 10008), including the `query` DSL verb and parsing the request content into `params` - [@ericproulx](https://github.com/ericproulx).
 * [#2885](https://github.com/ruby-grape/grape/pull/2885): Share the content-type lookup and mime-type tables between middleware instances that register the same content types, instead of building a copy per API - [@ericproulx](https://github.com/ericproulx).
+* [#2891](https://github.com/ruby-grape/grape/pull/2891): Look registrations up in a plain Hash carrying both spellings instead of a `HashWithIndifferentAccess` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/util/registry.rb
+++ b/lib/grape/util/registry.rb
@@ -8,7 +8,7 @@ module Grape
         return if short_name.nil?
 
         warn "#{short_name} is already registered with class #{registry[short_name]}. It will be overridden globally with the following: #{klass.name}" if registry.key?(short_name)
-        registry[short_name] = klass
+        registry[short_name] = registry[short_name.to_sym] = klass
       end
 
       private
@@ -19,8 +19,18 @@ module Grape
         klass.name.demodulize.underscore
       end
 
+      # Every registration under both spellings in one plain Hash, so a lookup
+      # is a single +Hash#[]+. A +HashWithIndifferentAccess+ converted the key
+      # on every read instead -- and these registries are read on the request
+      # path, by +Grape::Formatter+ once per response, by +Grape::Parser+ once
+      # per parsed body and by +Grape::ParamsBuilder+ once per params build,
+      # always with a Symbol, which is the spelling +convert_key+ allocates a
+      # String for.
+      #
+      # +register+ derives the short name as a String, so the Symbol is the
+      # alias.
       def registry
-        @registry ||= ActiveSupport::HashWithIndifferentAccess.new
+        @registry ||= {}
       end
     end
   end

--- a/spec/support/deregister.rb
+++ b/spec/support/deregister.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 module Deregister
+  # A registration lives under both its String and its Symbol spelling
+  # (see Grape::Util::Registry#register), so undoing one takes both.
   def deregister(key)
-    registry.delete(key)
+    registry.delete(key.to_s)
+    registry.delete(key.to_sym)
   end
 end


### PR DESCRIPTION
Sibling of #2883, one level down. `Grape::Util::Registry` backs the format, parser, error-formatter, versioner, validator and params-builder registries with a `HashWithIndifferentAccess`, because registration and lookup disagree on spelling: `register` derives the short name as a String (`klass.name.demodulize.underscore`), while the readers arrive with a Symbol.

Three of those registries are read on the request path — `Grape::Formatter` once per response, `Grape::Parser` once per parsed body, `Grape::ParamsBuilder` once per params build — so `convert_key` ran on each of those lookups to answer a question that only ever had one answer. Store both spellings instead:

```ruby
registry[short_name] = registry[short_name.to_sym] = klass
```

```
HWIA[:json]     109.4 ns  ->  Hash[:json]     34.3 ns   3.19x
HWIA['json']    117.7 ns  ->  Hash['json']    61.1 ns   1.93x
```

## Measurements

`Benchmark.ips`, median of 5 interleaved subprocess runs against master, Ruby 4.0.5:

| scenario | delta |
|---|---:|
| minimal versioned GET | **+2.8%** |
| GET with params + validations | **+2.8%** |

## Removing a registration

A registration now lives under two keys, so deleting one by hand would leave the other behind. Nothing in the library ever does that — only the suite removes registrations, through the `Deregister` helper `spec_helper` already mixes into `Grape::Util::Registry`. That helper deletes both spellings now, so the fix stays in the only place that needs it rather than widening the public surface.

## Test plan
- [x] Full RSpec suite (2681 examples, 0 failures) — including the custom-validator and i18n specs that deregister
- [x] RuboCop clean
- [x] Byte-identical to master across a 66-case request matrix
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)