### PR TITLE
Speed up header versioning, content negotiation, params validation and error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#2921](https://github.com/ruby-grape/grape/pull/2921): Pin the router's request-time isolation regressions through requests instead of its instance variables - [@ericproulx](https://github.com/ericproulx).
 * [#2935](https://github.com/ruby-grape/grape/pull/2935): Return the elements of an Array params scope that are not a Hash from `declared` instead of raising - [@ericproulx](https://github.com/ericproulx).
 * [#2937](https://github.com/ruby-grape/grape/pull/2937): Forward the class methods kept off an API class to its base instance explicitly, and pin what `delegate_missing_to` still answers - [@ericproulx](https://github.com/ericproulx).
+* [#2936](https://github.com/ruby-grape/grape/pull/2936): Speed up header versioning, content negotiation, params validation and error responses on the request path - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 4.0.0 (2026-09-07)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,20 @@
 Upgrading Grape
 ===============
 
+### Upgrading to >= 4.1.0
+
+#### The header versioner's `api.*` env values are frozen
+
+`version ..., using: :header` now answers the Accept headers most requests send from a table built once, so every request sending the same header is handed the same parsed media type ([#2936](https://github.com/ruby-grape/grape/pull/2936)). The strings it writes into the env — `api.type`, `api.subtype`, `api.vendor`, `api.version` and `api.format` — are therefore frozen, as is `Grape::Util::MediaType` itself. Code that altered one of them in place now raises `FrozenError`; build a new String instead:
+
+```ruby
+# Before
+env['api.version'] << '-beta'
+
+# After
+env['api.version'] = "#{env['api.version']}-beta"
+```
+
 ### Upgrading to >= 4.0.0
 
 #### A positional options Hash is no longer accepted by `auth`, `http_basic` or `desc`

--- a/lib/grape/declared_params_handler.rb
+++ b/lib/grape/declared_params_handler.rb
@@ -96,8 +96,11 @@ module Grape
       end
     end
 
+    # The lookup key is the param's whole path, built fresh -- two Arrays and a
+    # String per declared param -- and only an API using +as:+ has anything to
+    # find with it, so the common empty table is not asked.
     def build_memo_key(params_nested_path, declared_param, renamed_params)
-      renamed_param_name = renamed_params[nested_path_for(params_nested_path, declared_param)]
+      renamed_param_name = renamed_params[nested_path_for(params_nested_path, declared_param)] if renamed_params.any?
       param = renamed_param_name || declared_param
       @stringify ? param.to_s : param.to_sym
     end

--- a/lib/grape/error_formatter/json.rb
+++ b/lib/grape/error_formatter/json.rb
@@ -23,8 +23,11 @@ module Grape
           { error: ensure_utf8(message) }
         end
 
+        # Re-encoding a String that already is valid UTF-8 only copies it, for
+        # about 260 ns on every error response.
         def ensure_utf8(message)
           return message unless message.respond_to? :encode
+          return message if message.is_a?(String) && message.encoding == Encoding::UTF_8 && message.valid_encoding?
 
           message.encode('UTF-8', invalid: :replace, undef: :replace)
         end

--- a/lib/grape/exceptions/validation_errors.rb
+++ b/lib/grape/exceptions/validation_errors.rb
@@ -23,7 +23,19 @@ module Grape
         as_json.to_json
       end
 
+      # Translated once, when the error is built for its #message, and handed
+      # out as a copy from then on. Every lookup here is an I18n call of a few
+      # microseconds, and the README's recipe for answering with the list,
+      # +error!({ messages: e.full_messages }, 400)+, asked for all of them a
+      # second time. It also keeps the list the same as #message, which was
+      # already fixed at that point, if the locale changes in between.
       def full_messages
+        (@full_messages ||= translate_full_messages).dup
+      end
+
+      private
+
+      def translate_full_messages
         messages = errors.flat_map do |attributes, errs|
           errs.map do |error|
             translate(
@@ -38,8 +50,6 @@ module Grape
         messages.uniq!
         messages
       end
-
-      private
 
       def translate_attributes(keys)
         keys.map do |key|

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -66,9 +66,13 @@ module Grape
 
       private
 
+      # +headers+ is handed over as it is: Rack::Response copies it into a
+      # Headers of its own on every supported Rack (Rack 2.2 through
+      # +HeaderHash[]+, which only adopts a Hash that already is one), and every
+      # caller builds it fresh for this response.
       def rack_response(status, headers, message)
         body = html_content_type?(headers[Rack::CONTENT_TYPE]) ? Rack::Utils.escape_html(message) : message
-        Rack::Response.new(Array.wrap(body), Rack::Utils.status_code(status), Grape::Util::Header.new.merge!(headers))
+        Rack::Response.new(Array.wrap(body), Rack::Utils.status_code(status), headers)
       end
 
       # Escaping must key off the media type only, case-insensitively. Comparing
@@ -192,11 +196,13 @@ module Grape
         )
       end
 
+      # No +backtrace:+: #resolved_backtrace reads it off +original_exception+
+      # when the API asked for one, and only then, since building it is the
+      # dearest part of rendering the error.
       def default_rescue_handler(exception)
         error_response(
           Grape::Exceptions::ErrorResponse.new(
             message: exception.message,
-            backtrace: exception.backtrace,
             original_exception: exception
           )
         )
@@ -268,7 +274,7 @@ module Grape
       def run_rescue_handler(handler, error, endpoint, redispatched: false)
         callable = handler.is_a?(Symbol) ? endpoint.public_method(handler) : handler
         response = catch(:error) do
-          callable.arity.zero? ? endpoint.instance_exec(&callable) : endpoint.instance_exec(error, &callable)
+          call_rescue_handler(callable, error, endpoint)
         rescue StandardError => e
           return redispatch(e, endpoint, redispatched)
         end
@@ -277,6 +283,20 @@ module Grape
         return response if response.is_a?(Rack::Response)
 
         run_rescue_handler(method(:default_rescue_handler), Grape::Exceptions::InvalidResponse.new, endpoint)
+      end
+
+      # A +rescue_from+ block runs as the endpoint. A Method (the middleware's
+      # own handlers, or the endpoint's for a +with:+ Symbol) is already bound
+      # to a receiver that instance_exec cannot change, so it is called as it
+      # is rather than turned into a Proc first.
+      def call_rescue_handler(callable, error, endpoint)
+        if callable.is_a?(Method)
+          callable.arity.zero? ? callable.call : callable.call(error)
+        elsif callable.arity.zero?
+          endpoint.instance_exec(&callable)
+        else
+          endpoint.instance_exec(error, &callable)
+        end
       end
 
       # Route an exception raised inside a +rescue_from+ block.

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -13,6 +13,40 @@ module Grape
 
       ALL_MEDIA_TYPES = '*/*'
 
+      # @api private
+      # The format an Accept header asks for out of +mime_types+, or nil.
+      # Callers scrub the header first.
+      #
+      # Media types are case-insensitive (RFC 9110 §8.3.1) but the registered
+      # ones are spelled in lower case and Rack matches them literally, so an
+      # `Accept: TEXT/PLAIN` found nothing and fell through to the default
+      # format — the client quietly got something other than what it asked for.
+      def self.format_for_accept(accept_header, mime_types)
+        return if accept_header.blank? || accept_header == ALL_MEDIA_TYPES
+
+        media_type = Rack::Utils.best_q_match(accept_header.downcase, mime_types.keys)
+        mime_types[media_type] if media_type
+      end
+
+      # +format_for_accept+ answers from the header and +mime_types+ alone. A
+      # client that names the format it wants sends one of those media types as
+      # it is registered (+application/json+), and most others send +*/*+ or
+      # nothing, so those answers are worked out once instead of re-running
+      # Rack's q-value match on every request. Any other header misses and is
+      # negotiated as before; only registered media types are keys, so a client
+      # cannot grow a table.
+      #
+      # Shared per +mime_types+, which Grape::ContentTypes already shares per
+      # content-type registry: every endpoint builds its own formatter.
+      class FormatForAcceptCache < Grape::Util::Cache
+        def initialize
+          super
+          @cache = Hash.new do |h, mime_types|
+            h[mime_types] = [*mime_types.keys, ALL_MEDIA_TYPES, nil].to_h { |accept| [accept, Formatter.format_for_accept(accept, mime_types)] }.freeze
+          end
+        end
+      end
+
       # The request methods that can carry a body worth parsing. See
       # {#read_body_input?}, which tests the env against this before anything
       # asks for a Rack::Request. QUERY is here because its content *is* the
@@ -36,6 +70,8 @@ module Grape
         @formatters = config.formatters
         @parsers = config.parsers
         mime_types
+        # Only an API that pins no format negotiates one from the Accept header.
+        @format_for_accept = FormatForAcceptCache[mime_types] unless format
       end
 
       def before
@@ -152,12 +188,22 @@ module Grape
             end
             env[Rack::RACK_REQUEST_FORM_INPUT] = env[Rack::RACK_INPUT]
           end
-        rescue Grape::Exceptions::Base => e
-          raise e
-        rescue StandardError => e
+        rescue ForeignParserError => e
           throw :error, Grape::Exceptions::ErrorResponse.new(status: 400, message: e.message, backtrace: e.backtrace, original_exception: e)
         end
       end
+
+      # What a parser raises that is not a Grape error, and so is answered as a
+      # 400 here. A Grape error goes on to the error middleware as it is. It
+      # used to be rescued just to be raised again, and re-raising at request
+      # depth cost about 25 µs -- paid by every malformed body, since the
+      # built-in parsers report one as InvalidMessageBody.
+      module ForeignParserError
+        def self.===(exception)
+          exception.is_a?(StandardError) && !exception.is_a?(Grape::Exceptions::Base)
+        end
+      end
+      private_constant :ForeignParserError
 
       # this middleware will not try to format the following content-types since Rack already handles them
       # when calling Rack's `params` function
@@ -221,16 +267,11 @@ module Grape
         query_params['format']
       end
 
-      # Media types are case-insensitive (RFC 9110 §8.3.1) but the registered
-      # ones are spelled in lower case and Rack matches them literally, so an
-      # `Accept: TEXT/PLAIN` found nothing and fell through to the default
-      # format — the client quietly got something other than what it asked for.
+      # The keys are registered media types -- valid strings, which scrubbing
+      # leaves alone -- so only a miss needs the header scrubbed.
       def format_from_header
-        accept_header = try_scrub(env['HTTP_ACCEPT'])
-        return if accept_header.blank? || accept_header == ALL_MEDIA_TYPES
-
-        media_type = Rack::Utils.best_q_match(accept_header.downcase, mime_types.keys)
-        mime_types[media_type] if media_type
+        accept_header = env['HTTP_ACCEPT']
+        @format_for_accept.fetch(accept_header) { Formatter.format_for_accept(try_scrub(accept_header), mime_types) }
       end
     end
   end

--- a/lib/grape/middleware/versioner/base.rb
+++ b/lib/grape/middleware/versioner/base.rb
@@ -27,11 +27,20 @@ module Grape
 
         attr_reader :available_media_types, :error_headers, :versions
 
+        # Read off ivars rather than delegated through +version_options+ into
+        # +config+: the versioners ask for +vendor+, +strict+ or +parameter+ on
+        # every request, and each read went two Forwardable frames and two Data
+        # readers deep for a value fixed when the middleware was built.
+        attr_reader :cascade, :parameter, :strict, :vendor
+
         def_delegators :config, :mount_path, :prefix, :version_options
-        def_delegators :version_options, :cascade, :parameter, :strict, :vendor
 
         def initialize(app, **options)
           super
+          @cascade = version_options.cascade
+          @parameter = version_options.parameter
+          @strict = version_options.strict
+          @vendor = version_options.vendor
           @versions = config.versions&.map(&:to_s) # making sure versions are strings to ease potential match
           @error_headers = cascade ? CASCADE_PASS_HEADER : {}
           @available_media_types = build_available_media_types

--- a/lib/grape/middleware/versioner/header.rb
+++ b/lib/grape/middleware/versioner/header.rb
@@ -22,6 +22,42 @@ module Grape
       # X-Cascade header to alert Grape::Router to attempt the next matched
       # route.
       class Header < Base
+        # Accept headers answered up front besides the declared media types:
+        # +*/*+, what curl, Net::HTTP and most HTTP libraries send unless told
+        # otherwise, and no Accept header at all.
+        COMMON_ACCEPT_HEADERS = ['*/*', nil].freeze
+
+        # +MediaType.best_quality+ answers from the header and
+        # +available_media_types+ alone, and the latter is fixed once the
+        # middleware is built. Most requests send one of a handful of headers --
+        # a declared media type spelled as declared (+application/vnd.acme-v1+json+)
+        # or one of COMMON_ACCEPT_HEADERS -- so their answers are worked out
+        # once instead of re-running Rack's q-value match and a parse on every
+        # request. Any other header (a q-value list, another casing) is not a
+        # key and takes the full path, so a client cannot grow a table.
+        #
+        # Shared per list: every endpoint builds its own versioner, and all of
+        # an API's declare the same media types. The key is a frozen copy, as
+        # the middleware's own list stays reachable through
+        # +available_media_types+.
+        class MediaTypeForAcceptCache < Grape::Util::Cache
+          def initialize
+            super
+            @cache = Hash.new do |h, available_media_types|
+              declared = available_media_types.map(&:-@).freeze
+              h[declared] = [*declared, *COMMON_ACCEPT_HEADERS].each_with_object({}) do |accept, media_types|
+                media_type = Grape::Util::MediaType.best_quality(accept, declared)
+                media_types[accept] = media_type if media_type
+              end.freeze
+            end
+          end
+        end
+
+        def initialize(app, **options)
+          super
+          @media_type_for_accept = MediaTypeForAcceptCache[available_media_types]
+        end
+
         def before
           match_best_quality_media_type! do |media_type|
             env.update(
@@ -40,7 +76,7 @@ module Grape
           return unless vendor
 
           strict_header_checks!
-          media_type = Grape::Util::MediaType.best_quality(accept_header, available_media_types)
+          media_type = @media_type_for_accept[accept_header] || Grape::Util::MediaType.best_quality(accept_header, available_media_types)
           return yield media_type if media_type
 
           fail!

--- a/lib/grape/util/media_type.rb
+++ b/lib/grape/util/media_type.rb
@@ -13,14 +13,19 @@ module Grape
       # in the case they will be compared in.
       VENDOR_VERSION_HEADER_REGEX = /\Avnd\.(?<vendor>[a-z0-9.\-_!^]+?)(?:-(?<version>[a-z0-9*.]+))?(?:\+(?<format>[a-z0-9*\-.]+))?\z/
 
+      # Immutable, strings included: the header versioner shares one instance
+      # per declared media type across every request that sends it, and these
+      # strings are what it writes into the env. The arguments are copied
+      # rather than frozen, as they are the caller's.
       def initialize(type:, subtype:)
-        @type = type
-        @subtype = subtype
-        VENDOR_VERSION_HEADER_REGEX.match(subtype) do |m|
-          @vendor = m[:vendor]
-          @version = m[:version]
-          @format = m[:format]
+        @type = -type
+        @subtype = -subtype
+        VENDOR_VERSION_HEADER_REGEX.match(@subtype) do |m|
+          @vendor = m[:vendor].freeze
+          @version = m[:version].freeze
+          @format = m[:format].freeze
         end
+        freeze
       end
 
       def ==(other)

--- a/lib/grape/validations/attributes_iterator.rb
+++ b/lib/grape/validations/attributes_iterator.rb
@@ -19,20 +19,42 @@ module Grape
 
       def each(params, &)
         original_params = @scope.params(params)
+        iterates_elements = @scope.iterates_elements?
         # A scope resolves to a Hash unless the declaration nests arrays, and
         # then #do_each has nothing to do but hand it straight back: Array.wrap
         # boxes it, the loop unboxes it on its only iteration, and with no Array
         # anywhere neither the nesting descent nor the index bookkeeping
         # applies. Every validator on a flat +params+ block comes through here.
-        return yield_attributes(original_params, &) if original_params.is_a?(Hash) && !@scope.iterates_elements?
+        return yield_attributes(original_params, &) if original_params.is_a?(Hash) && !iterates_elements
+
+        array_params = original_params.is_a?(Array)
+        # Do not validate the content of an array scope that did not get one.
+        return if iterates_elements && !array_params
+
+        # Where each element's index is recorded depends on the scope and on
+        # whether its params are an Array, never on the element, so it is
+        # settled once here rather than per element. A lateral scope (no
+        # @element) whose params resolved to an array hands its index to the
+        # nearest element-iterating ancestor, so full_name still produces the
+        # right bracketed index.
+        index_scope = iterates_elements ? @scope : (@scope.nearest_array_ancestor if array_params)
+        # No tracker means we're outside a ParamScopeTracker.track block (e.g.
+        # a unit test that invokes a validator directly). Index tracking is
+        # skipped — full_name will produce bracket-less names — but validation
+        # continues rather than crashing.
+        tracker = ParamScopeTracker.current if index_scope
 
         # because we need recursion for nested arrays
-        do_each(Array.wrap(original_params), original_params, &)
+        do_each(Array.wrap(original_params), tracker, index_scope, NO_PARENT_INDICES, &)
       end
 
       private
 
-      def do_each(params_to_process, original_params, parent_indices = [], &block)
+      # The top-level call's parent indices; only ever read.
+      NO_PARENT_INDICES = [].freeze
+      private_constant :NO_PARENT_INDICES
+
+      def do_each(params_to_process, tracker, index_scope, parent_indices, &block)
         params_to_process.each_with_index do |resource_params, index|
           # when we get arrays of arrays it means that target element located inside array
           # we need this because we want to know parent arrays indices
@@ -42,32 +64,16 @@ module Grape
           # validators see a non-hash and fail it the same way any other
           # unexpected element type does.
           if resource_params.is_a?(Array) && parent_indices.size < @max_nesting
-            do_each(resource_params, original_params, [index] + parent_indices, &block)
+            do_each(resource_params, tracker, index_scope, [index] + parent_indices, &block)
             next
           end
 
-          if @scope.iterates_elements?
-            next unless original_params.is_a?(Array) # do not validate content of array if it isn't array
-
-            store_indices(@scope, index, parent_indices)
-          elsif original_params.is_a?(Array)
-            # Lateral scope (no @element) whose params resolved to an array —
-            # delegate index tracking to the nearest element-iterating ancestor
-            # so that full_name produces the correct bracketed index.
-            target = @scope.nearest_array_ancestor
-            store_indices(target, index, parent_indices) if target
-          end
-
+          store_indices(tracker, index_scope, index, parent_indices) if tracker
           yield_attributes(resource_params, &block)
         end
       end
 
-      def store_indices(target_scope, index, parent_indices)
-        # No tracker means we're outside a ParamScopeTracker.track block (e.g.
-        # a unit test that invokes a validator directly). Index tracking is
-        # skipped — full_name will produce bracket-less names — but validation
-        # continues rather than crashing.
-        tracker = ParamScopeTracker.current or return
+      def store_indices(tracker, target_scope, index, parent_indices)
         parent_scope = target_scope.parent
         parent_indices.each do |parent_index|
           break unless parent_scope

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -5,7 +5,14 @@ module Grape
     class ParamsScope
       attr_reader :parent, :type, :nearest_array_ancestor, :array_depth, :full_path
 
+      # The elements a +given+ scope narrowed its Array params down to during
+      # this request (see #meets_dependency?). Only a scope with a dependency
+      # ever stores any, so every other scope answers without the fiber-storage
+      # and tracker lookups -- which #params pays on each nested resolution,
+      # twice per validator, on every request.
       def qualifying_params
+        return unless @dependent_on
+
         ParamScopeTracker.current&.qualifying_params(self)
       end
 
@@ -164,6 +171,23 @@ module Grape
       # @return [Boolean] whether or not this scope is the root-level scope
       def root?
         !@parent
+      end
+
+      # Whether #should_validate? answers true for every request: this scope
+      # and each of its ancestors is required and depends on nothing, so
+      # neither the params nor the parent chain have anything to say.
+      # @return [Boolean]
+      def always_validated?
+        !@optional && validated_when_given?
+      end
+
+      # Whether #should_validate? has nothing to ask but whether this scope's
+      # own params were given: it depends on no other param, and every scope
+      # above it is always validated. A required scope like that is then
+      # always validated, an optional one whenever its params are there.
+      # @return [Boolean]
+      def validated_when_given?
+        !@dependent_on && (@parent.nil? || @parent.always_validated?)
       end
 
       # A nested scope is contained in one of its parent's elements.

--- a/lib/grape/validations/types/dry_type_coercer.rb
+++ b/lib/grape/validations/types/dry_type_coercer.rb
@@ -17,14 +17,10 @@ module Grape
           #    collection_coercer_for(Array)
           #    #=> Grape::Validations::Types::ArrayCoercer
           def collection_coercer_for(type)
-            case type
-            when Array
-              ArrayCoercer
-            when Set
-              SetCoercer
-            else
-              raise ArgumentError, "unknown type: `#{type}`"
-            end
+            return ArrayCoercer if type.is_a?(Array)
+            return SetCoercer if type.is_a?(Set)
+
+            raise ArgumentError, "unknown type: `#{type}`"
           end
 
           # Returns an instance of a coercer for a given type
@@ -43,13 +39,25 @@ module Grape
         # Coerces the given value to a type which was specified during
         # initialization as a type argument.
         #
+        # Given a block, dry-types reports a value it cannot coerce by calling
+        # the block instead of raising. Raising is what cost: its CoercionError
+        # is re-raised with the backtrace of the error underneath, and building
+        # that backtrace as strings at request depth took about 25 µs for every
+        # rejected value -- every `types: [Integer, String]` param given a
+        # string, every 400 for a mistyped value.
+        #
+        # Every coercion dry-types runs takes that block, so none of them
+        # raises a CoercionError here. Anything that raises something else --
+        # +Kernel#String+, which +Coercible::String+ is built from, ignores the
+        # block and raises TypeError -- is answered by
+        # +CoerceValidator#coerce_value+, which rescues StandardError with the
+        # same InvalidValue.
+        #
         # @param val [Object]
         def call(val)
           return if val.nil?
 
-          @coercer[val]
-        rescue Dry::Types::CoercionError
-          InvalidValue.new
+          @coercer.call(val) { InvalidValue.new }
         end
 
         protected

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -69,6 +69,12 @@ module Grape
           @opts = SharedOptions.new(**opts.slice(:allow_blank, :fail_fast))
           @exception_message = message(self.class.default_message_key) if self.class.default_message_key
           @iterator = iterator_class.new(@attrs, @scope).freeze
+          # A scope's parent, optionality, dependency and type are all set
+          # before its block declares anything, so these are settled by the
+          # time a validator is built. See #validate and #validate!.
+          @always_validated = scope.always_validated?
+          @direct = @always_validated && !scope.iterates_elements?
+          @direct_elements = scope.validated_when_given? && scope.iterates_elements? && scope.array_depth == 1
         end
 
         # Validates a given request.
@@ -78,7 +84,7 @@ module Grape
         # @return [void]
         def validate(request)
           params = request.params
-          return unless scope.should_validate?(params)
+          return unless @always_validated || scope.should_validate?(params)
 
           validate!(params)
         end
@@ -90,6 +96,11 @@ module Grape
         # @raise [Grape::Exceptions::Validation] if validation failed
         # @return [void]
         def validate!(params)
+          return validate_elements!(scope.params(params)) if @direct_elements
+
+          scoped = scope.params(params) if @direct
+          return validate_attributes!(scoped) if scoped.is_a?(Hash)
+
           # we collect errors inside array because
           # there may be more than one error per field
           array_errors = nil
@@ -122,6 +133,67 @@ module Grape
         attr_reader :options, :scope, :required, :exception_message
 
         alias required? required
+
+        # #validate! on a scope that always validates and does not iterate
+        # elements, once its params resolved to a Hash: the root scope and the
+        # required Hash scopes under it, which is most validators of most
+        # endpoints. There the iterator hands back that Hash once per
+        # attribute, and every scope on the chain is required with no
+        # dependency, so the per-attribute checks reduce to this. The
+        # machinery cost more than the validation itself.
+        def validate_attributes!(params)
+          array_errors = nil
+
+          @attrs.each do |attr_name|
+            validate_param!(attr_name, params) if required? || params.key?(attr_name)
+          rescue Grape::Exceptions::Validation => e
+            (array_errors ||= []) << e
+          end
+
+          raise Grape::Exceptions::ValidationArrayErrors.new(array_errors) if array_errors
+        end
+
+        # #validate_attributes! for each element of an Array scope, such as
+        # +requires :items, type: Array do+ at the root, when it is the only
+        # scope on the chain that iterates elements: its params are then the
+        # request's Array as it came in, with no nesting for the iterator to
+        # descend into. It depends on no other param and every scope above it
+        # is always validated, so the iterator's per-element checks come down
+        # to the index it records for the error names and, for an optional
+        # scope, passing over an empty element. An element that is not a Hash
+        # goes through the same +hash_like?+ test as on the iterator path, and
+        # the members of a scope that did not get an Array are left alone, as
+        # they are there: the scope's own type check reports it.
+        def validate_elements!(elements)
+          return unless elements.is_a?(Array)
+
+          tracker = ParamScopeTracker.current
+          optional = !scope.required?
+          array_errors = nil
+
+          elements.each_with_index do |element, index|
+            tracker&.store_index(scope, index)
+            next if optional && empty_element?(element)
+
+            @attrs.each do |attr_name|
+              validate_param!(attr_name, element) if required? || (hash_like?(element) && element.key?(attr_name))
+            rescue Grape::Exceptions::Validation => e
+              (array_errors ||= []) << e
+            end
+          end
+
+          raise Grape::Exceptions::ValidationArrayErrors.new(array_errors) if array_errors
+        end
+
+        # What the iterator passes over in an optional scope: an element given
+        # empty, or the placeholder +map_params+ puts where an optional scope's
+        # params were not given at all, which it can only do here when a scope
+        # above was handed an Array instead of a Hash.
+        def empty_element?(element)
+          return true if Grape::DSL::Parameters::EmptyOptionalValue.equal?(element)
+
+          element.respond_to?(:empty?) ? element.empty? : element.nil?
+        end
 
         # The AttributesIterator subclass used to walk this validator's
         # attributes. Built once in #initialize and reused across requests.

--- a/spec/grape/error_formatter/json_spec.rb
+++ b/spec/grape/error_formatter/json_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+describe Grape::ErrorFormatter::Json do
+  let(:app) do
+    Class.new(Grape::API) do
+      format :json
+      get('/utf8') { error!('café', 400) }
+      get('/binary') { error!("caf\xC3\xA9".b, 400) }
+      get('/malformed') { error!("caf\xC3", 400) }
+    end
+  end
+
+  # A String message goes out as UTF-8 whatever it arrived as: one that already
+  # is valid UTF-8 as it is, anything else converted, with what does not
+  # convert replaced rather than failing the response.
+  it 'renders a UTF-8 message as it is' do
+    get '/utf8'
+    expect(JSON.parse(last_response.body)).to eq('error' => 'café')
+  end
+
+  it 'converts a binary message, replacing the bytes it cannot map' do
+    get '/binary'
+    expect(JSON.parse(last_response.body)).to eq('error' => 'caf��')
+  end
+
+  it 'replaces the invalid bytes of a malformed UTF-8 message' do
+    get '/malformed'
+    expect(JSON.parse(last_response.body)).to eq('error' => 'caf�')
+  end
+end

--- a/spec/grape/exceptions/validation_errors_spec.rb
+++ b/spec/grape/exceptions/validation_errors_spec.rb
@@ -65,6 +65,15 @@ describe Grape::Exceptions::ValidationErrors do
         expect(subject.first).to eq('admin_field Can not set admin-only field')
       end
     end
+
+    context 'when the caller changes the array it was given' do
+      subject(:error) { described_class.new(exceptions: [Grape::Exceptions::Validation.new(params: ['id'], message: :presence)]) }
+
+      it 'returns the same messages the next time' do
+        error.full_messages << 'name is missing'
+        expect(error.full_messages).to eq(['id is missing'])
+      end
+    end
   end
 
   context 'api' do

--- a/spec/grape/middleware/formatter_spec.rb
+++ b/spec/grape/middleware/formatter_spec.rb
@@ -527,4 +527,27 @@ describe Grape::Middleware::Formatter do
       expect(error.original_exception.class).to eq StandardError
     end
   end
+
+  # Only a parser's StandardErrors are answered with a 400. Anything else --
+  # an Interrupt, a SystemExit -- is not the body's fault and keeps going.
+  context 'custom parser raises an exception that is not a StandardError' do
+    it 'lets it through rather than answering 400' do
+      subject = described_class.new(
+        app,
+        parsers: { json: ->(_object, _env) { raise NotImplementedError, 'fatal' } }
+      )
+      io = StringIO.new('{}')
+      expect do
+        catch(:error) do
+          subject.call(
+            Rack::PATH_INFO => '/info',
+            Rack::REQUEST_METHOD => Rack::POST,
+            'CONTENT_TYPE' => 'application/json',
+            Rack::RACK_INPUT => io,
+            'CONTENT_LENGTH' => io.length.to_s
+          )
+        end
+      end.to raise_error(NotImplementedError, 'fatal')
+    end
+  end
 end

--- a/spec/grape/middleware/versioner/header_spec.rb
+++ b/spec/grape/middleware/versioner/header_spec.rb
@@ -145,6 +145,17 @@ describe Grape::Middleware::Versioner::Header do
         expect(exception.message).to include('API version not found')
       end
     end
+
+    # Requests sending the same Accept header are all answered from one parsed
+    # media type, so what a request is handed must not be alterable in place.
+    it 'cannot be altered by one request for the next' do
+      keys = [Grape::Env::API_TYPE, Grape::Env::API_SUBTYPE, Grape::Env::API_VENDOR, Grape::Env::API_VERSION, Grape::Env::API_FORMAT]
+      _, _, env = subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1+json')
+      keys.each { |key| expect { env[key] << '-altered' }.to raise_error(FrozenError) }
+
+      _, _, env = subject.call('HTTP_ACCEPT' => 'application/vnd.vendor-v1+json')
+      expect(env.values_at(*keys)).to eq(%w[application vnd.vendor-v1+json vendor v1 json])
+    end
   end
 
   it 'succeeds if :strict is not set' do

--- a/spec/grape/validations/params_scope_spec.rb
+++ b/spec/grape/validations/params_scope_spec.rb
@@ -209,6 +209,41 @@ describe Grape::Validations::ParamsScope do
     end
   end
 
+  # An Array group handed something other than an Array fails its own type
+  # check, and its members are not then validated against that value as
+  # though it were one element.
+  context 'array group given a Hash' do
+    it 'reports the group as invalid without validating its members' do
+      subject.params do
+        requires :items, type: Array do
+          requires :id, type: Integer
+        end
+      end
+      subject.post('/items') { 'ok' }
+
+      post '/items', { items: { name: 'x' } }.to_json, 'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq('items is invalid')
+    end
+  end
+
+  context 'hash group given an Array' do
+    it 'reports the group as invalid without validating the optional array group inside it' do
+      subject.params do
+        requires :meta, type: Hash do
+          optional :items, type: Array do
+            requires :id, type: Integer
+          end
+        end
+      end
+      subject.post('/meta') { 'ok' }
+
+      post '/meta', { meta: [{}] }.to_json, 'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(400)
+      expect(last_response.body).to eq('meta is invalid')
+    end
+  end
+
   context 'coercing values validation with a variant-member-type collection' do
     it 'accepts values compatible with the declared member types' do
       expect do
@@ -1019,6 +1054,32 @@ describe Grape::Validations::ParamsScope do
         }
         post '/array_with_given', params.to_json, 'CONTENT_TYPE' => 'application/json'
         expect(last_response.body).to eq('array[1][b] is missing, array[2][b] is missing')
+        expect(last_response.status).to eq(400)
+      end
+    end
+
+    # A with group inside an array scope is a lateral scope whose params are
+    # the array itself, so each element's index is recorded against the array
+    # scope. Failing a first element as well as the last shows it was: a stale
+    # index names the wrong element.
+    context 'array with a with group' do
+      before do
+        subject.params do
+          requires :array, type: Array do
+            requires :a, type: Integer
+            with(type: Integer) do
+              requires :b
+            end
+          end
+        end
+
+        subject.post '/array_with_group'
+      end
+
+      it 'names the elements that failed' do
+        params = { array: [{ a: 1 }, { a: 3, b: 4 }, { a: 5 }] }
+        post '/array_with_group', params.to_json, 'CONTENT_TYPE' => 'application/json'
+        expect(last_response.body).to eq('array[0][b] is missing, array[2][b] is missing')
         expect(last_response.status).to eq(400)
       end
     end

--- a/spec/grape/validations_spec.rb
+++ b/spec/grape/validations_spec.rb
@@ -881,6 +881,32 @@ describe Grape::Validations do
         expect(last_response.body).to eq('items[0][key] is missing')
       end
 
+      it 'skips the elements that are empty' do
+        subject.params do
+          optional :items, type: Array do
+            requires :key
+          end
+        end
+        subject.post('/optional_group') { 'optional group works' }
+
+        post_with_json '/optional_group', items: [{}, { not_key: 'foo' }]
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to eq('items[1][key] is missing')
+      end
+
+      it "doesn't validate the group when every element is blank" do
+        subject.params do
+          optional :items, type: Array do
+            requires :key
+          end
+        end
+        subject.post('/optional_group') { 'optional group works' }
+
+        post_with_json '/optional_group', items: [false, ' ']
+        expect(last_response.status).to eq(201)
+        expect(last_response.body).to eq('optional group works')
+      end
+
       it "errors when param is present but isn't an Array" do
         get '/optional_group', items: 'hello'
         expect(last_response.status).to eq(400)


### PR DESCRIPTION
This combines #2922–#2934 into one PR: 13 request-path changes to Grape, found by benchmarking features that earlier throughput work never exercised (header versioning, content negotiation, nested and array params, typed params given bad input, `rescue_from`). Each PR has its full write-up (behaviour matrix, mutation results) and was green on CI (69/69). This PR is their union, squashed to one commit and re-benchmarked as a whole against master.

Against master on the same machine, without JIT (with YJIT in brackets):

- **Header versioning:** +59% (+81%) for a vendor Accept, +48% (+64%) for `*/*`.
- **Content-negotiated JSON:** +37% (+52%).
- **Validation:** a JSON body with a nested Hash +25% (+22%); arrays of Hashes +38% to +42% (+27% to +41%); a JSON body with typed params +17% (+10%).
- **Typed params given a bad value:** `types: [Integer, String]` +136% (+218%); a 400 for a mistyped Integer +55% (+105%).
- **Error responses:** a 500 from `rescue_from :all` +98% (+162%); a malformed JSON body +34% (+56%); the README's `full_messages` handler +28% to +35% (+28% to +40%).
- **Controls:** 10 paths none of the changes target stay within −1.6% to +0.7% (YJIT −1.2% to +1.1%).
- **Averages:** across the 37 targeted scenarios, +25.5% mean and +14.2% median (YJIT +33.9% / +12.6%).
- **A real app:** in grape-on-rack, its header-versioned endpoint is +38.5% and a JSON-array GET +19.1%.

There is one contract change, listed under **Contract change** below, with an UPGRADING entry. There are no new dependencies, and no public method changes signature.

## What changed, and why it was slow

### Versioning and content negotiation

| # | Change | Measured alone, against master |
|---|---|---|
| #2922 | **Header versioner answers common Accept headers from a table.** `version ..., using: :header` ran `Rack::Utils.best_q_match` and `MediaType.parse` on every request. That took about 3.6 µs of a 12.4 µs request, because `best_q_match` splits both strings for every candidate. The answer depends only on the Accept header and the middleware's `available_media_types`, which are fixed at build. It is now computed once for every declared type, for `*/*` and for no header; any other header takes the unchanged full path. Every endpoint builds its own versioner, so the table is shared per list through `Grape::Util::Cache`: a per-instance table cost +3.5 MB and +120 ms at 500 endpoints. `Grape::Util::MediaType` is now immutable. | vendor Accept **+55.4%** (YJIT **+79.6%**); `*/*` +43.1%; no Accept +19.3% |
| #2923 | **Versioners read their options off instance variables.** `cascade`, `parameter`, `strict` and `vendor` each went through two Forwardable frames and two Data readers (~150 ns) for a value fixed at build. | header +3.4%, param +2.8%, accept-version +1.7% |
| #2924 | **Formatter answers common Accept headers from a table.** This is the same idea as #2922, for APIs that negotiate the format instead of pinning one. The negotiation cost ~1.7 µs per request for `Accept: application/json`. | `Accept: application/json` **+40.3%** (YJIT **+54.1%**); `*/*` +5.3% |

### Params validation

| # | Change | Measured alone, against master |
|---|---|---|
| #2927 | **Required Hash scopes skip the attributes iterator.** When a scope and all its ancestors are required and depend on nothing, `should_validate?` is always true. The iterator's per-attribute checks then reduce to "validate if required or present". This covers the root scope and required Hash scopes, which hold most validators of most endpoints. The plumbing took ~570 of a root validator's 840 ns. Per validator: root presence 658 → 311 ns, nested coerce 1.77 → 1.02 µs. | JSON POST **+20.5%**; nested Hash POST **+19.3%**; 3-param GET +11.5%; 10-validator GET +11.1%; `declared` POST +6.5% |
| #2933 | **Array element scopes skip it too.** `requires`/`optional :items, type: Array do … end` qualifies when it is the only element-iterating scope on such a chain. Optional scopes keep the empty-element skip and `should_validate?`'s all-blank check. Stacked on #2927. | 1 / 10 / 50 elements **+28.5% / +32.4% / +40.5%**; optional array +21.2% (YJIT +26% to +39%), all against #2927 |
| #2928 | **The iterator settles its per-scope state once per pass**, instead of once per element per validator (fiber-storage read, index scope, array checks). | 10-element array body +4.1% |
| #2925 | **`qualifying_params` returns early for scopes other than `given`.** Only `given` ever stores any, yet every nested scope looked them up twice per validator. | nested Hash POST +5.4% |
| #2926 | **`declared` skips the renamed-params lookup when nothing is renamed.** It built a fresh path key per declared param for a table that is empty without `as:`. | `declared` call −11% (4.81 → 4.29 µs); +1.4% end to end, within noise |
| #2930 | **Coercion uses dry-types' non-raising block form.** A rejected value made dry-types' `CoercionError.handle` re-raise with the underlying error's backtrace, built as Strings: ~30 µs at request depth. A rejected Integer went from 31.2 to 4.4 µs. Every `types: [Integer, String]` param given a String pays this, as does every 400 for a mistyped value. Every coercion dry-types runs takes the block, so the `rescue Dry::Types::CoercionError` around the call is gone: it could no longer be reached, and `CoerceValidator#coerce_value` rescues `StandardError` to the same `InvalidValue` for anything that raises something else. | `types: [Integer, String]` given `abc` **+114.7%** (YJIT **+195.1%**); 400 for `?id=abc` **+49.1%** (YJIT **+95.6%**) |

### Error responses

| # | Change | Measured alone, against master |
|---|---|---|
| #2931 | **The default rescue handler stops reading `exception.backtrace`.** `rescue_from :all` (no block) built the whole backtrace and discarded it unless `backtrace: true`. `#resolved_backtrace` already reads it lazily from `original_exception` when asked. | 500 from `rescue_from :all` **+92.8%** |
| #2932 | **Parser errors are not re-raised.** `rescue Grape::Exceptions::Base => e; raise e` made Ruby read the backtrace (`setup_exception` → `rb_get_backtrace`) on every malformed body. A matcher module in the `rescue` clause now keeps Grape errors out of it. | malformed JSON body **+28.7%**; +29.8% on top of #2931 with `rescue_from :all` |
| #2934 | **`ValidationErrors#full_messages` is translated once.** Each call re-ran an I18n lookup per error and per attribute, a few µs each. The README's `error!({ messages: e.full_messages }, 400)` paid for all of them twice. | README handler, 1 / 2 errors **+21.9% / +27.3%** (YJIT +24.9% / +34.4%) |
| #2929 | **Three redundant steps on every error response:** a header copy that `Rack::Response` makes again anyway, `instance_exec` on handlers that are already Methods, and re-encoding a message that is already valid UTF-8. | 405 +4.9%, 401 +3.3%, 400/404/500 +2.3% to +2.6% |

Two things sit behind most of these:

- At a request's stack depth (~60 frames), a plain raise and rescue costs 1–3 µs, but reading `exception.backtrace` or re-raising costs ~25 µs. That's why #2930–#2932 gain so much.
- `best_q_match` and the attributes iterator's plumbing cost more than the work they guard, for inputs that are fixed when the API is built.

## Benchmarks, this branch against master

Each row compares `lib/` from master (a0462ac2) with `lib/` from this branch. Each round runs both in separate processes, one after the other, and alternates which goes first; the table shows the median of 7 rounds without JIT and 5 with YJIT. Every run warms up for 5,000 requests and then measures for 1.5 s. The µs/request columns are without JIT. Setup: Ruby 4.0.6 (arm64), Rack 3.2.7, Apple M2 Pro, macOS 26.6.

The noise floor is about ±1.6%: master against itself read −0.8% and −1.2% on two scenarios in the same harness, and the control group below spans −1.6% to +1.1%.

#### Versioning and content negotiation

| request | master µs/req | branch µs/req | no JIT | YJIT |
|---|---:|---:|---:|---:|
| `using: :header`, `Accept: application/vnd.acme-v1+json` | 12.5 | 7.9 | **+58.9%** | **+80.6%** |
| `using: :header`, `Accept: */*` | 11.5 | 7.8 | **+48.0%** | **+63.7%** |
| `using: :header`, no Accept header | 9.6 | 7.9 | **+22.1%** | **+28.8%** |
| two header versions of one path, first-mounted version | 12.5 | 7.9 | **+59.7%** | **+81.0%** |
| two header versions of one path, second version (cascades) | 65.0 | 58.8 | +10.6% | +13.9% |
| `using: :accept_version_header` | 7.9 | 7.8 | +1.2% | +0.8% |
| `using: :param` | 11.0 | 10.7 | +3.0% | +0.7% |
| `default_format :json`, `Accept: application/json` | 9.3 | 6.8 | **+36.7%** | **+51.6%** |
| `default_format :json`, `Accept: */*` | 7.2 | 6.9 | +4.5% | +5.4% |

#### Params and validation

| request | master µs/req | branch µs/req | no JIT | YJIT |
|---|---:|---:|---:|---:|
| GET, 3 typed query params | 29.0 | 26.6 | +9.1% | +4.3% |
| form POST, 2 typed params | 25.5 | 22.3 | +14.2% | +5.5% |
| JSON POST, 5 typed root params | 27.7 | 23.7 | **+17.0%** | +9.9% |
| JSON POST, required nested Hash (`regexp`, `values`) | 41.8 | 33.4 | **+25.0%** | **+22.2%** |
| JSON POST returning `declared(params, include_missing: false)` | 37.5 | 34.5 | +8.8% | +12.6% |
| GET, pagination helper with `values`/defaults + `mutually_exclusive` | 29.8 | 27.0 | +10.6% | +10.1% |
| GET, typed `route_param` | 16.7 | 15.1 | +10.3% | +9.7% |
| GET, before/after/validation/finally filters on 3 namespace levels | 16.7 | 15.7 | +6.2% | +8.0% |
| GET, `before` filter reading a header, typed route param | 20.9 | 20.0 | +4.2% | +5.1% |
| JSON POST with a `given` block | 22.3 | 21.1 | +5.7% | +10.4% |
| GET, `Date`/`Time`/`DateTime` params | 49.2 | 46.3 | +6.1% | +5.7% |
| GET, `types: [Integer, String]` given a String + `coerce_with` | 53.4 | 22.6 | **+135.8%** | **+218.4%** |
| JSON POST, `requires :items, type: Array do`, 1 element | 33.0 | 24.0 | **+37.8%** | **+26.9%** |
| … 10 elements | 82.3 | 59.8 | **+37.6%** | **+37.6%** |
| … 50 elements | 287.1 | 202.6 | **+41.7%** | **+41.4%** |
| JSON POST, `optional :items, type: Array do`, 10 elements | 82.5 | 65.5 | **+25.9%** | **+29.1%** |

#### Error responses

| request | master µs/req | branch µs/req | no JIT | YJIT |
|---|---:|---:|---:|---:|
| 400, required param missing | 52.1 | 49.5 | +5.1% | +4.6% |
| 400, `?id=abc` for an Integer | 85.9 | 55.5 | **+54.7%** | **+105.1%** |
| 400 via the README's `rescue_from ValidationErrors` + `e.full_messages`, 1 error | 67.8 | 53.1 | **+27.8%** | **+28.0%** |
| … 2 errors | 90.8 | 67.4 | **+34.7%** | **+40.3%** |
| 400, malformed JSON body | 51.0 | 38.1 | **+33.7%** | **+55.8%** |
| 400, malformed JSON body, `rescue_from :all` | 51.7 | 38.7 | **+33.6%** | **+55.9%** |
| 401 via `error!` | 14.2 | 13.5 | +5.1% | +5.5% |
| 404 via a `rescue_from` block calling `error!` | 16.3 | 16.1 | +1.2% | +1.8% |
| 405, wrong method | 18.7 | 17.8 | +4.9% | +7.4% |
| 500 via `rescue_from :all` (default handler) | 30.2 | 15.3 | **+97.7%** | **+162.0%** |
| 500 via a `rescue_from :all` block calling `error!` | 17.2 | 16.8 | +2.0% | +2.2% |
| 422 via `rescue_from ..., backtrace: true` | 17.7 | 17.4 | +1.4% | +2.3% |

#### Controls (paths none of the changes target)

| request | master µs/req | branch µs/req | no JIT | YJIT |
|---|---:|---:|---:|---:|
| GET, no params, path-versioned | 7.9 | 8.0 | -1.1% | -1.0% |
| GET, no version | 6.6 | 6.8 | -1.6% | +0.6% |
| GET, 5 namespaces deep | 8.5 | 8.5 | +0.4% | -0.4% |
| POST, `status` + custom header | 8.2 | 8.2 | +0.0% | +1.1% |
| DELETE, `body false` | 7.0 | 7.1 | -1.3% | -1.1% |
| GET, `redirect` | 8.1 | 8.1 | -0.0% | -0.2% |
| GET, cookies read and written | 16.7 | 16.6 | +0.6% | -0.3% |
| GET, grape-entity `present` of 5 objects | 44.3 | 44.1 | +0.5% | -1.2% |
| multipart file upload | 184.3 | 183.8 | +0.3% | -0.7% |
| unrouted path | 1.3 | 1.3 | -0.3% | +1.0% |

### A real application

[grape-on-rack](https://github.com/ruby-grape/grape-on-rack), booted in-process through its own bundle with each `lib/` loaded ahead of the gem. 5 interleaved rounds of 2 s per endpoint, no JIT:

| endpoint | master i/s | branch i/s | delta |
|---|---:|---:|---:|
| `header_version` (`Accept: application/vnd.acme-v1+json`) | 57,372 | 79,481 | **+38.5%** |
| `get_json` (a JSON-array query param) | 19,065 | 22,714 | **+19.1%** |
| `header_key` (route param) | 51,149 | 53,893 | +5.4% |
| `ring_put` (PUT with a typed param) | 48,971 | 51,561 | +5.3% |
| `spline` (POST with a typed param) | 52,131 | 54,801 | +5.1% |
| the other 11 endpoints (ping, entities in JSON and XML, path versioning, plain text, `raise`, …) | | | −0.8% to +0.1% |

### Boot and memory

Both Accept tables are built once per list of media types and shared through `Grape::Util::Cache`, the way `ContentTypes::MimeTypesCache` already is, so their cost doesn't grow with the number of endpoints. Compiling an API, 3 runs each:

| API | master | branch |
|---|---|---|
| 500 header-versioned endpoints | 6,166 KB retained, 149–153 ms | 6,175 KB retained, 149–150 ms |
| 500 content-negotiated endpoints | 4,412 KB retained, 136–138 ms | 4,413 KB retained, 137 ms |

A table built per middleware instance instead cost +3.5 MB and +120 ms at 500 endpoints, which is why the tables are shared.

## Behaviour

Besides the full suite, each change was checked against master with a response matrix. The combined branch was then re-run through them:

| matrix | responses | against master |
|---|---:|---|
| header versioning: 5 APIs (one version, two, `strict`, `cascade: false`, dotted vendor/version) × 30 Accept values (q-lists, wildcards, casings, whitespace, parameters, invalid bytes, binary) | 150 | identical apart from the `api.*` strings being frozen, the contract change below |
| content negotiation: 7 APIs × 25 Accept values × 3 paths (plain, `.json`, `?format=`) | 525 | identical |
| coercion: 27 types, each coerced and strict, × 41 inputs, through `Types.build_coercer` | 2,214 | identical (1,640 are rejections, the changed path) |
| validation: every built-in validator, a custom one, nested Hashes 3 deep, `with`, wrong shapes, under the Hash and HWIA builders | 104 | identical |
| Array element scopes: required/optional, flat/nested, `Array[JSON]`, `fail_fast`, `given` in an element, a Hash given an Array, malformed elements, both builders | 164 | identical |
| error responses: JSON/txt/XML/negotiated × `error!` shapes, `rescue_from` handler kinds, 405/404/OPTIONS × 3 Accept headers (status, headers, body) | 228 | identical |
| `rescue_from :all` with and without `backtrace:`/`original_exception:`, malformed bodies | 30 | identical; rendered backtraces have the same frames, and only line numbers in `formatter.rb` moved |
| `rescue_from ValidationErrors` handlers reading `full_messages`, `message`, `as_json`, `to_json`, `errors`, re-raising, in two locales | 120 | identical except the 5 responses of a handler that switches locale before reading `full_messages` (see below) |

## Contract change

The header versioner's `api.*` env strings (`api.type`, `api.subtype`, `api.vendor`, `api.version`, `api.format`) are frozen now, because requests sending the same Accept header share one parsed `Grape::Util::MediaType`. Code that altered one of them in place raises `FrozenError`. UPGRADING has an entry with the one-line fix (`env['api.version'] = "#{env['api.version']}-beta"` instead of `<<`). `MediaType#initialize` copies its arguments, so it never freezes a caller's Strings.

## Behaviour notes

- `ValidationErrors#full_messages` now returns the list as it was translated when the error was raised, which is also when `#message` is built. A handler that switched locale and then asked for the list used to get a half-translated mix: the new locale's format and attribute names around messages still in the old one. The list is handed out as a copy, so a caller changing it can't affect the next caller.
- Apart from this and the frozen strings, the matrices above show no difference in status, headers or bodies. Rendered backtraces keep the same frames; only line numbers in the changed files move.

## Specs added

Every spec below pins behaviour a mutation showed was unpinned: the mutation passed the whole suite. Apart from the frozen-strings one, each passes on master and on this branch.

- `versioner/header_spec.rb`: the `api.*` env strings can't be altered by one request for the next. This one pins the contract change, so it fails on master.
- `params_scope_spec.rb`:
  - An Array group handed a Hash reports only its own type error, and its members are not validated against the Hash.
  - A `with` group inside an Array records each element's index against the nearest Array ancestor.
  - A Hash group handed an Array reports only itself, not the optional Array group inside it.
- `validations_spec.rb`: an optional Array scope skips its empty elements, and is not validated at all when every element is blank (`[false, ' ']`).
- `error_formatter/json_spec.rb` (new): a UTF-8 message goes out as is; binary and malformed messages go out with the bad bytes replaced.
- `middleware/formatter_spec.rb`: a parser raising something that is not a `StandardError` keeps propagating instead of becoming a 400.
- `exceptions/validation_errors_spec.rb`: changing the array `#full_messages` returned doesn't change the next answer.

## Not in this PR

- #2920 (router: look for a 405 neighbour only on paths the method has no route on) is a separate router change with its own boot-time trade-off.
- #2935 (`declared` on non-Hash Array elements) is a bug fix, not a performance change.
- A multi-version header API (two `version`s of one path, told apart by cascading) is still 7.6× slower for a non-first version. It builds, raises and renders an `InvalidVersionHeader` per request before cascading. Every shortcut would be observable, so that needs a design decision first.

## Test plan

- [x] Full RSpec suite passes locally: 2858 examples, 0 failures.
- [x] RuboCop clean.
- [x] Each change was mutation-checked in its own PR; every surviving mutation got one of the specs above.
- [x] #2922–#2934 each green on CI (69/69).
- [ ] CI green on this branch.

Supersedes #2922, #2923, #2924, #2925, #2926, #2927, #2928, #2929, #2930, #2931, #2932, #2933, #2934.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
