### PR TITLE
Validate required Hash params scopes without the attributes iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#2918](https://github.com/ruby-grape/grape/pull/2918): Skip the dry-types round trip when a value already is the declared type - [@ericproulx](https://github.com/ericproulx).
 * [#2917](https://github.com/ruby-grape/grape/pull/2917): Read path captures out of the router's union match instead of re-running the route's pattern - [@ericproulx](https://github.com/ericproulx).
 * [#2921](https://github.com/ruby-grape/grape/pull/2921): Pin the router's request-time isolation regressions through requests instead of its instance variables - [@ericproulx](https://github.com/ericproulx).
+* [#2927](https://github.com/ruby-grape/grape/pull/2927): Validate required Hash params scopes without the attributes iterator - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 4.0.0 (2026-09-07)

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -166,6 +166,14 @@ module Grape
         !@parent
       end
 
+      # Whether #should_validate? answers true for every request: this scope
+      # and each of its ancestors is required and depends on nothing, so
+      # neither the params nor the parent chain have anything to say.
+      # @return [Boolean]
+      def always_validated?
+        !@optional && !@dependent_on && (@parent.nil? || @parent.always_validated?)
+      end
+
       # A nested scope is contained in one of its parent's elements.
       # @return [Boolean] whether or not this scope is nested
       def nested?

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -69,6 +69,10 @@ module Grape
           @opts = SharedOptions.new(**opts.slice(:allow_blank, :fail_fast))
           @exception_message = message(self.class.default_message_key) if self.class.default_message_key
           @iterator = iterator_class.new(@attrs, @scope).freeze
+          # A scope's parent, optionality, dependency and type are all set
+          # before its block declares anything, so this is settled by the time
+          # a validator is built. See #validate!.
+          @direct = scope.always_validated? && !scope.iterates_elements?
         end
 
         # Validates a given request.
@@ -78,7 +82,7 @@ module Grape
         # @return [void]
         def validate(request)
           params = request.params
-          return unless scope.should_validate?(params)
+          return unless @direct || scope.should_validate?(params)
 
           validate!(params)
         end
@@ -90,6 +94,9 @@ module Grape
         # @raise [Grape::Exceptions::Validation] if validation failed
         # @return [void]
         def validate!(params)
+          scoped = scope.params(params) if @direct
+          return validate_attributes!(scoped) if scoped.is_a?(Hash)
+
           # we collect errors inside array because
           # there may be more than one error per field
           array_errors = nil
@@ -122,6 +129,25 @@ module Grape
         attr_reader :options, :scope, :required, :exception_message
 
         alias required? required
+
+        # #validate! on a scope that always validates and does not iterate
+        # elements, once its params resolved to a Hash: the root scope and the
+        # required Hash scopes under it, which is most validators of most
+        # endpoints. There the iterator hands back that Hash once per
+        # attribute, and every scope on the chain is required with no
+        # dependency, so the per-attribute checks reduce to this. The
+        # machinery cost more than the validation itself.
+        def validate_attributes!(params)
+          array_errors = nil
+
+          @attrs.each do |attr_name|
+            validate_param!(attr_name, params) if required? || params.key?(attr_name)
+          rescue Grape::Exceptions::Validation => e
+            (array_errors ||= []) << e
+          end
+
+          raise Grape::Exceptions::ValidationArrayErrors.new(array_errors) if array_errors
+        end
 
         # The AttributesIterator subclass used to walk this validator's
         # attributes. Built once in #initialize and reused across requests.

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -209,6 +209,24 @@ describe Grape::Validations::ParamsScope do
     end
   end
 
+  # An Array group handed something other than an Array fails its own type
+  # check, and its members are not then validated against that value as
+  # though it were one element.
+  context 'array group given a Hash' do
+    it 'reports the group as invalid without validating its members' do
+      subject.params do
+        requires :items, type: Array do
+          requires :id, type: Integer
+        end
+      end
+      subject.post('/items') { 'ok' }
+
+      post '/items', { items: { name: 'x' } }.to_json, 'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq('items is invalid')
+    end
+  end
+
   context 'coercing values validation with a variant-member-type collection' do
     it 'accepts values compatible with the declared member types' do
       expect do


### PR DESCRIPTION
## Summary

Most validators of most endpoints sit on the root `params` scope or a required Hash scope under it, and for them `Validators::Base` ran the generic machinery: `scope.should_validate?`, which resolves the scope's params and walks the parent chain, then an `AttributesIterator` pass that resolves the params again, checks for arrays and the empty-optional sentinel and yields once per attribute, then a block that re-checks the scope's requiredness and dependency. For a root-scope validator that plumbing took about 570 of its 840 ns; a nested one paid more.

When a scope and every one of its ancestors is required and depends on nothing, `should_validate?` is true for every request and has no side effects. `ParamsScope#always_validated?` answers that. If the scope also does not iterate elements and its params resolve to a Hash, the iterator path reduces to: for each attribute, `validate_param!(attr, params)` if it is required or present. So:

- `#validate` skips `should_validate?` for such a scope.
- `#validate!` resolves the scope's params once and runs that loop (`#validate_attributes!`).
- Array scopes, `given`, optional scopes and their descendants, and params that resolve to something other than a Hash keep the existing path. `DefaultValidator` and the multiple-params validators, which override `#validate!`, only skip `should_validate?`.
- The flag is set in `#initialize`, since validators are frozen once built; a scope's parent, optionality, dependency and type are fixed before its block declares anything.

Per validator: root presence 658 → 311 ns, root coerce 728 → 406 ns, nested coerce 1.77 → 1.02 µs.

## Benchmarks

Median of 7 interleaved subprocess rounds against master, Ruby 4.0.6, no JIT:

| request | delta |
|---|---|
| JSON POST, 5 typed root params | **+20.5%** |
| JSON POST with a required nested Hash (3 attributes) | **+19.3%** |
| GET, 3 query params | +11.5% |
| GET, pagination helper with `values` and defaults, `mutually_exclusive` (10 validators) | +11.1% |
| POST returning `declared(params)`, optional nested Hash | +6.5% |
| GET with a before filter and a typed route param | +4.4% |
| GET with no params (control) | +0.2% (noise) |

Under YJIT, an earlier root-only version of this measured +11.3% on the JSON POST, +12.0% on the 10-validator GET and +7.3% on the 3-param GET.

## Missing spec, added

An Array group handed a Hash reports only its own type error; its members are not validated against the Hash as though it were one element. Nothing pinned that: sending such a scope down the new path passed the whole suite while adding `items[id] is missing` to the error. The new spec passes before and after this change and fails in that case.

## Behaviour

Byte-identical to master over a 104-case validation matrix, under both the HashWithIndifferentAccess and Hash params builders: every built-in validator (`values`, `except_values`, `regexp`, `length`, `same_as`, `allow_blank`, `default`, `as`, `mutually_exclusive`, `all_or_none_of`, `at_least_one_of`, `given`, `fail_fast`, a custom validator), required and optional nested Hashes three levels deep, a `with` group inside a nested Hash, a String or an Array sent where a Hash is declared, a Hash sent for an Array group, and `type: JSON` given a Hash, an Array and garbage. The routing and coercion matrices are unchanged too.

## Test plan

- [x] Full RSpec suite passes locally.
- [x] RuboCop clean.
- [x] Mutation-checked: the loop ignoring `required?` fails 29 specs; ignoring whether the key is present, 6; taking the new path for every scope, 74; stopping at the first error, 2; skipping `should_validate?` for every scope, 6; `always_validated?` ignoring optionality, 7; ignoring the parent chain, 1; taking the new path for array scopes, 1 (the new spec); dropping the Hash guard, 2.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
