### PR TITLE
Read the request method once in default_status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 * [#2890](https://github.com/ruby-grape/grape/pull/2890): Read the path version off the route the router already matched instead of re-deriving it from `PATH_INFO` in `Grape::Middleware::Versioner::Path` - [@ericproulx](https://github.com/ericproulx).
 * [#2892](https://github.com/ruby-grape/grape/pull/2892): Resolve the params builder when `params` are first read rather than in every `Grape::Request` - [@ericproulx](https://github.com/ericproulx).
 * [#2893](https://github.com/ruby-grape/grape/pull/2893): Scrub the format extension rather than the whole request path when negotiating a format - [@ericproulx](https://github.com/ericproulx).
+* [#2894](https://github.com/ruby-grape/grape/pull/2894): Read the request method once in `default_status` instead of asking through `post?` and `delete?` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -197,9 +197,13 @@ module Grape
       end
 
       # The default HTTP status when none has been set explicitly.
+      # Reads the request method once instead of asking through +post?+ and
+      # +delete?+, each of which reads it again. Every response that did not set
+      # a status of its own comes through here.
       def default_status
-        return 201 if request.post?
-        return 204 if request.delete? && @body.blank?
+        request_method = request.request_method
+        return 201 if request_method == Rack::POST
+        return 204 if request_method == Rack::DELETE && @body.blank?
 
         200
       end

--- a/spec/grape/dsl/inside_route_spec.rb
+++ b/spec/grape/dsl/inside_route_spec.rb
@@ -100,7 +100,7 @@ describe Grape::DSL::InsideRoute do
     %w[GET PUT OPTIONS].each do |method|
       it 'defaults to 200 on GET' do
         request = Grape::Request.new(Rack::MockRequest.env_for('/', method:))
-        expect(subject).to receive(:request).and_return(request).twice
+        expect(subject).to receive(:request).and_return(request)
         expect(subject.status).to eq 200
       end
     end
@@ -113,14 +113,14 @@ describe Grape::DSL::InsideRoute do
 
     it 'defaults to 204 on DELETE' do
       request = Grape::Request.new(Rack::MockRequest.env_for('/', method: Rack::DELETE))
-      expect(subject).to receive(:request).and_return(request).twice
+      expect(subject).to receive(:request).and_return(request)
       expect(subject.status).to eq 204
     end
 
     it 'defaults to 200 on DELETE with a body present' do
       request = Grape::Request.new(Rack::MockRequest.env_for('/', method: Rack::DELETE))
       subject.body 'content here'
-      expect(subject).to receive(:request).and_return(request).twice
+      expect(subject).to receive(:request).and_return(request)
       expect(subject.status).to eq 200
     end
 


### PR DESCRIPTION
`default_status` supplies the status for every response that did not set one, and asked the request twice for the same thing:

```ruby
return 201 if request.post?
return 204 if request.delete? && @body.blank?
```

`Rack::Request::Helpers#post?` and `#delete?` are each `request_method == ...`, so a GET — the common case, and the one that reaches the third line — walked `request`, `request_method` and the env twice over.

```
post? + delete?  158.4 ns  ->  request_method  90.7 ns   1.75x
```

End to end this is at the edge of what an interleaved `Benchmark.ips` run resolves (+1.4% on a minimal versioned GET, median of 5), so the per-call figure is the honest measurement.

## Spec change

Five examples in `inside_route_spec` asserted `receive(:request).twice`, pinning how many times `default_status` reads the request rather than what it answers. They keep the stub and drop the count.

## Test plan
- [x] Full RSpec suite (2650 examples, 0 failures)
- [x] RuboCop clean
- [x] Byte-identical to master across a 66-case request matrix, including POST/DELETE/HEAD/OPTIONS and DELETE with and without a body
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)