### PR TITLE
Stop eager loading grape/testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 
 #### Fixes
 
+* [#2898](https://github.com/ruby-grape/grape/pull/2898): Stop eager loading `grape/testing`, so the module is opt-in as its 3.3 release note has always said instead of being installed in every process (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2767](https://github.com/ruby-grape/grape/pull/2767): Update rubocop to 1.88.0 and rubocop-rspec to 3.10.2 - [@ericproulx](https://github.com/ericproulx).
 * [#2863](https://github.com/ruby-grape/grape/pull/2863): Enable `Style/MutableConstant`'s `Recursive` option, so a literal nested inside a frozen constant has to be frozen too - [@ericproulx](https://github.com/ericproulx).
 * [#2816](https://github.com/ruby-grape/grape/pull/2816): Guard `length`, `same_as` and `oneof` validators against non-hash params (500 → 400) - [@ericproulx](https://github.com/ericproulx).

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,18 @@ Upgrading Grape
 
 ### Upgrading to >= 4.0.0
 
+#### `grape/testing` is no longer loaded unless you require it
+
+`Grape::Testing` has been documented as opt-in since 3.3 — "intended for test environments only and is not loaded by default" — but it was never excluded from Grape's eager load, so `require 'grape'` installed it anyway. It extends `Grape::Endpoint` with `before_each` / `reset_before_each` and prepends a wrapper around `Grape::Endpoint#run` that every request goes through.
+
+It is now excluded, so the documented behaviour is the actual one. If your suite calls `Grape::Endpoint.before_each` without requiring the module first, it will now raise `NoMethodError`. Add the require the 3.3 note already asked for to your test helper:
+
+```ruby
+require 'grape/testing'
+```
+
+Nothing else changes: the module's API is the same, and referencing the `Grape::Testing` constant still autoloads it.
+
 #### The versioner's `pattern` option has been removed
 
 `Grape::Middleware::Versioner::Base` accepted a `pattern` option, which `Versioner::Path` matched the candidate version segment against before recording it. It dates from the original versioner (2010), where it was the only way to decide whether the first path segment was a version — there was no declared version list yet.

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -42,7 +42,12 @@ loader.inflector.inflect(
   'dsl' => 'DSL'
 )
 railtie = "#{__dir__}/grape/railtie.rb"
-loader.do_not_eager_load(railtie)
+# Grape::Testing is a test-environment helper -- it extends Grape::Endpoint with
+# `before_each` and prepends a hook to Grape::Endpoint#run. It is documented as
+# opt-in (`require 'grape/testing'`), which eager loading quietly contradicted
+# by installing it in every process.
+testing = "#{__dir__}/grape/testing.rb"
+loader.do_not_eager_load(railtie, testing)
 loader.setup
 
 I18n.load_path << File.expand_path('grape/locale/en.yml', __dir__)


### PR DESCRIPTION
`Grape::Testing` has been documented as opt-in since 3.3, but nothing ever made it so.

> **UPGRADING.md**, § *Upgrading to >= 3.3*:
> `Grape::Endpoint.before_each` and `Grape::Endpoint.reset_before_each` are now only available after requiring `grape/testing`. This module is intended for test environments only and **is not loaded by default**.

> **README.md**: This feature is provided by `Grape::Testing`, a standalone module intended for test environments only. Add it to your test helper: `require 'grape/testing'`

It was loaded by default. On master today:

```ruby
require 'grape'
Grape::Endpoint.respond_to?(:before_each)   # => true
```

## How the two got out of order

`loader.eager_load` arrived with Zeitwerk in `2c79b2f9` (2024-04-11), excluding only the railtie. `lib/grape/testing.rb` was added later, in `ba7386a8` (2026-04-17), and was never added to that exclusion list — so the module the same PR documented as opt-in has been eagerly loaded ever since. The released 3.3.5 gem still excludes only `railtie`, so it has never actually been opt-in in any shipped version.

What that installs in a production process: `Grape::Endpoint.extend(Grape::Testing::ClassMethods)`, and a `Grape::Testing::RunBeforeEach` module prepended to `Grape::Endpoint` so that every request calls `self.class.run_before_each(self)` and walks up the endpoint class chain looking for hooks a production app never registers.

## The fix

```ruby
testing = "#{__dir__}/grape/testing.rb"
loader.do_not_eager_load(railtie, testing)
```

| | `before_each` available? | module loaded? |
|---|---|---|
| `require 'grape'` | **no** — matches the docs | no; Zeitwerk registers the autoload only |
| `require 'grape/testing'` | yes | yes |
| referencing `Grape::Testing` | yes | yes — the autoload still resolves it |

`spec/grape/testing_spec.rb` already opens with `require 'grape/testing'` and needed no change. Full suite **2689 examples, 0 failures**; RuboCop clean.

## Upgrading

UPGRADING carries a note under 4.0.0. The documented contract is not changing — it is being honoured for the first time — but an application that never read the 3.3 note can be relying on the accident, and will now get `NoMethodError` on `Grape::Endpoint.before_each`. The fix is the one line 3.3 already asked for in the test helper.

## Relation to #2895

Independent, no file overlap, either order merges cleanly. #2895 makes the `RunBeforeEach` prepend happen on the first `before_each` call instead of at load; this PR keeps the module out of non-test processes altogether. They compose: with both, a test suite that requires `grape/testing` but never registers a hook doesn't pay for the wrapper either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
