### PR TITLE
Copy response headers with merge! instead of merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@
 * [#2905](https://github.com/ruby-grape/grape/pull/2905): Nest any `route_param` requirement under the param name, not just a Regexp, and reject the `requirements` shapes that have no param to attach to where they are written rather than on the first request - [@ericproulx](https://github.com/ericproulx).
 * [#2908](https://github.com/ruby-grape/grape/pull/2908): Stop reassigning method parameters across `lib`, so a parameter keeps the value its caller passed for the whole method; the `oneof` collection in `Grape::Validations::ParamsScope` no longer writes into the Hash it was given - [@ericproulx](https://github.com/ericproulx).
 * [#2910](https://github.com/ruby-grape/grape/pull/2910): Restore `Grape::Middleware::Formatter`'s in-place content-type negotiation as `ensure_content_type!`, which #2908 had turned into a copy of the response headers on every response - [@ericproulx](https://github.com/ericproulx).
+* [#2911](https://github.com/ruby-grape/grape/pull/2911): Copy response headers with `merge!` instead of `merge` in `Grape::API::Instance#call` and `Grape::Middleware::Error`, which allocated a `Grape::Util::Header` only to discard it - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 3.3.5 (2026-07-30)

--- a/lib/grape/api/instance.rb
+++ b/lib/grape/api/instance.rb
@@ -118,7 +118,12 @@ module Grape
       def call(env)
         status, headers, response = @router.call(env)
         unless @cascade
-          headers = Grape::Util::Header.new.merge(headers)
+          # +merge!+, not +merge+: the latter is a `dup` plus a `merge!`, so the
+          # Header built on this line would be allocated only to be discarded.
+          # The copy stays because +headers+ can come from a mounted Rack app,
+          # which is free to hand back a frozen or shared Hash that the delete
+          # below must not reach into.
+          headers = Grape::Util::Header.new.merge!(headers)
           headers.delete('X-Cascade')
         end
 

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -68,7 +68,7 @@ module Grape
 
       def rack_response(status, headers, message)
         body = html_content_type?(headers[Rack::CONTENT_TYPE]) ? Rack::Utils.escape_html(message) : message
-        Rack::Response.new(Array.wrap(body), Rack::Utils.status_code(status), Grape::Util::Header.new.merge(headers))
+        Rack::Response.new(Array.wrap(body), Rack::Utils.status_code(status), Grape::Util::Header.new.merge!(headers))
       end
 
       # Escaping must key off the media type only, case-insensitively. Comparing

--- a/spec/grape/api/instance_spec.rb
+++ b/spec/grape/api/instance_spec.rb
@@ -117,4 +117,29 @@ describe Grape::API::Instance do
       expect(an_instance.compile!.cascade?).to be(true)
     end
   end
+
+  describe '#call' do
+    context 'when cascade is false' do
+      let(:rack_headers) { { 'content-type' => 'text/plain', 'x-cascade' => 'pass' }.freeze }
+      let(:root_api) do
+        headers = rack_headers
+        Class.new(Grape::API::Instance) do
+          cascade false
+          mount ->(_env) { [200, headers, ['from rack']] } => '/rack'
+        end
+      end
+
+      it 'strips X-Cascade from the response' do
+        get '/rack'
+        expect(last_response.headers).not_to have_key('x-cascade')
+      end
+
+      # The mounted app owns the Hash it returned and is free to hand back a
+      # frozen or shared one, so removing X-Cascade has to happen on a copy.
+      it 'does not write into the headers the mounted app returned' do
+        get '/rack'
+        expect(rack_headers).to eq('content-type' => 'text/plain', 'x-cascade' => 'pass')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Follow-up to #2910. Sweeping the request path for the same shape turned up two more sites where a response-header copy costs twice what it needs to:

```ruby
Grape::Util::Header.new.merge(headers)
```

`merge` is a `dup` plus a `merge!`, so the `Header` built on the same line is allocated only to be thrown away. `merge!` fills the one already in hand and returns it.

| | obj/call |
| --- | --- |
| `Header.new.merge(h)` | 2 |
| `Header.new.merge!(h)` | 1 |

Both sites are on live paths:

* `Grape::API::Instance#call` — every request when `cascade false` is set, the usual configuration for Grape mounted inside Rails. (The default `cascade true` skips the branch, which is why it didn't show up in the profile behind #2910.)
* `Grape::Middleware::Error#rack_response` — every error response.

## Both copies stay

Unlike #2910, these are not removable. `headers` can come from a mounted Rack app, which is free to hand back a frozen or shared Hash, and both call sites go on to write into what they are given. The `cascade false` path is now pinned by a spec that mounts a Rack app returning a frozen Hash — without the copy it raises `FrozenError`.

## Rack compatibility

`merge!` behaves identically across the supported range (`rack >= 2.2.4`; CI covers 2.2 / 3.0 / 3.1 / 3.2):

* Rack 2.2 — `Rack::Utils::HeaderHash#merge!` is `other.each { |k, v| self[k] = v }`
* Rack 3 — `Rack::Headers` defines `update` and does `alias merge! update`

Both route through the overridden `[]=`, so header names are still downcased.

Worth recording for anyone tempted by the shorter form: `Grape::Util::Header.new(headers)` is **not** equivalent. `Rack::Headers` subclasses `Hash`, so on Rack 3 the argument silently becomes the Hash default value and the result is empty. It happens to work on Rack 2.2, so it would only fail half the matrix.

## Test plan

- [x] Full RSpec suite passes locally (2836 examples, 0 failures).
- [x] New spec verified to fail (`FrozenError`) when the copy is removed.
- [x] RuboCop clean on the changed files.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)