### PR TITLE
Require a formatter in error_formatter and drop the unreachable 406 throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@
 * [#2865](https://github.com/ruby-grape/grape/pull/2865): Pass `required` from `requires`/`optional` as an argument instead of writing a `presence` key into the caller's options, deprecating a user-supplied `presence` and letting a `with` block's `message` reach the presence validator (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2871](https://github.com/ruby-grape/grape/pull/2871): Move the endpoint replacement behind `mount`'s private re-mounting path, deprecating the undocumented `refresh_already_mounted` option, and recognise a mount mapping by `Hash` rather than by `respond_to?(:each_pair)` (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2886](https://github.com/ruby-grape/grape/pull/2886): Compile the router's optimized map from the registered routes, so a route declared with a verb outside `Grape::HTTP_SUPPORTED_METHODS` is served instead of being advertised in `Allow` and answered with 405 - [@ericproulx](https://github.com/ericproulx).
+* [#2901](https://github.com/ruby-grape/grape/pull/2901): Reject `error_formatter` without a formatter instead of registering `nil`, which left the format with no error formatter at all and answered every error for it with a failsafe 500 (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -78,6 +78,23 @@ end
 ```
 
 `@options`, `option_value` and the rest of the documented custom-validator surface are unchanged.
+#### `error_formatter` now requires a formatter
+
+`error_formatter` takes the formatter positionally or as `with:`. Called with neither, it used to register `nil` for that format:
+
+```ruby
+error_formatter :json # no formatter given
+```
+
+`Grape::ErrorFormatter.formatter_for` hands a registered value back as-is, so the format resolved to no formatter at all — and every error response in that format then failed to render and came back as the failsafe `500 Internal Server Error` in `text/plain`, whatever status and message the API had asked for.
+
+That call now raises `ArgumentError` when the API is defined, rather than on the first error the API tries to render. Pass the formatter:
+
+```ruby
+error_formatter :json, with: MyErrorFormatter
+```
+
+An API that already passes one is unaffected, and a format with no `error_formatter` of its own keeps falling back to `default_error_formatter` and then to `Grape::ErrorFormatter::Txt`.
 
 #### `grape/testing` is no longer loaded unless you require it
 

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -43,8 +43,16 @@ module Grape
         inheritable_setting.default_error_formatter = Grape::ErrorFormatter.formatter_for(new_formatter_name)
       end
 
+      # Specify a custom error formatter for a format, passed positionally or
+      # as +with:+. A nil formatter used to be registered as-is, and
+      # +ErrorFormatter.formatter_for+ hands a registered value back verbatim
+      # — so the format resolved to no formatter at all and every error
+      # response for it died in the middleware. Reject it here instead, where
+      # the mistake is.
       def error_formatter(format, options = nil, with: nil)
         formatter = with || options
+        raise ArgumentError, "error_formatter #{format.inspect} requires a formatter, given positionally or as `with:`" if formatter.nil?
+
         inheritable_setting.add_error_formatter(format.to_sym, formatter)
       end
 

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -74,17 +74,18 @@ module Grape
         Grape::ContentTypes.media_type(content_type).to_s.casecmp?('text/html')
       end
 
+      # +formatter_for+ always resolves to something callable — a registered
+      # formatter, the API's +default_error_formatter+, or +ErrorFormatter::Txt+
+      # — and +error_formatter+ no longer lets a nil registration through, so
+      # there is no no-formatter case to handle here. The +throw :error, 406+
+      # that used to stand in for one could not work anyway: nothing catches
+      # +:error+ around this call (+#call!+ has left its +catch+ by the time
+      # +error_response+ runs), so it raised +UncaughtThrowError+ and the
+      # request answered with the failsafe 500 rather than the 406 it named.
       def format_message(error)
         current_format = env[Grape::Env::API_FORMAT] || format
         formatter = Grape::ErrorFormatter.formatter_for(current_format, error_formatters, default_error_formatter)
-        return formatter.call(error:, env:, include_backtrace:, include_original_exception:) if formatter
-
-        throw :error, Grape::Exceptions::ErrorResponse.new(
-          status: 406,
-          message: "The requested format '#{current_format}' is not supported.",
-          backtrace: error.backtrace,
-          original_exception: error.original_exception
-        )
+        formatter.call(error:, env:, include_backtrace:, include_original_exception:)
       end
 
       def find_handler(klass)

--- a/spec/grape/dsl/request_response_spec.rb
+++ b/spec/grape/dsl/request_response_spec.rb
@@ -65,6 +65,15 @@ describe Grape::DSL::RequestResponse do
       subject.error_formatter format, with: :error_formatter
       expect(subject.inheritable_setting.error_formatters).to eq(format.to_sym => :error_formatter)
     end
+
+    it 'raises when no formatter is given' do
+      expect { subject.error_formatter format }.to raise_error(ArgumentError, 'error_formatter "txt" requires a formatter, given positionally or as `with:`')
+      expect(subject.inheritable_setting.error_formatters).to be_nil
+    end
+
+    it 'raises when the formatter is nil' do
+      expect { subject.error_formatter format, with: nil }.to raise_error(ArgumentError)
+    end
   end
 
   describe '.content_type' do

--- a/spec/grape/middleware/error_spec.rb
+++ b/spec/grape/middleware/error_spec.rb
@@ -54,6 +54,17 @@ describe Grape::Middleware::Error do
     expect(last_response.body).to eq('Aww, hamburgers.')
   end
 
+  context 'with a format that has no error formatter of its own' do
+    let(:options) { { default_message: 'Aww, hamburgers.', format: :custom } }
+
+    it 'renders through the text formatter' do
+      err_app.error = { status: 410, message: 'Awesome stuff.' }
+      get '/'
+      expect(last_response.status).to eq(410)
+      expect(last_response.body).to eq('Awesome stuff.')
+    end
+  end
+
   context 'with http code' do
     let(:options) {  { default_message: 'Aww, hamburgers.' } }
 


### PR DESCRIPTION
`error_formatter :json` — with no formatter, positionally or as `with:` — registered `nil`:

```ruby
def error_formatter(format, options = nil, with: nil)
  formatter = with || options   # nil
  inheritable_setting.add_error_formatter(format.to_sym, formatter)
end
```

`Grape::ErrorFormatter.formatter_for` hands a registered value back verbatim through its `key?` short-circuit, so that format resolved to no formatter at all and `Middleware::Error#format_message` fell through to a `throw :error, 406`.

That throw could never deliver its 406. Nothing catches `:error` around the call: `#call!` has already left its `catch` by the time `error_response` runs with the caught value, and `run_rescue_handler` re-renders outside its own `catch`. So it raised `UncaughtThrowError`, `render_response` rescued it, and the request answered with the failsafe `500 Internal Server Error` in `text/plain` — whatever status and message the API had asked for:

| path (`format :json` + `error_formatter :json`) | response | `format_message` calls | uncaught throws |
| --- | --- | --- | --- |
| `error!('nope', 422)` | 500 `text/plain` | 2 | 2 |
| validation failure | 500 `text/plain` | 3 | 2 |

Both ends are fixed here:

* `DSL::RequestResponse#error_formatter` raises `ArgumentError` when no formatter is given, so the mistake surfaces where it is made rather than on the first error the API renders.
* `format_message` drops the dead branch — `formatter_for` always resolves to a registered formatter, `default_error_formatter` or `ErrorFormatter::Txt`.

An API that passes a formatter is unaffected, and a format with no `error_formatter` of its own keeps falling back to `default_error_formatter` and then to `Txt` (pinned by a new middleware spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)