### PR TITLE
Stop Grape::Endpoint::Options from appending to the caller's path Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@
 * [#2908](https://github.com/ruby-grape/grape/pull/2908): Stop reassigning method parameters across `lib`, so a parameter keeps the value its caller passed for the whole method; the `oneof` collection in `Grape::Validations::ParamsScope` no longer writes into the Hash it was given - [@ericproulx](https://github.com/ericproulx).
 * [#2910](https://github.com/ruby-grape/grape/pull/2910): Restore `Grape::Middleware::Formatter`'s in-place content-type negotiation as `ensure_content_type!`, which #2908 had turned into a copy of the response headers on every response - [@ericproulx](https://github.com/ericproulx).
 * [#2911](https://github.com/ruby-grape/grape/pull/2911): Copy response headers with `merge!` instead of `merge` in `Grape::API::Instance#call` and `Grape::Middleware::Error`, which allocated a `Grape::Util::Header` only to discard it - [@ericproulx](https://github.com/ericproulx).
+* [#2907](https://github.com/ruby-grape/grape/pull/2907): Stop `Grape::Endpoint::Options` from appending the default `'/'` into the path Array it was given, so declaring a route with an empty Array of paths inside a `namespace`, `resource`, `group` or `route_param` block no longer mutates the caller's Array — and raises `FrozenError` at boot when it is frozen - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/lib/grape/endpoint/options.rb
+++ b/lib/grape/endpoint/options.rb
@@ -8,10 +8,17 @@ module Grape
     # stays a plain Hash for downstream gems (e.g. grape-swagger).
     Options = Data.define(:path, :http_methods, :api, :route_options, :app, :params, :requirements, :anchor) do
       def initialize(path:, http_methods:, api:, route_options: {}, app: nil, params: {}, requirements: nil, anchor: true)
-        path = Array(path)
-        path << '/' if path.empty?
-        http_methods = Array(http_methods)
-        super
+        # +Array()+ hands back the very Array it was given, so defaulting an
+        # empty one by appending would append to the caller's Array — and raise
+        # FrozenError on a frozen one. Build a new Array instead of growing
+        # theirs: nothing about constructing an endpoint should be visible in
+        # the path the caller passed in.
+        paths = Array(path)
+        super(
+          path: paths.presence || ['/'],
+          http_methods: Array(http_methods),
+          api:, route_options:, app:, params:, requirements:, anchor:
+        )
       end
     end
   end

--- a/spec/grape/endpoint/options_spec.rb
+++ b/spec/grape/endpoint/options_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+describe Grape::Endpoint::Options do
+  describe '#path' do
+    subject { described_class.new(path: paths, http_methods: :get, api: nil).path }
+
+    context 'when a String' do
+      let(:paths) { '/users' }
+
+      it { is_expected.to eq(['/users']) }
+    end
+
+    context 'when a non-empty Array' do
+      let(:paths) { ['/users', '/people'] }
+
+      it { is_expected.to eq(['/users', '/people']) }
+
+      it 'does not modify the Array it was given' do
+        subject
+        expect(paths).to eq(['/users', '/people'])
+      end
+    end
+
+    context 'when an empty Array' do
+      let(:paths) { [] }
+
+      it { is_expected.to eq(['/']) }
+
+      it 'does not append the default to the Array it was given' do
+        subject
+        expect(paths).to be_empty
+      end
+    end
+
+    context 'when a frozen empty Array' do
+      let(:paths) { [].freeze }
+
+      it { is_expected.to eq(['/']) }
+    end
+  end
+
+  describe '#http_methods' do
+    subject { described_class.new(path: '/', http_methods: methods, api: nil).http_methods }
+
+    context 'when a Symbol' do
+      let(:methods) { :get }
+
+      it { is_expected.to eq([:get]) }
+    end
+
+    context 'when an Array' do
+      let(:methods) { %i[get post] }
+
+      it { is_expected.to eq(%i[get post]) }
+    end
+  end
+
+  # The reachable path through the public DSL: a route nested in a namespace,
+  # resource, group or route_param block reaches Grape::Endpoint directly. A
+  # top-level route does not, because Grape::API replays recorded setup steps
+  # through `evaluate_arguments`, which rebuilds Array arguments on the way in.
+  context 'when a route is defined inside a namespace' do
+    let(:paths) { [] }
+    let(:app) do
+      route_paths = paths
+      Class.new(Grape::API) do
+        format :txt
+        namespace :v1 do
+          get(route_paths) { 'ok' }
+        end
+      end
+    end
+
+    it 'routes the default path' do
+      get '/v1'
+      expect(last_response.body).to eq('ok')
+    end
+
+    it "leaves the caller's Array untouched" do
+      app.routes
+      expect(paths).to be_empty
+    end
+
+    context 'when the Array is frozen' do
+      let(:paths) { [].freeze }
+
+      it 'defines the API without raising' do
+        expect { app.routes }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
`Grape::Endpoint::Options#initialize` normalizes `path` into an Array and defaults an empty one to `['/']` — by appending:

```ruby
Options = Data.define(:path, :http_methods, :api, :route_options, :app, :params, :requirements, :anchor) do
  def initialize(path:, http_methods:, api:, route_options: {}, app: nil, params: {}, requirements: nil, anchor: true)
    path = Array(path)
    path << '/' if path.empty?
    http_methods = Array(http_methods)
    super
  end
end
```

`Array()` is not a copy. Given an Array it returns the very object it was handed:

```ruby
a = []
Array(a).equal?(a) # => true
```

so `path << '/'` grows the Array the caller passed in.

## What a user sees

A route declared inside a `namespace`, `resource`, `group` or `route_param` block reaches `Grape::Endpoint` directly, so an empty Array of paths is mutated in place:

```ruby
PATHS = []

class API < Grape::API
  namespace :v1 do
    get(PATHS) { 'ok' }
  end
end

PATHS # => ["/"]
```

and a frozen one — which is what `Style/MutableConstant` asks for, and what an Array built from configuration is likely to be — takes the class definition down at boot, not on the first request:

```ruby
PATHS = [].freeze

class API < Grape::API
  namespace :v1 do
    get(PATHS) { 'ok' }
  end
end
# FrozenError: can't modify frozen Array: []
#   lib/grape/endpoint/options.rb:12:in 'Grape::Endpoint::Options#initialize'
#   lib/grape/endpoint.rb:73:in 'Grape::Endpoint#initialize'
#   lib/grape/dsl/routing.rb:193:in 'Class#new'
```

`namespace`, `resource`, `group` and `route_param` all reproduce it.

Only the empty-Array case is affected. A String path (`get '/users'`) goes through `Array('/users')`, which builds a fresh Array, and a non-empty Array never reaches the `<<`.

## Why a top-level route does not reproduce it

`get(PATHS)` written directly in the class body is fine, and that is the only reason this has gone unnoticed. It is not a guard, though — `Grape::API` records DSL calls and replays them onto its instance, and `replay_step_on` rebuilds the argument list on the way through:

```ruby
def replay_step_on(instance, method:, args:, kwargs:, block:)
  return if skip_immediate_run?(instance, args, kwargs)

  eval_args = evaluate_arguments(instance.configuration, *args)
```

`evaluate_arguments` recurses into an Array argument with `evaluate_arguments(configuration, *argument)`, whose body is a `map` — so the endpoint receives a copy and the append lands on that copy. That machinery exists to resolve `Grape::Util::Lazy::Base` arguments when an API is re-mounted; shielding this is a side effect of it.

A nested scope's block is executed against the instance rather than being replayed argument-by-argument, so it never passes through `evaluate_arguments` and the endpoint gets the caller's Array. Same for `Grape::API::Instance` subclasses and direct `Grape::Endpoint` / `Grape::Endpoint::Options` construction.

## The fix

```ruby
paths = Array(path)
super(
  path: paths.presence || ['/'],
  http_methods: Array(http_methods),
  api:, route_options:, app:, params:, requirements:, anchor:
)
```

Two things worth calling out:

- **A new Array rather than a bigger one.** `paths.presence || ['/']` allocates the default only when it is needed, and never touches what the caller holds.
- **An explicit `super(...)` rather than zsuper.** The mutate-in-place shape existed *because* of the bare `super`: it forwards whatever the parameters currently hold, so normalizing an input meant assigning back over the parameter, and once you are assigning over `path` anyway, `<<` looks like the natural way to add the default. Naming the keywords at the call to `super` removes that pressure — the normalization is an expression now, and neither `path` nor `http_methods` is reassigned.

## Scope

The non-empty case still hands the caller's Array straight to the `Data` object, so a caller who mutates it afterwards would still be observed by the endpoint. That is unchanged behavior and the harmless direction — this PR closes the direction where *Grape* writes into the caller's argument. Copying every path Array on the way in is a separate call if it is wanted.

## Tests

`spec/grape/endpoint/options_spec.rb` is new: `path` normalization (String, non-empty Array, empty Array, frozen empty Array), `http_methods` normalization, and the namespace-nested definition through the public DSL, including the frozen case. Reverting the change fails four of them:

```
rspec ./spec/grape/endpoint/options_spec.rb:29 # ...when an empty Array does not append the default to the Array it was given
rspec ./spec/grape/endpoint/options_spec.rb:38 # ...when a frozen empty Array is expected to eq ["/"]
rspec ./spec/grape/endpoint/options_spec.rb:79 # ...inside a namespace leaves the caller's Array untouched
rspec ./spec/grape/endpoint/options_spec.rb:87 # ...inside a namespace when the Array is frozen defines the API without raising
```

Full suite green (2714 examples), rubocop clean.

No UPGRADING entry: nothing that worked before stops working, and the previous behavior was not something an API could have depended on deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
