### PR TITLE
Pin the router's regressions through requests, not its instance variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#2915](https://github.com/ruby-grape/grape/pull/2915): Update rubocop to 1.90.0 and rubocop-performance to 1.27.0 - [@ericproulx](https://github.com/ericproulx).
 * [#2918](https://github.com/ruby-grape/grape/pull/2918): Skip the dry-types round trip when a value already is the declared type - [@ericproulx](https://github.com/ericproulx).
 * [#2917](https://github.com/ruby-grape/grape/pull/2917): Read path captures out of the router's union match instead of re-running the route's pattern - [@ericproulx](https://github.com/ericproulx).
+* [#2921](https://github.com/ruby-grape/grape/pull/2921): Pin the router's request-time isolation regressions through requests instead of its instance variables - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 4.0.0 (2026-09-07)

--- a/spec/grape/router_spec.rb
+++ b/spec/grape/router_spec.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 describe Grape::Router do
-  describe 'request-time map isolation' do
+  # Regression: the maps used to be auto-vivifying hashes, so a request whose
+  # HTTP method had no routes inserted a key at request time — a data race
+  # under concurrency and unbounded growth from arbitrary methods. A compiled
+  # router freezes its maps, and Grape::API::Instance freezes the router
+  # itself, so a write like that raises rather than passing silently: routing
+  # such a request without error is what shows none happens.
+  describe 'routing a method that has no routes' do
     subject(:router) { described_class.new }
 
     let(:endpoint) { instance_double(Grape::Endpoint) }
@@ -13,31 +19,15 @@ describe Grape::Router do
     before do
       router.append(route)
       router.compile!
+      router.freeze
     end
 
-    it 'freezes the internal maps after compilation' do
-      expect(router.instance_variable_get(:@map)).to be_frozen
-      expect(router.instance_variable_get(:@optimized_map)).to be_frozen
-    end
+    %w[POST PUT PROPFIND CUSTOM].each do |http_method|
+      it "answers #{http_method} with the default 404" do
+        status, = router.call(Rack::MockRequest.env_for('/hello', method: http_method))
 
-    # Regression: the maps used to be auto-vivifying hashes, so a request whose
-    # HTTP method had no routes inserted a key at request time — a data race
-    # under concurrency and unbounded growth from arbitrary methods.
-    it 'does not mutate the maps when routing a method that has no routes' do
-      map = router.instance_variable_get(:@map)
-      optimized_map = router.instance_variable_get(:@optimized_map)
-      keys_before = [map.keys.sort, optimized_map.keys.sort]
-
-      %w[POST PUT PROPFIND CUSTOM].each do |http_method|
-        router.call(Rack::MockRequest.env_for('/hello', method: http_method))
+        expect(status).to eq(404)
       end
-
-      expect([map.keys.sort, optimized_map.keys.sort]).to eq(keys_before)
-    end
-
-    it 'routes a method with no routes to the default 404 response without error' do
-      status, = router.call(Rack::MockRequest.env_for('/hello', method: 'POST'))
-      expect(status).to eq(404)
     end
   end
 
@@ -56,10 +46,6 @@ describe Grape::Router do
     before do
       router.append(Grape::Router::Route.new(endpoint, :purge, pattern, {}, forward_match: false))
       router.compile!
-    end
-
-    it 'compiles the method into the optimized map' do
-      expect(router.instance_variable_get(:@optimized_map)).to have_key('PURGE')
     end
 
     it 'matches a request using that method' do


### PR DESCRIPTION
Three specs in `spec/grape/router_spec.rb` reached into the router with `instance_variable_get`:

* two asserting that `@map` and `@optimized_map` are frozen and gain no key when a method with no routes is routed (#2790);
* one asserting that `@optimized_map` has a key for a non-standard verb (#2886).

They pinned where the router keeps its state rather than anything a caller can see.

### #2886

Already caught by its behavioural sibling in the same block: a PURGE route left out of the optimized map answers 404 instead of 200. The `have_key` spec goes.

### #2790

The maps being frozen is what makes that bug observable: an auto-vivifying lookup on a frozen Hash raises instead of silently inserting a key. The spec now routes POST, PUT, PROPFIND and CUSTOM (the methods the old one used) through a compiled router, frozen as `Grape::API::Instance` leaves it, and expects the default 404 for each. It absorbs the POST-only example that sat beside it.

### Checked by reintroducing each bug

| Mutation | Result |
| --- | --- |
| `@optimized_map` auto-vivifying again (#2790) | all four new examples fail with `FrozenError` |
| optimized map compiled from `HTTP_SUPPORTED_METHODS` only (#2886) | `matches a request using that method` fails |
| a request-time write to the router's own instance variables | all four new examples fail — the old specs could not see this one |

No `instance_variable_get` is left in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
