### PR TITLE
Translate ValidationErrors#full_messages once instead of on every call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#2918](https://github.com/ruby-grape/grape/pull/2918): Skip the dry-types round trip when a value already is the declared type - [@ericproulx](https://github.com/ericproulx).
 * [#2917](https://github.com/ruby-grape/grape/pull/2917): Read path captures out of the router's union match instead of re-running the route's pattern - [@ericproulx](https://github.com/ericproulx).
 * [#2921](https://github.com/ruby-grape/grape/pull/2921): Pin the router's request-time isolation regressions through requests instead of its instance variables - [@ericproulx](https://github.com/ericproulx).
+* [#2934](https://github.com/ruby-grape/grape/pull/2934): Translate `ValidationErrors#full_messages` once instead of on every call - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 4.0.0 (2026-09-07)

--- a/lib/grape/exceptions/validation_errors.rb
+++ b/lib/grape/exceptions/validation_errors.rb
@@ -23,7 +23,19 @@ module Grape
         as_json.to_json
       end
 
+      # Translated once, when the error is built for its #message, and handed
+      # out as a copy from then on. Every lookup here is an I18n call of a few
+      # microseconds, and the README's recipe for answering with the list,
+      # +error!({ messages: e.full_messages }, 400)+, asked for all of them a
+      # second time. It also keeps the list the same as #message, which was
+      # already fixed at that point, if the locale changes in between.
       def full_messages
+        (@full_messages ||= translate_full_messages).dup
+      end
+
+      private
+
+      def translate_full_messages
         messages = errors.flat_map do |attributes, errs|
           errs.map do |error|
             translate(
@@ -38,8 +50,6 @@ module Grape
         messages.uniq!
         messages
       end
-
-      private
 
       def translate_attributes(keys)
         keys.map do |key|

--- a/spec/grape/exceptions/validation_errors_spec.rb
+++ b/spec/grape/exceptions/validation_errors_spec.rb
@@ -65,6 +65,15 @@ describe Grape::Exceptions::ValidationErrors do
         expect(subject.first).to eq('admin_field Can not set admin-only field')
       end
     end
+
+    context 'when the caller changes the array it was given' do
+      subject(:error) { described_class.new(exceptions: [Grape::Exceptions::Validation.new(params: ['id'], message: :presence)]) }
+
+      it 'returns the same messages the next time' do
+        error.full_messages << 'name is missing'
+        expect(error.full_messages).to eq(['id is missing'])
+      end
+    end
   end
 
   context 'api' do


### PR DESCRIPTION
## Summary

`ValidationErrors` builds its `#message` from `#full_messages` when it is created. `#full_messages` then translated every error again on each call: an I18n lookup for the `grape.errors.format` string (with interpolation) and one per attribute name. Each is a few microseconds on I18n 1.15.

The README's recipe for answering with the list, below, therefore paid for every translation twice:

```ruby
rescue_from Grape::Exceptions::ValidationErrors do |e|
  error!({ messages: e.full_messages }, 400)
end
```

The list is now kept from the first call and handed out as a copy, so a caller changing it cannot change what the next caller gets. `#message` is still built through `#full_messages`, so a subclass overriding it keeps working as before.

## Benchmarks

Median of 7 interleaved subprocess rounds, Ruby 4.0.6. The API uses the README handler above, with `requires :id, type: Integer` and `requires :name, type: String`.

| request | no JIT | YJIT |
|---|---|---|
| one param missing | **+21.9%** | **+24.9%** |
| both params missing | **+27.3%** | **+34.4%** |
| default handler, missing param | −0.1% | |
| default handler, invalid Integer | −0.1% | |

## Behaviour

The list now stays what `#message` was built from. Before, a handler that switched the locale and then asked for the list got a mix of both locales. With a French format and a French `presence` message, `I18n.with_locale(:fr) { e.full_messages }` answered `["id : is missing", "nick : is missing"]` for an error raised in English: the French format and untranslated attribute names around the English messages, which were translated when each `Validation` was raised. It now answers `["id is missing", "Nickname is missing"]`, the same text as `#message`. I did not add an UPGRADING entry, since the old output was half-translated anyway; happy to add one.

Otherwise responses are byte-identical to master over:

- a 120-request matrix of `rescue_from ValidationErrors` handlers reading `full_messages` (once, twice, and after changing the list), `message`, both together, `as_json`, `to_json`, `errors`, `error!(e)`, and re-raising. It includes translated attribute names, a request in another locale, `mutually_exclusive` (several params in one error) and `values`. The locale-switching handler above is the only difference.
- the 228-case error-path matrix and the 104-case and 108-case validation matrices from earlier PRs.

## Missing spec, added

A caller changing the array `#full_messages` returned must not change the next answer. The spec passes on master, where each call builds a new array, and fails if the copy is dropped.

## Test plan

- [x] Full RSpec suite passes locally.
- [x] RuboCop clean.
- [x] Mutation-checked: dropping the copy fails the new spec. Dropping the memo is invisible by design, and the benchmark covers it.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
