### PR TITLE
Validate the elements of an Array params scope without the attributes iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#2917](https://github.com/ruby-grape/grape/pull/2917): Read path captures out of the router's union match instead of re-running the route's pattern - [@ericproulx](https://github.com/ericproulx).
 * [#2921](https://github.com/ruby-grape/grape/pull/2921): Pin the router's request-time isolation regressions through requests instead of its instance variables - [@ericproulx](https://github.com/ericproulx).
 * [#2927](https://github.com/ruby-grape/grape/pull/2927): Validate required Hash params scopes without the attributes iterator - [@ericproulx](https://github.com/ericproulx).
+* [#2933](https://github.com/ruby-grape/grape/pull/2933): Validate the elements of an Array params scope without the attributes iterator - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 4.0.0 (2026-09-07)

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -171,7 +171,16 @@ module Grape
       # neither the params nor the parent chain have anything to say.
       # @return [Boolean]
       def always_validated?
-        !@optional && !@dependent_on && (@parent.nil? || @parent.always_validated?)
+        !@optional && validated_when_given?
+      end
+
+      # Whether #should_validate? has nothing to ask but whether this scope's
+      # own params were given: it depends on no other param, and every scope
+      # above it is always validated. A required scope like that is then
+      # always validated, an optional one whenever its params are there.
+      # @return [Boolean]
+      def validated_when_given?
+        !@dependent_on && (@parent.nil? || @parent.always_validated?)
       end
 
       # A nested scope is contained in one of its parent's elements.

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -70,9 +70,11 @@ module Grape
           @exception_message = message(self.class.default_message_key) if self.class.default_message_key
           @iterator = iterator_class.new(@attrs, @scope).freeze
           # A scope's parent, optionality, dependency and type are all set
-          # before its block declares anything, so this is settled by the time
-          # a validator is built. See #validate!.
-          @direct = scope.always_validated? && !scope.iterates_elements?
+          # before its block declares anything, so these are settled by the
+          # time a validator is built. See #validate and #validate!.
+          @always_validated = scope.always_validated?
+          @direct = @always_validated && !scope.iterates_elements?
+          @direct_elements = scope.validated_when_given? && scope.iterates_elements? && scope.array_depth == 1
         end
 
         # Validates a given request.
@@ -82,7 +84,7 @@ module Grape
         # @return [void]
         def validate(request)
           params = request.params
-          return unless @direct || scope.should_validate?(params)
+          return unless @always_validated || scope.should_validate?(params)
 
           validate!(params)
         end
@@ -94,6 +96,8 @@ module Grape
         # @raise [Grape::Exceptions::Validation] if validation failed
         # @return [void]
         def validate!(params)
+          return validate_elements!(scope.params(params)) if @direct_elements
+
           scoped = scope.params(params) if @direct
           return validate_attributes!(scoped) if scoped.is_a?(Hash)
 
@@ -147,6 +151,48 @@ module Grape
           end
 
           raise Grape::Exceptions::ValidationArrayErrors.new(array_errors) if array_errors
+        end
+
+        # #validate_attributes! for each element of an Array scope, such as
+        # +requires :items, type: Array do+ at the root, when it is the only
+        # scope on the chain that iterates elements: its params are then the
+        # request's Array as it came in, with no nesting for the iterator to
+        # descend into. It depends on no other param and every scope above it
+        # is always validated, so the iterator's per-element checks come down
+        # to the index it records for the error names and, for an optional
+        # scope, passing over an empty element. An element that is not a Hash
+        # goes through the same +hash_like?+ test as on the iterator path, and
+        # the members of a scope that did not get an Array are left alone, as
+        # they are there: the scope's own type check reports it.
+        def validate_elements!(elements)
+          return unless elements.is_a?(Array)
+
+          tracker = ParamScopeTracker.current
+          optional = !scope.required?
+          array_errors = nil
+
+          elements.each_with_index do |element, index|
+            tracker&.store_index(scope, index)
+            next if optional && empty_element?(element)
+
+            @attrs.each do |attr_name|
+              validate_param!(attr_name, element) if required? || (hash_like?(element) && element.key?(attr_name))
+            rescue Grape::Exceptions::Validation => e
+              (array_errors ||= []) << e
+            end
+          end
+
+          raise Grape::Exceptions::ValidationArrayErrors.new(array_errors) if array_errors
+        end
+
+        # What the iterator passes over in an optional scope: an element given
+        # empty, or the placeholder +map_params+ puts where an optional scope's
+        # params were not given at all, which it can only do here when a scope
+        # above was handed an Array instead of a Hash.
+        def empty_element?(element)
+          return true if Grape::DSL::Parameters::EmptyOptionalValue.equal?(element)
+
+          element.respond_to?(:empty?) ? element.empty? : element.nil?
         end
 
         # The AttributesIterator subclass used to walk this validator's

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -227,6 +227,23 @@ describe Grape::Validations::ParamsScope do
     end
   end
 
+  context 'hash group given an Array' do
+    it 'reports the group as invalid without validating the optional array group inside it' do
+      subject.params do
+        requires :meta, type: Hash do
+          optional :items, type: Array do
+            requires :id, type: Integer
+          end
+        end
+      end
+      subject.post('/meta') { 'ok' }
+
+      post '/meta', { meta: [{}] }.to_json, 'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq('meta is invalid')
+    end
+  end
+
   context 'coercing values validation with a variant-member-type collection' do
     it 'accepts values compatible with the declared member types' do
       expect do

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -881,6 +881,32 @@ describe Grape::Validations do
         expect(last_response.body).to eq('items[0][key] is missing')
       end
 
+      it 'skips the elements that are empty' do
+        subject.params do
+          optional :items, type: Array do
+            requires :key
+          end
+        end
+        subject.post('/optional_group') { 'optional group works' }
+
+        post_with_json '/optional_group', items: [{}, { not_key: 'foo' }]
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('items[1][key] is missing')
+      end
+
+      it "doesn't validate the group when every element is blank" do
+        subject.params do
+          optional :items, type: Array do
+            requires :key
+          end
+        end
+        subject.post('/optional_group') { 'optional group works' }
+
+        post_with_json '/optional_group', items: [false, ' ']
+        expect(last_response.status).to eq(201)
+        expect(last_response.body).to eq('optional group works')
+      end
+
       it "errors when param is present but isn't an Array" do
         get '/optional_group', items: 'hello'
         expect(last_response.status).to eq(400)


### PR DESCRIPTION
Stacked on #2927 (it builds on `ParamsScope#always_validated?` and follows `validate_attributes!`); this PR targets that branch, so the diff shows only this change.

## Summary

A validator on `requires :items, type: Array do ... end`, or `optional`, went through the `AttributesIterator` for every element. That meant an index bookkeeping call, a yield per attribute, an emptiness test, and, per attribute, the scope's `required?` and `meets_dependency?`.

Those answers are fixed when three things hold:

- the scope depends on no other param;
- every scope above it is always validated;
- it is the only scope on the chain that iterates elements.

Its params are then the request's Array as it came in. The iterator only contributes the element index that the error names carry (`items[3][id] is missing`) and, for an optional scope, passing over empty elements.

`Validators::Base#validate_elements!` covers that case the way #2927's `validate_attributes!` covers a Hash scope:

- It records each element's index in the tracker.
- In an optional scope, it passes over the elements the iterator did: empty ones, and the placeholder `map_params` puts where the scope's params were missing.
- It runs the same per-attribute check, `required? || (hash_like?(element) && element.key?(attr_name))`, collecting the errors in the same order.

`ParamsScope#validated_when_given?` names the condition, and `always_validated?` is now that plus being required. A required scope like that also skips `should_validate?`, which always answers true for it. An optional one still asks, because its "every element is blank" check uses `blank?`, which also covers `false` and whitespace. Nested Array scopes and `given` blocks keep the iterator.

## Benchmarks

Median of interleaved subprocess rounds, Ruby 4.0.6. POST with a JSON body `{"items": [...]}`, where each element holds `requires :id, type: Integer`, `optional :name, type: String` and `optional :qty, type: Integer, values: 1..100`.

| scenario | vs master + #2927, no JIT (9 rounds) | YJIT (7 rounds) |
|---|---|---|
| `requires`, 1 element | **+28.5%** | |
| `requires`, 10 elements | **+32.4%** | **+33.6%** |
| `requires`, 50 elements | **+40.5%** | **+38.9%** |
| `optional`, 10 elements | **+21.2%** | **+25.9%** |

Paths without an Array scope are flat: JSON body −0.3%, nested Hash body −0.8%, query params +0.4% (another run: −1.7%, with base-vs-base at −0.8%). The noise floor today is about ±1.6%.

## Behaviour

Byte-identical to master and to #2927 over 164 requests: 82 cases against both the Hash and the HashWithIndifferentAccess params builder. They cover:

- required and optional Array scopes with every built-in validator, a custom one, `as:`, `default:`, and `mutually_exclusive`;
- nested Hash and Array scopes inside elements, and `given` inside an element;
- `Array[JSON]`, and Arrays of Arrays;
- `fail_fast`, an Array inside a Hash, and a `with` group inside an Array;
- a Hash scope given an Array, with optional and required Array scopes inside it;
- malformed elements (`nil`, `false`, blank Strings, numbers, nested Arrays), a Hash or a String where the Array should be, and query-string Arrays.

The 104-case validation matrix from #2927 is also byte-identical.

## Missing specs, added

Each of these passed the whole suite when mutated. The new specs pass on master and on this branch:

- An optional Array scope skips the elements that are empty. `[{}, {not_key: 'foo'}]` reports only `items[1][key] is missing`.
- An optional Array scope is not validated at all when every element is blank. `[false, ' ']` passes, because `should_validate?` uses `blank?`.
- A Hash scope given an Array reports only itself. `meta: [{}]` answers `meta is invalid` and nothing about the optional Array scope inside it.

## Test plan

- [x] Full RSpec suite passes locally.
- [x] RuboCop clean.
- [x] Mutation-checked, 15 of 15 killed, each against the validation, endpoint, API, exception and integration specs:
  - ignoring the nesting depth;
  - recording no index, or index 0;
  - ignoring `required?`, or validating absent optional attributes;
  - dropping the `hash_like?` guard, or the Array guard;
  - stopping at the first error;
  - dropping the empty-element skip, or applying it to required scopes;
  - validating the placeholder, or treating only `nil` as empty;
  - letting optional scopes skip `should_validate?`;
  - `validated_when_given?` ignoring the dependency, or the parent chain.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
