### PR TITLE
Derive the deprecation horizon from Grape's version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 
 #### Fixes
 
+* [#2899](https://github.com/ruby-grape/grape/pull/2899): Derive `Grape.deprecator`'s deprecation horizon from `Grape::VERSION` instead of the hardcoded `2.0` it has announced since 2023 - [@ericproulx](https://github.com/ericproulx).
 * [#2898](https://github.com/ruby-grape/grape/pull/2898): Stop eager loading `grape/testing`, so the module is opt-in as its 3.3 release note has always said instead of being installed in every process (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2767](https://github.com/ruby-grape/grape/pull/2767): Update rubocop to 1.88.0 and rubocop-rspec to 3.10.2 - [@ericproulx](https://github.com/ericproulx).
 * [#2863](https://github.com/ruby-grape/grape/pull/2863): Enable `Style/MutableConstant`'s `Recursive` option, so a literal nested inside a frozen constant has to be frozen too - [@ericproulx](https://github.com/ericproulx).

--- a/lib/grape.rb
+++ b/lib/grape.rb
@@ -95,8 +95,15 @@ module Grape
       ]
     end.freeze
 
+  # The deprecation horizon is the version a deprecation announces as its
+  # removal point, so it is the *next* major rather than the current one, and
+  # it is derived from VERSION rather than written out. Written out, it went
+  # stale: it said '2.0' from 2023 (#2353) through all of 2.x, 3.x and 4.x, so
+  # a method deprecated through this deprecator announced a removal version
+  # that had already shipped, and every custom `behavior` lambda -- how a Rails
+  # app consumes deprecations -- was handed the same wrong number.
   def self.deprecator
-    @deprecator ||= ActiveSupport::Deprecation.new('2.0', 'Grape')
+    @deprecator ||= ActiveSupport::Deprecation.new("#{Gem::Version.new(VERSION).segments.first + 1}.0", 'Grape')
   end
 end
 

--- a/spec/grape/deprecator_spec.rb
+++ b/spec/grape/deprecator_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+describe Grape do
+  describe '.deprecator' do
+    subject { described_class.deprecator }
+
+    it { is_expected.to be_an(ActiveSupport::Deprecation) }
+
+    it 'is memoized' do
+      expect(subject).to be(described_class.deprecator)
+    end
+
+    it 'announces Grape as the gem being deprecated from' do
+      expect(subject.gem_name).to eq('Grape')
+    end
+
+    # The horizon is the version a deprecation says it will be removed in, so it
+    # has to be ahead of the one running. It was hardcoded for three major
+    # versions and announced a removal version that had already shipped.
+    it 'announces the next major version as the removal horizon' do
+      expect(subject.deprecation_horizon).to eq("#{Gem::Version.new(Grape::VERSION).segments.first + 1}.0")
+    end
+
+    it 'announces a horizon later than the running version' do
+      expect(Gem::Version.new(subject.deprecation_horizon)).to be > Gem::Version.new(Grape::VERSION)
+    end
+  end
+end


### PR DESCRIPTION
`ActiveSupport::Deprecation.new`'s first argument is the *deprecation horizon* — the version a deprecation announces as its removal point. Grape has been passing `'2.0'`:

```ruby
def self.deprecator
  @deprecator ||= ActiveSupport::Deprecation.new('2.0', 'Grape')
end
```

It was correct when written — `4e2a2ff4` (2023-10-12, #2353), when 2.0 was the next major — and has stayed there through 2.x, 3.x and 4.x. With `Grape::VERSION` now `4.0.0`, it names a version that shipped three majors ago.

## It is not inert

`Module#deprecate` routed through this deprecator renders it verbatim:

```ruby
Object.deprecate(:old_thing, deprecator: Grape.deprecator)
Object.new.old_thing
# => DEPRECATION WARNING: old_thing is deprecated and will be removed from Grape 2.0
```

and every custom `behavior` lambda receives it as an argument — which is how a Rails app consumes deprecations, since `Grape::Railtie` registers this object as `app.deprecators[:grape]`:

```ruby
Grape.deprecator.behavior = ->(message, callstack, horizon, gem_name) { ... }
# horizon => "2.0", gem_name => "Grape"
```

The reason nobody has hit it is that Grape's own eleven deprecations all pass a written-out message to `deprecator.warn`, which doesn't interpolate the horizon. The first use of `deprecate_methods` would have printed it.

## The fix

```ruby
ActiveSupport::Deprecation.new("#{Gem::Version.new(VERSION).segments.first + 1}.0", 'Grape')
```

Two things worth being explicit about:

- **The next major, not `VERSION` itself.** The horizon is the version something will be *removed* in, so pointing it at `Grape::VERSION` would announce "will be removed from Grape 4.0.0" while 4.0.0 is what you are running. Deprecating in 4.x means removing in 5.0, which is the release cadence UPGRADING already documents.
- **Derived, not written out.** Being written out is precisely why it rotted for three majors. Derived, a version bump carries it along.

`Grape::VERSION` is safe to reference there: `Zeitwerk::GemInflector` maps `lib/grape/version.rb` to `VERSION`, and `deprecator` is memoized, so it resolves on first call rather than at load.

## Spec

`spec/grape/deprecator_spec.rb` pins the gem name and both halves of the horizon — that it equals the next major, and that it is ahead of the version running. Against the hardcoded value both fail:

```
expected: "5.0"                        expected: > #<Gem::Version "4.0.0">
     got: "2.0"                             got:   #<Gem::Version "2.0">
```

Full suite 2694 examples, 0 failures; RuboCop clean. No UPGRADING entry — no contract changes, a wrong value becomes the right one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
