### PR TITLE
Read the versioners' version options off instance variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#2918](https://github.com/ruby-grape/grape/pull/2918): Skip the dry-types round trip when a value already is the declared type - [@ericproulx](https://github.com/ericproulx).
 * [#2917](https://github.com/ruby-grape/grape/pull/2917): Read path captures out of the router's union match instead of re-running the route's pattern - [@ericproulx](https://github.com/ericproulx).
 * [#2921](https://github.com/ruby-grape/grape/pull/2921): Pin the router's request-time isolation regressions through requests instead of its instance variables - [@ericproulx](https://github.com/ericproulx).
+* [#2923](https://github.com/ruby-grape/grape/pull/2923): Read the versioners' `vendor`, `strict`, `parameter` and `cascade` off instance variables instead of two delegators per request - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 4.0.0 (2026-09-07)

--- a/lib/grape/middleware/versioner/base.rb
+++ b/lib/grape/middleware/versioner/base.rb
@@ -27,11 +27,20 @@ module Grape
 
         attr_reader :available_media_types, :error_headers, :versions
 
+        # Read off ivars rather than delegated through +version_options+ into
+        # +config+: the versioners ask for +vendor+, +strict+ or +parameter+ on
+        # every request, and each read went two Forwardable frames and two Data
+        # readers deep for a value fixed when the middleware was built.
+        attr_reader :cascade, :parameter, :strict, :vendor
+
         def_delegators :config, :mount_path, :prefix, :version_options
-        def_delegators :version_options, :cascade, :parameter, :strict, :vendor
 
         def initialize(app, **options)
           super
+          @cascade = version_options.cascade
+          @parameter = version_options.parameter
+          @strict = version_options.strict
+          @vendor = version_options.vendor
           @versions = config.versions&.map(&:to_s) # making sure versions are strings to ease potential match
           @error_headers = cascade ? CASCADE_PASS_HEADER : {}
           @available_media_types = build_available_media_types


### PR DESCRIPTION
## Summary

`Versioner::Base` delegated `cascade`, `parameter`, `strict` and `vendor` through `version_options` into `config`, so each read went two Forwardable frames and two Data readers deep (about 150 ns) for a value fixed when the middleware was built. The header versioner reads `vendor` and `strict` on every request, the accept-version one `strict`, and the param one `parameter` twice.

They are now plain readers over instance variables set in `#initialize`, the pattern the formatter's options already use. The public readers keep their names.

## Benchmarks

Median of 7 interleaved subprocess rounds against master, Ruby 4.0.6, no JIT:

| request | delta |
|---|---|
| header-versioned | +3.4% |
| accept-version | +1.7% |
| param-versioned | +2.8% |
| path-versioned (control, reads none of them) | −0.7% (noise) |

The path versioner carries the four extra variables on its per-request `dup`, but stays in the same 160-byte object slot (15 of its 18 embedded slots).

## Test plan

- [x] Full RSpec suite passes locally.
- [x] RuboCop clean.
- [x] Mutation-checked through existing specs: forcing `strict` to false, `vendor` to nil, a wrong `parameter` or an inverted `cascade` fails 10, 36, 18 and 34 specs respectively.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
