### PR TITLE
Read path captures out of the router's union match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#2916](https://github.com/ruby-grape/grape/pull/2916): Pin `json` below 3 in the gemfiles whose dependencies cannot use it - [@ericproulx](https://github.com/ericproulx).
 * [#2915](https://github.com/ruby-grape/grape/pull/2915): Update rubocop to 1.90.0 and rubocop-performance to 1.27.0 - [@ericproulx](https://github.com/ericproulx).
 * [#2918](https://github.com/ruby-grape/grape/pull/2918): Skip the dry-types round trip when a value already is the declared type - [@ericproulx](https://github.com/ericproulx).
+* [#2917](https://github.com/ruby-grape/grape/pull/2917): Read path captures out of the router's union match instead of re-running the route's pattern - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 4.0.0 (2026-09-07)

--- a/lib/grape/api/instance.rb
+++ b/lib/grape/api/instance.rb
@@ -116,18 +116,22 @@ module Grape
 
       # Handle a request. See Rack documentation for what `env` is.
       def call(env)
-        status, headers, response = @router.call(env)
-        unless @cascade
-          # +merge!+, not +merge+: the latter is a `dup` plus a `merge!`, so the
-          # Header built on this line would be allocated only to be discarded.
-          # The copy stays because +headers+ can come from a mounted Rack app,
-          # which is free to hand back a frozen or shared Hash that the delete
-          # below must not reach into.
-          headers = Grape::Util::Header.new.merge!(headers)
-          headers.delete('X-Cascade')
-        end
+        response = @router.call(env)
+        return response if @cascade
 
-        [status, headers, response]
+        headers = response[1]
+        # A Grape::Util::Header folds case the way the copy below does, so it can
+        # answer for it; any other Hash cannot, and still goes through the copy.
+        return response if headers.is_a?(Grape::Util::Header) && !headers.key?('X-Cascade')
+
+        # +merge!+, not +merge+: the latter is a `dup` plus a `merge!`, so the
+        # Header built on this line would be allocated only to be discarded.
+        # The copy stays because +headers+ can come from a mounted Rack app,
+        # which is free to hand back a frozen or shared Hash that the delete
+        # below must not reach into.
+        headers = Grape::Util::Header.new.merge!(headers)
+        headers.delete('X-Cascade')
+        [response[0], headers, response[2]]
       end
 
       # Some requests may return a HTTP 404 error if grape cannot find a matching

--- a/lib/grape/request.rb
+++ b/lib/grape/request.rb
@@ -136,6 +136,10 @@ module Grape
       ["HTTP_#{header.upcase.tr('-', '_')}", header]
     end.freeze
 
+    # Routing-args keys that are Grape's own, not request params.
+    GRAPE_OWNED_ROUTING_ARGS = %i[version route_info].freeze
+    ROUTE_INFO_ONLY = %i[route_info].freeze
+
     alias rack_params params
     alias rack_cookies cookies
 
@@ -195,9 +199,13 @@ module Grape
     # on a route that had matched, losing the segment silently.
     def routing_args_as_params(routing_args)
       return if routing_args.nil?
-      return routing_args.except(:version, :route_info) if grape_owns_version?(routing_args)
 
-      routing_args.except(:route_info)
+      grape_owned = grape_owns_version?(routing_args) ? GRAPE_OWNED_ROUTING_ARGS : ROUTE_INFO_ONLY
+      # Nothing but Grape's own keys: +except+ would build an empty Hash for
+      # +make_params+ to find blank and discard.
+      return if routing_args.size == grape_owned.count { |key| routing_args.key?(key) }
+
+      routing_args.except(*grape_owned)
     end
 
     # A route reports a +version+ only when the API declared one, which is the

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -76,8 +76,14 @@ module Grape
     # candidate has declined too, so the caller (or a mounting app upstream)
     # can keep looking.
     def transaction(input, method, env)
-      exact_route = match?(input, method)
-      response = process_route(exact_route, input, env) if exact_route
+      # Matched here rather than through #match? so the MatchData survives: the
+      # route's path captures are groups of it (see Route#params_for).
+      exact_route = nil
+      response = nil
+      @optimized_map[method]&.match(input) do |m|
+        exact_route = @map[method].detect { |route| m[route.regexp_capture_group] }
+        response = process_route(exact_route, input, env, m) if exact_route
+      end
       return response if halt?(response)
 
       # A cascading route has only declined this request. Its siblings — the
@@ -91,6 +97,13 @@ module Grape
         return response if response && !cascade?(response)
       end
 
+      neighbours(input, method, env, response, cascaded)
+    end
+
+    # The ANY ('*') routes and the greedy neighbour, tried once the routes for
+    # +method+ have declined. +cascaded+ says whether any of them matched: the
+    # auto-OPTIONS and 405 answers are only right when none did.
+    def neighbours(input, method, env, response, cascaded)
       last_neighbor_route = greedy_match?(input)
 
       # If last_neighbor_route exists and request method is OPTIONS,
@@ -151,10 +164,10 @@ module Grape
     # Routing args are rebuilt for every attempt: when a route cascades
     # (X-Cascade pass), the next candidate must not observe the previous
     # attempt's +route_info+ or path captures.
-    def process_route(route, input, env, include_allow_header: false)
+    def process_route(route, input, env, match = nil, include_allow_header: false)
       # The path captures are the hash: +route_info+ is written into them
       # rather than merged in from a second one.
-      routing_args = route.params_for(input) || {}
+      routing_args = route.params_for(input, match) || {}
       routing_args[:route_info] = route
       env[Grape::Env::GRAPE_ROUTING_ARGS] = routing_args
       env[Grape::Env::GRAPE_ALLOWED_METHODS] = route.allow_header if include_allow_header

--- a/lib/grape/router/base_route.rb
+++ b/lib/grape/router/base_route.rb
@@ -66,10 +66,17 @@ module Grape
         Regexp.new("(?<#{regexp_capture_index}>#{pattern_regexp})")
       end
 
+      # This route's named captures mapped to their group numbers in the router's
+      # union, or nil when a union match would not reproduce what Mustermann
+      # returns (see Route#params_for). Assigned in {#resolve_capture_group!},
+      # never at request time -- instances are shared across threads.
+      attr_reader :union_captures
+
       # @api private
       # @see #regexp_capture_group
       def resolve_capture_group!(union_named_captures)
         @regexp_capture_group = union_named_captures.fetch(regexp_capture_index).first
+        @union_captures = resolve_union_captures
       end
 
       class CaptureIndexCache < Grape::Util::Cache
@@ -79,6 +86,27 @@ module Grape
             h[index] = "_#{index}"
           end
         end
+      end
+
+      private
+
+      # +to_regexp+'s wrapper is the group just before the pattern's own, and
+      # +Regexp.union+ shifts numbering only by the groups preceding a branch --
+      # what +regexp_capture_group+ counts. So the capture at position +n+ of the
+      # route's regexp is group +regexp_capture_group + n+ of the union.
+      def resolve_union_captures
+        own = @pattern.to_regexp.named_captures
+        return if own.empty?
+
+        # Mustermann returns an Array for a name matched at several positions.
+        return unless own.each_value.all? { |positions| positions.size == 1 }
+
+        # Rejects param converters and the always-Array +splat+/+captures+ names.
+        # Empty strings probe only what holds for every request; unescaping, the
+        # one thing that does not, is gated on the path in Route#params_for.
+        return unless @pattern.pattern.identity_params?(own.transform_values { '' })
+
+        own.to_h { |name, positions| [name.to_sym, @regexp_capture_group + positions.first] }
       end
     end
   end

--- a/lib/grape/router/greedy_route.rb
+++ b/lib/grape/router/greedy_route.rb
@@ -22,7 +22,7 @@ module Grape
         nil
       end
 
-      def params_for(_input)
+      def params_for(_input, _match = nil)
         nil
       end
     end

--- a/lib/grape/router/route.rb
+++ b/lib/grape/router/route.rb
@@ -50,8 +50,17 @@ module Grape
       # match entirely and answers nil — the same way {GreedyRoute#params_for}
       # does, and what the router already coerces into the Hash it builds
       # routing args in.
-      def params_for(input)
+      #
+      # +match+, when given, is the union MatchData the router matched this route
+      # with; its groups already hold the substrings a second match would produce
+      # (see {BaseRoute#union_captures}). Mustermann percent-decodes a captured
+      # value containing '%', and none can unless the path does -- so a '%'-free
+      # path reads the groups, anything else the full match below.
+      def params_for(input, match = nil)
         return unless pattern.captures?
+
+        captures = union_captures
+        return params_from_union(captures, match) if match && captures && !input.include?('%')
 
         parsed = pattern.params(input)
         return unless parsed
@@ -68,6 +77,17 @@ module Grape
       end
 
       private
+
+      # MatchData yields fresh, unfrozen Strings, as Mustermann's Hash does, so
+      # +tag_utf8!+ stays safe in place.
+      def params_from_union(captures, match)
+        params = {}
+        captures.each do |name, group|
+          value = match[group]
+          params[name] = tag_utf8!(value) unless value.nil?
+        end
+        params
+      end
 
       # Mustermann decodes path captures out of +PATH_INFO+, which Rack hands us
       # tagged ASCII-8BIT, so path params came back binary while Rack tags query


### PR DESCRIPTION
The router runs its compiled union to pick a route, then throws the `MatchData` away — and `Route#params_for` runs the route's *own* decode-aware regexp a second time to pull out the same captures. That second match is **1.01 µs of an 8.76 µs bare request (11.5%)**.

The union embeds each route's pattern verbatim, so those captures are already groups of the match that just ran. `compile!` now records, per route, the number each of its captures carries in the union, and `params_for` reads them straight off the match.

### Why the group numbers line up

The `(?<_N>…)` wrapper `to_regexp` adds is the group immediately before the pattern's own, and `Regexp.union` shifts numbering only by the groups preceding a branch — which is exactly what `regexp_capture_group` already counts. So the capture at position `n` of a route's own regexp is group `regexp_capture_group + n` of the union. On a three-route path-versioned API that is wrappers `1, 3, 5` and `version => [2, 4, 6]`.

### When it applies

Eligibility is settled once, at compile time, by two checks:

- every name occupies a **single position** in the route's own regexp — a multi-position name comes back from Mustermann as an Array, which one group number cannot stand for;
- `identity_params?` probed with empty strings. It is public on `Mustermann::AST::Pattern`, and its AST override folds in both `param_converters.empty?` and the `splat`/`captures` names Mustermann always answers with an Array. Probing with `''` leaves exactly the checks that hold for every request.

The one genuinely per-request condition is unescaping: `map_param` is `unescape(value, true)`, which returns the value untouched unless it contains `'%'`. No capture can contain `%` unless the path does, so the fast path is gated on `input.include?('%')` and anything else falls through to the full match — as do routes reached through `#rotation` or the ANY map (no `MatchData` to hand over) and `GreedyRoute`, whose `params_for` is `nil` anyway.

So `/dup/:id/x/:id` still yields `{"id":["1","2"]}`, `/star/*` still yields `{"splat":["x/y"]}`, and `/items/a%2Eb` still yields `a.b`. A *named* splat `*path` does take the fast path — `always_array?` lists only `splat` and `captures`.

### Two smaller allocations on the same path

- **`Instance#call`** destructured the router's tuple only to build an identical Array back up. Cascading is the default, so it now hands that tuple back. On the `cascade false` path the header copy is skipped when there is no `X-Cascade` to strip — but only for a `Grape::Util::Header`, which answers `key?` the way the copy's `delete` would. A mounted Rack app's plain Hash can spell the name in any case (it is matched case-sensitively there, while the copy folds case), so it still goes through the copy. `spec/grape/api/instance_spec.rb:132` pins this.
- **`Request#routing_args_as_params`** called `except` on routing args holding nothing but Grape's own keys, building an empty Hash for `make_params` to find blank and discard.

### Numbers

Ruby 4.0.6, no YJIT, median of 9 interleaved rounds against a worktree snapshot of `master`. Noise floor ±1.6%, established by A/B-ing identical code; the runner alternates which lib goes first, because running second gave a reproducible ~1% edge.

| scenario | delta |
| --- | ---: |
| bare GET (path-versioned) | **+16.7%** |
| POST | +6.7% |
| GET with params + validations | +4.7% |
| 400 validation error | +2.0% |
| unversioned static GET | +0.5% |

Allocations for a bare request: **23 → 18 objects**.

By route count, hitting the last route: +9.9% at 10 routes, +2.2% at 50, ~+1% at 200–500. The saving is constant per request, so it shrinks as a fraction once the union match itself dominates — that one is still the `uri_decode` expansion, untouched here.

These are laptop numbers on a single machine; worth a second opinion on other hardware.

### Notes for review

`transaction` runs the union match itself rather than going through `#match?`. The first cut passed a block through `#match?` and yielded, which cost the no-capture path ~1.6% (`unversioned` went to −1.6%); running it inline brings that back to +0.5%. `#match?` is otherwise unchanged, for the ANY and greedy callers. Inlining pushed `transaction` past `Metrics/CyclomaticComplexity` (17/15), so the ANY/greedy tail moved to `#neighbours`.

The three changes are independent and can be split if you'd rather review them separately.

### Verification

- Full suite 2847 examples, 0 failures; RuboCop clean over 362 files.
- Byte-identical responses (status, headers, body) across a 51-case matrix against a `git archive HEAD lib` snapshot: percent-encoded paths, dots in captures and `.format` suffixes, named and anonymous splats, duplicate capture names, regexp requirements, `anchor: false`, namespaces, path/header versioning, version cascading between mounted APIs, mounted plain Rack apps with and without `cascade false`, auto-OPTIONS, 405, HEAD and 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
