### PR TITLE
Skip the renamed-params lookup in `declared` when nothing is renamed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#2918](https://github.com/ruby-grape/grape/pull/2918): Skip the dry-types round trip when a value already is the declared type - [@ericproulx](https://github.com/ericproulx).
 * [#2917](https://github.com/ruby-grape/grape/pull/2917): Read path captures out of the router's union match instead of re-running the route's pattern - [@ericproulx](https://github.com/ericproulx).
 * [#2921](https://github.com/ruby-grape/grape/pull/2921): Pin the router's request-time isolation regressions through requests instead of its instance variables - [@ericproulx](https://github.com/ericproulx).
+* [#2926](https://github.com/ruby-grape/grape/pull/2926): Skip the renamed-params lookup in `declared` when nothing is renamed - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 4.0.0 (2026-09-07)

--- a/lib/grape/declared_params_handler.rb
+++ b/lib/grape/declared_params_handler.rb
@@ -87,8 +87,11 @@ module Grape
       end
     end
 
+    # The lookup key is the param's whole path, built fresh -- two Arrays and a
+    # String per declared param -- and only an API using +as:+ has anything to
+    # find with it, so the common empty table is not asked.
     def build_memo_key(params_nested_path, declared_param, renamed_params)
-      renamed_param_name = renamed_params[nested_path_for(params_nested_path, declared_param)]
+      renamed_param_name = renamed_params[nested_path_for(params_nested_path, declared_param)] unless renamed_params.empty?
       param = renamed_param_name || declared_param
       @stringify ? param.to_s : param.to_sym
     end


### PR DESCRIPTION
## Summary

`DeclaredParamsHandler#build_memo_key` looks every declared param up in the route's renamed params, keyed by the param's whole path. That key is built fresh each time (two Arrays and a String per declared param) on every `declared` call. Only an API using `as:` has anything in that table; everywhere else it is empty and every lookup misses. The lookup is now skipped when the table is empty.

## Benchmarks

`declared` on five params (one nested Hash), isolated:

| call | master | branch |
|---|---|---|
| `declared(params, include_missing: false)` | 4.81 µs | 4.29 µs (−11%) |
| `declared(params)` | 6.16 µs | 5.59 µs (−9%) |

End to end, a JSON POST returning `declared(params, include_missing: false)` measured +1.4% (median of 7 interleaved subprocess rounds, Ruby 4.0.6, no JIT), which is inside that harness's noise floor: master against itself read −1.2% the same day. The saving is about 100 ns per declared param, so it is a small, fixed win that scales with how many params an endpoint declares rather than a headline number.

## Test plan

- [x] Full RSpec suite passes locally.
- [x] RuboCop clean.
- [x] Mutation-checked through existing specs: inverting the guard fails 14 `as:` specs.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
