### PR TITLE
Stop reassigning method parameters across lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@
 * [#2902](https://github.com/ruby-grape/grape/pull/2902): Make `Grape::ErrorFormatter.formatter_for` a lookup that answers `nil` for an unregistered format, like `Grape::Parser.parser_for`, and move the `default_error_formatter` / `Grape::ErrorFormatter::Txt` fallback to `Grape::Middleware::Error`, which owns it; `default_error_formatter` naming nothing registered now raises `Grape::Exceptions::UnknownErrorFormatter` instead of silently storing `Txt` (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2904](https://github.com/ruby-grape/grape/pull/2904): Document and spec route `requirements` given as a Mustermann capture type, which constrains the match and hands the endpoint the converted value - [@ericproulx](https://github.com/ericproulx).
 * [#2905](https://github.com/ruby-grape/grape/pull/2905): Nest any `route_param` requirement under the param name, not just a Regexp, and reject the `requirements` shapes that have no param to attach to where they are written rather than on the first request - [@ericproulx](https://github.com/ericproulx).
+* [#2908](https://github.com/ruby-grape/grape/pull/2908): Stop reassigning method parameters across `lib`, so a parameter keeps the value its caller passed for the whole method; `Grape::Middleware::Formatter#ensure_content_type` and the `oneof` collection in `Grape::Validations::ParamsScope` no longer write into the Hash they were given - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/lib/grape/dsl/desc.rb
+++ b/lib/grape/dsl/desc.rb
@@ -54,19 +54,22 @@ module Grape
       #     end
       #
       def desc(description, **options, &config_block)
-        if options.key?(:default)
-          Grape.deprecator.warn('The `default` option of `desc` is deprecated. Use `default_response` instead.')
-          # Rebuilt rather than mutated in place: an explicit +default_response+
-          # still wins, since the merged Hash is the one that keeps its key.
-          options = { default_response: options[:default] }.merge(options.except(:default))
-        end
+        resolved_options =
+          if options.key?(:default)
+            Grape.deprecator.warn('The `default` option of `desc` is deprecated. Use `default_response` instead.')
+            # Rebuilt rather than mutated in place: an explicit +default_response+
+            # still wins, since the merged Hash is the one that keeps its key.
+            { default_response: options[:default] }.merge(options.except(:default))
+          else
+            options
+          end
 
         settings =
           if config_block
             endpoint_config = defined?(configuration) ? configuration : nil
             Grape::Util::ApiDescription.new(description, endpoint_config, &config_block).settings
           else
-            options.merge(description:)
+            resolved_options.merge(description:)
           end
         # Only the route scope is consumed downstream (by +route+ and the
         # route's readers, e.g. +http_codes+); the namespace scope was

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -27,10 +27,10 @@ module Grape
       # @param backtrace [Array<String>] The backtrace of the exception that caused the error.
       # @param original_exception [Exception] The original exception that caused the error.
       def error!(message, status = nil, additional_headers = nil, backtrace = nil, original_exception = nil)
-        status = self.status(status || inheritable_setting.default_error_status)
+        resolved_status = self.status(status || inheritable_setting.default_error_status)
         headers = additional_headers.present? ? header.merge(additional_headers) : header
         throw :error, Grape::Exceptions::ErrorResponse.new(
-          message:, status:, headers:, backtrace:, original_exception:
+          message:, status: resolved_status, headers:, backtrace:, original_exception:
         )
       end
 

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -191,9 +191,8 @@ module Grape
       # @return hash of parameters relevant for the current scope
       # @api private
       def params(params)
-        params = @parent.qualifying_params.presence || @parent.params(params) if @parent
-        params = map_params(params, @element) if @element
-        params
+        scoped = @parent ? (@parent.qualifying_params.presence || @parent.params(params)) : params
+        @element ? map_params(scoped, @element) : scoped
       end
 
       private
@@ -211,7 +210,7 @@ module Grape
       # +except+ and +:none+ uses it to drop fields entirely.
       def declare(attrs, opts, required:, using:, except:, as:, &block)
         merged_opts = @group&.deep_merge(opts) || opts
-        as ||= merged_opts[:as]
+        declared_as = as || merged_opts[:as]
 
         if using
           return require_required_and_optional_fields(attrs.first, using:, except:) if required
@@ -220,9 +219,9 @@ module Grape
         end
 
         validates(attrs, merged_opts, required:)
-        return push_declared_params(attrs, as:) unless block
+        return push_declared_params(attrs, as: declared_as) unless block
 
-        new_scope(attrs.first, type: merged_opts[:type], as:, optional: !required, &block)
+        new_scope(attrs.first, type: merged_opts[:type], as: declared_as, optional: !required, &block)
       end
 
       def legacy_options?(args)

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -124,17 +124,18 @@ module Grape
       end
 
       def mount(mounts, opts = {})
+        mount_opts = opts
         if opts[:refresh_already_mounted]
           Grape.deprecator.warn('`refresh_already_mounted` is not a `mount` option and will be ignored in a future release.')
           drop_endpoints_mounted_for(mounts)
           # Dropped before the recursion below re-enters with the same options,
           # so a Grape API does not warn once per mount and once per instance.
-          opts = opts.except(:refresh_already_mounted)
+          mount_opts = opts.except(:refresh_already_mounted)
         end
 
         normalize_mounts(mounts).each_pair do |app, path|
           if app.respond_to?(:mount_instance)
-            mount({ app.mount_instance(configuration: opts[:with] || {}) => path }, opts)
+            mount({ app.mount_instance(configuration: mount_opts[:with] || {}) => path }, mount_opts)
             next
           end
           in_setting = inheritable_setting
@@ -260,7 +261,7 @@ module Grape
         # capture this namespace does not introduce, and belongs on +namespace+.
         raise ArgumentError, "route_param :#{param} constrains :#{param}; pass the constraint itself, or a Hash of requirements to the enclosing namespace" if requirements.respond_to?(:to_hash)
 
-        param_requirements = { param.to_sym => requirements } unless requirements.nil?
+        param_requirements = requirements ? { param.to_sym => requirements } : requirements
 
         Grape::Validations::ParamsScope.new(api: self) do
           requires param, type: type

--- a/lib/grape/error_formatter/base.rb
+++ b/lib/grape/error_formatter/base.rb
@@ -26,12 +26,13 @@ module Grape
           # Extract it here so the presenter can be resolved and the key is not serialized in the response.
           # See spec/integration/grape_entity/entity_spec.rb for examples.
           with = nil
+          payload = message
           if message.is_a?(Hash) && message.key?(:with)
-            message = message.dup
-            with = message.delete(:with)
+            payload = message.dup
+            with = payload.delete(:with)
           end
 
-          presenter = with || env[Grape::Env::API_ENDPOINT].entity_class_for_obj(message)
+          presenter = with || env[Grape::Env::API_ENDPOINT].entity_class_for_obj(payload)
 
           unless presenter || env[Grape::Env::GRAPE_ROUTING_ARGS].nil?
             # env['api.endpoint'].route does not work when the error occurs within a middleware
@@ -44,11 +45,11 @@ module Grape
             presenter = found_code[2] if found_code
           end
 
-          return message unless presenter
+          return payload unless presenter
 
           embeds = { env: }
           embeds[:version] = env[Grape::Env::API_VERSION] if env.key?(Grape::Env::API_VERSION)
-          presenter.represent(message, embeds).serializable_hash
+          presenter.represent(payload, embeds).serializable_hash
         end
 
         def wrap_message(message)

--- a/lib/grape/exceptions/validation.rb
+++ b/lib/grape/exceptions/validation.rb
@@ -9,15 +9,16 @@ module Grape
 
       def initialize(params:, message: nil, status: nil, headers: nil)
         @params = Array(params)
-        if message
-          @message_key = case message
-                         when Symbol then message
-                         when Hash then message[:key]
-                         end
-          message = translate_message(message)
-        end
+        translated =
+          if message
+            @message_key = case message
+                           when Symbol then message
+                           when Hash then message[:key]
+                           end
+            translate_message(message)
+          end
 
-        super(status:, message:, headers:)
+        super(status:, message: translated, headers:)
         # Pre-seed the backtrace so Ruby's raise skips capture. Validation errors are
         # a hot path (raised per bad attribute) and end up as 400 Bad Request responses;
         # backtraces here point into Grape internals and have no diagnostic value.

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -27,9 +27,14 @@ module Grape
           # keyword defaults above, so restore them here rather than letting nil
           # propagate to `def_delegator :rescue_options, :backtrace` or to the
           # formatter lookup in `#format_message`.
-          rescue_options ||= Grape::DSL::RescueOptions.new
-          default_error_formatter ||= Grape::ErrorFormatter::Txt
-          super
+          super(
+            rescue_options: rescue_options || Grape::DSL::RescueOptions.new,
+            default_error_formatter: default_error_formatter || Grape::ErrorFormatter::Txt,
+            all_rescue_handler:, base_only_rescue_handlers:, content_types:,
+            default_message:, default_status:, error_formatters:, format:,
+            grape_exceptions_rescue_handler:, internal_grape_exceptions_rescue_handler:,
+            rescue_all:, rescue_grape_exceptions:, rescue_handlers:
+          )
         end
       end
 
@@ -62,8 +67,8 @@ module Grape
       private
 
       def rack_response(status, headers, message)
-        message = Rack::Utils.escape_html(message) if html_content_type?(headers[Rack::CONTENT_TYPE])
-        Rack::Response.new(Array.wrap(message), Rack::Utils.status_code(status), Grape::Util::Header.new.merge(headers))
+        body = html_content_type?(headers[Rack::CONTENT_TYPE]) ? Rack::Utils.escape_html(message) : message
+        Rack::Response.new(Array.wrap(body), Rack::Utils.status_code(status), Grape::Util::Header.new.merge(headers))
       end
 
       # Escaping must key off the media type only, case-insensitively. Comparing
@@ -261,9 +266,9 @@ module Grape
       end
 
       def run_rescue_handler(handler, error, endpoint, redispatched: false)
-        handler = endpoint.public_method(handler) if handler.is_a?(Symbol)
+        callable = handler.is_a?(Symbol) ? endpoint.public_method(handler) : handler
         response = catch(:error) do
-          handler.arity.zero? ? endpoint.instance_exec(&handler) : endpoint.instance_exec(error, &handler)
+          callable.arity.zero? ? endpoint.instance_exec(&callable) : endpoint.instance_exec(error, &callable)
         rescue StandardError => e
           return redispatch(e, endpoint, redispatched)
         end

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -56,25 +56,25 @@ module Grape
       private
 
       def build_formatted_response(status, headers, bodies)
-        headers = ensure_content_type(headers)
+        typed_headers = ensure_content_type(headers)
 
         if bodies.is_a?(Grape::ServeStream::StreamResponse)
-          Grape::ServeStream::SendfileResponse.new([], status, headers) do |resp|
+          Grape::ServeStream::SendfileResponse.new([], status, typed_headers) do |resp|
             resp.body = bodies.stream
           end
         else
           # Allow content-type to be explicitly overwritten
-          formatter = fetch_formatter(headers)
+          formatter = fetch_formatter(typed_headers)
           bodymap = instrument_format_response(formatter) do
             bodies.map { |body| formatter.call(body, env) }
           end
-          # A bare Rack tuple rather than a Rack::Response: +headers+ is already
+          # A bare Rack tuple rather than a Rack::Response: +typed_headers+ is already
           # a Grape::Util::Header (a Rack::Headers on Rack 3), so wrapping only
           # re-normalizes the same keys into a second Headers hash that
           # +Middleware::Base#call+ unwraps again with +to_a+ on the way out.
           # The 204/304 bodies Rack::Response#finish would blank are returned
           # above, before this point.
-          [status, headers, bodymap]
+          [status, typed_headers, bodymap]
         end
       rescue Grape::Exceptions::InvalidFormatter => e
         throw :error, Grape::Exceptions::ErrorResponse.new(status: 500, message: e.message, backtrace: e.backtrace, original_exception: e)
@@ -101,8 +101,10 @@ module Grape
       def ensure_content_type(headers)
         return headers if headers[Rack::CONTENT_TYPE]
 
-        headers[Rack::CONTENT_TYPE] = content_type_for(env[Grape::Env::API_FORMAT])
-        headers
+        # Merged rather than written in place: +headers+ belongs to the response
+        # the app returned, and negotiating a content type for it is not a reason
+        # to reach back into it.
+        headers.merge(Rack::CONTENT_TYPE => content_type_for(env[Grape::Env::API_FORMAT]))
       end
 
       def read_body_input
@@ -140,12 +142,12 @@ module Grape
         return env[Grape::Env::API_REQUEST_BODY] = body unless parser
 
         begin
-          body = (env[Grape::Env::API_REQUEST_BODY] = parser.call(body, env))
-          if body.is_a?(Hash)
+          parsed = (env[Grape::Env::API_REQUEST_BODY] = parser.call(body, env))
+          if parsed.is_a?(Hash)
             if (form_hash = env[Rack::RACK_REQUEST_FORM_HASH])
-              form_hash.merge!(body)
+              form_hash.merge!(parsed)
             else
-              env[Rack::RACK_REQUEST_FORM_HASH] = body
+              env[Rack::RACK_REQUEST_FORM_HASH] = parsed
             end
             env[Rack::RACK_REQUEST_FORM_INPUT] = env[Rack::RACK_INPUT]
           end

--- a/lib/grape/middleware/stack.rb
+++ b/lib/grape/middleware/stack.rb
@@ -64,15 +64,15 @@ module Grape
       end
 
       def insert(index, klass, *args, &block)
-        index = assert_index(index, :before)
-        middlewares.insert(index, self.class::Middleware.new(klass, args, block))
+        at = assert_index(index, :before)
+        middlewares.insert(at, self.class::Middleware.new(klass, args, block))
       end
 
       alias insert_before insert
 
       def insert_after(index, ...)
-        index = assert_index(index, :after)
-        insert(index + 1, ...)
+        at = assert_index(index, :after)
+        insert(at + 1, ...)
       end
 
       def use(klass, *args, &block)

--- a/lib/grape/util/path_normalizer.rb
+++ b/lib/grape/util/path_normalizer.rb
@@ -19,17 +19,18 @@ module Grape
         # same predicate, and the scan stays in C without building a match.
         return path if path.start_with?('/') && !(path.end_with?('/') || path.include?('%') || path.include?('//'))
 
-        # Slow path
+        # Slow path. The bangs below are safe because +normalized+ is a fresh
+        # String built here, never the one the caller passed in.
         encoding = path.encoding
-        path = "/#{path}"
-        path.squeeze!('/')
+        normalized = "/#{path}"
+        normalized.squeeze!('/')
 
-        unless path == '/'
-          path.delete_suffix!('/')
-          path.gsub!(/(%[a-f0-9]{2})/) { ::Regexp.last_match(1).upcase }
+        unless normalized == '/'
+          normalized.delete_suffix!('/')
+          normalized.gsub!(/(%[a-f0-9]{2})/) { ::Regexp.last_match(1).upcase }
         end
 
-        path.force_encoding(encoding)
+        normalized.force_encoding(encoding)
       end
     end
   end

--- a/lib/grape/validations/contract_scope.rb
+++ b/lib/grape/validations/contract_scope.rb
@@ -9,19 +9,20 @@ module Grape
       # @yield a block yielding a new schema class. Optional.
       def initialize(api, contract = nil, &block)
         # When block is passed, the first arg is either schema or nil.
-        contract = Dry::Schema.Params(parent: contract, &block) if block
+        declared = block ? Dry::Schema.Params(parent: contract, &block) : contract
 
-        if contract.respond_to?(:schema)
+        if declared.respond_to?(:schema)
           # It's a Dry::Validation::Contract, then.
-          contract = contract.new
-          key_map = contract.schema.key_map
+          schema = declared.new
+          key_map = schema.schema.key_map
         else
           # Dry::Schema::Processor, hopefully.
-          key_map = contract.key_map
+          schema = declared
+          key_map = declared.key_map
         end
 
         api.inheritable_setting.add_contract_key_map(key_map)
-        api.inheritable_setting.add_validation(Validators::ContractScopeValidator.new(schema: contract))
+        api.inheritable_setting.add_validation(Validators::ContractScopeValidator.new(schema:))
       end
     end
   end

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -364,10 +364,9 @@ module Grape
           Grape.deprecator.warn('Passing a `presence` option is deprecated and it will be ignored in a future release. Declare the parameter with `requires` to make it required, `optional` to make it optional.')
         end
 
-        validations = validations.merge(presence: { value: true, message: validations[:message] }) if required
-
-        process_oneof!(validations) if validations.key?(:oneof)
-        spec = ValidationsSpec.from(validations)
+        declared = required ? validations.merge(presence: { value: true, message: validations[:message] }) : validations
+        declared = declared.merge(oneof: collected_oneof(declared)) if declared.key?(:oneof)
+        spec = ValidationsSpec.from(declared)
 
         document_params(attrs, spec)
 
@@ -419,14 +418,17 @@ module Grape
       # {OneofCollector} so the full params DSL is available inside variants
       # and the resulting validators are kept out of the real API's
       # registration list.
-      def process_oneof!(validations)
+      # Returns the collected variants rather than writing them back into
+      # +validations+, which is the options Hash the +requires+/+optional+ call
+      # site built.
+      def collected_oneof(validations)
         raise ArgumentError, 'oneof: requires type: Hash' unless validations[:type] == Hash
 
         variants = validations[:oneof]
         raise ArgumentError, 'oneof: must be a non-empty Array of blocks' unless variants.is_a?(Array) && variants.any?
         raise ArgumentError, 'oneof: each variant must be a Proc' unless variants.all?(Proc)
 
-        validations[:oneof] = variants.map { |block| OneofCollector.collect(block) }
+        variants.map { |block| OneofCollector.collect(block) }
       end
 
       def validate(type, options, attrs, required, opts)

--- a/lib/grape/validations/types.rb
+++ b/lib/grape/validations/types.rb
@@ -162,20 +162,20 @@ module Grape
 
       def create_coercer_instance(type, method, strict)
         # map_special doesn't recurse into collections — applied only to the top-level type here.
-        type = map_special(type)
+        mapped = map_special(type)
 
         # Multiply-typed parameters, e.g. types: [Integer, String].
-        return MultipleTypeCoercer.new(type, method) if multiple?(type)
+        return MultipleTypeCoercer.new(mapped, method) if multiple?(mapped)
 
         # User-supplied coercion method, or a custom type with its own #parse.
-        return CustomTypeCoercer.new(type, method) if method || custom?(type)
+        return CustomTypeCoercer.new(mapped, method) if method || custom?(mapped)
 
         # Array/Set of a custom type — CustomTypeCoercer already handles single
         # custom types when an explicit coercion method is supplied.
-        return CustomTypeCollectionCoercer.new(map_special(type.first), set: type.is_a?(Set)) if collection_of_custom?(type)
+        return CustomTypeCollectionCoercer.new(map_special(mapped.first), set: mapped.is_a?(Set)) if collection_of_custom?(mapped)
 
         # Fallback: let dry-types handle primitives, structures, and known specials.
-        DryTypeCoercer.coercer_instance_for(type, strict:)
+        DryTypeCoercer.coercer_instance_for(mapped, strict:)
       end
 
       class CoercerCache < Grape::Util::Cache

--- a/lib/grape/validations/types/multiple_type_coercer.rb
+++ b/lib/grape/validations/types/multiple_type_coercer.rb
@@ -41,12 +41,12 @@ module Grape
         #   of {InvalidValue} if the value could not be coerced.
         def call(val)
           # once the value is coerced by the custom method, its type should be checked
-          val = @method.call(val) if @method
+          candidate = @method ? @method.call(val) : val
 
           coerced_val = InvalidValue.new
 
           @type_coercers.each do |coercer|
-            coerced_val = coercer.call(val)
+            coerced_val = coercer.call(candidate)
 
             return coerced_val unless coerced_val.is_a?(InvalidValue)
           end

--- a/lib/grape/validations/types/variant_collection_coercer.rb
+++ b/lib/grape/validations/types/variant_collection_coercer.rb
@@ -48,15 +48,15 @@ module Grape
         def call(value)
           return unless value.is_a? Array
 
-          value =
+          coerced =
             if @method
               @method.call(value)
             else
               value.map { |v| @member_coercer.call(v) }
             end
-          return Set.new value if @types.is_a? Set
+          return Set.new coerced if @types.is_a? Set
 
-          value
+          coerced
         end
       end
     end

--- a/lib/grape/validations/validations_spec.rb
+++ b/lib/grape/validations/validations_spec.rb
@@ -97,13 +97,13 @@ module Grape
       def validate_value_coercion(coerce_type, *values_list)
         return unless coerce_type
 
-        coerce_type = coerce_type.first if coerce_type.is_a?(Enumerable)
+        element_type = coerce_type.is_a?(Enumerable) ? coerce_type.first : coerce_type
         values_list.each do |values|
           next if !values || values.is_a?(Proc)
 
           value_types = values.is_a?(Range) ? [values.begin, values.end].compact : values
-          value_types = value_types.map { |type| Grape::API::Boolean.build(type) } if coerce_type == Grape::API::Boolean
-          raise Grape::Exceptions::IncompatibleOptionValues.new(:type, coerce_type, :values, values) unless value_types.all?(coerce_type)
+          value_types = value_types.map { |type| Grape::API::Boolean.build(type) } if element_type == Grape::API::Boolean
+          raise Grape::Exceptions::IncompatibleOptionValues.new(:type, element_type, :values, values) unless value_types.all?(element_type)
         end
       end
 


### PR DESCRIPTION
A method that reassigns one of its parameters gives the same name two meanings: what the signature documents, and what the lines below the reassignment actually hold. Nothing escapes to the caller — Ruby parameters are local bindings — but the reader has to carry the reassignment for the rest of the method, and a later edit that moves a line above it changes behaviour silently.

This is a sweep of every such site in `lib`. Each derived value gets its own local; the parameter keeps what the caller passed.

## The two that mattered

Most of the diff is naming. Two sites were reassignment wrapped around a mutation of the argument itself, and those did escape.

**`Middleware::Formatter#ensure_content_type`** wrote into the response headers Hash and returned the same object, which the caller then reassigned over its own parameter:

```ruby
headers = ensure_content_type(headers)   # caller

def ensure_content_type(headers)
  return headers if headers[Rack::CONTENT_TYPE]

  headers[Rack::CONTENT_TYPE] = content_type_for(env[Grape::Env::API_FORMAT])
  headers
end
```

The Hash belongs to the response the app returned; negotiating a content type for it is not a reason to reach back into it. It merges now. `Grape::Util::Header#merge` preserves the class and its case-insensitive lookup on both Rack 2 (`Rack::Utils::HeaderHash`) and Rack 3 (`Rack::Headers`).

**`ParamsScope#process_oneof!`** wrote the collected variants back into the options Hash the `requires` / `optional` call site built:

```ruby
validations[:oneof] = variants.map { |block| OneofCollector.collect(block) }
```

`#validates` only copied that Hash on the `required` path (`validations.merge(presence: …)`), so on the `optional` path the write landed on the caller's Hash. It is contained today only because `**opts` manufactures a fresh Hash per call — an accidental defensive copy, one signature change away from being load-bearing. `#collected_oneof` returns the variants now and `#validates` merges them.

## The rest

| File | Method | Parameter → local |
|---|---|---|
| `dsl/desc.rb` | `desc` | `options` → `resolved_options` |
| `dsl/inside_route.rb` | `error!` | `status` → `resolved_status` |
| `dsl/parameters.rb` | `params` | `params` → `scoped` |
| `dsl/parameters.rb` | `declare` | `as` → `declared_as` |
| `dsl/routing.rb` | `mount` | `opts` → `mount_opts` |
| `dsl/routing.rb` | `route_param` | `requirements` → `param_requirements` |
| `error_formatter/base.rb` | `present` | `message` → `payload` |
| `exceptions/validation.rb` | `initialize` | `message` → `translated` |
| `middleware/error.rb` | `Options#initialize` | `rescue_options`, `default_error_formatter` |
| `middleware/error.rb` | `rack_response` | `message` → `body` |
| `middleware/error.rb` | `run_rescue_handler` | `handler` → `callable` |
| `middleware/formatter.rb` | `build_formatted_response` | `headers` → `typed_headers` |
| `middleware/formatter.rb` | `read_rack_input` | `body` → `parsed` |
| `middleware/stack.rb` | `insert`, `insert_after` | `index` → `at` |
| `util/path_normalizer.rb` | `call` | `path` → `normalized` |
| `validations/contract_scope.rb` | `initialize` | `contract` → `declared` / `schema` |
| `validations/params_scope.rb` | `validates` | `validations` → `declared` |
| `validations/types.rb` | `create_coercer_instance` | `type` → `mapped` |
| `types/multiple_type_coercer.rb` | `call` | `val` → `candidate` |
| `types/variant_collection_coercer.rb` | `call` | `value` → `coerced` |
| `validations/validations_spec.rb` | `validate_value_coercion` | `coerce_type` → `element_type` |

Three are worth a second look:

- **`run_rescue_handler`** is the strongest case, because the *type* changed rather than the value. `handler` arrives as a `Symbol`, a `Method` or a `Proc` — `rescue_from with: :some_endpoint_method` produces the first, `find_handler`'s `method(:error_response)` the second, a `rescue_from` block the third — and `arity` / `&` are valid only after resolution. The method re-enters itself from five places, so tracing the recursion meant re-deriving the shape on each pass. `callable` states the invariant.
- **`path_normalizer.rb`** and **`error_formatter/base.rb`** reassign *in order to* protect the caller: `path = "/#{path}"` before a chain of `squeeze!` / `delete_suffix!` / `gsub!`, and `message = message.dup` before `delete(:with)`. The naming was what made that hard to see — it reads as mutating the argument. `normalized` and `payload` say the mutated object is a fresh one, and `path_normalizer` gets a comment recording why the bangs are safe.
- **`middleware/error.rb`'s `Options#initialize`** needed `super(...)` with explicit keywords instead of zsuper, since bare `super` forwards whatever the parameters currently hold — which is exactly the pressure that produces `x ||= default` in a `Data` initializer.

## Not in scope

`Grape::Endpoint::Options` has the same shape and is fixed separately in #2907, where the reassignment is hiding a real bug rather than only obscuring one.

## Verification

- `bundle exec rspec` — 2703 examples, 0 failures.
- `bundle exec rubocop` — 343 files, no offenses.
- `gemfiles/grape_entity.gemfile` (exercises `error_formatter/base.rb#present`) — 2726 examples, 0 failures.
- `gemfiles/dry_validation.gemfile` (exercises `contract_scope.rb`) — 13 examples, 0 failures.
- `gemfiles/multi_xml.gemfile` has 3 pre-existing failures in `api_spec.rb`'s XML error-format examples; identical on `master` at the same seed, so unrelated to this change.

No new specs: nothing new is asserted, and the behavioural half is covered by the existing formatter and `oneof` suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
