### PR TITLE
Correct code comments that no longer match the code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#2935](https://github.com/ruby-grape/grape/pull/2935): Return the elements of an Array params scope that are not a Hash from `declared` instead of raising - [@ericproulx](https://github.com/ericproulx).
 * [#2937](https://github.com/ruby-grape/grape/pull/2937): Forward the class methods kept off an API class to its base instance explicitly, and pin what `delegate_missing_to` still answers - [@ericproulx](https://github.com/ericproulx).
 * [#2936](https://github.com/ruby-grape/grape/pull/2936): Speed up header versioning, content negotiation, params validation and error responses on the request path - [@ericproulx](https://github.com/ericproulx).
+* [#2938](https://github.com/ruby-grape/grape/pull/2938): Correct code comments that no longer match the code - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 4.0.0 (2026-09-07)

--- a/lib/grape/api/instance.rb
+++ b/lib/grape/api/instance.rb
@@ -140,7 +140,7 @@ module Grape
       # looking for a matching route on other resources.
       #
       # In some applications (e.g. mounting grape on rails), one might need to trap
-      # errors from reaching upstream. This is effectivelly done by unsetting
+      # errors from reaching upstream. This is effectively done by unsetting
       # X-Cascade. Default :cascade is true.
       #
       # Resolved in the constructor rather than per request: answering it walks
@@ -171,7 +171,7 @@ module Grape
         setting = self.class.inheritable_setting
         routes_by_regexp = all_routes.group_by(&:pattern_regexp)
 
-        # Build the configuration based on the first endpoint and the collection of methods supported.
+        # Build the configuration from the collection of methods supported.
         routes_by_regexp.each_value do |routes|
           next if routes.any? { |route| route.request_method == '*' }
 

--- a/lib/grape/content_types.rb
+++ b/lib/grape/content_types.rb
@@ -51,11 +51,10 @@ module Grape
     end
 
     # Both tables below are derived from nothing but the content-type registry,
-    # and one content-type-aware middleware is built per API instance — so an
-    # app mounting N APIs held N copies of tables it only ever reads. Keying
-    # the cache on the registry itself collapses them: Hash keys compare by
-    # value, so every API that registers the same content types shares one
-    # table.
+    # and every endpoint builds its own content-type-aware middlewares — so an
+    # app held one copy per endpoint of tables it only ever reads. Keying the
+    # cache on the registry collapses them: Hash keys compare by value, so
+    # every registry with the same content types shares one table.
     #
     # Both the key and the table are frozen: the caller's registry stays
     # reachable (through +middleware.options[:content_types]+, among others)

--- a/lib/grape/cookies.rb
+++ b/lib/grape/cookies.rb
@@ -30,7 +30,7 @@ module Grape
       send_cookies << name
     end
 
-    # see https://github.com/rack/rack/blob/main/lib/rack/utils.rb#L338-L340
+    # Same attributes Rack::Utils uses to delete a cookie
     def delete(name, **opts)
       self.[]=(name, opts.merge(DELETED_COOKIES_ATTRS))
     end

--- a/lib/grape/dsl/declared.rb
+++ b/lib/grape/dsl/declared.rb
@@ -15,10 +15,11 @@ module Grape
       # consisting only of keys that have been declared by a
       # `params` statement against the current/target endpoint or parent
       # namespaces.
-      # @param params [Hash] The initial hash to filter. Usually this will just be `params`
-      # @param options [Hash] Can pass `:include_missing`, `:stringify` and `:include_parent_namespaces`
-      # options. `:include_parent_namespaces` defaults to true, hence must be set to false if
-      # you want only to return params declared against the current/target endpoint.
+      # @param passed_params [Hash] The initial hash to filter. Usually this will just be `params`
+      # @param include_parent_namespaces [Boolean] false to only return params declared against the current/target endpoint
+      # @param include_missing [Boolean] include declared params that were not passed
+      # @param evaluate_given [Boolean] drop params whose +given+ condition is not met
+      # @param stringify [Boolean] return String keys
       def declared(passed_params, include_parent_namespaces: true, include_missing: true, evaluate_given: false, stringify: false)
         raise MethodNotYetAvailable unless before_filter_passed
 

--- a/lib/grape/dsl/desc.rb
+++ b/lib/grape/dsl/desc.rb
@@ -9,8 +9,7 @@ module Grape
       # @param description [String] descriptive string for this endpoint
       #   or namespace
       # @param options [Hash] other properties you can set to describe the
-      #   endpoint or namespace. Optional. Pass these as keyword arguments;
-      #   passing a positional options Hash is deprecated.
+      #   endpoint or namespace, as keyword arguments. Optional.
       # @option options :detail [String] additional detail about this endpoint
       # @option options :summary [String] summary for this endpoint
       # @option options :params [Hash] param types and info. normally, you set

--- a/lib/grape/dsl/entity.rb
+++ b/lib/grape/dsl/entity.rb
@@ -43,10 +43,9 @@ module Grape
       end
 
       # Attempt to locate the Entity class for a given object, if not given
-      # explicitly. This is done by looking for the presence of Klass::Entity,
-      # where Klass is the class of the `object` parameter, or one of its
-      # ancestors. Object is excluded from the search: top-level constants
-      # live on it, so a global ::Entity class is not a representer.
+      # explicitly: a +represent+ registration or Klass::Entity for the object's
+      # class or an ancestor, then the same for its element class. Object is
+      # excluded: a global ::Entity class is not a representer.
       # @param object [Object] the object to locate the Entity class for
       # @return [Class] the located Entity class, or nil if none is found
       def entity_class_for_obj(object)

--- a/lib/grape/dsl/headers.rb
+++ b/lib/grape/dsl/headers.rb
@@ -4,10 +4,10 @@ module Grape
   module DSL
     module Headers
       # This method has four responsibilities:
-      # 1. Set a specifc header value by key
-      # 2. Retrieve a specifc header value by key
+      # 1. Set a specific header value by key
+      # 2. Retrieve a specific header value by key
       # 3. Retrieve all headers that have been set
-      # 4. Delete a specifc header key-value pair
+      # 4. Delete a specific header key-value pair
       def header(key = nil, val = nil)
         if key
           val ? header[key] = val : header.delete(key)

--- a/lib/grape/dsl/helpers.rb
+++ b/lib/grape/dsl/helpers.rb
@@ -6,8 +6,8 @@ module Grape
       # Add helper methods that will be accessible from any
       # endpoint within this namespace (and child namespaces).
       #
-      # When called without a block, all known helpers within this scope
-      # are included.
+      # When called with neither modules nor a block, returns a module
+      # including all known helpers within this scope.
       #
       # @param [Array] new_modules optional array of modules to include
       # @param [Block] block optional block of methods to include
@@ -77,11 +77,8 @@ module Grape
 
       # When +Grape.config.warn_on_helper_overrides+ is enabled, emit a
       # warning to +$stderr+ for any helper method that masks an instance
-      # method on +Grape::Endpoint+. Helpers are mixed into the endpoint's
-      # singleton class and therefore take precedence over +Endpoint+
-      # instance methods — usually intentional, but a common source of
-      # surprise when the framework gains a method that already collides
-      # with an existing helper name.
+      # method on +Grape::Endpoint+. Helpers are included into a subclass of
+      # the endpoint (see Endpoint#build_prototype), so they take precedence.
       def warn_on_endpoint_overrides(mod)
         overridden = mod.instance_methods(false).select { |m| Grape::Endpoint.method_defined?(m) }
         return if overridden.empty?

--- a/lib/grape/dsl/inside_route.rb
+++ b/lib/grape/dsl/inside_route.rb
@@ -9,7 +9,7 @@ module Grape
       # Backward compatibility: alias exception class to previous location
       MethodNotYetAvailable = Declared::MethodNotYetAvailable
 
-      # The API version as specified in the URL.
+      # The API version negotiated for this request.
       def version
         env[Grape::Env::API_VERSION]
       end
@@ -23,7 +23,7 @@ module Grape
       #
       # @param message [String] The message to display.
       # @param status [Integer] The HTTP Status Code. Defaults to default_error_status, 500 if not set.
-      # @param additional_headers [Hash] Addtional headers for the response.
+      # @param additional_headers [Hash] Additional headers for the response.
       # @param backtrace [Array<String>] The backtrace of the exception that caused the error.
       # @param original_exception [Exception] The original exception that caused the error.
       def error!(message, status = nil, additional_headers = nil, backtrace = nil, original_exception = nil)
@@ -121,7 +121,7 @@ module Grape
       #
       # @example
       #   get '/file' do
-      #     sendfile FileStreamer.new(...)
+      #     sendfile '/path/to/file'
       #   end
       #
       #   GET /file # => "contents of file"

--- a/lib/grape/dsl/logger.rb
+++ b/lib/grape/dsl/logger.rb
@@ -3,7 +3,7 @@
 module Grape
   module DSL
     module Logger
-      # Set or retrive the configured logger. If none was configured, this
+      # Set or retrieve the configured logger. If none was configured, this
       # method will create a new one, logging to stdout.
       # @param logger [Object] the new logger to use
       def logger(logger = nil)

--- a/lib/grape/dsl/parameters.rb
+++ b/lib/grape/dsl/parameters.rb
@@ -6,18 +6,13 @@ module Grape
     # and describe the parameters accepted by an endpoint, or all endpoints
     # within a namespace.
     module Parameters
-      # Set the module used to build the request.params.
+      # Set the builder used to build the request.params.
       #
-      # @param build_with the ParamBuilder module to use when building request.params
-      #   Available builders are:
-      #
-      #     * Grape::Extensions::ActiveSupport::HashWithIndifferentAccess::ParamBuilder (default)
-      #     * Grape::Extensions::Hash::ParamBuilder
-      #     * Grape::Extensions::Hashie::Mash::ParamBuilder
+      # @param build_with [Symbol] +:hash_with_indifferent_access+ (default,
+      #   see +Grape.config.param_builder+), +:hash+ or +:hashie_mash+
       #
       # @example
       #
-      #     require 'grape/extenstions/hashie_mash'
       #     class API < Grape::API
       #       desc "Get collection"
       #       params do
@@ -91,7 +86,7 @@ module Grape
       #   and validation rules for variant-type parameters.
       # @option attrs :desc [String] description to document this parameter
       # @option attrs :default [Object] default value, if parameter is optional
-      # @option attrs :values [Array] permissable values for this field. If any
+      # @option attrs :values [Array] permissible values for this field. If any
       #   other value is given, it will be handled as a validation error
       # @option attrs :using [Hash[Symbol => Hash]] a hash defining keys and
       #   options, like that returned by {Grape::Entity#documentation}. The value
@@ -110,7 +105,7 @@ module Grape
       #       # Basic usage: require a parameter of a certain type
       #       requires :user_id, type: Integer
       #
-      #       # You don't need to specify type; String is default
+      #       # Without a type, the value is not coerced
       #       requires :foo
       #
       #       # Multiple params can be specified at once if they share
@@ -156,9 +151,9 @@ module Grape
 
       # Define a block of validations which should be applied if and only if
       # the given parameter is present. The parameters are not nested.
-      # @param attr [Symbol] the parameter which, if present, triggers the
-      #   validations
-      # @raise Grape::Exceptions::UnknownParameter if `attr` has not been
+      # @param attrs [Array<Symbol, Hash>] the parameters which, if present (or
+      #   passing the Proc they map to), trigger the validations
+      # @raise Grape::Exceptions::UnknownParameter if one has not been
       #   defined in this scope yet
       # @yield a parameter definition DSL
       def given(*attrs, &)
@@ -176,8 +171,7 @@ module Grape
         # Elements of @declared_params of lateral scope are pushed in @parent. So check them in @parent.
         return @parent.declared_param?(param) if lateral?
 
-        # @declared_params also includes hashes of options and such, but those
-        # won't be flattened out.
+        # A nested scope is recorded as an Attr keyed by { element => children }.
         @declared_params.flatten.any? do |declared_param_attr|
           first_hash_key_or_param(declared_param_attr.key) == param
         end
@@ -197,10 +191,6 @@ module Grape
 
       private
 
-      # @deprecated A trailing positional options Hash is deprecated; pass keyword
-      #   arguments instead. Before Ruby 3 keyword separation this Hash was pulled
-      #   off the argument list by `extract_options!`; now it lands in the splat and
-      #   would silently be treated as a parameter name.
       # +requires+ and +optional+ differ only in whether what they declare is
       # required, so the declaration itself lives here.
       #
@@ -224,6 +214,8 @@ module Grape
         new_scope(attrs.first, type: merged_opts[:type], as: declared_as, optional: !required, &block)
       end
 
+      # A trailing positional options Hash (deprecated): since Ruby 3 keyword
+      # separation it lands in the splat and would be read as a parameter name.
       def legacy_options?(args)
         args.size > 1 && args.last.is_a?(Hash)
       end

--- a/lib/grape/dsl/request_response.rb
+++ b/lib/grape/dsl/request_response.rb
@@ -4,7 +4,7 @@ module Grape
   module DSL
     module RequestResponse
       # Specify the default format for the API's serializers.
-      # May be `:json` or `:txt` (default).
+      # e.g. `:json`, `:xml` or `:txt` (default).
       def default_format(new_format = nil)
         return inheritable_setting.default_format if new_format.nil?
 
@@ -78,6 +78,9 @@ module Grape
         inheritable_setting.default_error_status = new_status
       end
 
+      META_RESCUE_SELECTORS = %i[all grape_exceptions internal_grape_exceptions].freeze
+      private_constant :META_RESCUE_SELECTORS
+
       # Allows you to rescue certain exceptions that occur to return
       # a grape error rather than raising all the way to the
       # server level.
@@ -89,17 +92,15 @@ module Grape
       #       rescue_from CustomError
       #     end
       #
-      META_RESCUE_SELECTORS = %i[all grape_exceptions internal_grape_exceptions].freeze
-      private_constant :META_RESCUE_SELECTORS
-
       # @overload rescue_from(*exception_classes, **options)
       #   @param [Array] exception_classes A list of classes that you want to rescue, or
       #     one of the meta selectors +:all+, +:grape_exceptions+,
       #     +:internal_grape_exceptions+. Meta selectors must be used alone;
       #     mixing with exception classes raises +ArgumentError+.
-      #   @param [Block] block Execution block to handle the given exception.
-      #   @param [Proc] with Execution proc to handle the given exception as an alternative
-      #     to passing a block.
+      #   @param [Block] block Execution block to handle the given exception; a
+      #     trailing Proc argument works too.
+      #   @param [Proc, Symbol, String] with Alternative to a block; a Symbol or
+      #     String names an endpoint method.
       #   @param [Boolean] rescue_subclasses Also rescue subclasses of exception classes;
       #     defaults to +true+.
       #   @param [Boolean] backtrace Include the rescued exception's backtrace in the

--- a/lib/grape/dsl/routing.rb
+++ b/lib/grape/dsl/routing.rb
@@ -254,7 +254,8 @@ module Grape
       # in your API.
       #
       # @param param [Symbol] The name of the parameter you wish to declare.
-      # @option options [Regexp, Class, Symbol] The constraint the declared parameter must meet — a Regexp, or a capture type such as +Integer+.
+      # @param requirements [Regexp, Class, Symbol] The constraint the parameter must meet.
+      # @param type [Class] Declares the parameter with this type.
       def route_param(param, requirements: nil, type: nil, **, &)
         # The param is named here, so the constraint is its own: nest whatever
         # it is, not just a Regexp. A Hash would name the param twice, or key a

--- a/lib/grape/dsl/settings.rb
+++ b/lib/grape/dsl/settings.rb
@@ -47,7 +47,7 @@ module Grape
       private
 
       # Execute the block within a context where our inheritable settings are forked
-      # to a new copy (see #namespace_start).
+      # to a new child scope.
       def within_namespace
         new_inheritable_settings = Grape::Util::InheritableSetting.new
         new_inheritable_settings.inherit_from inheritable_setting

--- a/lib/grape/dsl/version_options.rb
+++ b/lib/grape/dsl/version_options.rb
@@ -5,7 +5,7 @@ module Grape
     # Immutable value object holding the resolved options from
     # +Grape::DSL::Routing#version+. Stored on the inheritable settings as
     # +Grape::Util::InheritableSetting#version_options+ and read by internal call
-    # sites (`Path`, `Endpoint`, `API::Instance#cascade?`,
+    # sites (`Path`, `Endpoint`, `API::Instance`,
     # `Middleware::Versioner::Base`) via accessors.
     #
     # Defaults are duplicated on +#initialize+ here and on +#version+'s

--- a/lib/grape/middleware/base.rb
+++ b/lib/grape/middleware/base.rb
@@ -54,7 +54,7 @@ module Grape
 
       # @abstract
       # Called after the application is called in the middleware lifecycle.
-      # @return [Response, nil] a Rack SPEC response or nil to call the application afterwards.
+      # @return [Response, nil] a Rack SPEC response, or nil to keep the application's.
       def after; end
 
       def rack_request

--- a/lib/grape/middleware/error.rb
+++ b/lib/grape/middleware/error.rb
@@ -135,11 +135,11 @@ module Grape
         raw.backtrace || raw.original_exception&.backtrace || []
       end
 
-      # Rendering runs inside #call!'s own rescue clause, so it is not covered by
-      # that rescue: an error formatter that raises on the payload it was handed
-      # takes the exception out through every middleware above Grape. By this
-      # point Grape has committed to answering with an error, so it answers with
-      # one that does not depend on the payload rather than dropping the request.
+      # An error formatter that raises on its payload would take the exception
+      # out through every middleware above Grape: rendering from a rescue
+      # handler runs in #call!'s rescue clause, which nothing covers. Grape has
+      # committed to an error by now, so it answers with one that does not
+      # depend on the payload.
       #
       # +Grape.config.raise_rendering_errors+ opts back out, for an application
       # that would rather have the exception propagate as it did before.

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -99,7 +99,7 @@ module Grape
             resp.body = bodies.stream
           end
         else
-          # Allow content-type to be explicitly overwritten
+          # Picked by env['api.format']; the Content-Type header only counts when that is unset
           formatter = fetch_formatter(headers)
           bodymap = instrument_format_response(formatter) do
             bodies.map { |body| formatter.call(body, env) }

--- a/lib/grape/middleware/versioner.rb
+++ b/lib/grape/middleware/versioner.rb
@@ -6,7 +6,7 @@
 #   :header - version from HTTP Accept header.
 #   :accept_version_header - version from HTTP Accept-Version header
 #   :path   - version from uri. e.g. /v1/resource
-#   :param  - version from uri query string, e.g. /v1/resource?apiver=v1
+#   :param  - version from uri query string, e.g. /resource?apiver=v1
 # See individual classes for details.
 module Grape
   module Middleware

--- a/lib/grape/middleware/versioner/param.rb
+++ b/lib/grape/middleware/versioner/param.rb
@@ -8,14 +8,12 @@ module Grape
       # request parameters for subsequent middleware and API.
       # If the version substring does not match any potential initialized
       # versions, a 404 error is thrown.
-      # If the version substring is not passed the version (highest mounted)
-      # version will be used.
+      # If no version is passed, none is set and the first matching route answers.
       #
       # Example: For a uri path
       #   /resource?apiver=v1
       #
-      # The following rack env variables are set and path is rewritten to
-      # '/resource':
+      # The following rack env variable is set:
       #
       #   env['api.version'] => 'v1'
       class Param < Base

--- a/lib/grape/middleware/versioner/path.rb
+++ b/lib/grape/middleware/versioner/path.rb
@@ -4,15 +4,14 @@ module Grape
   module Middleware
     module Versioner
       # This middleware sets various version related rack environment variables
-      # based on the uri path and removes the version substring from the uri
-      # path. If the version substring does not match any potential initialized
-      # versions, a 404 error is thrown.
+      # based on the uri path, which it leaves unchanged. If the version
+      # substring does not match any potential initialized versions, a 404
+      # error is thrown.
       #
       # Example: For a uri path
       #   /v1/resource
       #
-      # The following rack env variables are set and path is rewritten to
-      # '/resource':
+      # The following rack env variable is set:
       #
       #   env['api.version'] => 'v1'
       #

--- a/lib/grape/mountable.rb
+++ b/lib/grape/mountable.rb
@@ -8,10 +8,8 @@ module Grape
   # rather than duck-typing on an incidental internal method such as
   # `inheritable_setting`.
   #
-  # `Grape::API` and `Grape::API::Instance` are not related by inheritance and
-  # do not even respond to the same methods (the former to `mount_instance`,
-  # the latter to `inheritable_setting`/`endpoints`), so there is no common
-  # ancestor to key an `is_a?` check on without this marker.
+  # `Grape::API` and `Grape::API::Instance` are not related by inheritance, so
+  # there is no common ancestor to key an `is_a?` check on without this marker.
   #
   # It answers identity only ("is this a Grape app?"). Capability checks that
   # go on to call a stage-specific method — e.g. `respond_to?(:endpoints)`

--- a/lib/grape/namespace.rb
+++ b/lib/grape/namespace.rb
@@ -8,10 +8,9 @@ module Grape
     attr_reader :space, :requirements, :options
 
     # @param space [String] the name of this namespace
+    # @param requirements [Hash] param-regex pairs a request's path must meet
+    #   for this namespace's endpoints to match
     # @param options [Hash] options hash
-    # @option options :requirements [Hash] param-regex pairs, all of which must
-    #   be met by a request's params for all endpoints in this namespace, or
-    #   validation will fail and return a 422.
     def initialize(space, requirements: nil, **options)
       @space = space.to_s
       @requirements = requirements

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -69,7 +69,8 @@ module Grape
     # 1. the routes registered for +method+ — the compiled-union match first,
     #    then, when that route cascades, its siblings (see #rotation);
     # 2. the ANY (+'*'+) routes;
-    # 3. the greedy neighbour, which answers auto-OPTIONS and 405.
+    # 3. the greedy neighbour, which answers 405 — and auto-OPTIONS, ahead of
+    #    the ANY routes.
     #
     # Returns nil when nothing answered, leaving the caller to 404. A response
     # that cascades is never final: it is returned only once every later

--- a/lib/grape/router/pattern.rb
+++ b/lib/grape/router/pattern.rb
@@ -13,8 +13,8 @@ module Grape
       def_delegators :to_regexp, :===
       alias match? ===
 
-      # Build a Pattern from a raw path, namespace and the API's inheritable
-      # settings. {Path} owns the settings-aware assembly of +origin+/+suffix+;
+      # Build a Pattern from a raw path, namespace and a PathSettings snapshot.
+      # {Path} owns the settings-aware assembly of +origin+/+suffix+;
       # the Pattern itself stays value-based (see {#initialize}).
       def self.build(path:, namespace:, settings:, anchor:, params:, version:, requirements:)
         built_path = Path.new(path, namespace, settings)

--- a/lib/grape/util/inheritable_setting.rb
+++ b/lib/grape/util/inheritable_setting.rb
@@ -99,7 +99,7 @@ module Grape
 
       # Create a point-in-time copy of this settings instance, with clones of
       # all our values. Note that, should this instance's parent be set or
-      # changed via #inherit_from, it will copy that inheritence to any copies
+      # changed via #inherit_from, it will copy that inheritance to any copies
       # which were made.
       def point_in_time_copy
         new_setting = self.class.new
@@ -172,8 +172,8 @@ module Grape
       end
 
       # The route-scope settings handed to each Grape::Router::Route: every
-      # +route_setting+ registration plus the description, minus the internal
-      # param snapshots (#route_validations / #route_declared_params).
+      # +route_setting+ registration, the description and renamed params,
+      # minus #route_validations / #route_declared_params.
       def route_settings
         route.except(:declared_params, :validations)
       end
@@ -593,11 +593,9 @@ module Grape
         set_inheritable(:root_prefix, prefix)
       end
 
-      # Cascade flag assigned by the +cascade+ DSL. An explicit nil is
-      # meaningful and distinct from never-set (the backing store is
-      # key-presence based), so #cascade_defined? reports whether any scope
-      # assigned it — Grape::API::Instance#cascade? falls back to the
-      # version options' cascade, then to true, when it was never assigned.
+      # Cascade flag assigned by the +cascade+ DSL. An explicit nil is distinct
+      # from never-set, which #cascade_defined? tells apart; when never set,
+      # Grape::API::Instance falls back to the version options' cascade, then true.
       def cascade
         inheritable(:cascade)
       end
@@ -701,7 +699,7 @@ module Grape
       protected
 
       # This scope's own inheritable overrides, before inheritance; nil when
-      # the scope overrode nothing. Peer access for #copy_state_from.
+      # the scope overrode nothing. Peer access for #copy_state_from and #==.
       attr_reader :namespace_inheritable
 
       # The nearest scope's value for +key+: this scope's own override when it
@@ -723,9 +721,7 @@ module Grape
       end
 
       # Every inheritable value along the chain resolved into one Hash, nearest
-      # scope winning. Like #stacked it hands back the backing Hash when only
-      # one scope in the chain has values, so callers must treat the result as
-      # read-only.
+      # scope winning. May be the root scope's own Hash: treat it as read-only.
       def inheritable_values
         inherited = parent&.inheritable_values
         own = @namespace_inheritable
@@ -739,14 +735,12 @@ module Grape
       attr_reader :rescue_handler_maps
 
       # This scope's own stackable registrations, before inheritance; nil when
-      # the scope registered nothing. Peer access for #copy_state_from.
+      # the scope registered nothing. Peer access for #copy_state_from and #==.
       attr_reader :stackable_values
 
-      # Every registration for +key+ along the chain, outermost scope first.
-      # Returns the frozen EMPTY_STACK when nothing is registered anywhere, and
-      # — like the store it replaced — the backing Array itself when only this
-      # scope registered anything, so callers must treat the result as
-      # read-only.
+      # Every registration for +key+ along the chain, outermost scope first;
+      # the frozen EMPTY_STACK when there is none. May be the root scope's own
+      # Array: treat it as read-only.
       def stacked(key)
         inherited = parent&.stacked(key)
         own = @stackable_values&.[](key)
@@ -816,9 +810,8 @@ module Grape
         keys.each { |key| @stackable_values.delete(key) }
       end
 
-      # Compares two lazily-allocated own-registration stores (see #stack and
-      # #add_rescue_handlers): nil and an emptied Hash both mean "this scope
-      # registered nothing", so #== must not tell them apart.
+      # Compares two lazily-allocated own stackable stores (see #stack): nil and
+      # an emptied Hash both mean "registered nothing".
       def same_own_store?(mine, theirs)
         return theirs.blank? if mine.blank?
 

--- a/lib/grape/util/translation.rb
+++ b/lib/grape/util/translation.rb
@@ -6,9 +6,7 @@ module Grape
       FALLBACK_LOCALE = :en
       private_constant :FALLBACK_LOCALE
       # Sentinel returned by I18n when a key is missing (passed as the default:
-      # value). Using a named class rather than plain Object.new makes it
-      # identifiable in debug output and immune to backends that call .to_s on
-      # the default before returning it.
+      # value). Its +inspect+ names it in debug output.
       MISSING = Class.new { def inspect = 'Grape::Util::Translation::MISSING' }.new.freeze
       private_constant :MISSING
 

--- a/lib/grape/validations/coerce_options.rb
+++ b/lib/grape/validations/coerce_options.rb
@@ -6,7 +6,7 @@ module Grape
     # by {ValidationsSpec#coerce_options} from the parsed +type+/+coerce_with+/
     # +coerce_message+ declaration — never written by the user — and consumed
     # by {ParamsScope#check_coerce_with} / {ParamsScope#validate_coerce} and by
-    # {Validators::Validators::CoerceValidator} (which receives it as its
+    # {Validators::CoerceValidator} (which receives it as its
     # +options+ argument).
     #
     # All three fields may be +nil+ (e.g. a remountable API evaluated on its

--- a/lib/grape/validations/params_scope.rb
+++ b/lib/grape/validations/params_scope.rb
@@ -57,7 +57,7 @@ module Grape
       end
 
       # Open up a new ParamsScope, allowing parameter definitions per
-      #   Grape::DSL::Params.
+      #   Grape::DSL::Parameters.
       # @param api [API] the API endpoint to modify
       # @param element [Symbol] the element that contains this scope; for
       #   this to be relevant, parent must be set
@@ -66,10 +66,10 @@ module Grape
       # @param parent [ParamsScope] the scope containing this scope
       # @param optional [Boolean] whether or not this scope needs to have
       #   any parameters set or not
-      # @param type [Class] a type meant to govern this scope (deprecated)
-      # @param type [Hash] group options for this scope
-      # @param dependent_on [Symbol] if present, this scope should only
-      #   validate if this param is present in the parent scope
+      # @param type [Class] a type meant to govern this scope
+      # @param group [Hash] group options for this scope
+      # @param dependent_on [Array<Symbol, Hash>] if present, this scope should
+      #   only validate if these params are present in the parent scope
       # @yield the instance context, open for parameter definitions
       def initialize(api:, element: nil, element_renamed: nil, parent: nil, optional: false, type: nil, group: nil, dependent_on: nil, &block)
         @element          = element
@@ -323,8 +323,8 @@ module Grape
 
       # Returns a new parameter scope, not nested under any current-level param
       # but instead at the same level as the current scope.
-      # @param dependent_on [Symbol] if given, specifies that this scope should
-      #   only validate if this parameter from the above scope is present
+      # @param dependent_on [Array<Symbol, Hash>] if given, this scope only
+      #   validates if these parameters from the above scope are present
       # @yield parameter scope
       def new_lateral_scope(dependent_on:, &)
         self.class.new(

--- a/lib/grape/validations/types.rb
+++ b/lib/grape/validations/types.rb
@@ -9,8 +9,8 @@ module Grape
     # Grape uses a number of tests and assertions to
     # work out exactly how a parameter should be handled,
     # based on the +type+ and +coerce_with+ options that
-    # may be supplied to {Grape::Dsl::Parameters#requires}
-    # and {Grape::Dsl::Parameters#optional}. The main
+    # may be supplied to {Grape::DSL::Parameters#requires}
+    # and {Grape::DSL::Parameters#optional}. The main
     # entry point for this process is {Types.build_coercer}.
     module Types
       module_function
@@ -112,11 +112,10 @@ module Grape
           type.respond_to?(:parse) && type.method(:parse).arity == 1
       end
 
-      # Is the declared type an +Array+ or +Set+ of a {#custom?} type?
+      # Is the declared type an +Array+ or +Set+ of a {#custom?} or {#special?} type?
       #
       # @param type [Array<Class>,Class] type to check
-      # @return [Boolean] true if +type+ is a collection of a type that implements
-      #   its own +#parse+ method.
+      # @return [Boolean] true if +type+ is a one-element collection of such a type
       def collection_of_custom?(type)
         array_or_set?(type) && type.length == 1 && (custom?(type.first) || special?(type.first))
       end
@@ -131,26 +130,21 @@ module Grape
       #
       # There are a few very special coercers which might be returned.
       #
-      # +Grape::Types::MultipleTypeCoercer+ is a coercer which is returned when
-      # the given type implies values in an array with different types.
-      # For example, +[Integer, String]+ allows integer and string values in
-      # an array.
+      # +MultipleTypeCoercer+ is returned for a value that may be one of
+      # several types, e.g. +types: [Integer, String]+.
       #
-      # +Grape::Types::CustomTypeCoercer+ is a coercer which is returned when
-      # a method is specified by a user with +coerce_with+ option or the user
-      # specifies a custom type which implements requirments of
-      # +Grape::Types::CustomTypeCoercer+.
+      # +CustomTypeCoercer+ is returned for a +coerce_with+ method or a type
+      # with its own +parse+ (see {#custom?}).
       #
-      # +Grape::Types::CustomTypeCollectionCoercer+ is a very similar to the
-      # previous one, but it expects an array or set of values having a custom
-      # type implemented by the user.
+      # +CustomTypeCollectionCoercer+ is returned for an array or set of such
+      # a type (see {#collection_of_custom?}).
       #
       # There is also a group of custom types implemented by Grape, check
       # +Grape::Validations::Types::SPECIAL+ to get the full list.
       #
-      # @param type [Class] the type to which input strings
-      #   should be coerced
+      # @param type [Class] the type to which input values should be coerced
       # @param method [Class,#call] the coercion method to use
+      # @param strict [Boolean] check the type rather than coerce
       # @return [Object] object to be used
       #   for coercion and type validation
       def build_coercer(type, method: nil, strict: false)

--- a/lib/grape/validations/types/custom_type_coercer.rb
+++ b/lib/grape/validations/types/custom_type_coercer.rb
@@ -10,7 +10,7 @@ module Grape
       # there are any problems parsing the string.
       #
       # Alternately an optional +method+ may be supplied (see the
-      # +coerce_with+ option of {Grape::Dsl::Parameters#requires}).
+      # +coerce_with+ option of {Grape::DSL::Parameters#requires}).
       # This may be any class or object implementing +parse+ or +call+,
       # with the same contract as described above.
       #
@@ -53,8 +53,7 @@ module Grape
 
         # Coerces the given value.
         #
-        # @param value [String] value to be coerced, in grape
-        #   this should always be a string.
+        # @param val [Object] value to be coerced
         # @return [Object] the coerced result
         def call(val)
           coerced_val = @method.call(val)

--- a/lib/grape/validations/types/custom_type_collection_coercer.rb
+++ b/lib/grape/validations/types/custom_type_collection_coercer.rb
@@ -4,7 +4,7 @@ module Grape
   module Validations
     module Types
       # See {CustomTypeCoercer} for details on types
-      # that will be supported by this by this coercer.
+      # that will be supported by this coercer.
       # This coercer works in the same way as +CustomTypeCoercer+
       # except that it expects to receive an array of strings to
       # coerce and will return an array (or optionally, a set)

--- a/lib/grape/validations/types/dry_type_coercer.rb
+++ b/lib/grape/validations/types/dry_type_coercer.rb
@@ -14,7 +14,7 @@ module Grape
           # Returns a collection coercer which corresponds to a given type.
           # Example:
           #
-          #    collection_coercer_for(Array)
+          #    collection_coercer_for([Integer])
           #    #=> Grape::Validations::Types::ArrayCoercer
           def collection_coercer_for(type)
             return ArrayCoercer if type.is_a?(Array)

--- a/lib/grape/validations/types/multiple_type_coercer.rb
+++ b/lib/grape/validations/types/multiple_type_coercer.rb
@@ -35,8 +35,7 @@ module Grape
 
         # Coerces the given value.
         #
-        # @param val [String] value to be coerced, in grape
-        #   this should always be a string.
+        # @param val [Object] value to be coerced
         # @return [Object,InvalidValue] the coerced result, or an instance
         #   of {InvalidValue} if the value could not be coerced.
         def call(val)

--- a/lib/grape/validations/validations_spec.rb
+++ b/lib/grape/validations/validations_spec.rb
@@ -9,9 +9,8 @@ module Grape
     #
     # Splits the raw entries into three logical buckets:
     #
-    # * Spec-consumed keys (type/types/coerce*, presence/message,
-    #   default/fail_fast, doc keys) — exposed via named accessors and never
-    #   handed to validator dispatch.
+    # * Spec-consumed keys (type/types/coerce*, presence/message, fail_fast,
+    #   doc keys) — never handed to validator dispatch.
     # * Shared opts (allow_blank, fail_fast) — read by every validator at
     #   construction time via {#shared_opts}.
     # * Validator entries (everything else, e.g. +regexp+, +length+, +values+,

--- a/lib/grape/validations/validators/as_validator.rb
+++ b/lib/grape/validations/validators/as_validator.rb
@@ -4,9 +4,8 @@ module Grape
   module Validations
     module Validators
       class AsValidator < Base
-        # We use a validator for renaming parameters. This is just a marker for
-        # the parameter scope to handle the renaming. No actual validation
-        # happens here.
+        # Never dispatched: +as:+ renaming is handled by ParamsScope. No
+        # validation happens here.
         def validate_param!(*); end
       end
     end

--- a/lib/grape/validations/validators/base.rb
+++ b/lib/grape/validations/validators/base.rb
@@ -7,10 +7,10 @@ module Grape
       #
       # == Freeze contract
       # Validator instances are shared across requests and are frozen after
-      # initialization (via +.new+). All inputs (+options+, +opts+, +attrs+)
-      # arrive pre-frozen from the DSL boundary, so subclass ivars derived
-      # from them are frozen by construction. Lazy ivar assignment
-      # (e.g. +memoize+, <tt>||=</tt>) will raise +FrozenError+ at request time.
+      # initialization (via +.new+). #initialize freezes +attrs+ and
+      # deep-freezes +options+, so subclass ivars derived from them are frozen
+      # by construction. Lazy ivar assignment (e.g. +memoize+, <tt>||=</tt>)
+      # will raise +FrozenError+ at request time.
       class Base
         extend Forwardable
         extend Grape::Util::FreezeOnNew

--- a/lib/grape/validations/validators/coerce_validator.rb
+++ b/lib/grape/validations/validators/coerce_validator.rb
@@ -35,7 +35,7 @@ module Grape
           validation_error!(attr_name, new_value.message || exception_message) if new_value.is_a?(Types::InvalidValue)
 
           # Don't assign a value if it is identical. It fixes a problem with Hashie::Mash
-          # which looses wrappers for hashes and arrays after reassigning values
+          # which loses wrappers for hashes and arrays after reassigning values
           #
           #     h = Hashie::Mash.new(list: [1, 2, 3, 4])
           #     => #<Hashie::Mash list=#<Hashie::Array [1, 2, 3, 4]>>


### PR DESCRIPTION
## Summary

A pass over every comment under `lib/` against the code it describes. Comments that no longer match are corrected, each kept short; accurate ones are left alone.

The one non-comment change moves `META_RESCUE_SELECTORS` above the `rescue_from` docs, so YARD attaches them to the method rather than to the constant.

## Behaviour the comments got wrong

Each checked by running it on master:

| Comment | What happens |
|---|---|
| `requires :foo` — "String is default" | No type, no coercion: JSON `1` stays an `Integer` |
| `desc` — a positional options Hash "is deprecated" | `desc 'x', { detail: 'd' }` raises `ArgumentError` |
| `Namespace` requirements — "validation will fail and return a 422" | The route does not match: 404 |
| `Versioner::Param` — without the param, "the highest mounted version" is used | No version is set; the first matching route answers (`v1`) |
| `Versioner::Path` / `Versioner::Param` — "path is rewritten" | `PATH_INFO` is unchanged |
| Formatter — "Allow content-type to be explicitly overwritten" | `content_type 'application/json'` still renders through the negotiated `txt` formatter |
| `sendfile FileStreamer.new(...)` example | Raises: only a file path is accepted |
| `collection_coercer_for(Array)` example | Raises: it takes an instance such as `[Integer]` |
| `MultipleTypeCoercer` — values "in an array" | Coerces a single value; `['1']` is invalid |
| `InheritableSetting#stacked` — the backing Array "when only this scope registered anything" | Only the root scope's own store is ever handed back |
| `Mountable` — `Grape::API` does not respond to `inheritable_setting` | It does |

## Docs attached to the wrong thing, or naming what no longer exists

- The `rescue_from` description and example were attached to `META_RESCUE_SELECTORS`.
- A `@deprecated` tag about positional options sat on `declare`; the note now documents `legacy_options?`.
- `build_with` listed the removed `Grape::Extensions::*::ParamBuilder` classes.
- Helpers were described as mixed into the singleton class (they go into a subclass, see `Endpoint#build_prototype`), `AsValidator` as a renaming marker (it is never dispatched), and a `#namespace_start` that does not exist was referenced.
- The YARD params of `ParamsScope.new`, `given`, `declared`, `route_param` and the coercers now match their signatures.

Plus smaller corrections and typos.

## Test plan

- [x] Full RSpec suite passes locally (2862 examples, 0 failures).
- [x] RuboCop clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)