### PR TITLE
Speed up error responses, param defaults and deciding whether to read a request body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#2937](https://github.com/ruby-grape/grape/pull/2937): Forward the class methods kept off an API class to its base instance explicitly, and pin what `delegate_missing_to` still answers - [@ericproulx](https://github.com/ericproulx).
 * [#2936](https://github.com/ruby-grape/grape/pull/2936): Speed up header versioning, content negotiation, params validation and error responses on the request path - [@ericproulx](https://github.com/ericproulx).
 * [#2938](https://github.com/ruby-grape/grape/pull/2938): Correct code comments that no longer match the code - [@ericproulx](https://github.com/ericproulx).
+* [#2939](https://github.com/ruby-grape/grape/pull/2939): Speed up error responses, param defaults and deciding whether to read a request body - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 4.0.0 (2026-09-07)

--- a/lib/grape/dsl/entity.rb
+++ b/lib/grape/dsl/entity.rb
@@ -85,6 +85,8 @@ module Grape
           return representations[potential] if potential && representations[potential]
         end
 
+        return unless klass.const_defined?(:Entity)
+
         owner = klass.ancestors.detect { |ancestor| ancestor != Object && ancestor.const_defined?(:Entity, false) }
         return unless owner
 

--- a/lib/grape/middleware/formatter.rb
+++ b/lib/grape/middleware/formatter.rb
@@ -48,10 +48,21 @@ module Grape
       end
 
       # The request methods that can carry a body worth parsing. See
-      # {#read_body_input?}, which tests the env against this before anything
-      # asks for a Rack::Request. QUERY is here because its content *is* the
-      # query (RFC 10008, Section 2), not an optional payload.
+      # {#body_given?}, which tests the env against this before anything asks
+      # for a Rack::Request. QUERY is here because its content *is* the query
+      # (RFC 10008, Section 2), not an optional payload.
       BODY_CARRYING_METHODS = [Rack::POST, Rack::PUT, Rack::PATCH, Rack::DELETE, Grape::QUERY].freeze
+
+      # The media types whose bodies Rack parses itself once the params are
+      # asked for, so the formatter leaves them alone.
+      #
+      # Tested against the media type the formatter parses anyway, rather than
+      # through Rack's +form_data?+ and +parseable_data?+, which parse
+      # CONTENT_TYPE again each. It is the same answer: +form_data?+ also holds
+      # for a POST with no media type, but Rack only finds none when
+      # CONTENT_TYPE is missing or empty, and a body like that was never left
+      # to Rack.
+      RACK_PARSED_MEDIA_TYPES = (Rack::Request::FORM_DATA_MEDIA_TYPES + Rack::Request::PARSEABLE_DATA_MEDIA_TYPES).freeze
 
       # Read off ivars rather than delegated into +config+ on every request:
       # +negotiate_content_type+ asks for +format+ and +default_format+ per
@@ -145,7 +156,10 @@ module Grape
       end
 
       def read_body_input
-        return unless read_body_input?
+        return unless body_given?
+
+        media_type = rack_request.media_type
+        return if RACK_PARSED_MEDIA_TYPES.include?(media_type)
 
         input = rack_request.body # reads RACK_INPUT
         return if input.nil?
@@ -155,16 +169,14 @@ module Grape
         input.rewind if rewind
         body = env[Grape::Env::API_REQUEST_INPUT] = input.read
         begin
-          read_rack_input(body)
+          read_rack_input(body, media_type)
         ensure
           input.rewind if rewind
         end
       end
 
-      def read_rack_input(body)
+      def read_rack_input(body, media_type)
         return if body.empty?
-
-        media_type = rack_request.media_type
 
         # RFC 10008, Sections 2 and 2.1: a QUERY carries its query in the
         # content, so a request that never says what that content is cannot be
@@ -205,22 +217,15 @@ module Grape
       end
       private_constant :ForeignParserError
 
-      # this middleware will not try to format the following content-types since Rack already handles them
-      # when calling Rack's `params` function
-      # - application/x-www-form-urlencoded
-      # - multipart/form-data
-      # - multipart/related
-      # - multipart/mixed
-      def read_body_input?
-        # Read off the env rather than through Rack::Request's predicates: this
-        # is what decides the question for every request, and on the GET, HEAD
-        # and OPTIONS majority it is the only thing the formatter would have
-        # built a Rack::Request for.
+      # Whether the request carries a body at all, read off the env alone. Every
+      # request asks, and the ones answered no -- the GET, HEAD and OPTIONS
+      # majority, and a POST or DELETE with nothing in it -- are answered before
+      # CONTENT_TYPE is parsed or a Rack::Request is built. The env key is
+      # spelled out: on Rack 3, +Rack::CONTENT_LENGTH+ names the response header.
+      def body_given?
         return false unless BODY_CARRYING_METHODS.include?(env[Rack::REQUEST_METHOD])
-        return false if rack_request.form_data? && rack_request.content_type
-        return false if rack_request.parseable_data?
 
-        rack_request.content_length.to_i.positive? || env['HTTP_TRANSFER_ENCODING'] == 'chunked'
+        env['CONTENT_LENGTH'].to_i.positive? || env['HTTP_TRANSFER_ENCODING'] == 'chunked'
       end
 
       def negotiate_content_type

--- a/lib/grape/validations/validators/default_validator.rb
+++ b/lib/grape/validations/validators/default_validator.rb
@@ -18,10 +18,27 @@ module Grape
         end
 
         def validate!(params)
+          scoped = scope.params(params) if @direct
+          return apply_defaults(scoped) if scoped.is_a?(Hash)
+
           @iterator.each(params) do |resource_params, attr_name|
             next unless scope.meets_dependency?(resource_params, params)
 
             resource_params[attr_name] = @default_call.call(resource_params) if hash_like?(resource_params) && resource_params[attr_name].nil?
+          end
+        end
+
+        private
+
+        # #validate! where Base#validate_attributes! applies: a scope that is
+        # always validated and does not iterate elements, once its params
+        # resolved to a Hash -- the root scope of every +params+ block with a
+        # default in it. The iterator would hand that Hash back once per
+        # attribute, and a scope like that depends on no other param, so all
+        # that is left of its checks is whether the value is missing.
+        def apply_defaults(params)
+          @attrs.each do |attr_name|
+            params[attr_name] = @default_call.call(params) if params[attr_name].nil?
           end
         end
       end

--- a/spec/grape/validations/validators/default_validator_spec.rb
+++ b/spec/grape/validations/validators/default_validator_spec.rb
@@ -127,6 +127,32 @@ describe Grape::Validations::Validators::DefaultValidator do
     end
   end
 
+  describe 'values given in a JSON body' do
+    let(:app) do
+      Class.new(Grape::API) do
+        format :json
+
+        params do
+          optional :type, default: 'default-type'
+          optional :kept, default: 'default-kept'
+          requires :nested, type: Hash do
+            optional :label, default: ->(nested) { "#{nested[:name]}-label" }
+            requires :name
+          end
+        end
+        post '/defaults' do
+          { type: params[:type], kept: params[:kept], nested: params[:nested] }
+        end
+      end
+    end
+
+    it 'defaults a null, keeps a false and hands a proc the params of its own scope' do
+      post '/defaults', { type: nil, kept: false, nested: { name: 'n' } }.to_json, 'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(201)
+      expect(JSON.parse(last_response.body)).to eq('type' => 'default-type', 'kept' => false, 'nested' => { 'name' => 'n', 'label' => 'n-label' })
+    end
+  end
+
   describe '/optional_array' do
     let(:app) do
       Class.new(Grape::API) do

--- a/spec/integration/grape_entity/entity_spec.rb
+++ b/spec/integration/grape_entity/entity_spec.rb
@@ -101,6 +101,39 @@ describe 'Grape::Entity', if: defined?(Grape::Entity) do
       expect(last_response.body).to eq('Auto-detect!')
     end
 
+    it 'uses the Entity a superclass or an included module names' do
+      entity = Class.new(Grape::Entity)
+      allow(entity).to receive(:represent).and_return('Inherited!')
+      base_model = Class.new
+      base_model.const_set :Entity, entity
+      concern = Module.new
+      concern.const_set :Entity, entity
+      subclass = Class.new(base_model)
+      including = Class.new { include concern }
+
+      subject.get('/subclass') { present subclass.new }
+      subject.get('/including') { present including.new }
+
+      get '/subclass'
+      expect(last_response.body).to eq('Inherited!')
+      get '/including'
+      expect(last_response.body).to eq('Inherited!')
+    end
+
+    it 'does not use a top-level Entity' do
+      entity = Class.new(Grape::Entity)
+      allow(entity).to receive(:represent).and_return('Top-level!')
+      stub_const('Entity', entity)
+      inner_body = nil
+
+      subject.get '/example' do
+        present({ abc: 'def' })
+        inner_body = body
+      end
+      get '/example'
+      expect(inner_body).to eql(abc: 'def')
+    end
+
     it 'does not run autodetection for Entity when explicitly provided' do
       entity = Class.new(Grape::Entity)
       some_array = []


### PR DESCRIPTION
## Summary

Three changes on the request path. Each gives the same responses as master; they stop repeating work that has one answer.

- **Error responses, and `present` without `with:`.** Finding a presenter walked the object's ancestors and asked each one for an `Entity` constant of its own: one `const_defined?` per ancestor, plus the ancestors Array, for every error body the error formatter renders — and a Hash message walks twice, the second time for the class of its first entry. `klass.const_defined?(:Entity)` asks the whole chain in one call, so when nothing on it defines one the walk is skipped. It also looks on Object, which the walk passes over, so a top-level `::Entity` only sends the lookup on to the walk as before.
- **`default:` params.** `DefaultValidator` always went through the attributes iterator. On a scope that is always validated and does not iterate elements — the root scope and required Hash scopes — once its params are a Hash, the iterator's per-attribute checks come down to whether the value is nil. `Base#validate_attributes!` already makes the same reduction for the other validators.
- **Deciding whether to read a body.** The formatter asked Rack's `form_data?` and `parseable_data?`, then `media_type` to pick a parser: three parses of `CONTENT_TYPE` (a split, a strip and a downcase each), two of them paid by a POST, PUT or DELETE with no body before it found nothing to read. It now checks the method and the body's presence (`CONTENT_LENGTH` or chunked) off the env first, parses the media type once, and tests it against Rack's own `FORM_DATA_MEDIA_TYPES` and `PARSEABLE_DATA_MEDIA_TYPES`. That is the same answer on Rack 2.2 through 3.2: `form_data?`'s other branch, a POST with no media type, needs a nil media type, which Rack only returns when `CONTENT_TYPE` is missing or empty — and the old check required a non-empty `CONTENT_TYPE` alongside it.

No contract changes, so no UPGRADING entry.

## Benchmarks

`lib/` from master (df69f036; #2938 on top of it only corrects comments) against this branch. Each round runs both in separate processes and alternates which goes first; the tables show the median of 7 rounds, each measuring for 2 s after 5,000 warm-up requests. The µs columns are without JIT. Ruby 4.0.6 (arm64), Rack 3.2.7, macOS.

Requests are grouped by the changes they go through, so a group's numbers belong to those changes alone.

#### Only the formatter change runs on these

| request | master µs | branch µs | no JIT | YJIT |
|---|---:|---:|---:|---:|
| POST with no body | 8.7 | 7.5 | **+15.3%** | **+10.3%** |
| DELETE with no body | 7.1 | 6.1 | **+17.2%** | **+12.8%** |
| JSON POST, 5 typed params | 24.4 | 23.5 | +3.8% | +8.7% |
| JSON POST, nested Hash, `before` filter reading a header | 34.7 | 32.8 | +5.7% | +5.3% |
| JSON POST returning `declared(params)` | 35.7 | 33.8 | +5.4% | +7.9% |
| JSON POST, `requires :items, type: Array do`, 1 element | 25.6 | 24.7 | +3.8% | +4.0% |
| form POST, 2 typed params | 23.7 | 23.0 | +2.9% | +1.0%¹ |

#### Only the entity lookup runs on these (the error formatter looks for a presenter)

| request | master µs | branch µs | no JIT | YJIT |
|---|---:|---:|---:|---:|
| 401 via `error!` | 13.5 | 11.8 | **+14.8%** | **+29.4%** |
| 404 via a `rescue_from` block calling `error!` | 16.0 | 14.2 | **+13.0%** | **+23.6%** |
| 500 via a `rescue_from :all` block calling `error!` | 16.9 | 14.9 | **+13.3%** | **+24.1%** |
| 400, required param missing | 49.7 | 47.8 | +4.1% | +8.0% |
| 400 via the README's `rescue_from ValidationErrors` + `full_messages` | 52.7 | 50.5 | +4.4% | +6.4% |

#### Both the formatter and the entity lookup run on this: a POST with no body, answered with 405

| request | master µs | branch µs | no JIT | YJIT |
|---|---:|---:|---:|---:|
| 405, wrong method | 17.8 | 14.9 | **+19.2%** | **+25.2%** |

#### Only the defaults change runs on these

| request | master µs | branch µs | no JIT | YJIT |
|---|---:|---:|---:|---:|
| GET, pagination helper (2 defaults, `values`, `mutually_exclusive`) | 28.5 | 27.4 | +4.0% | +3.9% |
| GET, 3 typed query params, 1 default | 26.4 | 25.4 | +3.9% | +0.0% |

#### Controls (none of the changes run on these)

| request | master µs | branch µs | no JIT | YJIT |
|---|---:|---:|---:|---:|
| GET, no params, path-versioned | 8.2 | 8.4 | -2.0% | +3.9% |
| GET, no version | 6.8 | 6.8 | -0.4% | +0.4% |
| GET, `before` filter reading a header, route param | 20.9 | 21.3 | -2.0% | +1.8% |
| GET, `using: :header` | 8.3 | 8.2 | +0.3% | +1.0% |

¹ The 7-round YJIT run read -3.0%; this is an 11-round rerun of the same comparison.


The controls span −2.0% to +0.3% without JIT and +0.4% to +3.9% with YJIT. At 7 rounds this harness moves by 2–3% on its own, as the form POST row shows.

## Verification

- Full suite on this branch: 2863 examples, 0 failures. `spec/integration/grape_entity` under `gemfiles/grape_entity.gemfile`: 25 examples, 0 failures. RuboCop clean.
- Byte-identical responses against master for:
  - all 49 benchmark scenarios, plus 63 formatter edge cases: an empty, `;`, comma-separated, upper-case or charset-carrying `Content-Type`; method override; a missing, zero or non-numeric `Content-Length`; chunked bodies; DELETE and QUERY bodies; multipart;
  - 640 `default:` cases across the root scope, required and optional Hash scopes, Array elements, `given` and `with`, with nil, false and empty values and proc defaults, under both the HashWithIndifferentAccess and Hash params builders;
  - 32 entity lookups, run with and without a top-level `::Entity`;
  - the existing validation (104), Array element (164), error (228), `declared` (62) and message (120) matrices.
- Mutations, each failing the suite:
  - the Entity gate asked without inheritance;
  - defaults applied only for a missing key, or for any `blank?` value, or a proc default handed the wrong params;
  - the body length read through `Rack::CONTENT_LENGTH` (on Rack 3 that is the response header's name, not the env key);
  - multipart/related and multipart/mixed no longer left to Rack;
  - the body's presence not checked;
  - the parsed media type not passed on to pick the parser.
- New specs:
  - an `Entity` named by a superclass or an included module is used;
  - a top-level `Entity` is not;
  - a JSON `null` gets its default, a `false` is kept, and a proc default is handed its own scope's params.

## Test plan

- [x] Full RSpec suite passes locally.
- [x] `spec/integration/grape_entity` passes under `gemfiles/grape_entity.gemfile`.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
