### PR TITLE
Scrub the format extension rather than the whole request path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 * [#2889](https://github.com/ruby-grape/grape/pull/2889): Constrain the `:version` capture with a `Regexp` so Mustermann stops registering an identity param converter, which was defeating its `identity_params?` fast path on every path-versioned request - [@ericproulx](https://github.com/ericproulx).
 * [#2890](https://github.com/ruby-grape/grape/pull/2890): Read the path version off the route the router already matched instead of re-deriving it from `PATH_INFO` in `Grape::Middleware::Versioner::Path` - [@ericproulx](https://github.com/ericproulx).
 * [#2892](https://github.com/ruby-grape/grape/pull/2892): Resolve the params builder when `params` are first read rather than in every `Grape::Request` - [@ericproulx](https://github.com/ericproulx).
+* [#2893](https://github.com/ruby-grape/grape/pull/2893): Scrub the format extension rather than the whole request path when negotiating a format - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -179,12 +179,17 @@ module Grape
         throw :error, Grape::Exceptions::ErrorResponse.new(status: 406, message: "The requested format '#{fmt}' is not supported.")
       end
 
+      # Only the extension is scrubbed, and only once the path turns out to have
+      # one: +String#rindex+ takes a byte offset and never raises on an invalid
+      # sequence, and a +.+ byte cannot be part of a multi-byte one, so the dot
+      # sits at the same place before and after scrubbing. The overwhelming
+      # majority of paths carry no extension and now skip the scrub entirely.
       def format_from_extension
-        request_path = try_scrub(path_for_extension)
+        request_path = path_for_extension
         dot_pos = request_path.rindex('.')
         return unless dot_pos
 
-        extension = request_path[(dot_pos + 1)..]
+        extension = try_scrub(request_path[(dot_pos + 1)..])
         extension if content_type_for(extension)
       end
 


### PR DESCRIPTION
`format_from_extension` runs on every request, and scrubbed before it knew whether there was anything to scrub:

```ruby
request_path = try_scrub(path_for_extension)
dot_pos = request_path.rindex('.')
return unless dot_pos

extension = request_path[(dot_pos + 1)..]
```

`try_scrub` calls `valid_encoding?`, which walks the string, and `scrub`, which walks and copies it — for a path that in the overwhelming majority of requests carries no extension at all.

The scrub is only there for the extension, which `content_type_for` then looks up; nothing between the two needs a valid string. `String#rindex` takes a byte offset and does not raise on an invalid sequence, and `.` (0x2E) can never be part of a UTF-8 multi-byte sequence — continuation bytes are 0x80..0xBF — so the last dot sits at the same place before and after scrubbing, and slicing at it gives the same extension either way. The `"/info.\xNN"` case in `formatter_spec` still yields `"�"`.

## Measurements

```
scrub whole path  177.2 ns  ->  scrub extension   81.5 ns  2.17x  /api/v1/hello
scrub whole path  192.6 ns  ->  scrub extension   98.7 ns  1.95x  60-char path
scrub whole path  273.6 ns  ->  scrub extension  271.9 ns  same   /api/v1/hello.json
```

A path that does carry an extension pays what it always did, on a shorter string. End to end this sits at the edge of what an interleaved `Benchmark.ips` run resolves (+1.1% on a minimal versioned GET, median of 5), so the per-call figures are the honest measurement.

## Test plan
- [x] Full RSpec suite (2650 examples, 0 failures), `formatter_spec` included
- [x] RuboCop clean
- [x] Byte-identical to master across a 66-case request matrix, including invalid-UTF-8 paths and `.json` / `.xml` / `.txt` extensions
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)