### PR TITLE
Standardize bare Ruby exception messages to lowercase, unpunctuated

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - benchmark/**/*
 
 plugins:
+  - rubocop-exception_messages
   - rubocop-performance
   - rubocop-rspec
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 * [#2900](https://github.com/ruby-grape/grape/pull/2900): Remove the deprecations announced in 3.2 and 3.3: `Grape::Router.normalize_path`, Hash access on middleware `Options` and their `DEFAULT_OPTIONS` constants, the positional options Hash for `auth`/`http_basic`/`desc`, a Hash returned from a `rescue_from` handler, and `@option` on validators (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2896](https://github.com/ruby-grape/grape/pull/2896): Bring test suite line coverage to 100% - [@dblock](https://github.com/dblock).
 * [#2897](https://github.com/ruby-grape/grape/pull/2897): Improve test suite branch coverage - [@dblock](https://github.com/dblock).
+* [#2909](https://github.com/ruby-grape/grape/pull/2909): Standardize bare Ruby exception messages (`ArgumentError`, etc.) to lowercase, unpunctuated, matching Ruby's own core/stdlib style - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@
 * [#2900](https://github.com/ruby-grape/grape/pull/2900): Remove the deprecations announced in 3.2 and 3.3: `Grape::Router.normalize_path`, Hash access on middleware `Options` and their `DEFAULT_OPTIONS` constants, the positional options Hash for `auth`/`http_basic`/`desc`, a Hash returned from a `rescue_from` handler, and `@option` on validators (see UPGRADING) - [@ericproulx](https://github.com/ericproulx).
 * [#2896](https://github.com/ruby-grape/grape/pull/2896): Bring test suite line coverage to 100% - [@dblock](https://github.com/dblock).
 * [#2897](https://github.com/ruby-grape/grape/pull/2897): Improve test suite branch coverage - [@dblock](https://github.com/dblock).
-* [#2909](https://github.com/ruby-grape/grape/pull/2909): Standardize bare Ruby exception messages (`ArgumentError`, etc.) to lowercase, unpunctuated, matching Ruby's own core/stdlib style - [@dblock](https://github.com/dblock).
+* [#2909](https://github.com/ruby-grape/grape/pull/2909): Standardize bare Ruby exception messages (`ArgumentError`, etc.) to lowercase, unpunctuated, matching Ruby's own core/stdlib style, and wrap interpolated values in backticks via `rubocop-exception_messages` - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 #### Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,22 @@ Ruby style is enforced with [Rubocop](https://github.com/bbatsov/rubocop), run `
 
 Make sure that `bundle exec rake` completes without errors.
 
+##### Exception Messages
+
+When you `raise` a bare Ruby exception (`ArgumentError`, `NotImplementedError`, etc.) for programmer errors — invalid DSL usage, misconfiguration and the like — write the message as a lowercase fragment with no trailing period, matching Ruby's own core exceptions (e.g. `TypeError: no implicit conversion from nil to integer`). This reads naturally when Ruby prints it after the exception class name and colon in a backtrace:
+
+```ruby
+raise ArgumentError, 'a block is required'
+```
+
+rather than:
+
+```ruby
+raise ArgumentError, 'A block is required.'
+```
+
+This does not apply to `Grape::Exceptions::*` messages meant to be rendered in an API response body, which are already lowercase and unpunctuated by convention and typically come from locale YAML rather than inline strings.
+
 #### Write Documentation
 
 Document any external behavior in the [README](README.md).

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :development, :test do
   gem 'bundler'
   gem 'rake'
   gem 'rubocop', '1.88.0', require: false
+  gem 'rubocop-exception_messages', '0.1.0', require: false
   gem 'rubocop-performance', '1.26.1', require: false
   gem 'rubocop-rspec', '3.10.2', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :development, :test do
   gem 'bundler'
   gem 'rake'
   gem 'rubocop', '1.88.0', require: false
-  gem 'rubocop-exception_messages', '0.1.0', require: false
+  gem 'rubocop-exception_messages', '0.2.0', require: false
   gem 'rubocop-performance', '1.26.1', require: false
   gem 'rubocop-rspec', '3.10.2', require: false
 end

--- a/lib/grape/dry_types.rb
+++ b/lib/grape/dry_types.rb
@@ -48,7 +48,7 @@ module Grape
     def self.wrapped_dry_types_const_get(dry_type, type)
       dry_type.const_get(type.name, false)
     rescue NameError
-      raise ArgumentError, "type #{type} should support coercion via `[]`" unless type.respond_to?(:[])
+      raise ArgumentError, "type `#{type}` should support coercion via `[]`" unless type.respond_to?(:[])
     end
   end
 end

--- a/lib/grape/dsl/entity.rb
+++ b/lib/grape/dsl/entity.rb
@@ -34,7 +34,7 @@ module Grape
         if key
           representation = body&.merge(key => representation) || { key => representation }
         elsif entity_class.present? && body
-          raise ArgumentError, "representation of type #{representation.class} cannot be merged" unless representation.respond_to?(:merge)
+          raise ArgumentError, "representation of type `#{representation.class}` cannot be merged" unless representation.respond_to?(:merge)
 
           representation = body.merge(representation)
         end

--- a/lib/grape/dsl/entity.rb
+++ b/lib/grape/dsl/entity.rb
@@ -34,7 +34,7 @@ module Grape
         if key
           representation = body&.merge(key => representation) || { key => representation }
         elsif entity_class.present? && body
-          raise ArgumentError, "Representation of type #{representation.class} cannot be merged." unless representation.respond_to?(:merge)
+          raise ArgumentError, "representation of type #{representation.class} cannot be merged" unless representation.respond_to?(:merge)
 
           representation = body.merge(representation)
         end

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -72,7 +72,7 @@ module Grape
         when Symbol, Integer
           @status = Rack::Utils.status_code(status)
         else
-          raise ArgumentError, 'Status code must be Integer or Symbol.'
+          raise ArgumentError, 'status code must be Integer or Symbol'
         end
       end
 
@@ -128,7 +128,7 @@ module Grape
       def sendfile(value = nil)
         return stream if value.nil?
 
-        raise ArgumentError, 'Argument must be a file path' unless value.is_a?(String)
+        raise ArgumentError, 'argument must be a file path' unless value.is_a?(String)
 
         file_body = Grape::ServeStream::FileBody.new(value)
         @stream = Grape::ServeStream::StreamResponse.new(file_body)
@@ -191,7 +191,7 @@ module Grape
       def stream_body(value)
         return Grape::ServeStream::FileBody.new(value) if value.is_a?(String)
 
-        raise ArgumentError, 'Stream object must respond to :each.' unless value.respond_to?(:each)
+        raise ArgumentError, 'stream object must respond to :each' unless value.respond_to?(:each)
 
         value
       end

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -55,7 +55,7 @@ module Grape
       # the call had never been made. Reject it here, where the mistake is.
       def error_formatter(format, options = nil, with: nil)
         formatter = with || options
-        raise ArgumentError, "error_formatter #{format.inspect} requires a formatter, given positionally or as `with:`" if formatter.nil?
+        raise ArgumentError, "error_formatter `#{format.inspect}` requires a formatter, given positionally or as `with:`" if formatter.nil?
 
         inheritable_setting.add_error_formatter(format.to_sym, formatter)
       end
@@ -109,7 +109,7 @@ module Grape
       def rescue_from(*args, with: nil, rescue_subclasses: true, backtrace: false, original_exception: false, &block)
         handler = extract_handler(args, with:, block:)
         meta_selector = (args & META_RESCUE_SELECTORS).first
-        raise ArgumentError, "rescue_from #{meta_selector.inspect} does not accept additional arguments" if meta_selector && args.size > 1
+        raise ArgumentError, "rescue_from `#{meta_selector.inspect}` does not accept additional arguments" if meta_selector && args.size > 1
 
         case meta_selector
         when :all
@@ -163,7 +163,7 @@ module Grape
         case with
         when Proc, Symbol then with
         when String then with.to_sym
-        else raise ArgumentError, "with: #{with.class}, expected Symbol, String or Proc"
+        else raise ArgumentError, "with: `#{with.class}`, expected Symbol, String or Proc"
         end
       end
     end

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -259,7 +259,7 @@ module Grape
         # The param is named here, so the constraint is its own: nest whatever
         # it is, not just a Regexp. A Hash would name the param twice, or key a
         # capture this namespace does not introduce, and belongs on +namespace+.
-        raise ArgumentError, "route_param :#{param} constrains :#{param}; pass the constraint itself, or a Hash of requirements to the enclosing namespace" if requirements.respond_to?(:to_hash)
+        raise ArgumentError, "route_param :`#{param}` constrains :`#{param}`; pass the constraint itself, or a Hash of requirements to the enclosing namespace" if requirements.respond_to?(:to_hash)
 
         param_requirements = requirements ? { param.to_sym => requirements } : requirements
 
@@ -283,7 +283,7 @@ module Grape
       def validate_requirements!(requirements)
         return if requirements.nil? || requirements.respond_to?(:to_hash)
 
-        raise ArgumentError, "requirements must be a Hash of param name => constraint, got #{requirements.class}"
+        raise ArgumentError, "requirements must be a Hash of param name => constraint, got `#{requirements.class}`"
       end
 
       # Compose a route's params: the declared params (+params do … end+) deep-merged

--- a/lib/grape/dsl/validations.rb
+++ b/lib/grape/dsl/validations.rb
@@ -17,8 +17,8 @@ module Grape
       #   subclass, allowing to define the schema inline. When the
       #   +contract+ parameter is a schema, it will be used as a parent. Optional.
       def contract(contract = nil, &block)
-        raise ArgumentError, 'Either contract or block must be provided' unless contract || block
-        raise ArgumentError, 'Cannot inherit from contract, only schema' if block && contract.respond_to?(:schema)
+        raise ArgumentError, 'either contract or block must be provided' unless contract || block
+        raise ArgumentError, 'cannot inherit from contract, only schema' if block && contract.respond_to?(:schema)
 
         Grape::Validations::ContractScope.new(self, contract, &block)
       end

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -245,7 +245,7 @@ module Grape
         end
         required_fields.each do |field|
           field_opts = using[field]
-          raise ArgumentError, "required field not exist: #{field}" unless field_opts
+          raise ArgumentError, "required field not exist: `#{field}`" unless field_opts
 
           requires(field, **field_opts)
         end

--- a/lib/grape/validations/types/dry_type_coercer.rb
+++ b/lib/grape/validations/types/dry_type_coercer.rb
@@ -23,7 +23,7 @@ module Grape
             when Set
               SetCoercer
             else
-              raise ArgumentError, "unknown type: #{type}"
+              raise ArgumentError, "unknown type: `#{type}`"
             end
           end
 

--- a/lib/grape/validations/types/dry_type_coercer.rb
+++ b/lib/grape/validations/types/dry_type_coercer.rb
@@ -23,7 +23,7 @@ module Grape
             when Set
               SetCoercer
             else
-              raise ArgumentError, "Unknown type: #{type}"
+              raise ArgumentError, "unknown type: #{type}"
             end
           end
 

--- a/lib/grape/validations/validators/length_validator.rb
+++ b/lib/grape/validations/validators/length_validator.rb
@@ -10,7 +10,7 @@ module Grape
           @min, @max, @is = options.values_at(:min, :max, :is)
           validate_boundary!(:min, @min)
           validate_boundary!(:max, @max)
-          raise ArgumentError, "min #{@min} cannot be greater than max #{@max}" if @min && @max && @min > @max
+          raise ArgumentError, "min `#{@min}` cannot be greater than max `#{@max}`" if @min && @max && @min > @max
 
           return if @is.nil?
           raise ArgumentError, 'is must be an integer greater than zero' unless @is.is_a?(Integer) && @is.positive?
@@ -42,7 +42,7 @@ module Grape
         private
 
         def validate_boundary!(name, val)
-          raise ArgumentError, "#{name} must be an integer greater than or equal to zero" if !val.nil? && (!val.is_a?(Integer) || val.negative?)
+          raise ArgumentError, "`#{name}` must be an integer greater than or equal to zero" if !val.nil? && (!val.is_a?(Integer) || val.negative?)
         end
       end
     end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -5311,7 +5311,7 @@ describe Grape::API do
         rescue_from :all do
           error!(context.env, 400)
         end
-        get { raise ArgumentError, 'Oops!' }
+        get { raise ArgumentError, 'oops' }
       end
     end
 

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -430,7 +430,7 @@ describe Grape::API do
               get { params[:id].to_json }
             end
           end
-        end.to raise_error(ArgumentError, /route_param :id constrains :id/)
+        end.to raise_error(ArgumentError, /route_param :`id` constrains :`id`/)
       end
 
       # The declared type still owns what the endpoint sees: validation runs

--- a/spec/grape/dsl/inside_route_spec.rb
+++ b/spec/grape/dsl/inside_route_spec.rb
@@ -141,7 +141,7 @@ describe Grape::DSL::InsideRoute do
 
     it 'raises error if status is not a integer or symbol' do
       expect { subject.status Object.new }
-        .to raise_error(ArgumentError, 'Status code must be Integer or Symbol.')
+        .to raise_error(ArgumentError, 'status code must be Integer or Symbol')
     end
   end
 
@@ -230,7 +230,7 @@ describe Grape::DSL::InsideRoute do
         let(:file_object) { double('StreamerObject', each: nil) }
 
         it 'raises an error that only a file path is supported' do
-          expect { subject.sendfile file_object }.to raise_error(ArgumentError, /Argument must be a file path/)
+          expect { subject.sendfile file_object }.to raise_error(ArgumentError, /argument must be a file path/)
         end
       end
     end
@@ -392,7 +392,7 @@ describe Grape::DSL::InsideRoute do
           subject.present 'dummy1', with: entity_mock_one
           expect do
             subject.present 'dummy2', with: entity_mock_two
-          end.to raise_error ArgumentError, 'Representation of type String cannot be merged.'
+          end.to raise_error ArgumentError, 'representation of type String cannot be merged'
         end
       end
     end

--- a/spec/grape/dsl/inside_route_spec.rb
+++ b/spec/grape/dsl/inside_route_spec.rb
@@ -392,7 +392,7 @@ describe Grape::DSL::InsideRoute do
           subject.present 'dummy1', with: entity_mock_one
           expect do
             subject.present 'dummy2', with: entity_mock_two
-          end.to raise_error ArgumentError, 'representation of type String cannot be merged'
+          end.to raise_error ArgumentError, 'representation of type `String` cannot be merged'
         end
       end
     end

--- a/spec/grape/dsl/request_response_spec.rb
+++ b/spec/grape/dsl/request_response_spec.rb
@@ -72,7 +72,7 @@ describe Grape::DSL::RequestResponse do
     end
 
     it 'raises when no formatter is given' do
-      expect { subject.error_formatter format }.to raise_error(ArgumentError, 'error_formatter "txt" requires a formatter, given positionally or as `with:`')
+      expect { subject.error_formatter format }.to raise_error(ArgumentError, 'error_formatter `"txt"` requires a formatter, given positionally or as `with:`')
       expect(subject.inheritable_setting.error_formatters).to be_nil
     end
 
@@ -141,7 +141,7 @@ describe Grape::DSL::RequestResponse do
       end
 
       it 'abort if :with option value is not Symbol, String or Proc' do
-        expect { subject.rescue_from :all, with: 1234 }.to raise_error(ArgumentError, "with: #{integer_class_name}, expected Symbol, String or Proc")
+        expect { subject.rescue_from :all, with: 1234 }.to raise_error(ArgumentError, "with: `#{integer_class_name}`, expected Symbol, String or Proc")
       end
 
       it 'abort if both :with option and block are passed' do
@@ -198,17 +198,17 @@ describe Grape::DSL::RequestResponse do
     describe 'meta selector mixed with exception classes' do
       it 'raises ArgumentError for :all + exception class' do
         expect { subject.rescue_from :all, StandardError }
-          .to raise_error(ArgumentError, 'rescue_from :all does not accept additional arguments')
+          .to raise_error(ArgumentError, 'rescue_from `:all` does not accept additional arguments')
       end
 
       it 'raises ArgumentError for :grape_exceptions + exception class' do
         expect { subject.rescue_from :grape_exceptions, StandardError }
-          .to raise_error(ArgumentError, 'rescue_from :grape_exceptions does not accept additional arguments')
+          .to raise_error(ArgumentError, 'rescue_from `:grape_exceptions` does not accept additional arguments')
       end
 
       it 'raises ArgumentError for :internal_grape_exceptions + exception class' do
         expect { subject.rescue_from :internal_grape_exceptions, StandardError }
-          .to raise_error(ArgumentError, 'rescue_from :internal_grape_exceptions does not accept additional arguments')
+          .to raise_error(ArgumentError, 'rescue_from `:internal_grape_exceptions` does not accept additional arguments')
       end
     end
 

--- a/spec/grape/dsl/routing_spec.rb
+++ b/spec/grape/dsl/routing_spec.rb
@@ -149,7 +149,7 @@ describe Grape::DSL::Routing do
     # on the first request rather than here.
     it 'rejects requirements that are not a Hash' do
       expect { subject.route(:any, '/', requirements: Integer) }
-        .to raise_error(ArgumentError, 'requirements must be a Hash of param name => constraint, got Class')
+        .to raise_error(ArgumentError, 'requirements must be a Hash of param name => constraint, got `Class`')
     end
 
     it 'does not duplicate identical endpoints' do
@@ -233,7 +233,7 @@ describe Grape::DSL::Routing do
 
     it 'rejects requirements that are not a Hash' do
       expect { subject.namespace(:foo, requirements: Integer) {} }
-        .to raise_error(ArgumentError, 'requirements must be a Hash of param name => constraint, got Class')
+        .to raise_error(ArgumentError, 'requirements must be a Hash of param name => constraint, got `Class`')
     end
 
     it 'calls #joined_space_path on Namespace' do
@@ -326,7 +326,7 @@ describe Grape::DSL::Routing do
     # does not introduce — Mustermann resolves that to no constraint at all.
     it 'rejects a Hash of requirements' do
       expect { subject.route_param('foo', requirements: { foo: Integer }, &proc {}) }
-        .to raise_error(ArgumentError, 'route_param :foo constrains :foo; pass the constraint itself, or a Hash of requirements to the enclosing namespace')
+        .to raise_error(ArgumentError, 'route_param :`foo` constrains :`foo`; pass the constraint itself, or a Hash of requirements to the enclosing namespace')
     end
   end
 

--- a/spec/grape/dsl/validations_spec.rb
+++ b/spec/grape/dsl/validations_spec.rb
@@ -24,7 +24,7 @@ describe Grape::DSL::Validations do
   describe '.contract' do
     context 'when contract is nil and blockless' do
       it 'raises an ArgumentError' do
-        expect { dummy_class.contract }.to raise_error(ArgumentError, 'Either contract or block must be provided')
+        expect { dummy_class.contract }.to raise_error(ArgumentError, 'either contract or block must be provided')
       end
     end
 
@@ -69,7 +69,7 @@ describe Grape::DSL::Validations do
         end
 
         it 'raises an ArgumentError' do
-          expect { dummy_class.contract(my_contract.new) { :my_block } }.to raise_error(ArgumentError, 'Cannot inherit from contract, only schema')
+          expect { dummy_class.contract(my_contract.new) { :my_block } }.to raise_error(ArgumentError, 'cannot inherit from contract, only schema')
         end
       end
     end

--- a/spec/grape/middleware/error_spec.rb
+++ b/spec/grape/middleware/error_spec.rb
@@ -258,7 +258,7 @@ describe Grape::Middleware::Error do
           end
 
           rescue_from :all do |e|
-            raise custom_error_class, "wrapped(#{e.message})"
+            raise custom_error_class, "wrapped(`#{e.message}`)"
           end
 
           get('/') { raise ArgumentError, 'oops' }
@@ -267,7 +267,7 @@ describe Grape::Middleware::Error do
 
       it 'redispatches to the registered handler' do
         expect(response.status).to eq(422)
-        expect(response.body).to eq('custom-handled: wrapped(oops)')
+        expect(response.body).to eq('custom-handled: wrapped(`oops`)')
       end
     end
 

--- a/spec/grape/validations/types/dry_type_coercer_spec.rb
+++ b/spec/grape/validations/types/dry_type_coercer_spec.rb
@@ -11,7 +11,7 @@ describe Grape::Validations::Types::DryTypeCoercer do
     end
 
     it 'raises an ArgumentError for any other type' do
-      expect { described_class.collection_coercer_for({}) }.to raise_error(ArgumentError, /Unknown type/)
+      expect { described_class.collection_coercer_for({}) }.to raise_error(ArgumentError, /unknown type/)
     end
   end
 end

--- a/spec/grape/validations/types/primitive_coercer_spec.rb
+++ b/spec/grape/validations/types/primitive_coercer_spec.rb
@@ -115,7 +115,7 @@ describe Grape::Validations::Types::PrimitiveCoercer do
 
       it 'raises error on init' do
         expect(Grape::DryTypes::Params.constants).not_to include(type.name.to_sym)
-        expect { subject }.to raise_error(/type Complex should support coercion/)
+        expect { subject }.to raise_error(/type `Complex` should support coercion/)
       end
     end
 

--- a/spec/grape/validations/types_spec.rb
+++ b/spec/grape/validations/types_spec.rb
@@ -107,12 +107,12 @@ describe Grape::Validations::Types do
 
       it 'raises for an Array of it' do
         expect { described_class.build_coercer(Array[UncoercibleType]) }
-          .to raise_error(ArgumentError, 'type UncoercibleType should support coercion via `[]`')
+          .to raise_error(ArgumentError, 'type `UncoercibleType` should support coercion via `[]`')
       end
 
       it 'raises for a Set of it' do
         expect { described_class.build_coercer(Set[UncoercibleType]) }
-          .to raise_error(ArgumentError, 'type UncoercibleType should support coercion via `[]`')
+          .to raise_error(ArgumentError, 'type `UncoercibleType` should support coercion via `[]`')
       end
 
       it 'raises while the params block is evaluated' do
@@ -121,7 +121,7 @@ describe Grape::Validations::Types do
             params { requires :foos, type: Array[UncoercibleType] }
             get('/foos') { 'never reached' }
           end
-        end.to raise_error(ArgumentError, 'type UncoercibleType should support coercion via `[]`')
+        end.to raise_error(ArgumentError, 'type `UncoercibleType` should support coercion via `[]`')
       end
 
       # A one-argument `parse` makes it a custom type, which ::custom? accepts

--- a/spec/grape/validations/validators/length_validator_spec.rb
+++ b/spec/grape/validations/validators/length_validator_spec.rb
@@ -210,7 +210,7 @@ describe Grape::Validations::Validators::LengthValidator do
       end
 
       it 'raises an error' do
-        expect { post 'negative_min', list: [12] }.to raise_error(ArgumentError, 'min must be an integer greater than or equal to zero')
+        expect { post 'negative_min', list: [12] }.to raise_error(ArgumentError, '`min` must be an integer greater than or equal to zero')
       end
     end
   end
@@ -228,7 +228,7 @@ describe Grape::Validations::Validators::LengthValidator do
       end
 
       it do
-        expect { post 'negative_max', list: [12] }.to raise_error(ArgumentError, 'max must be an integer greater than or equal to zero')
+        expect { post 'negative_max', list: [12] }.to raise_error(ArgumentError, '`max` must be an integer greater than or equal to zero')
       end
     end
   end
@@ -246,7 +246,7 @@ describe Grape::Validations::Validators::LengthValidator do
       end
 
       it do
-        expect { post 'float_min', list: [12] }.to raise_error(ArgumentError, 'min must be an integer greater than or equal to zero')
+        expect { post 'float_min', list: [12] }.to raise_error(ArgumentError, '`min` must be an integer greater than or equal to zero')
       end
     end
   end
@@ -264,7 +264,7 @@ describe Grape::Validations::Validators::LengthValidator do
       end
 
       it do
-        expect { post 'float_max', list: [12] }.to raise_error(ArgumentError, 'max must be an integer greater than or equal to zero')
+        expect { post 'float_max', list: [12] }.to raise_error(ArgumentError, '`max` must be an integer greater than or equal to zero')
       end
     end
   end
@@ -282,7 +282,7 @@ describe Grape::Validations::Validators::LengthValidator do
       end
 
       it do
-        expect { post 'min_greater_than_max', list: [12] }.to raise_error(ArgumentError, 'min 15 cannot be greater than max 3')
+        expect { post 'min_greater_than_max', list: [12] }.to raise_error(ArgumentError, 'min `15` cannot be greater than max `3`')
       end
     end
   end

--- a/spec/support/versioned_helpers.rb
+++ b/spec/support/versioned_helpers.rb
@@ -13,7 +13,7 @@ module Spec
         when :param, :header, :accept_version_header
           File.join('/', options[:prefix] || '', options[:path])
         else
-          raise ArgumentError.new("unknown versioning strategy: #{options[:using]}")
+          raise ArgumentError.new("unknown versioning strategy: `#{options[:using]}`")
         end
       end
 
@@ -33,7 +33,7 @@ module Spec
             'HTTP_ACCEPT_VERSION' => options[:version].to_s
           }
         else
-          raise ArgumentError.new("unknown versioning strategy: #{options[:using]}")
+          raise ArgumentError.new("unknown versioning strategy: `#{options[:using]}`")
         end
       end
 


### PR DESCRIPTION
Lowercases and removes trailing periods from the 7 `ArgumentError` messages in `lib/` that deviated from the rest of the codebase's lowercase, unpunctuated style (`dsl/entity.rb`, `dsl/inside_route.rb`, `dsl/validations.rb`, `validations/types/dry_type_coercer.rb`), and documents the convention in CONTRIBUTING.md.

This matches Ruby's own core/stdlib exception style (e.g. `TypeError: no implicit conversion from nil to integer`), which reads naturally when printed after the exception class name and colon in a backtrace, and is consistent with how `Grape::Exceptions::*` messages are already written.

Updated the corresponding specs that asserted the old exact message text.

To help enforce this convention going forward, I created a new RuboCop plugin gem, [rubocop-exception_messages](https://github.com/dblock/rubocop-exception_messages), with `ExceptionMessages/Casing` and `ExceptionMessages/Punctuation` cops that flag/autocorrect exception messages violating this style. Added as a dev dependency here so CI catches any regressions.

Bumped to [0.2.0](https://github.com/dblock/rubocop-exception_messages/blob/master/CHANGELOG.md#020-2026090), which adds `ExceptionMessages/QuoteStyle`, enabled by default, wrapping interpolated values in backticks (e.g. `` "unknown type: `#{type}`" ``) for consistency across error messages. Autocorrected the 16 affected messages across `lib/` and `spec/`, and updated specs asserting exact message text accordingly.