### PR TITLE
Skip three redundant steps on every error response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#2918](https://github.com/ruby-grape/grape/pull/2918): Skip the dry-types round trip when a value already is the declared type - [@ericproulx](https://github.com/ericproulx).
 * [#2917](https://github.com/ruby-grape/grape/pull/2917): Read path captures out of the router's union match instead of re-running the route's pattern - [@ericproulx](https://github.com/ericproulx).
 * [#2921](https://github.com/ruby-grape/grape/pull/2921): Pin the router's request-time isolation regressions through requests instead of its instance variables - [@ericproulx](https://github.com/ericproulx).
+* [#2929](https://github.com/ruby-grape/grape/pull/2929): Skip a header copy, a message re-encode and a Proc conversion on every error response - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 4.0.0 (2026-09-07)

--- a/lib/grape/error_formatter/json.rb
+++ b/lib/grape/error_formatter/json.rb
@@ -23,8 +23,11 @@ module Grape
           { error: ensure_utf8(message) }
         end
 
+        # Re-encoding a String that already is valid UTF-8 only copies it, for
+        # about 260 ns on every error response.
         def ensure_utf8(message)
           return message unless message.respond_to? :encode
+          return message if message.is_a?(String) && message.encoding == Encoding::UTF_8 && message.valid_encoding?
 
           message.encode('UTF-8', invalid: :replace, undef: :replace)
         end

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -66,9 +66,13 @@ module Grape
 
       private
 
+      # +headers+ is handed over as it is: Rack::Response copies it into a
+      # Headers of its own on every supported Rack (Rack 2.2 through
+      # +HeaderHash[]+, which only adopts a Hash that already is one), and every
+      # caller builds it fresh for this response.
       def rack_response(status, headers, message)
         body = html_content_type?(headers[Rack::CONTENT_TYPE]) ? Rack::Utils.escape_html(message) : message
-        Rack::Response.new(Array.wrap(body), Rack::Utils.status_code(status), Grape::Util::Header.new.merge!(headers))
+        Rack::Response.new(Array.wrap(body), Rack::Utils.status_code(status), headers)
       end
 
       # Escaping must key off the media type only, case-insensitively. Comparing
@@ -268,7 +272,7 @@ module Grape
       def run_rescue_handler(handler, error, endpoint, redispatched: false)
         callable = handler.is_a?(Symbol) ? endpoint.public_method(handler) : handler
         response = catch(:error) do
-          callable.arity.zero? ? endpoint.instance_exec(&callable) : endpoint.instance_exec(error, &callable)
+          call_rescue_handler(callable, error, endpoint)
         rescue StandardError => e
           return redispatch(e, endpoint, redispatched)
         end
@@ -277,6 +281,18 @@ module Grape
         return response if response.is_a?(Rack::Response)
 
         run_rescue_handler(method(:default_rescue_handler), Grape::Exceptions::InvalidResponse.new, endpoint)
+      end
+
+      # A +rescue_from+ block runs as the endpoint. A Method (the middleware's
+      # own handlers, or the endpoint's for a +with:+ Symbol) is already bound
+      # to a receiver that instance_exec cannot change, so it is called as it
+      # is rather than turned into a Proc first.
+      def call_rescue_handler(callable, error, endpoint)
+        if callable.is_a?(Method)
+          callable.arity.zero? ? callable.call : callable.call(error)
+        else
+          callable.arity.zero? ? endpoint.instance_exec(&callable) : endpoint.instance_exec(error, &callable)
+        end
       end
 
       # Route an exception raised inside a +rescue_from+ block.

--- a/spec/grape/error_formatter/json_spec.rb
+++ b/spec/grape/error_formatter/json_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+describe Grape::ErrorFormatter::Json do
+  let(:app) do
+    Class.new(Grape::API) do
+      format :json
+      get('/utf8') { error!('café', 400) }
+      get('/binary') { error!("caf\xC3\xA9".b, 400) }
+      get('/malformed') { error!("caf\xC3", 400) }
+    end
+  end
+
+  # A String message goes out as UTF-8 whatever it arrived as: one that already
+  # is valid UTF-8 as it is, anything else converted, with what does not
+  # convert replaced rather than failing the response.
+  it 'renders a UTF-8 message as it is' do
+    get '/utf8'
+    expect(JSON.parse(last_response.body)).to eq('error' => 'café')
+  end
+
+  it 'converts a binary message, replacing the bytes it cannot map' do
+    get '/binary'
+    expect(JSON.parse(last_response.body)).to eq('error' => 'caf��')
+  end
+
+  it 'replaces the invalid bytes of a malformed UTF-8 message' do
+    get '/malformed'
+    expect(JSON.parse(last_response.body)).to eq('error' => 'caf�')
+  end
+end


### PR DESCRIPTION
## Summary

Three steps every error response took for nothing:

- **`Middleware::Error#rack_response` copied the headers into a `Grape::Util::Header`** only to hand them to `Rack::Response.new`, which copies its argument into a Headers of its own on every supported Rack: Rack 2.2's `HeaderHash[]` adopts only a Hash that already is a `HeaderHash`, and 3.x always builds a fresh `Rack::Headers`. #2911 kept this copy on the grounds that callers write into what they are given, but here the writer is `Rack::Response`, which writes into its own copy, and all three callers build the Hash fresh for this response. The copy #2911 kept in `API::Instance#call`, which can be handed a mounted app's frozen Hash, stays.
- **`run_rescue_handler` ran every handler through `instance_exec`**, turning a `Method` into a Proc first. The middleware's own handlers (`method(:error_response)`, `method(:default_rescue_handler)`) and the endpoint's for a `with:` Symbol are Methods, already bound to a receiver that `instance_exec` cannot change, so they are now called as they are. Blocks still run as the endpoint.
- **`ErrorFormatter::Json#ensure_utf8` re-encoded every String message.** For one that already is valid UTF-8, `encode` only returns a copy, for about 260 ns. Such a message is now returned as it is; anything else is converted as before.

## Benchmarks

Median of 7 interleaved subprocess rounds against master, Ruby 4.0.6, no JIT:

| response | delta |
|---|---|
| 405 (raised `MethodNotAllowed`) | +4.9% |
| 401 via `error!` | +3.3% |
| 400 validation error | +2.6% |
| 404 via a `rescue_from` block calling `error!` | +2.6% |
| 500 via `rescue_from :all` | +2.3% |
| successful GET (control) | +0.5% (noise) |

## Behaviour

Byte-identical to master (status, headers and body) over a 228-case matrix: JSON, txt, XML and content-negotiated APIs × `error!` with a String, a Hash, custom headers, an HTML content type, and frozen, binary, malformed and US-ASCII messages; `rescue_from` with a block, a `with:` Symbol, an arity-0 block, a handler that returns junk, one that raises again and one that returns a `Rack::Response`; unhandled exceptions, validation errors, 405, OPTIONS and 404; each with three Accept headers.

## Missing spec, added

What `ensure_utf8` does with a message that is not valid UTF-8 had no spec: dropping the encoding half of the new check passed the whole suite while a binary message went out as raw bytes (json 3 warns this "will raise an encoding error"). `spec/grape/error_formatter/json_spec.rb` pins the three cases: UTF-8 as it is, binary converted with the unmappable bytes replaced, and malformed UTF-8 with the invalid bytes replaced. It passes before and after this change.

## Test plan

- [x] Full RSpec suite passes locally.
- [x] RuboCop clean.
- [x] Mutation-checked: calling every Method handler with the error fails 2 specs (arity-0 `with:` handlers); skipping the validity half of the UTF-8 check fails 2; skipping the encoding half fails 1 (the new spec).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
