### PR TITLE
Make ErrorFormatter.formatter_for a lookup and move the fallback to its caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@
 * [#2871](https://github.com/ruby-grape/grape/pull/2871): Move the endpoint replacement behind `mount`'s private re-mounting path, deprecating the undocumented `refresh_already_mounted` option, and recognise a mount mapping by `Hash` rather than by `respond_to?(:each_pair)` (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2886](https://github.com/ruby-grape/grape/pull/2886): Compile the router's optimized map from the registered routes, so a route declared with a verb outside `Grape::HTTP_SUPPORTED_METHODS` is served instead of being advertised in `Allow` and answered with 405 - [@ericproulx](https://github.com/ericproulx).
 * [#2901](https://github.com/ruby-grape/grape/pull/2901): Reject `error_formatter` without a formatter instead of registering `nil`, which left the format with no error formatter at all and answered every error for it with a failsafe 500 (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
+* [#2902](https://github.com/ruby-grape/grape/pull/2902): Make `Grape::ErrorFormatter.formatter_for` a lookup that answers `nil` for an unregistered format, like `Grape::Parser.parser_for`, and move the `default_error_formatter` / `Grape::ErrorFormatter::Txt` fallback to `Grape::Middleware::Error`, which owns it; `default_error_formatter` naming nothing registered now raises `Grape::Exceptions::UnknownErrorFormatter` instead of silently storing `Txt` (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -78,6 +78,38 @@ end
 ```
 
 `@options`, `option_value` and the rest of the documented custom-validator surface are unchanged.
+#### `Grape::ErrorFormatter.formatter_for` answers `nil` for an unregistered format
+
+It used to take the API's `default_error_formatter` as a third argument and end in `default_error_formatter || Grape::ErrorFormatter::Txt` — a global registry implementing the caller's fallback policy. It is now a lookup, the same shape as `Grape::Parser.parser_for`:
+
+```ruby
+Grape::ErrorFormatter.formatter_for(:json)     # => Grape::ErrorFormatter::Json
+Grape::ErrorFormatter.formatter_for(:unknown)  # => nil, was Grape::ErrorFormatter::Txt
+```
+
+Passing a third argument now raises `ArgumentError`. The fallback moved to `Grape::Middleware::Error`, which applies the API's `default_error_formatter` and resolves that to `Grape::ErrorFormatter::Txt` when the API set none.
+
+Error responses are unchanged, including the precedence: a formatter registered for the requested format still wins over the API's `default_error_formatter`, which applies to formats that have none of their own.
+
+Two things follow at definition time, where the lookup's fallback used to hide them.
+
+`default_error_formatter` names an error formatter, so a name nothing is registered under is now an error rather than a silent `Txt`:
+
+```ruby
+default_error_formatter :jsonn
+# => Grape::Exceptions::UnknownErrorFormatter: unknown error formatter: jsonn
+```
+
+`format` names a *format*, and a format with no error formatter of its own is ordinary, so it still succeeds — but the stored setting is now `nil` rather than `Grape::ErrorFormatter::Txt`:
+
+```ruby
+content_type :xls, 'application/vnd.ms-excel'
+format :xls
+MyAPI.default_error_formatter # => nil, was Grape::ErrorFormatter::Txt
+```
+
+The middleware supplies `Txt` at render time, so error responses are unchanged; the setting is only visible if you read it back.
+
 #### `error_formatter` now requires a formatter
 
 `error_formatter` takes the formatter positionally or as `with:`. Called with neither, it used to register `nil` for that format:

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -36,19 +36,23 @@ module Grape
         inheritable_setting.add_parser(content_type.to_sym, new_parser)
       end
 
-      # Specify a default error formatter.
+      # Specify a default error formatter, by the name it is registered under.
+      # A name nothing is registered for used to be stored as
+      # +ErrorFormatter::Txt+ — the fallback the lookup applied — so a typo
+      # read back as a working setting and silently rendered errors as text.
       def default_error_formatter(new_formatter_name = nil)
         return inheritable_setting.default_error_formatter if new_formatter_name.nil?
 
-        inheritable_setting.default_error_formatter = Grape::ErrorFormatter.formatter_for(new_formatter_name)
+        formatter = Grape::ErrorFormatter.formatter_for(new_formatter_name)
+        raise Grape::Exceptions::UnknownErrorFormatter.new(new_formatter_name) if formatter.nil?
+
+        inheritable_setting.default_error_formatter = formatter
       end
 
       # Specify a custom error formatter for a format, passed positionally or
-      # as +with:+. A nil formatter used to be registered as-is, and
-      # +ErrorFormatter.formatter_for+ hands a registered value back verbatim
-      # — so the format resolved to no formatter at all and every error
-      # response for it died in the middleware. Reject it here instead, where
-      # the mistake is.
+      # as +with:+. A nil formatter used to be registered as-is, which is the
+      # one thing the registration cannot mean: the format then resolves as if
+      # the call had never been made. Reject it here, where the mistake is.
       def error_formatter(format, options = nil, with: nil)
         formatter = with || options
         raise ArgumentError, "error_formatter #{format.inspect} requires a formatter, given positionally or as `with:`" if formatter.nil?

--- a/lib/grape/error_formatter.rb
+++ b/lib/grape/error_formatter.rb
@@ -6,10 +6,14 @@ module Grape
 
     module_function
 
-    def formatter_for(format, error_formatters = nil, default_error_formatter = nil)
+    # Answers nil when nothing is registered for the format, the way
+    # +Parser.parser_for+ does. What to fall back to then is the API's own
+    # +default_error_formatter+, which is the caller's state rather than the
+    # registry's: +Middleware::Error+ holds it and applies it.
+    def formatter_for(format, error_formatters = nil)
       return error_formatters[format] if error_formatters&.key?(format)
 
-      registry[format] || default_error_formatter || Grape::ErrorFormatter::Txt
+      registry[format]
     end
   end
 end

--- a/lib/grape/exceptions/unknown_error_formatter.rb
+++ b/lib/grape/exceptions/unknown_error_formatter.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Grape
+  module Exceptions
+    class UnknownErrorFormatter < Base
+      def initialize(error_formatter_type)
+        super(message: compose_message(:unknown_error_formatter, error_formatter_type:))
+      end
+    end
+  end
+end

--- a/lib/grape/locale/en.yml
+++ b/lib/grape/locale/en.yml
@@ -48,6 +48,7 @@ en:
         regexp: 'is invalid'
         same_as: 'is not the same as %{parameter}'
         unknown_auth_strategy: 'unknown auth strategy: %{strategy}'
+        unknown_error_formatter: 'unknown error formatter: %{error_formatter_type}'
         unknown_options: 'unknown options: %{options}'
         unknown_parameter: 'unknown parameter: %{param}'
         unknown_params_builder: 'unknown params_builder: %{params_builder_type}'

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -21,11 +21,14 @@ module Grape
           rescue_all: false, rescue_grape_exceptions: false, rescue_handlers: nil,
           rescue_options: nil
         )
-          # `rescue_options:` arrives nil from `Endpoint#error_middleware_options`
-          # when no `rescue_from` has been called — fall back to the documented
-          # defaults rather than letting nil propagate to `def_delegator
-          # :rescue_options, :backtrace`.
+          # `rescue_options:` and `default_error_formatter:` arrive nil from
+          # `Endpoint#error_middleware_options` when the API called no
+          # `rescue_from` and no `format` — and an explicit nil bypasses the
+          # keyword defaults above, so restore them here rather than letting nil
+          # propagate to `def_delegator :rescue_options, :backtrace` or to the
+          # formatter lookup in `#format_message`.
           rescue_options ||= Grape::DSL::RescueOptions.new
+          default_error_formatter ||= Grape::ErrorFormatter::Txt
           super
         end
       end
@@ -74,17 +77,17 @@ module Grape
         Grape::ContentTypes.media_type(content_type).to_s.casecmp?('text/html')
       end
 
-      # +formatter_for+ always resolves to something callable — a registered
-      # formatter, the API's +default_error_formatter+, or +ErrorFormatter::Txt+
-      # — and +error_formatter+ no longer lets a nil registration through, so
-      # there is no no-formatter case to handle here. The +throw :error, 406+
-      # that used to stand in for one could not work anyway: nothing catches
-      # +:error+ around this call (+#call!+ has left its +catch+ by the time
-      # +error_response+ runs), so it raised +UncaughtThrowError+ and the
-      # request answered with the failsafe 500 rather than the 406 it named.
+      # The registry answers nil for a format nothing is registered for, and
+      # the API's +default_error_formatter+ — +ErrorFormatter::Txt+ unless the
+      # API set another — takes it from there, so this always has something
+      # callable. The +throw :error, 406+ that used to stand in for a missing
+      # formatter could not work anyway: nothing catches +:error+ around this
+      # call (+#call!+ has left its +catch+ by the time +error_response+ runs),
+      # so it raised +UncaughtThrowError+ and the request answered with the
+      # failsafe 500 rather than the 406 it named.
       def format_message(error)
         current_format = env[Grape::Env::API_FORMAT] || format
-        formatter = Grape::ErrorFormatter.formatter_for(current_format, error_formatters, default_error_formatter)
+        formatter = Grape::ErrorFormatter.formatter_for(current_format, error_formatters) || default_error_formatter
         formatter.call(error:, env:, include_backtrace:, include_original_exception:)
       end
 

--- a/spec/grape/dsl/request_response_spec.rb
+++ b/spec/grape/dsl/request_response_spec.rb
@@ -52,6 +52,11 @@ describe Grape::DSL::RequestResponse do
       subject.default_error_formatter :json
       expect(subject.inheritable_setting.default_error_formatter).to eq(Grape::ErrorFormatter::Json)
     end
+
+    it 'raises when nothing is registered under the given name' do
+      expect { subject.default_error_formatter :jsonn }.to raise_error(Grape::Exceptions::UnknownErrorFormatter, /unknown error formatter: jsonn/)
+      expect(subject.inheritable_setting.default_error_formatter).to be_nil
+    end
   end
 
   describe '.error_formatter' do

--- a/spec/grape/error_formatter_spec.rb
+++ b/spec/grape/error_formatter_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe Grape::ErrorFormatter do
+  subject { described_class }
+
+  describe '.formatter_for' do
+    it 'returns the registered formatter' do
+      expect(subject.formatter_for(:json)).to eq(Grape::ErrorFormatter::Json)
+    end
+
+    context 'when the API registered one for the format' do
+      let(:error_formatters) { { customized_json: Grape::ErrorFormatter::Json } }
+
+      it 'returns it' do
+        expect(subject.formatter_for(:customized_json, error_formatters)).to eq(Grape::ErrorFormatter::Json)
+      end
+
+      it 'wins over the registry' do
+        expect(subject.formatter_for(:txt, { txt: Grape::ErrorFormatter::Json })).to eq(Grape::ErrorFormatter::Json)
+      end
+    end
+
+    context 'when no formatter is registered for the format' do
+      it 'returns nil, leaving the fallback to the caller' do
+        expect(subject.formatter_for(:undefined)).to be_nil
+      end
+
+      it 'returns nil for a nil format' do
+        expect(subject.formatter_for(nil)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/grape/exceptions/unknown_error_formatter_spec.rb
+++ b/spec/grape/exceptions/unknown_error_formatter_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe Grape::Exceptions::UnknownErrorFormatter do
+  describe '#message' do
+    let(:error) do
+      described_class.new('jsonn')
+    end
+
+    it 'contains the problem in the message' do
+      expect(error.message).to include(
+        'unknown error formatter: jsonn'
+      )
+    end
+  end
+end

--- a/spec/grape/middleware/error_spec.rb
+++ b/spec/grape/middleware/error_spec.rb
@@ -63,6 +63,28 @@ describe Grape::Middleware::Error do
       expect(last_response.status).to eq(410)
       expect(last_response.body).to eq('Awesome stuff.')
     end
+
+    context 'when the API set a default error formatter' do
+      let(:options) do
+        { default_message: 'Aww, hamburgers.', format: :custom, content_types: { custom: 'application/json' }, default_error_formatter: Grape::ErrorFormatter::Json }
+      end
+
+      it 'renders through it' do
+        err_app.error = { status: 410, message: 'Awesome stuff.' }
+        get '/'
+        expect(last_response.body).to eq('{"error":"Awesome stuff."}')
+      end
+    end
+  end
+
+  context 'with a format that has an error formatter of its own' do
+    let(:options) { { default_message: 'Aww, hamburgers.', format: :txt, default_error_formatter: Grape::ErrorFormatter::Json } }
+
+    it "takes it over the API's default error formatter" do
+      err_app.error = { status: 410, message: 'Awesome stuff.' }
+      get '/'
+      expect(last_response.body).to eq('Awesome stuff.')
+    end
   end
 
   context 'with http code' do


### PR DESCRIPTION
Stacked on #2901 — review that one first; this PR's base is `error-formatter-nil-guard` and I'll retarget it to `master` once #2901 merges.

`ErrorFormatter.formatter_for` took the API's `default_error_formatter` as a third argument and ended in `default_error_formatter || Grape::ErrorFormatter::Txt`, so the global registry implemented the caller's precedence out of the caller's own state. It was the only registry in the family that did:

| module | signature | miss returns |
| --- | --- | --- |
| `Parser.parser_for` | `(format, parsers = nil)` | `nil` — caller decides |
| `ParamsBuilder.params_builder_for` | `(short_name)` | raises |
| `Formatter.formatter_for` | `(api_format, formatters)` | `DEFAULT_LAMBDA_FORMATTER` (its own constant) |
| `ErrorFormatter.formatter_for` | `(format, error_formatters, default_error_formatter)` | `default_error_formatter \|\| Txt` |

`error_formatters` is at least a table it can search; `default_error_formatter` is API policy threaded through a global module. The `|| Txt` alone would be fine — `Formatter` does the same — but it cannot stay once the other leaves: a caller can only insert its own default between "nothing registered" and `Txt` if the lookup reports the miss.

So `formatter_for` takes the `Parser.parser_for` shape, and `Middleware::Error` applies the fallback it owns:

```ruby
# error_formatter.rb
def formatter_for(format, error_formatters = nil)
  return error_formatters[format] if error_formatters&.key?(format)

  registry[format]
end

# middleware/error.rb — Options#initialize, next to the existing rescue_options ||=
default_error_formatter ||= Grape::ErrorFormatter::Txt

# format_message
formatter = Grape::ErrorFormatter.formatter_for(current_format, error_formatters) || default_error_formatter
```

`Options#initialize` is the right home for the default because `Endpoint#error_middleware_options` passes an explicit `nil` when the API called no `format`, which bypasses the `Data` keyword default — the same reason `rescue_options ||=` is already there.

Resolution is unchanged, precedence included: a formatter registered for the requested format still wins over the API's `default_error_formatter`, which applies to formats with none of their own (`format == nil` included — that is what makes the `default_error_formatter :json` spec pass). Both directions are now pinned by specs in `error_spec.rb`, and a new `spec/grape/error_formatter_spec.rb` pins the lookup contract, mirroring `parser_spec.rb`.

### Reporting the miss also lets the DSL see it

`default_error_formatter` names an error formatter, so a name nothing is registered under is a mistake. It used to store the `Txt` the lookup substituted, so the typo read back as a working setting and errors quietly rendered as text:

```ruby
default_error_formatter :jsonn
# => Grape::Exceptions::UnknownErrorFormatter: unknown error formatter: jsonn
```

`format` names a *format*, where having no error formatter of its own is ordinary (`format :xls`), so it still succeeds and stores `nil`, with the middleware supplying `Txt` at render time.

Both are in UPGRADING, along with the signature change: a third argument to `formatter_for` now raises `ArgumentError`, and the setting reads back `nil` instead of `Txt` for a format with no error formatter — visible only if you read it back, since error responses are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)