### PR TITLE
Stop building a backtrace in the default rescue handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#2918](https://github.com/ruby-grape/grape/pull/2918): Skip the dry-types round trip when a value already is the declared type - [@ericproulx](https://github.com/ericproulx).
 * [#2917](https://github.com/ruby-grape/grape/pull/2917): Read path captures out of the router's union match instead of re-running the route's pattern - [@ericproulx](https://github.com/ericproulx).
 * [#2921](https://github.com/ruby-grape/grape/pull/2921): Pin the router's request-time isolation regressions through requests instead of its instance variables - [@ericproulx](https://github.com/ericproulx).
+* [#2931](https://github.com/ruby-grape/grape/pull/2931): Stop building a backtrace in the default `rescue_from` handler unless the API asked for one - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 4.0.0 (2026-09-07)

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -192,11 +192,13 @@ module Grape
         )
       end
 
+      # No +backtrace:+: #resolved_backtrace reads it off +original_exception+
+      # when the API asked for one, and only then, since building it is the
+      # dearest part of rendering the error.
       def default_rescue_handler(exception)
         error_response(
           Grape::Exceptions::ErrorResponse.new(
             message: exception.message,
-            backtrace: exception.backtrace,
             original_exception: exception
           )
         )


### PR DESCRIPTION
## Summary

`Middleware::Error#default_rescue_handler` renders any exception matched by `rescue_from :all`, or by `rescue_from SomeError` given without a block, a common way to turn unexpected errors into 500s. It passed `backtrace: exception.backtrace` to the error payload. `Exception#backtrace` builds the whole backtrace as Strings, which at a request's stack depth is the dearest part of rendering the error, and the result was then discarded unless the API had asked for `rescue_from ..., backtrace: true`.

`#resolved_backtrace` already falls back to `original_exception.backtrace` when a backtrace is wanted, and the handler passes `original_exception`, so the eager read goes. What an API that asked for the backtrace renders is unchanged.

## Benchmarks

Median of 7 interleaved subprocess rounds against master, Ruby 4.0.6, no JIT:

| response | delta |
|---|---|
| 500 from `rescue_from :all` (no block) | **+92.8%** |
| 500 from a `rescue_from :all` block calling `error!` (control, does not use the default handler) | +0.6% (noise) |

## Not changed

`Formatter` builds its payload the same way in two places, for an `InvalidFormatter` and for a custom parser raising a non-Grape error, but a spec (`formatter_spec.rb:509`) pins the `backtrace` of the payload it throws, and neither path is hot: Grape's own parsers turn a parse failure into `InvalidMessageBody`, which does not go through that branch (a malformed JSON body measured +0.1% with both changed). They are left as they are.

## Behaviour

Byte-identical to master over a 30-case matrix of `rescue_from :all` APIs, with and without `backtrace: true` and `original_exception: true`, in JSON, txt and XML, for raised Ruby and Grape exceptions and malformed bodies: 18 of the responses render a backtrace, identical once paths are normalized. The 228-case error matrix from #2929 is unchanged too.

## Test plan

- [x] Full RSpec suite passes locally.
- [x] RuboCop clean.
- [x] Mutation-checked: also dropping `original_exception:` from the handler, so no backtrace is available when one is asked for, fails 5 specs.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
