### PR TITLE
Pin json below 3 in the gemfiles whose dependencies cannot use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Fixes
 
+* [#2916](https://github.com/ruby-grape/grape/pull/2916): Pin `json` below 3 in the gemfiles whose dependencies cannot use it - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 4.0.0 (2026-09-07)

--- a/gemfiles/multi_json_1_20.gemfile
+++ b/gemfiles/multi_json_1_20.gemfile
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 gem 'multi_json', '< 1.21'
+# multi_json < 1.21's json_gem adapter calls JSON.parse(source, opts) positionally, which json 3 rejects.
+gem 'json', '< 3'
 
 eval_gemfile '../Gemfile'

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -3,4 +3,6 @@
 eval_gemfile '../Gemfile'
 
 gem 'rails', '~> 7.2.0'
+# ActiveSupport < 8.1 passes `quirks_mode:` to JSON.generate, a keyword json 3 removed.
+gem 'json', '< 3'
 gem 'tzinfo-data', require: false

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -3,4 +3,6 @@
 eval_gemfile '../Gemfile'
 
 gem 'rails', '~> 8.0.0'
+# ActiveSupport < 8.1 passes `quirks_mode:` to JSON.generate, a keyword json 3 removed.
+gem 'json', '< 3'
 gem 'tzinfo-data', require: false


### PR DESCRIPTION
## Summary

`json` 3.0.0 was released today (2026-09-07 06:57 UTC) and turned three CI gemfiles red. In each case the incompatibility is in a dependency, not in Grape — no `lib/` change is needed.

| Gemfile | Failure | Cause |
| --- | --- | --- |
| `rails_7_2`, `rails_8_0` | `ArgumentError: unknown keyword: quirks_mode` | `ActiveSupport::JSON::Encoding::JSONGemEncoder#stringify` calls `JSON.generate(..., quirks_mode: true, ...)`; json 3 removed the keyword |
| `multi_json_1_20` | `ArgumentError: wrong number of arguments (given 2, expected 1)` | multi_json 1.20.1's `json_gem` adapter calls `JSON.parse(source, opts)` with the options positional |

Both are fixed upstream in versions these gemfiles deliberately exclude: Rails 8.1 no longer passes `quirks_mode:` (the `rails_8_1` job is green), and multi_json 1.21 fixed the adapter (the unpinned `multi_json` job is green). The latest 7.2.x and 8.0.x releases — 7.2.3.2 and 8.0.5.1, both from 2026-07-29 — predate json 3 and carry no backport, so there is no newer patch to move to.

The pin is scoped to those three gemfiles only. The default `Gemfile` and every other variant keep resolving json 3, so the suite still exercises it.

## Test plan

Each gemfile resolved and run locally against the specs that CI reported failing:

- [x] `rails_7_2` → json 2.21.2 with activesupport 7.2.3.2; `default_validator_spec.rb` + `except_values_validator_spec.rb`, 108 examples, 0 failures.
- [x] `rails_8_0` → json 2.21.2 with activesupport 8.0.5.1; same two specs, 108 examples, 0 failures.
- [x] `multi_json_1_20` → json 2.21.2 with multi_json 1.20.1; `spec/integration/multi_json`, 3 examples, 0 failures.
- [x] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)