### PR TITLE
Improve branch test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 * [#2895](https://github.com/ruby-grape/grape/pull/2895): Cut per-request work out of the endpoint, validation and router paths: scan the router's compiled union by capture number rather than by name, skip the Array boxing in `AttributesIterator` for a flat scope, read a coerced attribute once instead of three times, and resolve the formatter's config and the coercers' type checks once at build time - [@ericproulx](https://github.com/ericproulx).
 * [#2900](https://github.com/ruby-grape/grape/pull/2900): Remove the deprecations announced in 3.2 and 3.3: `Grape::Router.normalize_path`, Hash access on middleware `Options` and their `DEFAULT_OPTIONS` constants, the positional options Hash for `auth`/`http_basic`/`desc`, a Hash returned from a `rescue_from` handler, and `@option` on validators (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2896](https://github.com/ruby-grape/grape/pull/2896): Bring test suite line coverage to 100% - [@dblock](https://github.com/dblock).
+* [#2897](https://github.com/ruby-grape/grape/pull/2897): Improve test suite branch coverage - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 * [#2894](https://github.com/ruby-grape/grape/pull/2894): Read the request method once in `default_status` instead of asking through `post?` and `delete?` - [@ericproulx](https://github.com/ericproulx).
 * [#2895](https://github.com/ruby-grape/grape/pull/2895): Cut per-request work out of the endpoint, validation and router paths: scan the router's compiled union by capture number rather than by name, skip the Array boxing in `AttributesIterator` for a flat scope, read a coerced attribute once instead of three times, and resolve the formatter's config and the coercers' type checks once at build time - [@ericproulx](https://github.com/ericproulx).
 * [#2900](https://github.com/ruby-grape/grape/pull/2900): Remove the deprecations announced in 3.2 and 3.3: `Grape::Router.normalize_path`, Hash access on middleware `Options` and their `DEFAULT_OPTIONS` constants, the positional options Hash for `auth`/`http_basic`/`desc`, a Hash returned from a `rescue_from` handler, and `@option` on validators (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
+* [#2896](https://github.com/ruby-grape/grape/pull/2896): Bring test suite line coverage to 100% - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 #### Fixes

--- a/spec/grape/api/instance_spec.rb
+++ b/spec/grape/api/instance_spec.rb
@@ -105,4 +105,16 @@ describe Grape::API::Instance do
       expect(last_response.body).to eq 'Not found! (2)'
     end
   end
+
+  describe '.cascade?' do
+    subject(:an_instance) do
+      Class.new(Grape::API::Instance) do
+        cascade true
+      end
+    end
+
+    it 'returns the configured cascade setting' do
+      expect(an_instance.compile!.cascade?).to be(true)
+    end
+  end
 end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -2090,6 +2090,17 @@ describe Grape::API do
       expect(last_response.body).to eql 'Hello, world.'
     end
 
+    it 'includes all known helpers in scope when called with no args and no block' do
+      subject.helpers do
+        def hello
+          'Hello, world.'
+        end
+      end
+
+      new_mod = subject.helpers
+      expect(new_mod.instance_methods).to include(:hello)
+    end
+
     it 'is scopable' do
       subject.helpers do
         def generic

--- a/spec/grape/dsl/request_response_spec.rb
+++ b/spec/grape/dsl/request_response_spec.rb
@@ -134,6 +134,12 @@ describe Grape::DSL::RequestResponse do
         expect(subject.inheritable_setting.all_rescue_handler).to eq(with_block)
       end
 
+      it 'converts a String :with option to a Symbol' do
+        subject.rescue_from :all, with: 'my_handler'
+        expect(subject.inheritable_setting.rescue_all?).to be(true)
+        expect(subject.inheritable_setting.all_rescue_handler).to eq(:my_handler)
+      end
+
       it 'abort if :with option value is not Symbol, String or Proc' do
         expect { subject.rescue_from :all, with: 1234 }.to raise_error(ArgumentError, "with: #{integer_class_name}, expected Symbol, String or Proc")
       end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -1042,6 +1042,9 @@ describe Grape::Endpoint do
       subject.before do
         # Placeholder
       end
+      subject.params do
+        optional :id, type: Integer
+      end
       subject.get do
         'hello'
       end
@@ -1064,7 +1067,10 @@ describe Grape::Endpoint do
         have_attributes(name: 'endpoint_run_filters.grape', payload: { endpoint: a_kind_of(described_class),
                                                                        filters: a_collection_containing_exactly(an_instance_of(Proc)),
                                                                        type: :before }),
-        have_attributes(name: 'endpoint_render.grape',      payload: { endpoint: a_kind_of(described_class) }),
+        have_attributes(name: 'endpoint_run_validators.grape', payload: { endpoint: a_kind_of(described_class),
+                                                                          validators: an_instance_of(Array),
+                                                                          request: a_kind_of(Grape::Request) }),
+        have_attributes(name: 'endpoint_render.grape', payload: { endpoint: a_kind_of(described_class) }),
         have_attributes(name: 'endpoint_run.grape', payload: { endpoint: a_kind_of(described_class),
                                                                env: an_instance_of(Hash) }),
         have_attributes(name: 'format_response.grape', payload: { env: an_instance_of(Hash),
@@ -1078,7 +1084,10 @@ describe Grape::Endpoint do
         have_attributes(name: 'endpoint_run_filters.grape', payload: { endpoint: a_kind_of(described_class),
                                                                        filters: a_collection_containing_exactly(an_instance_of(Proc)),
                                                                        type: :before }),
-        have_attributes(name: 'endpoint_render.grape',      payload: { endpoint: a_kind_of(described_class) }),
+        have_attributes(name: 'endpoint_run_validators.grape', payload: { endpoint: a_kind_of(described_class),
+                                                                          validators: an_instance_of(Array),
+                                                                          request: a_kind_of(Grape::Request) }),
+        have_attributes(name: 'endpoint_render.grape', payload: { endpoint: a_kind_of(described_class) }),
         have_attributes(name: 'format_response.grape', payload: { env: an_instance_of(Hash),
                                                                   formatter: a_kind_of(Module) })
       )
@@ -1125,6 +1134,21 @@ describe Grape::Endpoint do
 
     it 'does not raise an error' do
       expect { subject }.not_to raise_error
+    end
+
+    context 'when the endpoint has handled a request (env is set)' do
+      it 'includes the route origin in the inspect output' do
+        inspect_output = nil
+        api = Class.new(Grape::API) do
+          get('/hello') do
+            inspect_output = inspect
+            'world'
+          end
+        end
+        env = Rack::MockRequest.env_for('/hello')
+        api.call(env)
+        expect(inspect_output).to eq("#{described_class} in '/hello' endpoint")
+      end
     end
   end
 end

--- a/spec/grape/error_formatter/base_spec.rb
+++ b/spec/grape/error_formatter/base_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+describe Grape::ErrorFormatter::Base do
+  describe '.format_structured_message' do
+    it 'raises NotImplementedError' do
+      expect { described_class.format_structured_message({}) }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/grape/exceptions/base_spec.rb
+++ b/spec/grape/exceptions/base_spec.rb
@@ -136,4 +136,40 @@ describe Grape::Exceptions::Base do
       end
     end
   end
+
+  describe '#translate_message (private)' do
+    subject(:translate_message) { described_class.new.__send__(:translate_message, translation_key) }
+
+    context 'when given a Proc' do
+      let(:translation_key) { -> { 'from a proc' } }
+
+      it 'calls the Proc' do
+        expect(translate_message).to eq('from a proc')
+      end
+    end
+
+    context 'when given a Hash matching {key:, **opts}' do
+      let(:translation_key) { { key: :invalid_formatter, klass: String, to_format: 'xml' } }
+
+      it 'translates using the key and forwards the remaining pairs as opts' do
+        expect(translate_message).to eq('cannot convert String to xml')
+      end
+    end
+
+    context 'when given a Hash that does not have a :key entry' do
+      let(:translation_key) { { klass: String, to_format: 'xml' } }
+
+      it 'raises NoMatchingPatternKeyError' do
+        expect { translate_message }.to raise_error(NoMatchingPatternKeyError)
+      end
+    end
+
+    context 'when given anything else (e.g. a plain String)' do
+      let(:translation_key) { 'a literal message' }
+
+      it 'returns it unchanged' do
+        expect(translate_message).to eq('a literal message')
+      end
+    end
+  end
 end

--- a/spec/grape/exceptions/request_error_spec.rb
+++ b/spec/grape/exceptions/request_error_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+describe Grape::Exceptions::RequestError do
+  describe '#initialize' do
+    context 'when raised inside a rescue block' do
+      it 'captures the current exception message' do
+        error = begin
+          raise 'boom'
+        rescue RuntimeError
+          described_class.new
+        end
+        expect(error.message).to eq('boom')
+      end
+    end
+
+    context 'when there is no current exception' do
+      it 'has no message from a prior exception' do
+        # $ERROR_INFO ($!) is read-only and only set by an active rescue, so
+        # simulate "no exception" the same way: outside any rescue block.
+        # `StandardError#message` defaults to the class name when no message
+        # was given, so this pins the $ERROR_INFO&.message safe-nav's nil case.
+        expect(described_class.new.message).to eq(described_class.name)
+      end
+    end
+
+    it 'defaults status to 400' do
+      expect(described_class.new.status).to eq(400)
+    end
+
+    it 'accepts a custom status' do
+      expect(described_class.new(status: 422).status).to eq(422)
+    end
+  end
+end

--- a/spec/grape/exceptions/validation_errors_spec.rb
+++ b/spec/grape/exceptions/validation_errors_spec.rb
@@ -37,6 +37,13 @@ describe Grape::Exceptions::ValidationErrors do
     end
   end
 
+  describe '#to_json' do
+    it 'returns the JSON representation of #as_json' do
+      error = described_class.new(exceptions: [validation_error])
+      expect(error.to_json).to eq(error.as_json.to_json)
+    end
+  end
+
   describe '#full_messages' do
     context 'with errors' do
       subject { described_class.new(exceptions: [validation_error_1, validation_error_2]).full_messages }

--- a/spec/grape/exceptions/validation_spec.rb
+++ b/spec/grape/exceptions/validation_spec.rb
@@ -52,4 +52,11 @@ describe Grape::Exceptions::Validation do
       expect(error.message).to eq('raw message')
     end
   end
+
+  describe '#as_json' do
+    it 'returns the string representation of the error' do
+      error = described_class.new(params: ['id'], message: 'raw message')
+      expect(error.as_json).to eq(error.to_s)
+    end
+  end
 end

--- a/spec/grape/exceptions/validation_spec.rb
+++ b/spec/grape/exceptions/validation_spec.rb
@@ -5,6 +5,18 @@ describe Grape::Exceptions::Validation do
     expect { described_class.new(message: 'presence') }.to raise_error(ArgumentError, /missing keyword:.+?params/)
   end
 
+  context 'when message is omitted' do
+    subject(:error) { described_class.new(params: ['id']) }
+
+    it 'has a nil message_key' do
+      expect(error.message_key).to be_nil
+    end
+
+    it 'has no message from the given options' do
+      expect(error.message).to eq(described_class.name)
+    end
+  end
+
   context 'when message is a Symbol' do
     subject(:error) { described_class.new(params: ['id'], message: :presence) }
 

--- a/spec/grape/formatter/base_spec.rb
+++ b/spec/grape/formatter/base_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+describe Grape::Formatter::Base do
+  describe '.call' do
+    it 'raises NotImplementedError' do
+      expect { described_class.call({}, {}) }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/grape/formatter/json_spec.rb
+++ b/spec/grape/formatter/json_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe Grape::Formatter::Json do
+  describe '.call' do
+    it 'returns the string representation of a Grape::PrecompiledJson object' do
+      precompiled = Grape::PrecompiledJson.new('{"a":1}')
+      expect(described_class.call(precompiled, {})).to eq('{"a":1}')
+    end
+
+    it 'calls #to_json when the object responds to it' do
+      object = { a: 1 }
+      expect(described_class.call(object, {})).to eq(object.to_json)
+    end
+
+    it 'falls back to Grape::Json.dump when the object does not respond to #to_json' do
+      object = Object.new
+      allow(object).to receive(:respond_to?).with(:to_json).and_return(false)
+      expect(described_class.call(object, {})).to eq(Grape::Json.dump(object))
+    end
+  end
+end

--- a/spec/grape/formatter/serializable_hash_spec.rb
+++ b/spec/grape/formatter/serializable_hash_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+describe Grape::Formatter::SerializableHash do
+  describe '.call' do
+    it 'returns the string representation of a Grape::PrecompiledJson object' do
+      precompiled = Grape::PrecompiledJson.new('{"a":1}')
+      expect(described_class.call(precompiled, {})).to eq('{"a":1}')
+    end
+
+    it 'returns a String object unchanged' do
+      expect(described_class.call('already a string', {})).to eq('already a string')
+    end
+
+    it 'serializes an object responding to #serializable_hash' do
+      object = Class.new do
+        def serializable_hash
+          { a: 1 }
+        end
+      end.new
+      expect(described_class.call(object, {})).to eq(Grape::Json.dump(a: 1))
+    end
+
+    it 'serializes an Array of objects responding to #serializable_hash' do
+      klass = Class.new do
+        def initialize(value)
+          @value = value
+        end
+
+        def serializable_hash
+          { value: @value }
+        end
+      end
+      objects = [klass.new(1), klass.new(2)]
+      expect(described_class.call(objects, {})).to eq(Grape::Json.dump([{ value: 1 }, { value: 2 }]))
+    end
+
+    it 'serializes a Hash, recursively serializing its values' do
+      object = Class.new do
+        def serializable_hash
+          { a: 1 }
+        end
+      end.new
+      expect(described_class.call({ nested: object }, {})).to eq(Grape::Json.dump(nested: { a: 1 }))
+    end
+
+    it 'serializes a Hash, leaving non-serializable leaf values untouched' do
+      expect(described_class.call({ plain: 'value' }, {})).to eq(Grape::Json.dump(plain: 'value'))
+    end
+
+    it 'calls #to_json when the object responds to it and is not otherwise serializable' do
+      object = 1234
+      expect(described_class.call(object, {})).to eq(object.to_json)
+    end
+
+    it 'falls back to Grape::Json.dump when the object is not serializable and does not respond to #to_json' do
+      object = Object.new
+      allow(object).to receive(:respond_to?).and_call_original
+      allow(object).to receive(:respond_to?).with(:to_json).and_return(false)
+      expect(described_class.call(object, {})).to eq(Grape::Json.dump(object))
+    end
+  end
+end

--- a/spec/grape/middleware/base_spec.rb
+++ b/spec/grape/middleware/base_spec.rb
@@ -189,6 +189,24 @@ describe Grape::Middleware::Base do
       end
     end
 
+    context 'when a middleware defines an instance-level #default_options' do
+      let(:example_ware) do
+        Class.new(Grape::Middleware::Base) do
+          def default_options
+            { monkey: true }
+          end
+        end
+      end
+
+      it 'merges options through the instance method instead of a constant' do
+        expect(example_ware.new(blank_app).options[:monkey]).to be true
+      end
+
+      it 'overrides default options when provided' do
+        expect(example_ware.new(blank_app, monkey: false).options[:monkey]).to be false
+      end
+    end
+
     context 'when a middleware declares its own Options Data class' do
       let(:example_ware) do
         Class.new(Grape::Middleware::Base) do

--- a/spec/grape/middleware/base_spec.rb
+++ b/spec/grape/middleware/base_spec.rb
@@ -251,6 +251,23 @@ describe Grape::Middleware::Base do
       expect(last_response.headers['X-Test-Before']).to eq('Hi')
       expect(last_response.headers['X-Test-After']).to eq('Bye')
     end
+
+    context 'when the downstream app returns a Rack::Response' do
+      let(:app) do
+        context = self
+
+        Rack::Builder.app do
+          use context.example_ware
+          run ->(_) { Rack::Response.new('Yeah', 200, {}) }
+        end
+      end
+
+      it 'merges the header onto the Rack::Response' do
+        get '/'
+        expect(last_response.headers['X-Test-Before']).to eq('Hi')
+        expect(last_response.headers['X-Test-After']).to eq('Bye')
+      end
+    end
   end
 
   context 'header overwrite' do

--- a/spec/grape/middleware/error_spec.rb
+++ b/spec/grape/middleware/error_spec.rb
@@ -488,4 +488,34 @@ describe Grape::Middleware::Error do
       expect(middleware.__send__(:error?, 'not an error')).to be false
     end
   end
+
+  describe '#resolved_backtrace' do
+    subject(:middleware) { described_class.new(->(_env) {}, rescue_options: Grape::DSL::RescueOptions.new(backtrace: true)) }
+
+    context 'when the raw response has no backtrace of its own' do
+      it 'falls back to the original exception backtrace' do
+        original_exception = RuntimeError.new('boom')
+        original_exception.set_backtrace(['original.rb:1'])
+        raw = Grape::Exceptions::ErrorResponse.new(original_exception:)
+
+        expect(middleware.__send__(:resolved_backtrace, raw)).to eq(['original.rb:1'])
+      end
+    end
+
+    context 'when neither the raw response nor the original exception have a backtrace' do
+      it 'returns an empty array' do
+        raw = Grape::Exceptions::ErrorResponse.new
+        expect(middleware.__send__(:resolved_backtrace, raw)).to eq([])
+      end
+    end
+  end
+
+  describe '#grape_exceptions_precedence_handler' do
+    subject(:middleware) { described_class.new(->(_env) {}, rescue_grape_exceptions: true) }
+
+    it 'leaves InvalidVersionHeader alone so it keeps reaching Rack' do
+      handler = middleware.__send__(:grape_exceptions_precedence_handler, Grape::Exceptions::InvalidVersionHeader, nil)
+      expect(handler).to be_nil
+    end
+  end
 end

--- a/spec/grape/middleware/error_spec.rb
+++ b/spec/grape/middleware/error_spec.rb
@@ -460,4 +460,32 @@ describe Grape::Middleware::Error do
       end
     end
   end
+
+  describe '#error!' do
+    it 'sets the status and renders a formatted error response' do
+      env = Rack::MockRequest.env_for('/')
+      endpoint = Spec::Support::EndpointFaker::FakerAPI.endpoints.first
+      env[Grape::Env::API_ENDPOINT] = endpoint
+      middleware = described_class.new(->(_env) {})
+      middleware.instance_variable_set(:@env, env)
+
+      expect(endpoint).to receive(:status).with(422)
+      response = middleware.__send__(:error!, 'failure', 422)
+      expect(response.status).to eq(422)
+      expect(response.body).to eq(['failure'])
+    end
+  end
+
+  describe '#error?' do
+    subject(:middleware) { described_class.new(->(_env) {}) }
+
+    it 'returns true for a Grape::Exceptions::ErrorResponse' do
+      response = Grape::Exceptions::ErrorResponse.new(message: 'oops', status: 500, headers: {})
+      expect(middleware.__send__(:error?, response)).to be true
+    end
+
+    it 'returns false for any other object' do
+      expect(middleware.__send__(:error?, 'not an error')).to be false
+    end
+  end
 end

--- a/spec/grape/middleware/filter_spec.rb
+++ b/spec/grape/middleware/filter_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+describe Grape::Middleware::Filter do
+  let(:before_proc) { -> {} }
+  let(:after_proc) { -> {} }
+  let(:app) { ->(_env) { [200, {}, ['Hi there.']] } }
+  let(:middleware) { described_class.new(app, before: before_proc, after: after_proc) }
+
+  describe '#before' do
+    it 'instance_evals the :before option against the app' do
+      expect(app).to receive(:instance_eval) do |&block|
+        expect(block).to eq(before_proc)
+      end
+      middleware.before
+    end
+
+    context 'when no :before option is given' do
+      let(:middleware) { described_class.new(app) }
+
+      it 'does nothing' do
+        expect(app).not_to receive(:instance_eval)
+        middleware.before
+      end
+    end
+  end
+
+  describe '#after' do
+    it 'instance_evals the :after option against the app' do
+      expect(app).to receive(:instance_eval) do |&block|
+        expect(block).to eq(after_proc)
+      end
+      middleware.after
+    end
+
+    context 'when no :after option is given' do
+      let(:middleware) { described_class.new(app) }
+
+      it 'does nothing' do
+        expect(app).not_to receive(:instance_eval)
+        middleware.after
+      end
+    end
+  end
+end

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -281,6 +281,20 @@ describe Grape::Middleware::Formatter do
             expect(subject.env[Rack::RACK_REQUEST_FORM_HASH]['is_boolean']).to be true
             expect(subject.env[Rack::RACK_REQUEST_FORM_HASH]['string']).to eq('thing')
           end
+
+          it "merges into a pre-existing rack.request.form_hash when parsing the body from #{method}" do
+            subject.call(
+              Rack::PATH_INFO => '/info',
+              Rack::REQUEST_METHOD => method,
+              'CONTENT_TYPE' => content_type,
+              Rack::RACK_INPUT => io,
+              'CONTENT_LENGTH' => io.length.to_s,
+              Rack::RACK_REQUEST_FORM_HASH => { 'existing' => 'value' }
+            )
+            expect(subject.env[Rack::RACK_REQUEST_FORM_HASH]['existing']).to eq('value')
+            expect(subject.env[Rack::RACK_REQUEST_FORM_HASH]['is_boolean']).to be true
+            expect(subject.env[Rack::RACK_REQUEST_FORM_HASH]['string']).to eq('thing')
+          end
         end
 
         context 'when Content-Type is not supported' do

--- a/spec/grape/middleware/stack/middleware_spec.rb
+++ b/spec/grape/middleware/stack/middleware_spec.rb
@@ -2,6 +2,28 @@
 
 describe Grape::Middleware::Stack::Middleware do
   let(:middleware_class) { Class.new }
+  let(:foo_middleware) { Class.new }
+  let(:bar_middleware) { Class.new }
+
+  describe '#==' do
+    it 'compares equal to another Middleware wrapping the same class' do
+      first = described_class.new(foo_middleware, [], nil)
+      second = described_class.new(foo_middleware, [42], proc {})
+      expect(first).to eq(second)
+    end
+
+    it 'compares unequal to another Middleware wrapping a different class' do
+      first = described_class.new(foo_middleware, [], nil)
+      second = described_class.new(bar_middleware, [], nil)
+      expect(first).not_to eq(second)
+    end
+  end
+
+  describe '#inspect' do
+    it "returns the wrapped class's #to_s" do
+      expect(described_class.new(foo_middleware, [], nil).inspect).to eq(foo_middleware.to_s)
+    end
+  end
 
   describe '#hash' do
     it 'matches for two entries wrapping the same class' do

--- a/spec/grape/middleware/stack_spec.rb
+++ b/spec/grape/middleware/stack_spec.rb
@@ -18,7 +18,7 @@ describe Grape::Middleware::Stack do
   let(:others) { [[:use, bar_middleware], [:insert_before, bar_middleware, block_middleware, proc]] }
 
   before do
-    subject.use foo_middleware
+    subject.use foo_middleware if subject.respond_to?(:use)
   end
 
   describe '#use' do
@@ -149,6 +149,16 @@ describe Grape::Middleware::Stack do
     it 'calls +merge_with+ with the :use specs' do
       expect(subject).to receive(:merge_with).with [[:use, bar_middleware]]
       subject.concat others
+    end
+  end
+
+  describe Grape::Middleware::Stack::Middleware do
+    subject { described_class.new(foo_middleware, [], nil) }
+
+    describe '#==' do
+      it 'returns falsy for an object that is neither a Middleware nor a Class' do
+        expect(subject == 'not a middleware').to be_falsy
+      end
     end
   end
 end

--- a/spec/grape/middleware/versioner/header_spec.rb
+++ b/spec/grape/middleware/versioner/header_spec.rb
@@ -338,4 +338,13 @@ describe Grape::Middleware::Versioner::Header do
       expect { versioned_get '/', 'v1', using: :header }.to raise_error Grape::Exceptions::MissingVendorOption
     end
   end
+
+  context 'when the vendor option is not set on the middleware directly' do
+    subject { described_class.new(app, version_options: Grape::DSL::VersionOptions.new(using: :header, vendor: nil)) }
+
+    it 'skips the best-quality-media-type match entirely' do
+      status, = subject.call('HTTP_ACCEPT' => 'application/vnd.vendor+json')
+      expect(status).to eq(200)
+    end
+  end
 end

--- a/spec/grape/namespace_spec.rb
+++ b/spec/grape/namespace_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe Grape::Namespace do
+  subject(:namespace) { described_class.new('foo', requirements: { id: /\d+/ }, desc: 'bar') }
+
+  describe '#==' do
+    it 'is equal to another Namespace with the same space, requirements, and options' do
+      other = described_class.new('foo', requirements: { id: /\d+/ }, desc: 'bar')
+      expect(namespace).to eq(other)
+    end
+
+    it 'is not equal to another Namespace with a different space' do
+      other = described_class.new('bar', requirements: { id: /\d+/ }, desc: 'bar')
+      expect(namespace).not_to eq(other)
+    end
+
+    it 'is not equal to a non-Namespace object' do
+      expect(namespace).not_to eq('foo')
+    end
+  end
+
+  describe '#hash' do
+    it 'is the same for two Namespaces with the same space, requirements, and options' do
+      other = described_class.new('foo', requirements: { id: /\d+/ }, desc: 'bar')
+      expect(namespace.hash).to eq(other.hash)
+    end
+
+    it 'differs for Namespaces with different spaces' do
+      other = described_class.new('bar', requirements: { id: /\d+/ }, desc: 'bar')
+      expect(namespace.hash).not_to eq(other.hash)
+    end
+  end
+end

--- a/spec/grape/namespace_spec.rb
+++ b/spec/grape/namespace_spec.rb
@@ -30,4 +30,15 @@ describe Grape::Namespace do
       expect(namespace.hash).not_to eq(other.hash)
     end
   end
+
+  describe '.joined_space' do
+    it 'maps a list of Namespace objects to their #space' do
+      other = described_class.new('bar')
+      expect(described_class.joined_space([namespace, other])).to eq(%w[foo bar])
+    end
+
+    it 'returns nil for a nil settings list' do
+      expect(described_class.joined_space(nil)).to be_nil
+    end
+  end
 end

--- a/spec/grape/params_builder/base_spec.rb
+++ b/spec/grape/params_builder/base_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+describe Grape::ParamsBuilder::Base do
+  describe '.call' do
+    it 'raises NotImplementedError' do
+      expect { described_class.call({}) }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/grape/parser/base_spec.rb
+++ b/spec/grape/parser/base_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+describe Grape::Parser::Base do
+  describe '.call' do
+    it 'raises NotImplementedError' do
+      expect { described_class.call({}, {}) }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/grape/router/base_route_spec.rb
+++ b/spec/grape/router/base_route_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+describe Grape::Router::BaseRoute do
+  let(:pattern) { instance_double(Grape::Router::Pattern) }
+
+  describe '#initialize' do
+    context 'when options is a plain Hash' do
+      subject(:route) { described_class.new(pattern, { foo: 'bar' }) }
+
+      it 'wraps it in an ActiveSupport::OrderedOptions' do
+        expect(route.options).to be_a(ActiveSupport::OrderedOptions)
+      end
+
+      it 'reads back the given options' do
+        expect(route.options[:foo]).to eq('bar')
+      end
+    end
+
+    context 'when options is already an ActiveSupport::OrderedOptions' do
+      subject(:route) { described_class.new(pattern, options) }
+
+      let(:options) { ActiveSupport::OrderedOptions.new.update(foo: 'bar') }
+
+      it 'uses it as-is, without wrapping it again' do
+        expect(route.options).to equal(options)
+      end
+    end
+  end
+end

--- a/spec/grape/router/mustermann_pattern_spec.rb
+++ b/spec/grape/router/mustermann_pattern_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe Grape::Router::MustermannPattern do
+  describe '{name} capture syntax' do
+    it 'captures a single path segment' do
+      pattern = described_class.new('/foo/{bar}')
+      expect(pattern.params('/foo/baz')).to eq('bar' => 'baz')
+    end
+  end
+
+  describe '{+name} named splat syntax' do
+    it 'captures the remainder of the path as a single named value' do
+      pattern = described_class.new('/foo/{+bar}')
+      expect(pattern.params('/foo/a/b')).to eq('bar' => 'a/b')
+    end
+
+    context 'when the named splat is literally called "splat"' do
+      it 'captures the remainder of the path as an Array, like the plain splat node' do
+        pattern = described_class.new('/foo/{+splat}')
+        expect(pattern.params('/foo/a/b')).to eq('splat' => ['a/b'])
+      end
+    end
+  end
+end

--- a/spec/grape/router/mustermann_pattern_spec.rb
+++ b/spec/grape/router/mustermann_pattern_spec.rb
@@ -21,4 +21,21 @@ describe Grape::Router::MustermannPattern do
       end
     end
   end
+
+  describe ':name capture syntax' do
+    context 'when the param is declared as an Integer' do
+      it 'only matches digits' do
+        pattern = described_class.new('/foo/:bar', params: { 'bar' => { type: 'Integer' } })
+        expect(pattern.params('/foo/123')).to eq('bar' => '123')
+        expect(pattern).not_to match('/foo/abc')
+      end
+    end
+
+    context 'when the param is not declared as an Integer' do
+      it 'matches any single path segment' do
+        pattern = described_class.new('/foo/:bar')
+        expect(pattern.params('/foo/abc')).to eq('bar' => 'abc')
+      end
+    end
+  end
 end

--- a/spec/grape/router/pattern/path_spec.rb
+++ b/spec/grape/router/pattern/path_spec.rb
@@ -73,6 +73,15 @@ RSpec.describe Grape::Router::Pattern::Path do
       end
     end
 
+    context 'when versioning is used but not via path (e.g. header)' do
+      it "does not include a '/'" do
+        path = described_class.new(
+          nil, nil, path_settings(version: :v1, version_options: Grape::DSL::VersionOptions.new(using: :header))
+        )
+        expect(path.suffix).to eql('(.:format)')
+      end
+    end
+
     context 'when path versioning is not used' do
       it "does not include a '/' when the path has a namespace" do
         path = described_class.new(nil, 'namespace', path_settings)

--- a/spec/grape/router/pattern/path_spec.rb
+++ b/spec/grape/router/pattern/path_spec.rb
@@ -95,4 +95,11 @@ RSpec.describe Grape::Router::Pattern::Path do
       end
     end
   end
+
+  describe '#to_s' do
+    it 'concatenates the origin and the suffix' do
+      path = described_class.new('/foo', nil, path_settings)
+      expect(path.to_s).to eq("#{path.origin}#{path.suffix}")
+    end
+  end
 end

--- a/spec/grape/router_spec.rb
+++ b/spec/grape/router_spec.rb
@@ -134,6 +134,15 @@ describe Grape::Router do
       expect(status).to eq(404)
       expect(headers['X-Cascade']).to eq('pass')
     end
+
+    it 'marks the request as cascaded when only an ANY route responds' do
+      append_route(cascading, '*')
+      router.compile!
+
+      status, headers, = router.call(Rack::MockRequest.env_for('/hello'))
+      expect(status).to eq(404)
+      expect(headers['X-Cascade']).to eq('pass')
+    end
   end
 
   # Regression: routing args were seeded once (`||=`) and merged in place, so

--- a/spec/grape/serve_stream/file_body_spec.rb
+++ b/spec/grape/serve_stream/file_body_spec.rb
@@ -1,6 +1,37 @@
 # frozen_string_literal: true
 
 describe Grape::ServeStream::FileBody do
+  describe '#to_path' do
+    it 'returns the path' do
+      expect(described_class.new('/tmp/a').to_path).to eq('/tmp/a')
+    end
+  end
+
+  describe '#each' do
+    it 'yields the file contents in chunks' do
+      Tempfile.create('grape-file-body-spec') do |file|
+        file.write('hello world')
+        file.flush
+
+        chunks = []
+        # rubocop:disable Style/MapIntoArray -- FileBody#each is not Enumerable, so #map is unavailable here.
+        described_class.new(file.path).each { |chunk| chunks << chunk }
+        # rubocop:enable Style/MapIntoArray
+        expect(chunks.join).to eq('hello world')
+      end
+    end
+  end
+
+  describe '#==' do
+    it 'is true for two bodies with an equal path' do
+      expect(described_class.new('/tmp/a')).to eq(described_class.new(+'/tmp/a'))
+    end
+
+    it 'is false for two bodies with a different path' do
+      expect(described_class.new('/tmp/a')).not_to eq(described_class.new('/tmp/b'))
+    end
+  end
+
   describe '#hash' do
     it 'matches for two bodies with an equal path' do
       expect(described_class.new('/tmp/a').hash).to eq described_class.new(+'/tmp/a').hash

--- a/spec/grape/serve_stream/sendfile_response_spec.rb
+++ b/spec/grape/serve_stream/sendfile_response_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+describe Grape::ServeStream::SendfileResponse do
+  subject(:response) { described_class.new(body) }
+
+  context 'when the body responds to #to_path' do
+    let(:body) { Grape::ServeStream::FileBody.new('/tmp/a') }
+
+    describe '#respond_to?' do
+      it 'is true for :to_path' do
+        expect(response.respond_to?(:to_path)).to be true
+      end
+    end
+
+    describe '#to_path' do
+      it "delegates to the body's #to_path" do
+        expect(response.to_path).to eq('/tmp/a')
+      end
+    end
+  end
+
+  context 'when the body does not respond to #to_path' do
+    let(:body) { 'plain string body' }
+
+    describe '#respond_to?' do
+      it 'is false for :to_path' do
+        expect(response.respond_to?(:to_path)).to be false
+      end
+
+      it 'falls back to the default behavior for other methods' do
+        expect(response.respond_to?(:to_s)).to be true
+      end
+    end
+  end
+end

--- a/spec/grape/testing_spec.rb
+++ b/spec/grape/testing_spec.rb
@@ -42,5 +42,15 @@ describe Grape::Testing do
       Grape::Endpoint.reset_before_each
       expect { get '/' }.to raise_error(NoMethodError, /undefined method [`']authenticate_user!' for/)
     end
+
+    it 'raises an ArgumentError when no block is given' do
+      expect { Grape::Endpoint.before_each }.to raise_error(ArgumentError, 'a block is required')
+    end
+
+    it 'does nothing when no before_each hooks were registered' do
+      subject.get('/') { 'hello' }
+      expect { get '/' }.not_to raise_error
+      expect(last_response.body).to eq('hello')
+    end
   end
 end

--- a/spec/grape/util/lazy/value_array_spec.rb
+++ b/spec/grape/util/lazy/value_array_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+describe Grape::Util::Lazy::ValueArray do
+  describe '#evaluate' do
+    it 'evaluates every element of the array' do
+      value_array = described_class.new([1, 2, { a: 1 }])
+      expect(value_array.evaluate).to eq([1, 2, { 'a' => 1 }])
+    end
+  end
+
+  describe '#[]' do
+    it 'returns the Lazy::Value at the given index' do
+      value_array = described_class.new([1, 2])
+      expect(value_array[0].evaluate).to eq(1)
+    end
+
+    it 'returns a nil Lazy::Value for an out-of-bounds index' do
+      value_array = described_class.new([1, 2])
+      expect(value_array[10].evaluate).to be_nil
+    end
+  end
+end

--- a/spec/grape/util/lazy/value_enumerable_spec.rb
+++ b/spec/grape/util/lazy/value_enumerable_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+describe Grape::Util::Lazy::ValueEnumerable do
+  describe '#[]=' do
+    it 'wraps a Hash value in a ValueHash' do
+      value_array = Grape::Util::Lazy::ValueArray.new([{ a: 1 }])
+      expect(value_array[0]).to be_a(Grape::Util::Lazy::ValueHash)
+    end
+
+    it 'wraps an Array value in a ValueArray' do
+      value_array = Grape::Util::Lazy::ValueArray.new([[1, 2]])
+      expect(value_array[0]).to be_a(described_class)
+    end
+
+    it 'wraps any other value in a plain Value' do
+      value_array = Grape::Util::Lazy::ValueArray.new([1])
+      expect(value_array[0]).to be_a(Grape::Util::Lazy::Value)
+    end
+  end
+
+  describe '#fetch' do
+    it 'reduces a list of access keys down to the reached node' do
+      value_hash = Grape::Util::Lazy::ValueHash.new(a: { b: 1 })
+      expect(value_hash.fetch(%i[a b]).evaluate).to eq(1)
+    end
+  end
+end

--- a/spec/grape/util/translation_spec.rb
+++ b/spec/grape/util/translation_spec.rb
@@ -24,5 +24,43 @@ describe Grape::Util::Translation do
         expect { translator.translate_message(:reserved_key_test) }.to raise_error(I18n::ReservedInterpolationKey)
       end
     end
+
+    context 'when an explicit locale is given' do
+      it 'passes the locale through to I18n.translate' do
+        expect(I18n).to receive(:translate).with(:missing_key, hash_including(locale: :en)).and_call_original
+        translator.translate_message(:missing_key, locale: :en)
+      end
+    end
+
+    context 'when an explicit default is given and the key is missing' do
+      it 'returns the given default instead of the dotted key path' do
+        expect(translator.translate_message(:missing_key, default: 'fallback')).to eq('fallback')
+      end
+    end
+
+    context 'when no default is given and the key is missing' do
+      it 'returns the dotted scope+key path as the default' do
+        expect(translator.translate_message(:missing_key)).to eq('grape.errors.messages.missing_key')
+      end
+    end
+
+    context 'when a non-fallback locale is given, is available, and the key is missing there too' do
+      around do |example|
+        I18n.available_locales = %i[en fr]
+        example.run
+      ensure
+        I18n.available_locales = %i[en]
+      end
+
+      it 're-attempts translation against the fallback locale' do
+        expect(I18n).to receive(:translate).with(:missing_key, hash_including(locale: :fr)).and_call_original
+        expect(I18n).to receive(:translate).with(:missing_key, hash_including(locale: :en)).and_call_original
+        translator.translate_message(:missing_key, locale: :fr)
+      end
+
+      it 'forwards an explicit default to the fallback-locale retry' do
+        expect(translator.translate_message(:missing_key, locale: :fr, default: 'fallback')).to eq('fallback')
+      end
+    end
   end
 end

--- a/spec/grape/validations/attributes_iterator_spec.rb
+++ b/spec/grape/validations/attributes_iterator_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+describe Grape::Validations::AttributesIterator do
+  describe '#yield_attributes' do
+    it 'raises NotImplementedError' do
+      scope = instance_double(Grape::Validations::ParamsScope, array_depth: 0)
+      iterator = described_class.new([], scope)
+      expect { iterator.__send__(:yield_attributes, {}) }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -1966,4 +1966,33 @@ describe Grape::Validations::ParamsScope do
       end
     end
   end
+
+  describe Grape::Validations::ParamsScope::Attr do
+    let(:scope) { instance_double(Grape::Validations::ParamsScope) }
+
+    describe '.attr_key' do
+      it 'returns a plain value unchanged' do
+        expect(described_class.attr_key(:id)).to eq(:id)
+      end
+
+      it 'recurses into the #key of a nested Attr' do
+        inner = described_class.new(:id, scope)
+        outer = described_class.new(inner, scope)
+        expect(described_class.attr_key(outer)).to eq(:id)
+      end
+
+      it 'transforms the values of a Hash of nested declared params' do
+        inner = described_class.new(:id, scope)
+        result = described_class.attr_key(nested: [inner])
+        expect(result).to eq(nested: [:id])
+      end
+    end
+
+    describe '.attrs_keys' do
+      it 'maps declared params to their keys' do
+        declared_params = [described_class.new(:id, scope), described_class.new(:name, scope)]
+        expect(described_class.attrs_keys(declared_params)).to eq(%i[id name])
+      end
+    end
+  end
 end

--- a/spec/grape/validations/types/dry_type_coercer_spec.rb
+++ b/spec/grape/validations/types/dry_type_coercer_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+describe Grape::Validations::Types::DryTypeCoercer do
+  describe '.collection_coercer_for' do
+    it 'returns ArrayCoercer for an Array instance' do
+      expect(described_class.collection_coercer_for([])).to eq(Grape::Validations::Types::ArrayCoercer)
+    end
+
+    it 'returns SetCoercer for a Set instance' do
+      expect(described_class.collection_coercer_for(Set.new)).to eq(Grape::Validations::Types::SetCoercer)
+    end
+
+    it 'raises an ArgumentError for any other type' do
+      expect { described_class.collection_coercer_for({}) }.to raise_error(ArgumentError, /Unknown type/)
+    end
+  end
+end

--- a/spec/grape/validations/types/variant_collection_coercer_spec.rb
+++ b/spec/grape/validations/types/variant_collection_coercer_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+describe Grape::Validations::Types::VariantCollectionCoercer do
+  describe '#to_s' do
+    it 'renders an Array type as Array[...]' do
+      coercer = described_class.new([Integer, String])
+      expect(coercer.to_s).to eq('Array[Integer, String]')
+    end
+
+    it 'renders a Set type as Set[...]' do
+      coercer = described_class.new(Set[Integer, String])
+      expect(coercer.to_s).to eq('Set[Integer, String]')
+    end
+  end
+
+  describe '#call' do
+    it 'returns nil for a non-Array value' do
+      coercer = described_class.new([Integer, String])
+      expect(coercer.call('not an array')).to be_nil
+    end
+
+    it 'coerces each member via the member coercer when no method is given' do
+      coercer = described_class.new([Integer, String])
+      expect(coercer.call(%w[1 abc])).to eq([1, 'abc'])
+    end
+
+    it 'coerces the whole collection via the given method' do
+      method = ->(value) { value.map(&:upcase) }
+      coercer = described_class.new([String], method)
+      expect(coercer.call(%w[a b])).to eq(%w[A B])
+    end
+
+    it 'returns a Set when the declared types are a Set' do
+      coercer = described_class.new(Set[Integer, String])
+      expect(coercer.call(%w[1 abc])).to eq(Set[1, 'abc'])
+    end
+  end
+end

--- a/spec/grape/validations/validators/base_spec.rb
+++ b/spec/grape/validations/validators/base_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+describe Grape::Validations::Validators::Base do
+  describe '#validate_param!' do
+    it 'raises NotImplementedError' do
+      scope = Grape::Validations::ParamsScope.new(api: Class.new(Grape::API))
+      validator = described_class.new(:id, {}, false, scope, {})
+      expect { validator.__send__(:validate_param!, :id, { id: 'value' }) }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/grape/validations/validators/default_validator_spec.rb
+++ b/spec/grape/validations/validators/default_validator_spec.rb
@@ -552,4 +552,27 @@ describe Grape::Validations::Validators::DefaultValidator do
       expect(JSON.parse(last_response.body)).to eq(expected)
     end
   end
+
+  describe 'default value that is not duplicable' do
+    let(:app) do
+      Class.new(Grape::API) do
+        require 'singleton'
+        singleton_class = Class.new { include Singleton }
+
+        default_format :json
+
+        params do
+          optional :callback, default: singleton_class.instance
+        end
+        get '/non_duplicable_default' do
+          { callback: params[:callback].class.name }
+        end
+      end
+    end
+
+    it 'uses the singleton object directly, without attempting to #dup it' do
+      get '/non_duplicable_default'
+      expect(last_response.status).to eq(200)
+    end
+  end
 end

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -104,6 +104,21 @@ describe Grape::Validations do
       end
     end
 
+    context 'optional :none, except: using Grape::Entity documentation' do
+      before do
+        documentation = { field_a: { type: String }, field_b: { type: String } }
+        subject.params do
+          optional :none, except: :field_a, using: documentation
+        end
+        subject.get('/optional_none') { 'optional none works' }
+      end
+
+      it 'still requires the excepted field to be optional (unaffected by the :none context)' do
+        get '/optional_none', field_a: 'woof'
+        expect(last_response.status).to eq(200)
+      end
+    end
+
     context 'required' do
       before do
         subject.params do

--- a/spec/integration/multi_json/json_spec.rb
+++ b/spec/integration/multi_json/json_spec.rb
@@ -27,4 +27,16 @@ describe Grape::Json, if: (defined?(MultiJSON) || defined?(MultiJson)) && !defin
       expect(JSON.parse(response.body)).to eq('received' => 'hi')
     end
   end
+
+  describe '.dump' do
+    it 'serializes an object to a JSON string via the active multi_json backend' do
+      expect(JSON.parse(subject.dump(a: 1))).to eq('a' => 1)
+    end
+  end
+
+  describe '.parse' do
+    it 'deserializes a JSON string via the active multi_json backend' do
+      expect(subject.parse('{"a":1}')).to eq('a' => 1)
+    end
+  end
 end


### PR DESCRIPTION
## What

Stacked on top of #2896 (which brings line coverage to 100%). This PR
improves *branch* coverage where it was easy to do, without chasing
100%.

Method: ran the full CI-equivalent test matrix (main suite + all
integration/rack/rails Gemfile variants) and used `SimpleCov.collate`
to get the true combined coverage, then added direct unit tests for
previously-uncovered branches that were easy/cheap to reach:

- `Grape::Exceptions::Base#translate_message` — the Proc, Hash-pattern-match, plain-value, and Hash-without-`:key` branches.
- `Grape::Exceptions::RequestError` — no spec file existed; added one.
- `Grape::Exceptions::Validation` — the "message omitted" default branch.
- `Grape::Middleware::Base` — the instance-level `#default_options` fallback (for middleware subclasses outside this repo, e.g. 3rd-party gems).
- `Grape::Middleware::Error` — `#resolved_backtrace`'s fallback chain, and the `InvalidVersionHeader` precedence-handler branch.
- `Grape::Middleware::Stack::Middleware#==` — comparison against something that's neither a `Middleware` nor a `Class`.
- `Grape::Middleware::Versioner::Header` — skips the best-quality media-type match entirely when no vendor is configured.
- `Grape::Namespace.joined_space`.
- `Grape::Router::BaseRoute#initialize` — the `ActiveSupport::OrderedOptions` wrapping branch.
- `Grape::Router::MustermannPattern` — the `:name` capture syntax (no spec previously exercised it at all), both the `Integer`-constrained and default-constraint cases.
- `Grape::Router::Pattern::Path#suffix` — the non-path (e.g. header) versioning branch.
- `Grape::Testing` — missing-block and no-registered-hooks branches.
- `Grape::Util::Translation#translate` — explicit `locale:`, explicit `default:`, the no-default-given case, and the fallback-locale retry path.

Two branches (`Grape::DSL::Routing#version`'s trailing `@versions&.last`,
and `Grape::Util::Translation#translate`'s `effective_default` computation
when the caller's `default:` isn't `MISSING`) looked unreachable, but per
#2904's finding that a similarly-reasoned "unreachable" branch in
`Route#tag_utf8!` turned out to be reachable after all, no `simplecov:disable`
markers were added for them here — they're left as genuinely uncovered
rather than asserted dead, so a future contributor (or SimpleCov's report)
can still flag them if that reasoning turns out to be wrong too.

## Result

Full-matrix branch coverage: 95.58% (1278/1337) → ~96.8% (up from the
session-start baseline; exact combined number depends on which
integration/rack/rails Gemfile variants are included in the collate run).
Line coverage stays at 100%. Remaining uncovered branches are mostly
in validators/type coercion code that would need much more elaborate
setup to exercise, so they were left alone per "don't aim for 100%".

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
