### PR TITLE
Skip the dry-types round trip for an already-typed value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#2916](https://github.com/ruby-grape/grape/pull/2916): Pin `json` below 3 in the gemfiles whose dependencies cannot use it - [@ericproulx](https://github.com/ericproulx).
 * [#2915](https://github.com/ruby-grape/grape/pull/2915): Update rubocop to 1.90.0 and rubocop-performance to 1.27.0 - [@ericproulx](https://github.com/ericproulx).
+* [#2918](https://github.com/ruby-grape/grape/pull/2918): Skip the dry-types round trip when a value already is the declared type - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 4.0.0 (2026-09-07)

--- a/lib/grape/validations/types/primitive_coercer.rb
+++ b/lib/grape/validations/types/primitive_coercer.rb
@@ -22,6 +22,12 @@ module Grape
         end
 
         def call(val)
+          # A value already of the declared type is what the dry-types coercer
+          # hands back for it -- the very same object, in both the params and
+          # the strict cache -- so the round trip through it only costs time.
+          # +instance_of?+ rather than +is_a?+: a subclass is not covered by
+          # that, and Coercible::String does rebuild one.
+          return val if val.instance_of?(@type)
           return InvalidValue.new if reject?(val)
           return if val.nil? || treat_as_nil?(val)
 


### PR DESCRIPTION
`PrimitiveCoercer#call` hands every value to a dry-types coercer — including values that **already are** the declared type. For those the coercer is an identity: it hands back the very same object.

```ruby
return val if val.instance_of?(@type)
```

### Why this is the same answer

I checked every type the coercer can be built for — String, Integer, Float, BigDecimal, Numeric, Date, DateTime, Time, Symbol, TrueClass, FalseClass, `Grape::API::Boolean`, Hash — against a matrix of values, in **both** the params and the strict cache. In every case where `val.instance_of?(type)` holds, the coercer returns a value `equal?` to its input. Zero divergences.

`instance_of?` rather than `is_a?` is load-bearing: a subclass is *not* covered by that argument. `Coercible::String` rebuilds a String subclass, and a `HashWithIndifferentAccess` is not the `Hash` the declaration asked for — both keep going through the coercer.

The two checks the fast path jumps over cannot fire for such a value either:

- `reject?` only rejects an Array or Hash declared as `String`, and a String declared as `Hash` — none of which is `instance_of?` its declared type;
- `treat_as_nil?` only maps `''` to nil, and `@treat_empty_as_nil` is false for `String`, the one type `''` is an instance of. `{s: ""}` still comes back as `""`.

It is also invisible downstream regardless: `CoerceValidator#validate_param!` already skips the write-back when the coerced value is `==` and same-class as the input, which it is here by construction.

### Numbers

Ruby 4.0.6, no YJIT, median of 9 interleaved rounds against a worktree snapshot of the base. Noise floor ±1.6%, established by A/B-ing identical code; the runner alternates which lib goes first.

| scenario | delta |
| --- | ---: |
| POST JSON body, 6 typed params | **+16.1%** |
| GET, query params + validations | +6.5% |
| POST form-encoded | +4.9% |
| 400 from a failed presence check | −0.9% |
| bare GET | +0.2% |
| unversioned static GET | −1.2% |

The three scenarios that coerce nothing all land inside the noise floor, which is what you'd expect — the fast path is only reachable from a coercion.

The win is largest for a JSON body, where values arrive already typed and the coercer had the least to do. A form-encoded or query param arrives as a String and still coerces in full — unless it was declared `type: String`, which is the common case that was paying `Coercible::String#to_s` to do nothing (~280 ns per value).

These are laptop numbers on one machine; worth a second opinion on other hardware.

### Verification

- Full suite 2847 examples, 0 failures; RuboCop clean.
- Byte-identical responses across **84 coercion cases** against a `git archive HEAD lib` snapshot — every type above, over JSON bodies and form bodies, covering successes and the 19 cases that end in a validation error, plus `coerce_with`, `values`, `regexp` and `default`. Includes the edges the fast path reasons about: `{s: ""}` staying `""`, `{h: "str"}` still rejected, `Numeric` never taking the fast path (nothing is `instance_of?(Numeric)`).
- Byte-identical across the 51-case routing/format matrix as well.

Independent of #2917 — different files, and the two stack cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
