### PR TITLE
Skip the qualifying-params lookup for scopes other than `given`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#2918](https://github.com/ruby-grape/grape/pull/2918): Skip the dry-types round trip when a value already is the declared type - [@ericproulx](https://github.com/ericproulx).
 * [#2917](https://github.com/ruby-grape/grape/pull/2917): Read path captures out of the router's union match instead of re-running the route's pattern - [@ericproulx](https://github.com/ericproulx).
 * [#2921](https://github.com/ruby-grape/grape/pull/2921): Pin the router's request-time isolation regressions through requests instead of its instance variables - [@ericproulx](https://github.com/ericproulx).
+* [#2925](https://github.com/ruby-grape/grape/pull/2925): Skip the qualifying-params lookup for params scopes other than `given` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 4.0.0 (2026-09-07)

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -5,7 +5,14 @@ module Grape
     class ParamsScope
       attr_reader :parent, :type, :nearest_array_ancestor, :array_depth, :full_path
 
+      # The elements a +given+ scope narrowed its Array params down to during
+      # this request (see #meets_dependency?). Only a scope with a dependency
+      # ever stores any, so every other scope answers without the fiber-storage
+      # and tracker lookups -- which #params pays on each nested resolution,
+      # twice per validator, on every request.
       def qualifying_params
+        return unless @dependent_on
+
         ParamScopeTracker.current&.qualifying_params(self)
       end
 


### PR DESCRIPTION
## Summary

A nested scope resolves its params through `@parent.qualifying_params.presence`, which reads the request's `ParamScopeTracker` out of fiber storage and looks the parent up in its identity Hash. That runs twice per validator on a nested scope (once in `should_validate?`, once in the attributes iterator) on every request.

Only `#meets_dependency?` ever stores qualifying params, and it returns before doing so unless the scope has a dependency, i.e. is a `given`. Every other scope therefore always answered empty; it now answers `nil` without the lookups. The sole caller applies `.presence`, so `nil` and the previous empty Array behave the same.

## Benchmarks

Median of 7 interleaved subprocess rounds against master, Ruby 4.0.6, no JIT:

| request | delta |
|---|---|
| JSON POST with a nested `requires :user, type: Hash do ... end` (3 attributes) | +5.4% |
| flat params GET (control) | +0.2% (noise) |

Per nested validator: 1.77 → 1.39 µs; per nested scope resolution, about 190 ns saved. The gain grows with nesting depth.

## Test plan

- [x] Full RSpec suite passes locally.
- [x] RuboCop clean.
- [x] Mutation-checked through existing specs: inverting the guard, or returning unconditionally, fails 2 `given` specs each.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
