### PR TITLE
Let a parser's Grape errors through the formatter without re-raising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#2918](https://github.com/ruby-grape/grape/pull/2918): Skip the dry-types round trip when a value already is the declared type - [@ericproulx](https://github.com/ericproulx).
 * [#2917](https://github.com/ruby-grape/grape/pull/2917): Read path captures out of the router's union match instead of re-running the route's pattern - [@ericproulx](https://github.com/ericproulx).
 * [#2921](https://github.com/ruby-grape/grape/pull/2921): Pin the router's request-time isolation regressions through requests instead of its instance variables - [@ericproulx](https://github.com/ericproulx).
+* [#2932](https://github.com/ruby-grape/grape/pull/2932): Let a parser's Grape errors through the formatter instead of rescuing them to raise again - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 4.0.0 (2026-09-07)

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -152,12 +152,22 @@ module Grape
             end
             env[Rack::RACK_REQUEST_FORM_INPUT] = env[Rack::RACK_INPUT]
           end
-        rescue Grape::Exceptions::Base => e
-          raise e
-        rescue StandardError => e
+        rescue ForeignParserError => e
           throw :error, Grape::Exceptions::ErrorResponse.new(status: 400, message: e.message, backtrace: e.backtrace, original_exception: e)
         end
       end
+
+      # What a parser raises that is not a Grape error, and so is answered as a
+      # 400 here. A Grape error goes on to the error middleware as it is. It
+      # used to be rescued just to be raised again, and re-raising at request
+      # depth cost about 25 µs -- paid by every malformed body, since the
+      # built-in parsers report one as InvalidMessageBody.
+      module ForeignParserError
+        def self.===(exception)
+          exception.is_a?(StandardError) && !exception.is_a?(Grape::Exceptions::Base)
+        end
+      end
+      private_constant :ForeignParserError
 
       # this middleware will not try to format the following content-types since Rack already handles them
       # when calling Rack's `params` function

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -527,4 +527,27 @@ describe Grape::Middleware::Formatter do
       expect(error.original_exception.class).to eq StandardError
     end
   end
+
+  # Only a parser's StandardErrors are answered with a 400. Anything else --
+  # an Interrupt, a SystemExit -- is not the body's fault and keeps going.
+  context 'custom parser raises an exception that is not a StandardError' do
+    it 'lets it through rather than answering 400' do
+      subject = described_class.new(
+        app,
+        parsers: { json: ->(_object, _env) { raise NotImplementedError, 'fatal' } }
+      )
+      io = StringIO.new('{}')
+      expect do
+        catch(:error) do
+          subject.call(
+            Rack::PATH_INFO => '/info',
+            Rack::REQUEST_METHOD => Rack::POST,
+            'CONTENT_TYPE' => 'application/json',
+            Rack::RACK_INPUT => io,
+            'CONTENT_LENGTH' => io.length.to_s
+          )
+        end
+      end.to raise_error(NotImplementedError, 'fatal')
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`Formatter#read_rack_input` answers a parser's StandardErrors with a 400, and let Grape's own errors go on to the error middleware by rescuing them first: `rescue Grape::Exceptions::Base => e; raise e`. Re-raising an exception makes Ruby read its backtrace (`setup_exception` calls `rb_get_backtrace`, which builds the lazily captured backtrace as Strings), and at request depth that is the dearest part of the error: about 25 µs. It was paid by every malformed body, since the built-in parsers report one as `InvalidMessageBody`.

A matcher module in the `rescue` clause now selects the errors to answer here, StandardErrors that are not Grape errors, so a Grape error is never rescued at this frame and travels on as it is. Unwinding past a frame that does not rescue it costs nothing extra.

## Benchmarks

Median of 7 interleaved subprocess rounds, Ruby 4.0.6, no JIT, POST with a malformed JSON body:

| API | compared against | delta |
|---|---|---|
| no `rescue_from` | master | **+28.7%** |
| `rescue_from :all` | master + #2931 | **+29.8%** |
| `rescue_from :all` | master | −0.6% |

The last row is not a contradiction. A backtrace is built once and then cached, so the cost is paid by whichever step reads it first. On an API with `rescue_from :all`, master's default handler also reads the backtrace eagerly (fixed by #2931), so either change alone just moves the cost to the other step, and the gain lands once both are in. Without `rescue_from`, nothing else reads it and this change alone gets it all.

## Missing spec, added

A parser raising something that is not a StandardError, such as an Interrupt or a SystemExit, keeps propagating rather than being answered as a 400. Nothing pinned that: dropping the `StandardError` bound from the matcher passed the whole suite. The new spec raises a `NotImplementedError` from a custom parser; it passes before and after this change.

## Behaviour

Byte-identical to master over a 30-case matrix of `rescue_from :all` APIs, with and without `backtrace: true` and `original_exception: true`, in JSON, txt and XML, including malformed bodies. The rendered backtraces of `InvalidMessageBody` are identical once paths are normalized, so re-raising never altered them.

## Test plan

- [x] Full RSpec suite passes locally.
- [x] RuboCop clean.
- [x] Mutation-checked: the matcher also taking Grape errors fails 4 specs; the matcher dropping its `StandardError` bound fails 1 (the new spec).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
