### PR TITLE
Return the elements of an Array params scope that are not a Hash from declared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#2918](https://github.com/ruby-grape/grape/pull/2918): Skip the dry-types round trip when a value already is the declared type - [@ericproulx](https://github.com/ericproulx).
 * [#2917](https://github.com/ruby-grape/grape/pull/2917): Read path captures out of the router's union match instead of re-running the route's pattern - [@ericproulx](https://github.com/ericproulx).
 * [#2921](https://github.com/ruby-grape/grape/pull/2921): Pin the router's request-time isolation regressions through requests instead of its instance variables - [@ericproulx](https://github.com/ericproulx).
+* [#2935](https://github.com/ruby-grape/grape/pull/2935): Return the elements of an Array params scope that are not a Hash from `declared` instead of raising - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 4.0.0 (2026-09-07)

--- a/lib/grape/declared_params_handler.rb
+++ b/lib/grape/declared_params_handler.rb
@@ -20,7 +20,16 @@ module Grape
 
     private
 
+    # An element of an Array scope that is not a Hash has no keys to filter,
+    # so it is returned as it came in, the way a leaf value is. Validation
+    # lets one through wherever nothing in the scope is required of it: an
+    # optional scope passes over blank elements, and a scope whose params are
+    # all optional checks nothing on an element that is not a Hash. Filtering
+    # it anyway meant building an empty copy of it, which raised for +nil+,
+    # +false+ and numbers and indexed a String with a Symbol.
     def recursive_declared(passed_params, declared_params:, route_params:, renamed_params:, params_nested_path: [])
+      return passed_params unless passed_params.is_a?(Array) || passed_params.respond_to?(:key?)
+
       res = if passed_params.is_a?(Array)
               passed_params.map do |passed_param|
                 recursive_declared(passed_param, declared_params:, params_nested_path:, renamed_params:, route_params:)

--- a/spec/grape/endpoint/declared_spec.rb
+++ b/spec/grape/endpoint/declared_spec.rb
@@ -888,4 +888,39 @@ describe Grape::Endpoint do
 
     it { is_expected.to be_successful }
   end
+
+  describe 'Array elements that are not a Hash' do
+    let(:app) do
+      Class.new(Grape::API) do
+        format :json
+
+        params do
+          optional :items, type: Array do
+            requires :id, type: Integer
+            optional :name, type: String
+          end
+        end
+        post('/items') { declared(params) }
+
+        params do
+          requires :tags, type: Array do
+            optional :label, type: String
+          end
+        end
+        post('/tags') { declared(params, include_missing: false) }
+      end
+    end
+
+    it 'returns the blank elements an optional Array passes over as they came in' do
+      post_with_json '/items', items: [nil, { id: 1, junk: 2 }, '']
+      expect(last_response.status).to eq(201)
+      expect(JSON.parse(last_response.body)).to eq('items' => [nil, { 'id' => 1, 'name' => nil }, ''])
+    end
+
+    it 'returns the elements an Array of optional params lets through as they came in' do
+      post_with_json '/tags', tags: ['x', 1, { label: 'y', junk: 3 }]
+      expect(last_response.status).to eq(201)
+      expect(JSON.parse(last_response.body)).to eq('tags' => ['x', 1, { 'label' => 'y' }])
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`declared` filters each element of an Array scope down to its declared keys. It does that by building an empty copy of the element (`passed_params.class.new`) and filling it. An element that is not a Hash has no keys, and copying it raised, so the request answered 500:

- `NoMethodError` (`undefined method 'new'`) for `nil`, `false`, `true` and numbers;
- `TypeError` (`no implicit conversion of Symbol into Integer`) for a String, which then got indexed with a Symbol.

Validation lets such an element through wherever nothing in the scope is required of it:

```ruby
params do
  optional :items, type: Array do   # an optional scope passes over blank elements
    requires :id, type: Integer
  end
  requires :tags, type: Array do    # all-optional params check nothing on a non-Hash
    optional :label, type: String
  end
end
post { declared(params) }
```

So `{"items": [null, {"id": 1}]}`, `{"items": [""]}` or `{"tags": ["x", {"label": "y"}]}` got past validation and then broke the endpoint calling `declared`. It fails the same way at any depth, and with `include_missing: false`, `stringify: true` and `evaluate_given: true`.

Such an element is now returned as it came in, the way `declared` already returns a leaf value. The test is `respond_to?(:key?)`, the one `declare_leaf` uses, so a Hash-like object that is not a Hash is still filtered.

## Behaviour

A 31-case matrix, run against both the Hash and the HashWithIndifferentAccess params builder, each case through `declared` with its four option combinations. It covers optional and required Array scopes, nested Arrays, `Array[JSON]`, and an Array inside a Hash. It includes elements that are `nil`, `false`, `true`, numbers, blank and non-blank Strings, empty Arrays and Hashes:

- master raises on 14 of the cases, under each builder; this branch raises on none;
- every response that did not raise on master is byte-identical;
- both builders answer the same.

Two neighbouring behaviours are left alone, since neither raises and changing them would change responses that work today:

- An Array whose elements are all falsy (`[null]`, `[false]`) still comes back as `[]`. `declare_nested` asks `passed_children.any?`, which tests truthiness, so it treats such an Array as not given.
- Validation still accepts non-Hash elements in an Array scope whose params are all optional.

## Test plan

- [x] Full RSpec suite passes locally.
- [x] RuboCop clean.
- [x] Both new specs fail on master (500) and pass on this branch. They cover the two ways validation lets these elements through: blank elements of an optional Array, and non-Hash elements of an Array of optional params.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
