### PR TITLE
Nest any route_param requirement, and reject the shapes with no param to attach to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@
 * [#2901](https://github.com/ruby-grape/grape/pull/2901): Reject `error_formatter` without a formatter instead of registering `nil`, which left the format with no error formatter at all and answered every error for it with a failsafe 500 (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2902](https://github.com/ruby-grape/grape/pull/2902): Make `Grape::ErrorFormatter.formatter_for` a lookup that answers `nil` for an unregistered format, like `Grape::Parser.parser_for`, and move the `default_error_formatter` / `Grape::ErrorFormatter::Txt` fallback to `Grape::Middleware::Error`, which owns it; `default_error_formatter` naming nothing registered now raises `Grape::Exceptions::UnknownErrorFormatter` instead of silently storing `Txt` (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2904](https://github.com/ruby-grape/grape/pull/2904): Document and spec route `requirements` given as a Mustermann capture type, which constrains the match and hands the endpoint the converted value - [@ericproulx](https://github.com/ericproulx).
+* [#2905](https://github.com/ruby-grape/grape/pull/2905): Nest any `route_param` requirement under the param name, not just a Regexp, and reject the `requirements` shapes that have no param to attach to where they are written rather than on the first request - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -180,6 +180,8 @@ module Grape
       #     end
       #   end
       def route(methods, paths = ['/'], requirements: nil, anchor: true, **route_options, &)
+        validate_requirements!(requirements)
+
         http_methods = methods == :any ? '*' : methods
         endpoint_description = inheritable_setting.route_description
 
@@ -228,6 +230,8 @@ module Grape
       def namespace(space = nil, requirements: nil, **options, &block)
         return inheritable_setting.namespace_path unless space || block
 
+        validate_requirements!(requirements)
+
         within_namespace do
           nest(block) do
             inheritable_setting.add_namespace(Grape::Namespace.new(space, requirements:, **options)) if space
@@ -249,15 +253,20 @@ module Grape
       # in your API.
       #
       # @param param [Symbol] The name of the parameter you wish to declare.
-      # @option options [Regexp] You may supply a regular expression that the declared parameter must meet.
+      # @option options [Regexp, Class, Symbol] The constraint the declared parameter must meet — a Regexp, or a capture type such as +Integer+.
       def route_param(param, requirements: nil, type: nil, **, &)
-        requirements = { param.to_sym => requirements } if requirements.is_a?(Regexp)
+        # The param is named here, so the constraint is its own: nest whatever
+        # it is, not just a Regexp. A Hash would name the param twice, or key a
+        # capture this namespace does not introduce, and belongs on +namespace+.
+        raise ArgumentError, "route_param :#{param} constrains :#{param}; pass the constraint itself, or a Hash of requirements to the enclosing namespace" if requirements.respond_to?(:to_hash)
+
+        param_requirements = { param.to_sym => requirements } unless requirements.nil?
 
         Grape::Validations::ParamsScope.new(api: self) do
           requires param, type: type
         end if type
 
-        namespace(":#{param}", requirements:, **, &)
+        namespace(":#{param}", requirements: param_requirements, **, &)
       end
 
       # @return array of defined versions
@@ -266,6 +275,15 @@ module Grape
       end
 
       private
+
+      # Requirements are keyed by param name and merged across namespaces, so
+      # anything else has nothing to attach to. Rejected here rather than at
+      # the merge, which runs on the first request that builds the routes.
+      def validate_requirements!(requirements)
+        return if requirements.nil? || requirements.respond_to?(:to_hash)
+
+        raise ArgumentError, "requirements must be a Hash of param name => constraint, got #{requirements.class}"
+      end
 
       # Compose a route's params: the declared params (+params do … end+) deep-merged
       # with any documented alongside +desc ..., params:+ (+description_params+).

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -388,7 +388,7 @@ describe Grape::API do
     context 'with a capture type as the requirement' do
       it 'converts the captured value' do
         subject.namespace :users do
-          route_param :id, requirements: { id: Integer } do
+          route_param :id, requirements: Integer do
             get { { id: params[:id], type: params[:id].class.to_s }.to_json }
           end
         end
@@ -399,7 +399,7 @@ describe Grape::API do
 
       it 'constrains what the route matches' do
         subject.namespace :users do
-          route_param :id, requirements: { id: Integer } do
+          route_param :id, requirements: Integer do
             get { params[:id].to_json }
           end
         end
@@ -412,7 +412,7 @@ describe Grape::API do
 
       it 'converts with a capture type named as a Symbol' do
         subject.namespace :events do
-          route_param :on, requirements: { on: :date } do
+          route_param :on, requirements: :date do
             get { { on: params[:on].to_s, type: params[:on].class.to_s }.to_json }
           end
         end
@@ -423,12 +423,22 @@ describe Grape::API do
         expect(last_response).to be_not_found
       end
 
+      it 'refuses a Hash, which route_param has no use for' do
+        expect do
+          subject.namespace :users do
+            route_param :id, requirements: { id: Integer } do
+              get { params[:id].to_json }
+            end
+          end
+        end.to raise_error(ArgumentError, /route_param :id constrains :id/)
+      end
+
       # The declared type still owns what the endpoint sees: validation runs
       # after the router, on the value the converter produced.
       it 'is still coerced to the type the params block declares' do
         subject.namespace :users do
           params { requires :id, type: String }
-          route_param :id, requirements: { id: Integer } do
+          route_param :id, requirements: Integer do
             get { { id: params[:id], type: params[:id].class.to_s }.to_json }
           end
         end

--- a/spec/grape/dsl/routing_spec.rb
+++ b/spec/grape/dsl/routing_spec.rb
@@ -144,6 +144,14 @@ describe Grape::DSL::Routing do
         .to change { subject.endpoints.count }.from(0).to(1)
     end
 
+    # Requirements are merged by param name when routes are built, so a lone
+    # constraint has nothing to attach to and used to raise a TypeError there,
+    # on the first request rather than here.
+    it 'rejects requirements that are not a Hash' do
+      expect { subject.route(:any, '/', requirements: Integer) }
+        .to raise_error(ArgumentError, 'requirements must be a Hash of param name => constraint, got Class')
+    end
+
     it 'does not duplicate identical endpoints' do
       subject.route(:any)
       expect { subject.route(:any) }
@@ -223,6 +231,11 @@ describe Grape::DSL::Routing do
       expect(subject.namespace(:foo, foo: 'bar')).to eq(Grape::Namespace.new(:foo, foo: 'bar'))
     end
 
+    it 'rejects requirements that are not a Hash' do
+      expect { subject.namespace(:foo, requirements: Integer) {} }
+        .to raise_error(ArgumentError, 'requirements must be a Hash of param name => constraint, got Class')
+    end
+
     it 'calls #joined_space_path on Namespace' do
       inside_namespace = nil
       subject.namespace(:foo, foo: 'bar') do
@@ -298,6 +311,22 @@ describe Grape::DSL::Routing do
       allow(subject).to receive(:namespace)
       expect { subject.route_param('foo', **options, &proc {}) }
         .not_to(change { options })
+    end
+
+    # The param is named here, so any lone constraint belongs to it — not just
+    # a Regexp, which was the only one nested before.
+    it 'nests a lone capture type under param name' do
+      expect(subject).to receive(:namespace) do |_param, options|
+        expect(options[:requirements]).to eq(foo: Integer)
+      end
+      subject.route_param('foo', requirements: Integer, &proc {})
+    end
+
+    # A Hash would name the param twice, or constrain a capture this namespace
+    # does not introduce — Mustermann resolves that to no constraint at all.
+    it 'rejects a Hash of requirements' do
+      expect { subject.route_param('foo', requirements: { foo: Integer }, &proc {}) }
+        .to raise_error(ArgumentError, 'route_param :foo constrains :foo; pass the constraint itself, or a Hash of requirements to the enclosing namespace')
     end
   end
 


### PR DESCRIPTION
Stacked on #2904 — it documents capture types in `requirements`, and this fixes the gap that documentation ran into. Base is `document-typed-route-requirements`; I'll retarget to `master` once #2904 merges.

`route_param` nests a lone `requirements:` under the param name, but only when it is a Regexp:

```ruby
requirements = { param.to_sym => requirements } if requirements.is_a?(Regexp)
```

That check comes from the commit that added `route_param` in 2013 (74b36c1), where a Regexp was the only kind of constraint there was. Anything else — the capture types Mustermann derives from a Class or a Symbol — travels unwrapped into `Endpoint#prepare_routes_requirements`, which merges the requirement Hashes of the namespaces a route sits in:

```ruby
route_param :id, requirements: Integer do   # accepted here
  get { params[:id] }
end
# GET /users/23 → TypeError: no implicit conversion of Class into Hash
#   from endpoint.rb:363, in `Enumerable#reduce'
```

The merge runs when routes are built, so a mistake written in the API's definition surfaced on the first request instead, from a method that names neither the route nor the requirement.

Nesting the constraint is what `route_param` is *for*, so it now nests whatever it is given, and each level takes the shape that has somewhere to attach:

| written | before | after |
| --- | --- | --- |
| `route_param :id, requirements: /[0-9]+/` | works | works |
| `route_param :id, requirements: Integer` | `TypeError` on first request | works — nested as `{ id: Integer }` |
| `route_param :id, requirements: { id: Integer }` | works | `ArgumentError` where it is written |
| `namespace :users, requirements: { id: Integer }` | works | works |
| `namespace :users, requirements: Integer` | `TypeError` on first request | `ArgumentError` where it is written |
| `get ':id', requirements: Integer` | `TypeError` on first request | `ArgumentError` where it is written |

A Hash on `route_param` is refused rather than nested because neither reading of it is useful: keyed by this param it names it twice, and keyed by another it constrains a capture the namespace does not introduce — which Mustermann resolves to *no constraint at all*, silently. `namespace` and an endpoint have the opposite problem, a path carrying several captures and so no param for a lone constraint to attach to, and reject a non-Hash for that reason.

Nothing in the suite or the README used the Hash form on `route_param`; the only occurrences were the ones #2904 had just added, updated here along with the README sentence.

Specs in `routing_spec.rb` (nesting a lone capture type, and all three rejections) and end-to-end in `api_spec.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)