### PR TITLE
Coerce through dry-types' non-raising call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#2918](https://github.com/ruby-grape/grape/pull/2918): Skip the dry-types round trip when a value already is the declared type - [@ericproulx](https://github.com/ericproulx).
 * [#2917](https://github.com/ruby-grape/grape/pull/2917): Read path captures out of the router's union match instead of re-running the route's pattern - [@ericproulx](https://github.com/ericproulx).
 * [#2921](https://github.com/ruby-grape/grape/pull/2921): Pin the router's request-time isolation regressions through requests instead of its instance variables - [@ericproulx](https://github.com/ericproulx).
+* [#2930](https://github.com/ruby-grape/grape/pull/2930): Coerce through dry-types' non-raising call so a rejected value no longer builds a backtrace - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 4.0.0 (2026-09-07)

--- a/lib/grape/validations/types/dry_type_coercer.rb
+++ b/lib/grape/validations/types/dry_type_coercer.rb
@@ -43,11 +43,18 @@ module Grape
         # Coerces the given value to a type which was specified during
         # initialization as a type argument.
         #
+        # Given a block, dry-types reports a value it cannot coerce by calling
+        # the block instead of raising. Raising is what cost: its CoercionError
+        # is re-raised with the backtrace of the error underneath, and building
+        # that backtrace as strings at request depth took about 25 µs for every
+        # rejected value -- every `types: [Integer, String]` param given a
+        # string, every 400 for a mistyped value.
+        #
         # @param val [Object]
         def call(val)
           return if val.nil?
 
-          @coercer[val]
+          @coercer.call(val) { InvalidValue.new }
         rescue Dry::Types::CoercionError
           InvalidValue.new
         end


### PR DESCRIPTION
## Summary

`DryTypeCoercer#call` coerced with `@coercer[val]` and rescued `Dry::Types::CoercionError` for a value it could not coerce. The raise is what cost: dry-types' `CoercionError.handle` re-raises with `backtrace: exception.backtrace` of the error underneath (the `ArgumentError` from `Integer()`, `Float()`, `Date.parse`, …), which builds that whole backtrace as Strings. At request depth a rejected value cost about 30 µs, where an accepted one costs a few hundred nanoseconds.

It is paid by:
- every `types: [Integer, String]` param given a string, since each coercer tried before the one that accepts it fails first;
- every 400 for a mistyped value (`?id=abc` for an Integer);
- invalid dates, numbers and booleans.

dry-types' documented block form of `Type#call` ("When a block is passed, `call` will never throw an exception on failed coercion, instead it will call the block") reports a failure by calling the block, so the coercer now passes one that answers `InvalidValue`. The `rescue` stays for anything that raises regardless.

A rejected Integer at a request's stack depth: 31.2 → 4.4 µs.

## Benchmarks

Median of interleaved subprocess rounds against master, Ruby 4.0.6 (7 rounds without JIT, 5 with YJIT):

| request | no JIT | YJIT |
|---|---|---|
| GET with `types: [Integer, String]` given `abc`, plus an `Array[Integer]` with `coerce_with` | **+114.7%** | **+195.1%** |
| 400 for `?id=abc` on `requires :id, type: Integer` | **+49.1%** | **+95.6%** |
| GET with valid query params (control) | −1.3% (noise) | |
| POST with a valid JSON body (control) | +1.1% (noise) | |

## Behaviour

Byte-identical to master over a 2,214-case coercer matrix, calling `Types.build_coercer` directly: 27 types (every primitive, `Numeric`, `Grape::API::Boolean`, `TrueClass`/`FalseClass`, `Hash`, `Array`, `Array[T]`, `Set[T]`, multiple-type lists including nested collections), each coerced and strict, × 41 inputs (valid, malformed, blank, `nil`, arrays, hashes, symbols, invalid bytes). 1,640 of those cases are rejections, so the changed path is the one exercised. The request-level coercion and validation matrices are unchanged too.

## Test plan

- [x] Full RSpec suite passes locally.
- [x] RuboCop clean.
- [x] Mutation-checked: a failed coercion answering `nil` fails 37 specs; answering the raw value fails 29. Reverting to the raising call changes nothing observable, which is the point; the benchmark pins that.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
